### PR TITLE
chore(ci): bump setup-dotnet v4 → v5.2.0 + dotnet-version 9.x → 10.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,9 @@ jobs:
         with:
           node-version: 24.x
           cache: npm
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
       - uses: dtolnay/rust-toolchain@stable
       # Pin vpk to a known-good prerelease that has --msi / --instLocation.
       # Stable vpk 0.0.1298 (the default with no --version) does NOT have
@@ -141,9 +141,9 @@ jobs:
         with:
           node-version: 24.x
           cache: npm
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`.github/workflows/release.yml` — `actions/setup-dotnet` v4.3.1 → v5.2.0 (SHA-pinned) + `dotnet-version` 9.x → 10.x in both `build-windows` and `build-linux` jobs.** Two motivations: (1) brings the action up to its current major (only breaking change in v5.0.0 is the action's internal Node 24 runtime, which GitHub-hosted runners already satisfy); (2) bumps the SDK from .NET 9 (STS, end-of-life Nov 2026) to .NET 10 (current LTS, end-of-life Nov 2028) — consistent with Control Menu's same upgrade landed 2026-05-09. `vpk` (Velopack 0.0.1589-ga2c5a97) is a global tool installed via `dotnet tool install -g`; it runs on the SDK's runtime support stack, and .NET 10 SDK ships runtimes for older TFMs. **Supersedes Dependabot PR #11** which only proposed the setup-dotnet bump in isolation. Validation: signed commit on a feature branch → PR with `build-and-test` green → squash-merge → fresh beta tag fires `release.yml` end-to-end exercising both Windows and Linux build legs.
+
 ### Security
 
 - **Repo hardening — Tier 3: CodeQL, required CI on main, SSH signed commits, Dependabot triage.** Continuation of the multi-tier hardening pass.


### PR DESCRIPTION
## Summary

Combined upgrade for the release pipeline's build-host .NET dependency stack:

- **`actions/setup-dotnet`**: v4.3.1 (`67a3573`) → **v5.2.0** (`c2fa09f`), SHA-pinned. Only breaking change in v5.0.0 is the action's internal Node 24 runtime, which GitHub-hosted runners already satisfy.
- **`dotnet-version`**: `9.x` → **`10.x`**. .NET 9 is STS (end-of-life Nov 2026); .NET 10 is current LTS (end-of-life Nov 2028). Consistent with Control Menu's same upgrade that landed 2026-05-09.

`vpk` (Velopack `0.0.1589-ga2c5a97`) is installed as a global tool via `dotnet tool install -g`; it runs on the SDK's runtime support stack, which .NET 10 SDK provides for older TFMs.

## Supersedes #11

Dependabot's PR #11 proposed only the setup-dotnet bump in isolation. Combining both changes into one PR avoids two separate release-pipeline-validation cycles for adjacent dependencies. PR #11 will be closed as superseded after this lands.

## Validation plan

1. `build-and-test` (`ci.yml`) green on this PR — validates YAML syntax + nothing else regressed. (`ci.yml` does not exercise `setup-dotnet`; that's only in `release.yml`.)
2. Squash-merge to `main`.
3. Cut a fresh beta tag (`v0.1.25-beta.5`) to fire `release.yml` end-to-end.
4. Verify both `build-windows` and `build-linux` legs run `setup-dotnet@v5.2.0` with .NET 10 SDK, install vpk, and emit Releases artifacts.

## Test plan

- [ ] `build-and-test` ✓ on this PR
- [ ] Squash-merge clean
- [ ] PR #11 closed with supersession comment
- [ ] `v0.1.25-beta.5` tag pushed
- [ ] `release.yml` run completes both build legs successfully