### PR TITLE
chore(release): v0.1.25-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.5] - 2026-05-18
+
 ### Changed
 
 - **`.github/workflows/release.yml` — `actions/setup-dotnet` v4.3.1 → v5.2.0 (SHA-pinned) + `dotnet-version` 9.x → 10.x in both `build-windows` and `build-linux` jobs.** Two motivations: (1) brings the action up to its current major (only breaking change in v5.0.0 is the action's internal Node 24 runtime, which GitHub-hosted runners already satisfy); (2) bumps the SDK from .NET 9 (STS, end-of-life Nov 2026) to .NET 10 (current LTS, end-of-life Nov 2028) — consistent with Control Menu's same upgrade landed 2026-05-09. `vpk` (Velopack 0.0.1589-ga2c5a97) is a global tool installed via `dotnet tool install -g`; it runs on the SDK's runtime support stack, and .NET 10 SDK ships runtimes for older TFMs. **Supersedes Dependabot PR #11** which only proposed the setup-dotnet bump in isolation. Validation: signed commit on a feature branch → PR with `build-and-test` green → squash-merge → fresh beta tag fires `release.yml` end-to-end exercising both Windows and Linux build legs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.4"
+version = "0.1.25-beta.5"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.4",
+  "version": "0.1.25-beta.5",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump to v0.1.25-beta.5. Files updated by `npm run version:bump`:

- `package.json` — `0.1.25-beta.4` → `0.1.25-beta.5`
- `Cargo.toml` — workspace.package.version bump (propagates to launcher + tray)
- `CHANGELOG.md` — `[Unreleased]` body promoted to `[0.1.25-beta.5] - 2026-05-18`

## Purpose

Validation tag for the `setup-dotnet` v4 → v5.2.0 + `dotnet-version` 9.x → 10.x bump that landed in #15. Beta-channel tag will fire `release.yml` end-to-end on both `build-windows` and `build-linux` legs, exercising the new action + new SDK + existing vpk 0.0.1589-ga2c5a97 pinning.

## Test plan

- [ ] `build-and-test` ✓ on this PR
- [ ] Squash-merge clean
- [ ] Tag `v0.1.25-beta.5` pushed on squashed main HEAD
- [ ] `release.yml` run completes both `build-windows` and `build-linux` successfully