### PR TITLE
chore(release): v0.1.25-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.6] - 2026-05-18
+
 ### Security
 
 - **Tier 4 hardening — workflow least-privilege + Sigstore build attestations.** Audited ws-scrcpy-web's lockdown against the Control Menu repo (which today represents the canonical hardening baseline across my projects) and closed four concrete gaps in the GitHub Actions workflows:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.5"
+version = "0.1.25-beta.6"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.5",
+  "version": "0.1.25-beta.6",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Validation tag for Tier 4 hardening (#17). Beta channel; exercises the new Sigstore attest-build-provenance steps and per-job permissions blocks in release.yml.

## Test plan

- [ ] build-and-test ✓
- [ ] Squash-merge
- [ ] Tag v0.1.25-beta.6 pushed
- [ ] release.yml run completes both build legs
- [ ] Sigstore attestations recorded for the new release artifacts