### PR TITLE
ci(security): SHA-pin 5 remaining moving-tag action references (§29a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 24.x
           cache: npm
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
       - run: npm ci

--- a/.github/workflows/docker-publish.yml.disabled
+++ b/.github/workflows/docker-publish.yml.disabled
@@ -12,13 +12,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/my-image-name:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.x
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       # Pin vpk to a known-good prerelease that has --msi / --instLocation.
       # Stable vpk 0.0.1298 (the default with no --version) does NOT have
       # those flags — they were added in the 0.0.1500+ prerelease line.
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.x
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-unknown-linux-musl
       - name: Install musl-tools (linker for musl target)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **§29(a) — SHA-pinned five remaining moving-tag action references across `.github/workflows/`.** Prerequisite to enabling repo-level `sha_pinning_required` enforcement to match Control Menu's hardening baseline.
+  - **`dtolnay/rust-toolchain@stable` → `@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable`** at three sites: `ci.yml:21` (build-and-test, `with: components: clippy`), `release.yml:61` (build-windows), `release.yml:172` (build-linux, `with: targets: x86_64-unknown-linux-musl`). The `stable` branch on `dtolnay/rust-toolchain` advances every Rust release; Dependabot keys on the trailing `# stable` comment for branch-tracking (parallel convention to `# v1.2.3` semver tracking for tagged actions — both supported by the `github-actions` ecosystem entry in `.github/dependabot.yml`).
+  - **`docker/login-action@v3` → `@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0`** at `docker-publish.yml.disabled:15`. Latest v3 release (2026-01-28); a newer v4 major exists (v4.1.0) but the workflow is currently disabled — preserve the existing v3 semantic for now, let Dependabot propose a major bump if/when the workflow is re-enabled.
+  - **`docker/build-push-action@v5` → `@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0`** at `docker-publish.yml.disabled:21`. Latest v5 release (2024-06-10); v7.1.0 is the current major but again, disabled workflow → preserve v5 semantic.
+  - Verification: `grep -r "uses:" .github/workflows/` returns every action reference now ending with either `# vX.Y.Z` (semver) or `# stable` (branch) — zero moving-tag refs remain.
+
 ### Added
 
 - **`.github/workflows/node-pty-prebuilds.yml` — paired `close-issue-on-success` job that auto-closes stale `prebuild-failure` issues when a subsequent matrix run completes successfully end-to-end.** Symmetric to the existing `open-issue-on-failure` job (which files an issue with labels `prebuild-failure` + `ci` whenever the matrix or publish fails — issue #6 was the first real-world firing, fired on the 2026-05-18 scheduled main run that hit the VS 2026 / node-gyp regression on the windows-latest x64 prior leg, and was closed manually after `d42de9e0` shipped the npm 11.14.1 fix). With this job in place, future failure → fix cycles self-heal on the next green run rather than leaving behind a manually-curated trail of resolved bot issues.


### PR DESCRIPTION
## Summary

§29(a) prerequisite for enabling repo-level `sha_pinning_required` enforcement to reach parity with Control Menu's hardening baseline.

Pre-state (verified via API just before this PR):

\`\`\`
ws-scrcpy-web: allowed_actions: "all", sha_pinning_required: false
control-menu:  allowed_actions: "selected", sha_pinning_required: true
\`\`\`

This PR removes the only blocker to flipping ws-scrcpy-web's repo settings to match: the 5 remaining moving-tag action references in workflow files.

## Changes

| File | Line | Before | After |
|---|---|---|---|
| `ci.yml` | 21 | `dtolnay/rust-toolchain@stable` | `@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable` |
| `release.yml` | 61 | `dtolnay/rust-toolchain@stable` | (same) |
| `release.yml` | 172 | `dtolnay/rust-toolchain@stable` | (same) |
| `docker-publish.yml.disabled` | 15 | `docker/login-action@v3` | `@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0` |
| `docker-publish.yml.disabled` | 21 | `docker/build-push-action@v5` | `@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0` |

The `dtolnay/rust-toolchain` action publishes by branch (`stable`, `beta`, `nightly`) not by version tag — pinning to the current `stable`-branch HEAD commit (29eef336, 2026-03-27) preserves the existing "track the latest Rust stable as it advances" semantic. The trailing `# stable` comment is the Dependabot-keying convention for branch-tracking, parallel to `# vX.Y.Z` for semver-tagged actions; the `github-actions` ecosystem entry in `.github/dependabot.yml` already covers SHA bumps on both conventions.

Docker actions: pinned to current latest of the existing major (v3.7.0 / v5.4.0). The `.disabled` workflow is currently inert; newer majors (v4.1.0 / v7.1.0) exist but a major bump is out of scope for a SHA-pinning hygiene pass. When/if the workflow is re-enabled, Dependabot will propose major bumps via the normal flow.

## Verification

- [ ] `grep -rn "uses:" .github/workflows/` returns every reference now ending with either `# vX.Y.Z` (semver) or `# stable` (branch) — zero moving-tag refs remain.
- [ ] All 4 workflow YAMLs parse cleanly (validated locally via Python yaml.safe_load).
- [ ] `build-and-test` CI passes on the PR head commit — this is the load-bearing test that the new dtolnay SHA actually resolves and Rust toolchain installs work the same as `@stable` did.

## Follow-up

Once this lands, §29(b) (out of scope for this PR — two-API-call repo settings flip):

1. \`gh api -X PUT repos/.../actions/permissions --field allowed_actions=selected --field sha_pinning_required=true\`
2. \`gh api -X PUT repos/.../actions/permissions/selected-actions\` with patterns_allowed: \`softprops/action-gh-release@*, dtolnay/rust-toolchain@*, docker/login-action@*, docker/build-push-action@*\` + github_owned_allowed: true + verified_allowed: false

After both: \`gh api repos/.../actions/permissions\` returns the same shape as control-menu.