### PR TITLE
ci(security): codeql-action SHA-pin comments # v3 → # v3.35.5

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,13 +82,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3.35.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           # query-suite: default (omitted — uses CodeQL's curated default suite)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3.35.5
         with:
           category: "/language:${{ matrix.language }}${{ matrix.category-suffix }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`.github/workflows/codeql.yml` — bare-major `# v3` SHA-pin comments on `github/codeql-action/init` + `/analyze` → precise `# v3.35.5`.** Cross-repo SOP audit ([[dependabot-precise-version-comment]] landed during this session via control-menu PR #14's `actions/upload-artifact` Dependabot blind-spot incident) flagged two bare-major comments in this repo. Bare `# v3` is interpreted by Dependabot as a "track v3 line" range pin — silently skipping major-bump PRs even when v4+ ships. The current SHA `458d36d7d4f47d0dd16ca424c1d3cda0060f1360` already resolves to v3.35.5 (released 2026-05-15); fix is comment-only, no SHA bump. Re-enables Dependabot bump discovery on the next weekly run. Audit also verified rule [[action-sha-pin-commit-not-tag-object]] across all 14 unique action pins in `ws-scrcpy-web/.github/workflows/` — every pin is a commit SHA (not annotated-tag-object SHA), including `actions/github-script@v9.0.0` which uses an annotated tag and was already correctly pinned to the commit. No SHA-type violations to fix.
+
 ### Changed
 
 - **§25 — TS6 `using` / `await using` adoption across `src/server/` + `src/packages/multiplexer/` (release-readiness gate).** Replaces every `try { … } finally { /* cleanup */ }` pattern in the server-side codebase with TC39 Stage 3 Explicit Resource Management (native in TypeScript 6, ES2026). User direction 2026-05-18 was MUST-CONVERT across `src/`, with frontend `src/app/*` allowed slower-paced. 13 conversion sites this pass; 10 frontend `src/app/*` sites carved out for a follow-up.


### PR DESCRIPTION
## Summary

Cross-repo SOP audit triggered by the two new MEMORY.md feedback memories that landed during this session ([[dependabot-precise-version-comment]] + [[action-sha-pin-commit-not-tag-object]] — both surfaced by control-menu PRs #14/#15). Both rules applied to ws-scrcpy-web's existing 14 action pins. Two violations found, both bare-major comments on the same SHA:

\`\`\`
codeql.yml:85  github/codeql-action/init@458d36d7…   # v3      ← BARE-MAJOR
codeql.yml:92  github/codeql-action/analyze@458d36d7…  # v3      ← BARE-MAJOR
\`\`\`

Bare `# v3` is read by Dependabot's `github-actions` ecosystem as a "track v3 line" range pin — silently skips major-bump PRs even when v4+ ships upstream. Precise `# v<x>.<y>.<z>` is the upgrade anchor.

## Verification

Current SHA `458d36d7d4f47d0dd16ca424c1d3cda0060f1360` already resolves to v3.35.5 (released 2026-05-15, commit message `Merge pull request #3907 from github/backport-v3.35.5-9e0d7b8d2`). Comment-only fix, no SHA bump needed.

Also verified rule [[action-sha-pin-commit-not-tag-object]] across all 14 unique action pins in `.github/workflows/`. Every pin is a commit SHA, not an annotated-tag-object SHA:

| Action | Tag-object type | Pin matches | Status |
|---|---|---|---|
| `actions/checkout@v6.0.2` | lightweight | commit | ✓ |
| `actions/setup-node@v6.4.0` | lightweight | commit | ✓ |
| `actions/upload-artifact@v7.0.1` | lightweight | commit | ✓ |
| `actions/download-artifact@v8.0.1` | lightweight | commit | ✓ |
| `actions/setup-dotnet@v5.2.0` | lightweight | commit | ✓ |
| `actions/attest-build-provenance@v4.1.0` | lightweight | commit | ✓ |
| `actions/github-script@v9.0.0` | annotated | **commit** (not tag-obj) | ✓ |
| `softprops/action-gh-release@v3.0.0` | lightweight | commit | ✓ |
| `docker/login-action@v3.7.0` | lightweight | commit | ✓ (just pinned PR #22) |
| `docker/build-push-action@v5.4.0` | lightweight | commit | ✓ (just pinned PR #22) |
| `dtolnay/rust-toolchain@stable` | branch ref | commit | ✓ (branch refs are commits) |
| `github/codeql-action/init@v3.35.5` | annotated | **commit** (not tag-obj) | ✓ |
| `github/codeql-action/analyze@v3.35.5` | annotated | **commit** (not tag-obj) | ✓ |

Zero SHA-type violations across the repo.

## Test plan

- [ ] `build-and-test` (CI) green on PR head — sanity check that the file edit is well-formed YAML.
- [ ] Post-merge CodeQL workflow run on main exercises the new `# v3.35.5` comments — should run identically to before (same SHA), but Dependabot will now propose v4+ major bumps when they ship.