### PR TITLE
chore(ts): enable noPropertyAccessFromIndexSignature (§25c-2.3) — 52 sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **§25c-2.3 — `tsconfig.json` `noPropertyAccessFromIndexSignature: true`.** Third flag in the §25c-2 series. 52 violations fixed across 8 files, all mechanical `obj.key` → `obj['key']` rewrites where `obj`'s static type is an index signature (`Record<string, unknown>`, `DOMStringMap`, `process.env`, runtime-shaped objects via `as Record<...>` casts, etc.). The flag enforces visual distinction between known compile-time properties (dot-access, type-checked) and string-keyed lookups into open-ended dictionaries (bracket-access, runtime-checked). Touched files:
+  - **`AudioSettingsStore.ts` (5)** — `v.enabled/source/codec` on the `Record<string, unknown>` validation type-guard
+  - **`DeviceTracker.ts` (4)** — `sleepBtn.dataset['awake']` (DOMStringMap is canonical index-signature)
+  - **`StreamClientScrcpy.ts` (2)** — `STATE['PAUSED']`/`STATE['PLAYING']` (BasePlayer's STATE enum is typed via index signature)
+  - **`GoogToolBox.ts` (1)** — `element.optional['code']`
+  - **`BaseCanvasBasedPlayer.ts` (2)** — `STATE['PLAYING']`
+  - **`BasePlayer.ts` (5)** — `STATE['STOPPED']` ×2, `STATE['PLAYING']` ×2, `STATE['PAUSED']`
+  - **`UpdatesApi.ts` (8)** — `raw['autoUpdate']/['channel']/['githubOwner']/['updateCheckIntervalMinutes']` on `Record<string, unknown>` validation
+  - **`server/index.ts` (8)** — diagnostic walk of arbitrary `Record<string, unknown>` handle objects: `handle['address']/['fd']/['spawnfile']/['path']/['_idleTimeout']`
+  - **Test files (17)** — `__tests__/ServiceApi.test.ts` (3), `__tests__/UpdatesApi.test.ts` (2), `__tests__/UpdateService.test.ts` (8 + 2)
+  - Vitest 684/684 unchanged. tsc clean. No behavioral change — pure access-syntax tightening.
+
 - **§25c-2.2 — `tsconfig.json` `noUnusedLocals: true`.** Second flag in the §25c-2 series. 19 violations fixed, falling into three categories:
   - **Stale class fields (write-only or fully dead) — deletions:** `WelcomeModal.platform` (assigned from status fetch, never read), `WelcomeModal.scopeUserRadio` (assigned from radio el, never read; sibling `scopeSystemRadio` is the live one), `ConfigureScrcpy.resetSettingsButton` + `loadSettingsButton` (the `(this.X = document.createElement(...))` write-then-store-locally idiom was redundant; reverted to plain `const X = document.createElement(...)`), `ListFilesModal.requireClean` + `requestedPath` (initial value, no assignments anywhere). Total: 6 deleted fields + 4 cleaned-up DOM assignments.
   - **Dead test-file imports — deletions:** `modal.test.ts: ModalOptions`, `dependencyTypes.test.ts: DependencyStatus`, `adbClient.test.ts: afterAll + beforeAll`, `discoverServicePort.test.ts: beforeEach`, `libcDetect.test.ts: beforeEach`, `ConfigApi.ts: path`, `StreamClientScrcpy.ts: HostTracker + CommandControlMessage`. Total: 9 dead import-binding deletions.

--- a/src/app/client/AudioSettingsStore.ts
+++ b/src/app/client/AudioSettingsStore.ts
@@ -27,11 +27,11 @@ function isValidStored(value: unknown): value is StoredAudioSettings {
     if (!value || typeof value !== 'object') return false;
     const v = value as Record<string, unknown>;
     return (
-        typeof v.enabled === 'boolean' &&
-        typeof v.source === 'string' &&
-        VALID_SOURCES.has(v.source) &&
-        typeof v.codec === 'string' &&
-        VALID_CODECS.has(v.codec)
+        typeof v['enabled'] === 'boolean' &&
+        typeof v['source'] === 'string' &&
+        VALID_SOURCES.has(v['source'] as string) &&
+        typeof v['codec'] === 'string' &&
+        VALID_CODECS.has(v['codec'] as string)
     );
 }
 

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -249,11 +249,11 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                 const isAwake = screenState === 'awake';
                 sleepBtn.className = `sleep-wake-btn ${isAwake ? 'state-on' : 'state-off'}`;
                 sleepBtn.textContent = isAwake ? 'turn off' : 'turn on';
-                sleepBtn.dataset.awake = String(isAwake);
+                sleepBtn.dataset['awake'] = String(isAwake);
             }
 
             sleepBtn.addEventListener('click', async () => {
-                const isAwake = sleepBtn.dataset.awake === 'true';
+                const isAwake = sleepBtn.dataset['awake'] === 'true';
                 sleepBtn.disabled = true;
                 // §25b — using-declaration replaces the prior try/finally that
                 // re-enabled the button on every exit path. Captures sleepBtn
@@ -270,11 +270,11 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                         body: JSON.stringify({ udid: device.udid, action: isAwake ? 'sleep' : 'wake' }),
                     });
                     const result = await res.json();
-                    sleepBtn.dataset.awake = String(result.awake);
+                    sleepBtn.dataset['awake'] = String(result.awake);
                     sleepBtn.textContent = result.awake ? 'turn off' : 'turn on';
                     sleepBtn.className = `sleep-wake-btn ${result.awake ? 'state-on' : 'state-off'}`;
                 } catch {
-                    sleepBtn.dataset.awake = String(isAwake);
+                    sleepBtn.dataset['awake'] = String(isAwake);
                     sleepBtn.textContent = isAwake ? 'turn off' : 'turn on';
                     sleepBtn.className = `sleep-wake-btn ${isAwake ? 'state-on' : 'state-off'}`;
                 }

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -270,10 +270,10 @@ export class StreamClientScrcpy
     public onVideoFrame = (data: Uint8Array, pts: bigint, isConfig: boolean, isKeyframe: boolean): void => {
         if (!this.player) return;
         const STATE = BasePlayer.STATE;
-        if (this.player.getState() === STATE.PAUSED) {
+        if (this.player.getState() === STATE['PAUSED']) {
             this.player.play();
         }
-        if (this.player.getState() === STATE.PLAYING) {
+        if (this.player.getState() === STATE['PLAYING']) {
             (this.player as WebCodecsPlayer).pushVideoFrame(data, pts, isConfig, isKeyframe);
         }
 

--- a/src/app/googDevice/toolbox/GoogToolBox.ts
+++ b/src/app/googDevice/toolbox/GoogToolBox.ts
@@ -59,7 +59,7 @@ export class GoogToolBox extends ToolBox {
             type: K,
             element: ToolBoxElement<T>,
         ) => {
-            if (!element.optional?.code) {
+            if (!element.optional?.['code']) {
                 return;
             }
             const { code } = element.optional;

--- a/src/app/player/BaseCanvasBasedPlayer.ts
+++ b/src/app/player/BaseCanvasBasedPlayer.ts
@@ -109,7 +109,7 @@ export abstract class BaseCanvasBasedPlayer extends BasePlayer {
     }
 
     private shiftFrame(): void {
-        if (this.getState() !== BasePlayer.STATE.PLAYING) {
+        if (this.getState() !== BasePlayer.STATE['PLAYING']) {
             return;
         }
         const first = this.framesList.shift();
@@ -179,7 +179,7 @@ export abstract class BaseCanvasBasedPlayer extends BasePlayer {
 
     public override play(): void {
         super.play();
-        if (this.getState() !== BasePlayer.STATE.PLAYING || !this.screenInfo) {
+        if (this.getState() !== BasePlayer.STATE['PLAYING'] || !this.screenInfo) {
             return;
         }
         if (!this.canvas) {

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -79,7 +79,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
     };
     private totalStatsCounter = 0;
     private dirtyStatsWidth = 0;
-    private state: number = BasePlayer.STATE.STOPPED;
+    private state: number = BasePlayer.STATE['STOPPED'];
     private qualityAnimationId?: number;
     private showQualityStats = BasePlayer.DEFAULT_SHOW_QUALITY_STATS;
     protected receivedFirstFrame = false;
@@ -311,15 +311,15 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
         if (this.needScreenInfoBeforePlay() && !this.screenInfo) {
             return;
         }
-        this.state = BasePlayer.STATE.PLAYING;
+        this.state = BasePlayer.STATE['PLAYING'];
     }
 
     public pause(): void {
-        this.state = BasePlayer.STATE.PAUSED;
+        this.state = BasePlayer.STATE['PAUSED'];
     }
 
     public stop(): void {
-        this.state = BasePlayer.STATE.STOPPED;
+        this.state = BasePlayer.STATE['STOPPED'];
     }
 
     public getState(): number {
@@ -445,7 +445,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
             this.totalStatsCounter++;
         }
         this.drawStats();
-        if (this.state !== BasePlayer.STATE.STOPPED) {
+        if (this.state !== BasePlayer.STATE['STOPPED']) {
             this.qualityAnimationId = requestAnimationFrame(this.updateQualityStats);
         }
     };

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -29,9 +29,9 @@ function makeReqRes(url: string, method = 'GET', body?: string, headers?: Record
             if (event === 'end') {
                 queueMicrotask(() => {
                     if (body) {
-                        for (const h of listeners.data ?? []) h(Buffer.from(body, 'utf8'));
+                        for (const h of listeners['data'] ?? []) h(Buffer.from(body, 'utf8'));
                     }
-                    for (const h of listeners.end ?? []) h();
+                    for (const h of listeners['end'] ?? []) h();
                 });
             }
             return this;
@@ -200,7 +200,7 @@ describe('ServiceApi', () => {
         expect((opts as { account?: unknown })?.account).toBeUndefined();
         expect(opts?.startType).toBe('Automatic');
         expect(opts?.maxRestartAttempts).toBe(3);
-        expect(opts?.envVars.DEPS_PATH).toBeDefined();
+        expect(opts?.envVars['DEPS_PATH']).toBeDefined();
         // v0.1.6: binPath must be the launcher exe in the install root,
         // NOT process.execPath. startupDir must equal the install root so
         // SCM hands the launched child the right CWD.

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -176,12 +176,12 @@ describe('UpdateService', () => {
 
         expect(receivedLocator).toBeDefined();
         const loc = receivedLocator as Record<string, unknown>;
-        expect(loc.RootAppDir).toBe(installRoot);
-        expect(loc.UpdateExePath).toBe(path.join(installRoot, 'Update.exe'));
-        expect(loc.PackagesDir).toBe(path.join(installRoot, 'packages'));
-        expect(loc.ManifestPath).toBe(path.join(installRoot, 'current', 'sq.version'));
-        expect(loc.CurrentBinaryDir).toBe(path.join(installRoot, 'current'));
-        expect(loc.IsPortable).toBe(false);
+        expect(loc['RootAppDir']).toBe(installRoot);
+        expect(loc['UpdateExePath']).toBe(path.join(installRoot, 'Update.exe'));
+        expect(loc['PackagesDir']).toBe(path.join(installRoot, 'packages'));
+        expect(loc['ManifestPath']).toBe(path.join(installRoot, 'current', 'sq.version'));
+        expect(loc['CurrentBinaryDir']).toBe(path.join(installRoot, 'current'));
+        expect(loc['IsPortable']).toBe(false);
     });
 
     it('reconfigure: passes the same locator to the new factory invocation', async () => {
@@ -205,8 +205,8 @@ describe('UpdateService', () => {
         expect(captured.length).toBeGreaterThanOrEqual(2);
         const initLocator = captured[0] as Record<string, unknown>;
         const reconfigLocator = captured[captured.length - 1] as Record<string, unknown>;
-        expect(initLocator.RootAppDir).toBe(installRoot);
-        expect(reconfigLocator.RootAppDir).toBe(installRoot);
+        expect(initLocator['RootAppDir']).toBe(installRoot);
+        expect(reconfigLocator['RootAppDir']).toBe(installRoot);
         expect(reconfigLocator).toEqual(initLocator);
     });
 

--- a/src/server/__tests__/UpdatesApi.test.ts
+++ b/src/server/__tests__/UpdatesApi.test.ts
@@ -25,9 +25,9 @@ function makeReqRes(url: string, method = 'GET', body?: string) {
             if (event === 'end') {
                 queueMicrotask(() => {
                     if (body !== undefined) {
-                        for (const h of listeners.data ?? []) h(Buffer.from(body, 'utf8'));
+                        for (const h of listeners['data'] ?? []) h(Buffer.from(body, 'utf8'));
                     }
-                    for (const h of listeners.end ?? []) h();
+                    for (const h of listeners['end'] ?? []) h();
                 });
             }
             return this;

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -217,32 +217,32 @@ function validatePatch(raw: Record<string, unknown>): ValidationResult {
     const out: UpdatesConfigPatchRequest = {};
 
     if ('autoUpdate' in raw) {
-        if (typeof raw.autoUpdate !== 'boolean') {
+        if (typeof raw['autoUpdate'] !== 'boolean') {
             return { ok: false, error: 'autoUpdate must be a boolean' };
         }
-        out.autoUpdate = raw.autoUpdate;
+        out.autoUpdate = raw['autoUpdate'];
     }
 
     if ('channel' in raw) {
-        if (typeof raw.channel !== 'string' || !VALID_CHANNELS.includes(raw.channel as UpdateChannel)) {
+        if (typeof raw['channel'] !== 'string' || !VALID_CHANNELS.includes(raw['channel'] as UpdateChannel)) {
             return {
                 ok: false,
                 error: `channel must be one of: ${VALID_CHANNELS.join(', ')}`,
             };
         }
-        out.channel = raw.channel as UpdateChannel;
+        out.channel = raw['channel'] as UpdateChannel;
     }
 
     if ('githubOwner' in raw) {
         // Decision 7: any non-empty string accepted.
-        if (typeof raw.githubOwner !== 'string' || raw.githubOwner.length === 0) {
+        if (typeof raw['githubOwner'] !== 'string' || (raw['githubOwner'] as string).length === 0) {
             return { ok: false, error: 'githubOwner must be a non-empty string' };
         }
-        out.githubOwner = raw.githubOwner;
+        out.githubOwner = raw['githubOwner'] as string;
     }
 
     if ('updateCheckIntervalMinutes' in raw) {
-        const n = raw.updateCheckIntervalMinutes;
+        const n = raw['updateCheckIntervalMinutes'];
         if (typeof n !== 'number' || !Number.isInteger(n) || n < 5 || n > 1440) {
             return {
                 ok: false,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -350,18 +350,18 @@ function exit(signal: string) {
                 let detail = '';
                 try {
                     const handle = h as Record<string, unknown>;
-                    if (typeof handle.address === 'function') {
+                    if (typeof handle['address'] === 'function') {
                         try {
-                            detail += ` addr=${JSON.stringify((handle.address as () => unknown)())}`;
+                            detail += ` addr=${JSON.stringify((handle['address'] as () => unknown)())}`;
                         } catch {
                             /* address() may throw on closed sockets */
                         }
                     }
-                    if (handle.fd !== undefined) detail += ` fd=${handle.fd}`;
-                    if (handle.spawnfile) detail += ` spawnfile=${handle.spawnfile as string}`;
-                    if (handle.path) detail += ` path=${handle.path as string}`;
-                    if (typeof handle._idleTimeout === 'number' && handle._idleTimeout > 0) {
-                        detail += ` timeoutMs=${handle._idleTimeout}`;
+                    if (handle['fd'] !== undefined) detail += ` fd=${handle['fd']}`;
+                    if (handle['spawnfile']) detail += ` spawnfile=${handle['spawnfile'] as string}`;
+                    if (handle['path']) detail += ` path=${handle['path'] as string}`;
+                    if (typeof handle['_idleTimeout'] === 'number' && handle['_idleTimeout'] > 0) {
+                        detail += ` timeoutMs=${handle['_idleTimeout']}`;
                     }
                 } catch {
                     /* best-effort property extraction */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitOverride": true,
         "noImplicitReturns": true,
+        "noPropertyAccessFromIndexSignature": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Third flag in the **§25c-2 series**. 52 violations fixed across 12 files, all mechanical `obj.key` → `obj['key']` rewrites where `obj`'s static type is an index signature (`Record<string, unknown>`, `DOMStringMap`, runtime-shaped objects cast through `as Record<string, unknown>`, etc.).

The flag enforces a visual distinction between:
- **Known-property access** (dot syntax) — type-checked at compile time
- **String-keyed lookup into open-ended dictionaries** (bracket syntax) — runtime-validated

## Per-file breakdown

| File | Sites | Pattern |
|---|---|---|
| `AudioSettingsStore.ts` | 5 | `v.enabled/source/codec` on `Record<string, unknown>` validation type-guard |
| `DeviceTracker.ts` | 4 | `sleepBtn.dataset['awake']` (DOMStringMap is canonical index-signature) |
| `StreamClientScrcpy.ts` | 2 | `STATE['PAUSED']`/`['PLAYING']` (BasePlayer's STATE enum) |
| `GoogToolBox.ts` | 1 | `element.optional['code']` |
| `BaseCanvasBasedPlayer.ts` | 2 | `STATE['PLAYING']` |
| `BasePlayer.ts` | 5 | `STATE['STOPPED'/'PLAYING'/'PAUSED']` |
| `UpdatesApi.ts` | 8 | `raw['autoUpdate'/'channel'/'githubOwner'/'updateCheckIntervalMinutes']` validation |
| `server/index.ts` | 8 | `handle['address'/'fd'/'spawnfile'/'path'/'_idleTimeout']` diagnostic walk |
| `ServiceApi.test.ts` | 3 | `listeners['data'/'end']`, `env['DEPS_PATH']` |
| `UpdatesApi.test.ts` | 2 | `listeners['data'/'end']` |
| `UpdateService.test.ts` | 10 | `loc['RootAppDir'/'UpdateExePath'/...]` |

## Verification

- vitest **684/684 across 61 files** (re-measured at branch HEAD)
- `npx tsc --noEmit`: clean
- No behavioral change — pure access-syntax tightening

## Why bother

Most valuable on the validation/sanitization functions (`AudioSettingsStore`, `UpdatesApi.validatePatch`, `server/index` handle-walk): bracket access makes it visually obvious those are user-controlled / external-source strings being looked up, not known properties of a typed object. The two patterns blended together before — same syntax for "I know this property exists" and "I'm probing an arbitrary key."