### PR TITLE
docs: strip stale scrcpy-server v3.3.4 version pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **README.md + CONTRIBUTING.md — stripped stale scrcpy-server version pin (`v3.3.4`).** Per user direction during the 2026-05-19 LATE session: "remove versions unless they are explicitly needed." Three pins removed: README "Genymobile's vanilla scrcpy-server v3.3.4" → "scrcpy-server"; README "Vanilla scrcpy-server v3.x" → "Vanilla scrcpy-server"; CONTRIBUTING.md "scrcpy-server v3.3.4" → "scrcpy-server". The v3.3.4 pin was stale (post-§17 we're on the v4.0 wire protocol) AND not actionable for users — the in-app dependency manager handles the version automatically, so the explicit pin in user-facing prose only served to mislead. Same rationale dropped "not supported in v0.1" → "not supported" in the glibc requirement section: the in-version qualifier signals "might change in v0.2+" but we have no plans to add musl support; the cleaner absolute statement is more accurate today and tomorrow. **Kept verbatim:** the historical upgrade-path warnings (v0.1.20-and-earlier PROGRAMDATA migration, v0.1.21/v0.1.22/v0.1.23-beta.{1..6} broken-updater chain) — those target users on specific old versions and are concrete migration help; removing would orphan them.
+
 ### Changed
 
 - **§25c-2.3 — `tsconfig.json` `noPropertyAccessFromIndexSignature: true`.** Third flag in the §25c-2 series. 52 violations fixed across 8 files, all mechanical `obj.key` → `obj['key']` rewrites where `obj`'s static type is an index signature (`Record<string, unknown>`, `DOMStringMap`, `process.env`, runtime-shaped objects via `as Record<...>` casts, etc.). The flag enforces visual distinction between known compile-time properties (dot-access, type-checked) and string-keyed lookups into open-ended dictionaries (bracket-access, runtime-checked). Touched files:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest. This document covers the essentials for getting a deve
 
 - **Node.js 24 LTS or newer** (`engines` field pins `>=24`)
 - **ADB** (Android Debug Bridge) available on `PATH` or inside a `dependencies/adb/` folder at the repo root
-- **scrcpy-server v3.3.4** binary (downloaded by the in-app updater; no manual step needed for local dev)
+- **scrcpy-server** binary (downloaded by the in-app updater; no manual step needed for local dev)
 - An Android device (physical or emulator) reachable via ADB, USB or network
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
   <img src="assets/banner.png" alt="ws-scrcpy-web" width="600">
 </p>
 
-ws-scrcpy-web is a self-hosted, browser-based Android screen-mirroring app (independent project at [bilbospocketses/ws-scrcpy-web](https://github.com/bilbospocketses/ws-scrcpy-web), descended from [NetrisTV/ws-scrcpy](https://github.com/NetrisTV/ws-scrcpy)) that needs no client install beyond a browser. A local Node.js server uses ADB to push Genymobile's vanilla [scrcpy-server](https://github.com/Genymobile/scrcpy) v3.3.4 onto the device and multiplexes its video/audio/control TCP sockets onto a single WebSocket via a 1-byte channel prefix. The browser client is a custom TypeScript protocol layer that demuxes the stream and decodes H.264/H.265/AV1 video and Opus/AAC/FLAC/PCM audio entirely through WebCodecs (no WASM fallbacks).
+ws-scrcpy-web is a self-hosted, browser-based Android screen-mirroring app (independent project at [bilbospocketses/ws-scrcpy-web](https://github.com/bilbospocketses/ws-scrcpy-web), descended from [NetrisTV/ws-scrcpy](https://github.com/NetrisTV/ws-scrcpy)) that needs no client install beyond a browser. A local Node.js server uses ADB to push Genymobile's vanilla [scrcpy-server](https://github.com/Genymobile/scrcpy) onto the device and multiplexes its video/audio/control TCP sockets onto a single WebSocket via a 1-byte channel prefix. The browser client is a custom TypeScript protocol layer that demuxes the stream and decodes H.264/H.265/AV1 video and Opus/AAC/FLAC/PCM audio entirely through WebCodecs (no WASM fallbacks).
 
 Input flows back as mouse, UHID keyboard, i16-fixed-point scroll, and a D-pad/Touch mode toggle for leanback TV apps, alongside extras like an ADB shell, file manager, mDNS scan, sleep/wake, and device labels. It ships self-contained (bundled Node + ADB, launcher scripts, in-app updater) and exposes a public `WsScrcpy.startStream()` UMD/ESM library plus an `embed.html` shim for embedding live streams into other apps.
 
 ## Key Design Decisions
 
-- **Vanilla scrcpy-server v3.x** -- uses unmodified Genymobile scrcpy-server binaries. No Java patching, no custom forks. Drop in new versions as they release.
+- **Vanilla scrcpy-server** -- uses unmodified Genymobile scrcpy-server binaries. No Java patching, no custom forks. Drop in new versions as they release; the in-app dependency manager checks for and applies updates.
 - **Node.js ADB proxy** -- the server bridges ADB tunnels to WebSocket connections for the browser. The protocol layer is implemented in TypeScript.
 - **WebCodecs only** -- no WASM decoder fallbacks. Modern browsers only.
 - **Pure browser code** -- no Node.js Buffer polyfill or path-browserify in the browser bundle.
@@ -278,7 +278,7 @@ AppImage signing is currently under evaluation; releases ship **unsigned** for n
 
 #### glibc requirement
 
-The bundled `node-pty` native binary is built against glibc. Musl-based distros (Alpine and similar) are not supported in v0.1. Run on glibc-based distros: Ubuntu, Debian, Fedora, Arch, openSUSE, etc. — anything that ships glibc 2.31+ should work.
+The bundled `node-pty` native binary is built against glibc. Musl-based distros (Alpine and similar) are not supported. Run on glibc-based distros: Ubuntu, Debian, Fedora, Arch, openSUSE, etc. — anything that ships glibc 2.31+ should work.
 
 #### Tray icon
 


### PR DESCRIPTION
## Summary

Per user direction 2026-05-19 LATE: "remove versions unless they are explicitly needed, which is unlikely."

Three stale scrcpy-server version pins removed (we're on v4.0 wire protocol post-§17, AND the in-app dependency manager handles the version automatically, so explicit pins in user-facing prose only mislead):

| File | Before | After |
|---|---|---|
| `README.md` (intro) | "Genymobile's vanilla scrcpy-server v3.3.4" | "scrcpy-server" |
| `README.md` (design decisions) | "Vanilla scrcpy-server v3.x" | "Vanilla scrcpy-server" + clarifying note on the in-app dep manager |
| `CONTRIBUTING.md` (prereqs) | "scrcpy-server v3.3.4 binary" | "scrcpy-server binary" |

Plus one related cleanup: `README.md`'s glibc section dropped "not supported in v0.1" → "not supported." The "in v0.1" qualifier signaled "might change in v0.2+" but we have no plans to add musl support.

## Kept verbatim (deliberately not removed)

- **v0.1.20-and-earlier PROGRAMDATA-migration upgrade note** — real user-facing migration help for old installs; removing would orphan those users.
- **v0.1.21/v0.1.22/v0.1.23-beta.{1..6} broken-updater warning** — real user-facing migration help for the broken-updater chain; same rationale.

## Verification

- [ ] `build-and-test` (CI) green on PR head — sanity check (docs-only changes shouldn't break anything, but CI also doesn't enforce doc consistency).