### PR TITLE
chore(release): v0.1.25-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.7] - 2026-05-19
+
 ### Docs
 
 - **README.md + CONTRIBUTING.md — stripped stale scrcpy-server version pin (`v3.3.4`).** Per user direction during the 2026-05-19 LATE session: "remove versions unless they are explicitly needed." Three pins removed: README "Genymobile's vanilla scrcpy-server v3.3.4" → "scrcpy-server"; README "Vanilla scrcpy-server v3.x" → "Vanilla scrcpy-server"; CONTRIBUTING.md "scrcpy-server v3.3.4" → "scrcpy-server". The v3.3.4 pin was stale (post-§17 we're on the v4.0 wire protocol) AND not actionable for users — the in-app dependency manager handles the version automatically, so the explicit pin in user-facing prose only served to mislead. Same rationale dropped "not supported in v0.1" → "not supported" in the glibc requirement section: the in-version qualifier signals "might change in v0.2+" but we have no plans to add musl support; the cleaner absolute statement is more accurate today and tomorrow. **Kept verbatim:** the historical upgrade-path warnings (v0.1.20-and-earlier PROGRAMDATA migration, v0.1.21/v0.1.22/v0.1.23-beta.{1..6} broken-updater chain) — those target users on specific old versions and are concrete migration help; removing would orphan them.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.6"
+version = "0.1.25-beta.7"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.6",
+  "version": "0.1.25-beta.7",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

First beta cut since beta.6 (`017b216`, 2026-05-18 LATE). Carries 17 PRs of work landed across 2026-05-19 — see commit message body for the full list.

**Headline payload for the breadcrumb smoke:**
- **§30 Rust UAC** via launcher `--request-uac` (PR #26) — PowerShell elevation path fully eliminated. The pre-§30 path was `execFileAsync('powershell.exe', […])` resolved via system PATH (CLAUDE.md Local-Dependencies-Only violation). Post-§30 path is Node → `launcherPath` → `ShellExecuteExW(verb="runas")`. This beta exists primarily to validate that end-to-end.
- **§25 + §25b + §25c-1.x/2.1/2.2/2.3/2.4/2.5** — full TS6 migration + 8 strict-mode flags layered. `tsconfig.json` now carries 10 strict flags total (highest the codebase has ever had).
- **§27 + §28 + §29a/b** — CodeQL Rust scanning + alert triage + repo `allowed_actions:selected` + `sha_pinning_required:true`.
- **PR #31** — OpenSSF Scorecard workflow.
- **CodeQL v3 → v4.35.5** (PRs #24 + #27).

## Test plan

- [ ] CI `build-and-test` green on PR head
- [ ] Auto-merge fires on green
- [ ] After merge: push annotated signed tag `v0.1.25-beta.7` from local `main`
- [ ] `release.yml` 4-job pipeline green (prepare / build-windows / build-linux / publish)
- [ ] Sigstore attestations land for MSI + Portable.zip + nupkg + AppImage
- [ ] GitHub release published as prerelease

After release publish, the v0.1.25-beta.4 service-mode smoke runs against the installer to validate §30 Rust-UAC end-to-end (install-service → confirm UAC prompt fires from launcher / not powershell → service registers + starts → tray Run-key + tray exe spawn → uninstall via settings → clean teardown).