### PR TITLE
chore(release): v0.1.25-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.8] - 2026-05-19
+
 ### Security
 
 - **`DependencyManager.extractZip` — system-PATH `powershell` + `unzip` shellouts replaced with launcher `--unzip` subcommand. CLAUDE.md Local-Dependencies-Only compliance.** §30 scrubbed PowerShell from the service-elevation path but missed the dependency-manager's zip-extraction path: `installNodejs` / `installAdb` on Windows shelled out to `execFileAsync('powershell', ['-NoProfile', '-Command', 'Expand-Archive ...'])`; the Linux branch shelled out to `execFileAsync('unzip', [...])`. Both resolved binaries via system PATH — same compliance violation, different code path. This change replaces both with a single cross-platform `execFileAsync(launcherPath, ['--unzip', src, dest], ...)` call. The launcher binary is SHA-pinned-to-release and ships in `current/` alongside the Node process; same compliance posture the §30 `--request-uac` path established.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.7"
+version = "0.1.25-beta.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.7"
+version = "0.1.25-beta.8"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.7"
+version = "0.1.25-beta.8"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.7"
+version = "0.1.25-beta.8"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.7",
+  "version": "0.1.25-beta.8",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Re-cut from `1dc5593` (post-PR #39 main HEAD) to ship the Local-Dependencies-Only fix in a real Velopack installer for the breadcrumb smoke.

**Delta vs v0.1.25-beta.7:** just PR #39 (the powershell/unzip → launcher --unzip replacement). No other commits to main between the beta.7 and beta.8 tags.

**Significance:** first beta with ZERO live PowerShell invocations in shipped runtime code.
- §30 (PR #26, already in beta.7) handled the service-elevation path
- PR #39 (this PR's prereq, already in main) handled the dep-extraction path
- Full repo `grep -i execFileAsync\(['"]powershell` returns ZERO hits in src/ and launcher/ now

## Test plan

- [ ] CI `build-and-test` green on PR head
- [ ] Auto-merge fires on green
- [ ] After merge: push annotated signed tag `v0.1.25-beta.8`
- [ ] `release.yml` 4-job pipeline green
- [ ] Sigstore attestations land for MSI + Portable.zip + nupkg + AppImage
- [ ] GitHub release published

The breadcrumb smoke runs against this installer; §30 Rust-UAC validation (D.4 fires from launcher / D.6 returns `reason='uac-declined'`) is the load-bearing assertion.