### PR TITLE
chore(release): v0.1.25-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.10] - 2026-05-19
+
+### Notes
+
+- **No code changes vs v0.1.25-beta.9.** This release exists solely as the destination half of the §32 service-mode upgrade smoke verification. The §32 fix (`UpdateService.applyUpdate` passes `restart=false` in service mode) lives in the SOURCE version's `applyUpdate` call, so verifying it requires upgrading FROM a fixed version (v0.1.25-beta.9, the first carrier of the fix) TO any later version. v0.1.25-beta.10 is that "any later version" — no functional delta, just a version bump (`package.json` + `Cargo.toml` + `Cargo.lock` + `CHANGELOG.md`) so the upgrade flow has somewhere to go. The load-bearing test: clean VM → install v0.1.25-beta.9 MSI → service mode → Settings → Apply update → confirm service stays RUNNING in `services.msc`, no ghost LocalSystem launcher process, no "stopped — uninstall?" affordance in Settings, app reachable on the same port, no reboot required.
+
 ## [0.1.25-beta.9] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.9"
+version = "0.1.25-beta.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.9"
+version = "0.1.25-beta.10"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.9"
+version = "0.1.25-beta.10"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.9"
+version = "0.1.25-beta.10"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.9",
+  "version": "0.1.25-beta.10",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump 0.1.25-beta.9 → 0.1.25-beta.10. **No code changes vs v0.1.25-beta.9.**

This release exists solely as the destination half of the §32 service-mode upgrade smoke verification. The §32 fix (in v0.1.25-beta.9) only takes effect in the SOURCE version's `applyUpdate` call, so verifying it requires upgrading FROM v0.1.25-beta.9 TO any later version. beta.10 is that "any later version" — version bump only across `package.json` + `Cargo.toml` + `Cargo.lock` + `CHANGELOG.md`.

## Load-bearing smoke test

1. Clean VM snapshot
2. Install v0.1.25-beta.9 MSI
3. Opt into service mode (WelcomeModal → "yes, install service")
4. Confirm baseline: service running in `services.msc`, tray icon present, page loads
5. Settings → Apply update → wait for v0.1.25-beta.10 swap
6. **Pass criteria:**
   - Service stays RUNNING in `services.msc` (no Stopped state)
   - No ghost LocalSystem launcher process in Task Manager
   - No "stopped — uninstall?" affordance in Settings
   - App reachable on the same port
   - No reboot required to recover

## Test plan

- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: push annotated signed tag `v0.1.25-beta.10` → release.yml fires
- [ ] release.yml run green across all 4 jobs
- [ ] User-side: §32 service-mode upgrade smoke per the load-bearing section above