### PR TITLE
chore(release): v0.1.25-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.11] - 2026-05-19
+
 ### Fixed
 
 - **Service-mode in-app upgrade: `--veloapp-updated` hook no longer synchronously calls `servy-cli restart` — instead spawns a detached `--deferred-servy-restart` subcommand that sleeps 8 seconds before invoking servy.** §32 follow-up fix caught by v0.1.25-beta.9 → v0.1.25-beta.10 manual VM smoke. The previous synchronous-hook design had Servy spawn the new SERVICE LAUNCHER while Update.exe was still alive (Update.exe is the parent of the hook process — it waits for the hook to exit before completing its own cleanup + exit). Update.exe's open file handles on `<installRoot>\current\` killed the new Node child via file-sharing-violation before it could reach even the first Logger init line (`[Config] adbPath=...` was missing from `server.log` for the Servy-spawned Node — confirming the kill happened sub-second after spawn). Servy then waited ~60 seconds for its `--recoveryDelay` to time out, then restarted the launcher — by which point Update.exe was gone and Node could initialize cleanly. Net effect: ~75-second window where the service appeared Stopped + app was unreachable, even though Servy/SCM eventually recovered without a reboot.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.10"
+version = "0.1.25-beta.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.10"
+version = "0.1.25-beta.11"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.10"
+version = "0.1.25-beta.11"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.10"
+version = "0.1.25-beta.11"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.10",
+  "version": "0.1.25-beta.11",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump 0.1.25-beta.10 → 0.1.25-beta.11. Carries **§32 Part 2** (PR #46, `b10ae76`) — the `--veloapp-updated` hook spawns a detached `--deferred-servy-restart` subcommand that sleeps 8s before invoking `servy-cli restart`, giving Update.exe time to exit and release file handles on `current/`.

Combined with §32 Part 1 (PR #43, in beta.9 — `restart=false` to Velopack in service mode), this is the full §32 fix.

## Load-bearing smoke test

1. Clean VM snapshot
2. Install **v0.1.25-beta.9** MSI (NOT beta.11 — we want beta.9 as the source so the SOURCE-side `restart=false` fix from Part 1 is in play)
3. Opt into service mode (WelcomeModal → "yes, install service")
4. Confirm baseline: service running in `services.msc`, tray icon present, page loads on `localhost:8001` (or 8000 if port didn't shift)
5. Settings → Apply update → wait for v0.1.25-beta.11 swap
6. **Pass criteria:**
   - Service stays RUNNING in `services.msc` throughout the upgrade (no Stopped state, no ~75s gap)
   - No ghost LocalSystem launcher process in Task Manager (confirmed gone post-Part 1)
   - No "stopped — uninstall?" affordance in Settings
   - App reachable on the configured port immediately post-update (no reboot required, no waiting for Servy `--recoveryDelay`)
   - Launcher.log shows new launcher start AT MOST a few seconds after `--veloapp-updated` hook fires (was ~75s before Part 2)

## Test plan

- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: push annotated signed tag `v0.1.25-beta.11` → release.yml fires
- [ ] release.yml run green across all 4 jobs (prepare + build-windows + build-linux + publish)
- [ ] User-side: §32 smoke per the load-bearing section above