### PR TITLE
chore(release): v0.1.25-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.12] - 2026-05-19
+
 ### Fixed
 
 - **Service-mode in-app upgrade: replaced the Part 2 hook-side detached spawn (beta.11) with a Servy-native `--postStopPath` post-stop handler.** §32 Part 3 — caught by v0.1.25-beta.9 → v0.1.25-beta.11 manual VM smoke. The deferred-spawn helper from Part 2 was killed by Velopack's Job Object cleanup during its 8-second sleep (launcher.log showed "sleeping 8000ms" but never "invoking servy-cli restart" — confirming kill mid-sleep). And worse than Part 1's behavior, the clean-exit + dead-helper combo meant SCM's `RestartProcess` RecoveryAction never fired (clean exits don't trigger recovery), so the service stayed Stopped indefinitely until reboot. Part 3 routes around the entire process-tree problem by using **Servy's `--postStopPath` mechanism**: a fire-and-forget executable that Servy itself spawns after the supervised process and all its children have exited. The post-stop process is in Servy's process tree (descended from SCM), completely independent of Velopack's Update.exe — no Job Object cleanup can touch it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.11"
+version = "0.1.25-beta.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.11"
+version = "0.1.25-beta.12"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.11"
+version = "0.1.25-beta.12"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.11"
+version = "0.1.25-beta.12"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.11",
+  "version": "0.1.25-beta.12",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump 0.1.25-beta.11 → 0.1.25-beta.12. Carries **§32 Part 3** (PR #48, `96119fe`).

Service-mode in-app upgrade now uses Servy's `--postStopPath` mechanism as the recovery primitive. UpdateService writes an apply-update-pending marker before exit; the post-stop handler reads it after Servy detects the launcher exit, sleeps 12s for Velopack cleanup, then `sc.exe start WsScrcpyWeb`. The recovery mechanism lives OUTSIDE Velopack's process tree, so it survives Velopack's Job Object cleanup that killed Parts 1 and 2.

## Bridge upgrade caveat

beta.9 → beta.12 specifically goes through the synchronous `--veloapp-updated` hook fallback (same path as beta.10) because beta.9's Servy install lacks `--postStopPath`. Expect ~60s SCM RestartProcess RecoveryAction window during the migration — one-time-bumpy.

Future beta.12 → beta.13+ upgrades have `--postStopPath` wired in the Servy config and use the clean post-stop path with <15s recovery and no SCM RecoveryAction involvement.

## Two smoke tests

1. **Bridge smoke**: clean VM → install v0.1.25-beta.9 MSI → service mode → apply update to v0.1.25-beta.12 → expect ~60-75s recovery via SCM RestartProcess (acceptable migration cost)
2. **Proper Part 3 smoke** (next beta after this): clean VM → install v0.1.25-beta.12 MSI → service mode → apply update to v0.1.25-beta.13 (or any later beta) → expect <15s recovery via post-stop handler

## Test plan

- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: push annotated signed tag `v0.1.25-beta.12` → release.yml fires
- [ ] release.yml run green across all 4 jobs
- [ ] User-side: bridge VM smoke per above