### PR TITLE
chore(release): v0.1.25-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.13] - 2026-05-20
+
+### Notes
+
+- **No code changes vs v0.1.25-beta.12.** This release exists solely as the destination version for the proper §32 Part 3 smoke validation. The beta.9 → beta.12 bridge smoke (2026-05-19 LATE+++) confirmed that the bridge upgrade still requires a reboot — expected migration cost, because beta.9's Servy install lacks `--postStopPath` so beta.12's `--veloapp-updated` hook falls back to the synchronous `servy-cli restart` path (same race that beta.10 hit). beta.13's purpose is the FOLLOW-UP smoke: install v0.1.25-beta.12 MSI first (Servy is now installed WITH `--postStopPath` argument wired), then upgrade to v0.1.25-beta.13. Expected behavior: launcher exits clean post-Velopack-swap → Servy's post-stop handler fires (in Servy's process tree, outside Velopack) → handler sees the apply-update-pending marker → sleeps 12s → `sc.exe start WsScrcpyWeb` → service comes back in <15s, no reboot required, no SCM RestartProcess RecoveryAction involvement.
+
 ## [0.1.25-beta.12] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.12"
+version = "0.1.25-beta.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.12"
+version = "0.1.25-beta.13"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.12"
+version = "0.1.25-beta.13"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.12"
+version = "0.1.25-beta.13"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.12",
+  "version": "0.1.25-beta.13",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump 0.1.25-beta.12 → 0.1.25-beta.13. **No code changes vs v0.1.25-beta.12.**

Destination version for the **proper §32 Part 3 smoke validation**.

## Bridge smoke result (2026-05-19 LATE+++ → 2026-05-20)

User confirmed: beta.9 → beta.12 bridge upgrade **still requires a reboot**. This is the expected migration cost — beta.9's Servy install lacks `--postStopPath`, so beta.12's `--veloapp-updated` hook falls back to the synchronous `servy-cli restart` path (same race that beta.10 hit). The bridge upgrade is documented as one-time bumpy in §32 Part 3.

## Proper Part 3 smoke target (this PR's purpose)

beta.12 → beta.13 is the load-bearing test. Recipe:

1. Clean VM snapshot
2. Install **v0.1.25-beta.12** MSI (Servy is now installed WITH `--postStopPath` argument wired into the service config)
3. Opt into service mode
4. Confirm baseline: service running, tray icon present, page loads
5. Settings → Apply update → wait for v0.1.25-beta.13 swap
6. **Expected behavior:**
   - Launcher exits clean post-Velopack-swap (no `process.exit` ghost-launcher race because of Part 1 from beta.9)
   - Servy's post-stop handler fires (in Servy's process tree, outside Velopack's Job Object)
   - Handler reads the `apply-update-pending` marker that UpdateService wrote pre-exit
   - Handler sleeps 12s (lets Update.exe finish + release file handles on `current/`)
   - Handler calls `sc.exe start WsScrcpyWeb` → SCM asks Servy to spawn a fresh launcher
   - Service back in <15s total, no reboot required, no SCM RestartProcess RecoveryAction involvement

## Test plan

- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: push annotated signed tag `v0.1.25-beta.13` → release.yml fires
- [ ] release.yml run green across all 4 jobs (prepare + build-windows + build-linux + publish)
- [ ] User-side: proper Part 3 VM smoke per the recipe above