### PR TITLE
fix(installer): use --postStopParams=value equals form for servy-cli install

### DIFF
--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -212,8 +212,14 @@ fn install_service(args: &InstallServiceArgs) -> ElevatedResult {
         args.log_path.clone(),
         "--postStopPath".to_string(),
         args.bin_path.clone(),
-        "--postStopParams".to_string(),
-        "--post-stop-handler".to_string(),
+        // §32 Part 3 follow-up — caught by v0.1.25-beta.12 fresh-install
+        // smoke (2026-05-20): Servy's CommandLineParser rejects values
+        // that start with `--` as separate args ("Option 'post-stop-handler'
+        // is unknown" + exit 1). Use the `--flag=value` form to keep the
+        // value bound to its flag through the parser. Confirmed via local
+        // servy-cli probe — without the `=` form, the install fails before
+        // touching SCM at all.
+        "--postStopParams=--post-stop-handler".to_string(),
         "--postStopStartupDir".to_string(),
         args.startup_dir.clone(),
     ];


### PR DESCRIPTION
## Summary

Hot-fix for a beta.12-introduced regression: fresh installs of beta.12+ fail when the user clicks **Install service** with error `servy-cli install exited with code Some(1)`. Caught by v0.1.25-beta.12 fresh-install smoke 2026-05-20.

## Root cause

§32 Part 3 (PR #48) added these args to the `servy-cli install` invocation:

```rust
"--postStopParams".to_string(),
"--post-stop-handler".to_string(),
```

Servy 8.2's CommandLineParser interprets `--post-stop-handler` as a new flag (because it starts with `--`), not as the value for `--postStopParams`. Confirmed empirically with the bundled servy-cli.exe:

```
ERROR(S):
  Option 'post-stop-handler' is unknown.
```

## Fix

Use the `--flag=value` form (single argv token) so the parser keeps the value bound to the flag:

```rust
"--postStopParams=--post-stop-handler".to_string(),
```

Validated locally with the same servy-cli.exe — error advances from "unknown option" to the next validation step (path check), confirming the parse succeeded.

## Test plan

- [x] Local probe with servy-cli.exe: equals form parses; two-token form fails with exit 1
- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: cut v0.1.25-beta.14 carrying this fix
- [ ] User smoke: fresh VM → install v0.1.25-beta.14 MSI → Install service → confirm success (no servy-cli error)
- [ ] Bonus smoke: upgrade beta.14 → beta.15 (cut as version-bump only) → confirm post-stop handler fires (THIS is the proper Part 3 validation we've been chasing — without this fix it was impossible to even register the service correctly)

## Bigger picture

Without this fix, Part 3 was untestable on fresh installs. Beta.12 / beta.13 install-service was silently broken on clean VMs (the user's earlier smokes succeeded only because they upgraded FROM beta.9, where the service was already registered with beta.9's args). The proper Part 3 smoke (post-stop handler firing on upgrade) was blocked by this parse error.