### PR TITLE
chore(release): v0.1.25-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.14] - 2026-05-20
+
+### Fixed
+
+- **`servy-cli install` no longer fails with `Option 'post-stop-handler' is unknown` on fresh installs.** §32 Part 3 (in beta.12) added `--postStopParams` followed by `--post-stop-handler` as two separate argv tokens, but Servy's CommandLineParser interprets the leading `--` as a new flag declaration rather than the value for `--postStopParams`. Fresh installs of beta.12 / beta.13 failed at the "Install service" step with `servy-cli install exited with code Some(1)`. The fix uses the `--flag=value` equals form (`--postStopParams=--post-stop-handler`) which keeps the value bound to its flag through the parser. Validated locally with the bundled servy-cli.exe before shipping. **This is the first beta where fresh installs can register the service correctly with the post-stop handler wired** — proper Part 3 smoke validation requires beta.14 (or later) installed FRESH on a clean VM, then upgrading to beta.15+ (or any later version).
+
 ## [0.1.25-beta.13] - 2026-05-20
 
 ### Notes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.13"
+version = "0.1.25-beta.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.13"
+version = "0.1.25-beta.14"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.13"
+version = "0.1.25-beta.14"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.13"
+version = "0.1.25-beta.14"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.13",
+  "version": "0.1.25-beta.14",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump 0.1.25-beta.13 → 0.1.25-beta.14. Carries PR #51 (`90d64ca`) — the parse-error fix that makes `Install service` work on fresh installs again.

**This is the first beta where fresh installs can register the service successfully with `--postStopPath` wired into the Servy config.** Earlier betas (beta.12, beta.13) silently broke fresh-install service registration due to the leading-`--` parser issue in Servy.

## Smoke recipe

1. Clean VM snapshot
2. Install v0.1.25-beta.14 MSI
3. Opt into service mode (WelcomeModal → "yes, install service")
4. **Confirm service installs successfully** (this is the regression fix verification)
5. From elevated cmd: `sc qc WsScrcpyWeb` — verify `BINARY_PATH_NAME` includes the postStopPath wiring (Servy embeds it as the path it actually launches)
6. Cut a v0.1.25-beta.15 (zero code, version bump only — same pattern as beta.10/beta.13)
7. Upgrade beta.14 → beta.15 → expect the proper Part 3 post-stop-handler flow to fire (clean <15s recovery, no reboot)

## Test plan

- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: push annotated signed tag `v0.1.25-beta.14` → release.yml fires
- [ ] release.yml run green across all 4 jobs
- [ ] User-side: fresh-install smoke + queued beta.15 cut for the proper Part 3 smoke