### PR TITLE
chore(release): v0.1.25-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.15] - 2026-05-20
+
 ## [0.1.25-beta.14] - 2026-05-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.14"
+version = "0.1.25-beta.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.14"
+version = "0.1.25-beta.15"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.14"
+version = "0.1.25-beta.15"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.14"
+version = "0.1.25-beta.15"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.14",
+  "version": "0.1.25-beta.15",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump 0.1.25-beta.14 → 0.1.25-beta.15. **No code changes vs v0.1.25-beta.14.**

Destination version for the **FIRST TRUE §32 Part 3 smoke validation**.

## Why this is "the first true Part 3 smoke"

Earlier Part 3 smoke attempts (beta.12 / beta.13) were doomed by the `--postStopParams` parse error in `servy-cli install` (fixed in beta.14, PR #51). Every prior service install silently used beta.9's args because the new install just failed. beta.14 is the first beta where fresh installs successfully register the service with `--postStopPath` wired into the SCM config. beta.15 is therefore the first valid upgrade target where the post-stop handler should genuinely fire.

## Smoke recipe

1. Clean VM snapshot
2. Install **v0.1.25-beta.14** MSI (NOT beta.15 — beta.14 is the SOURCE that registers `--postStopPath` correctly into the Servy config)
3. Opt into service mode (WelcomeModal → "yes, install service")
4. **Confirm service installs successfully** (regression-fix verification)
5. Optional: from elevated cmd, `sc qc WsScrcpyWeb` — verify `BINARY_PATH_NAME` shows Servy's wrapper config including the postStop wiring
6. Settings → Apply update → wait for v0.1.25-beta.15 swap
7. **Pass criteria:**
   - launcher.log shows the `--post-stop-handler` argv line (this is the load-bearing one we've never seen before)
   - launcher.log shows `post-stop-handler: apply-update-pending marker present at ...` followed by `sleeping 12s to let Update.exe finish` followed by `invoking sc.exe start WsScrcpyWeb`
   - Service back to Running in <15-20s total
   - No reboot required
   - No SCM RestartProcess RecoveryAction in Event Viewer

## Test plan

- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: push annotated signed tag `v0.1.25-beta.15` → release.yml fires
- [ ] release.yml run green across all 4 jobs
- [ ] User-side: fresh-install + upgrade smoke per recipe above