### PR TITLE
fix(settings): check-for-updates button text stays in sync with green state

### DIFF
--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -660,19 +660,24 @@ export class SettingsModal extends Modal {
         if (!this.updatesCheckNowBtn) return;
         const btn = this.updatesCheckNowBtn;
         btn.disabled = true;
-        const prev = btn.textContent;
         btn.textContent = 'checking…';
         if (this.updatesStatusEl) {
             this.updatesStatusEl.textContent = 'checking for updates…';
             this.updatesStatusEl.classList.remove('settings-status-error');
         }
-        // §25b — using-declaration replaces the prior try/finally. Captures
-        // `this`, `btn`, and `prev`; dispose restores text + conditionally
-        // re-enables the button (only when not actively checking/downloading,
-        // matching the original conditional re-enable logic).
+        // §25b using-declaration replaces the prior try/finally. The dispose
+        // ONLY re-enables the button (when appropriate) — it deliberately
+        // does NOT restore textContent. The success path runs
+        // applyActionButtonState which sets the correct final label
+        // ("apply v{X}" when ready, "check for updates now" otherwise),
+        // and the failure paths set their own labels below. Prior code
+        // captured `prev` before the fetch and restored it in dispose,
+        // which clobbered the correct "apply v{X}" label that
+        // applyActionButtonState had just set — visible as a button with
+        // green-ready styling but stale "check for updates now" text
+        // (caught by v0.1.25-beta.15 smoke 2026-05-20).
         using _restoreBtn = {
             [Symbol.dispose]: (): void => {
-                btn.textContent = prev;
                 if (
                     this.updatesLastStatus &&
                     this.updatesLastStatus.status !== 'checking' &&
@@ -689,6 +694,7 @@ export class SettingsModal extends Modal {
                     this.updatesStatusEl.textContent = `check failed (${r.status})`;
                     this.updatesStatusEl.classList.add('settings-status-error');
                 }
+                btn.textContent = 'check for updates now';
                 return;
             }
             const s = (await r.json()) as UpdatesStatusResponse;
@@ -701,6 +707,7 @@ export class SettingsModal extends Modal {
                 this.updatesStatusEl.textContent = "couldn't reach server";
                 this.updatesStatusEl.classList.add('settings-status-error');
             }
+            btn.textContent = 'check for updates now';
         }
     }
 


### PR DESCRIPTION
## Summary

Settings modal UI bug caught by v0.1.25-beta.15 smoke 2026-05-20: after clicking "check for updates now" and an update is found, the button correctly turns **green** but the text stays "check for updates now" instead of changing to "apply v{X}". Closing + reopening the modal shows the correct "apply v{X}" text because the open path rebuilds the row from current status.

## Root cause

In `src/app/client/SettingsModal.ts:onCheckNowClick`:

1. Capture `prev = btn.textContent` ("check for updates now")
2. Set `btn.textContent = 'checking…'`
3. `using _restoreBtn` declares a dispose that restores `btn.textContent = prev` at scope exit
4. Fetch returns; status='ready'; `applyActionButtonState(s)` sets `btn.textContent = 'apply v{X}'` + adds `settings-btn-ready` class
5. Function returns → dispose fires → `btn.textContent = prev` clobbers the just-set "apply v{X}" back to "check for updates now"
6. Class isn't touched by dispose, so green styling sticks → visual mismatch

The dispose-time text-restore was a defensive pattern from the earlier try/finally shape that doesn't account for the success path having ALREADY set the correct final text. With the dual-state button (check ↔ apply), restoring `prev` defeats applyActionButtonState's work.

## Fix

- Drop the `prev` capture
- Dispose only re-enables the button (when status is neither 'checking' nor 'downloading')
- Success path's `applyActionButtonState(s)` owns the final text
- Failure paths (non-OK fetch response, catch block) set `btn.textContent = 'check for updates now'` inline

## Test plan

- [x] Vitest 688/688 (re-measured on branch HEAD)
- [x] tsc --noEmit clean
- [ ] `build-and-test` green on this PR head
- [ ] Manual verification post-merge / post-beta: click check for updates, observe button text + color update together