### PR TITLE
chore(release): v0.1.25-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.16] - 2026-05-20
+
 ### Fixed
 
 - **Service-mode in-app upgrade: post-stop handler relocated from launcher binary (in `current/`) to a bat file in `<dataRoot>/post-stop/`, invoked via `cmd.exe`.** §32 Part 4 — caught by v0.1.25-beta.15 smoke 2026-05-20. Part 3 used `current/ws-scrcpy-web-launcher.exe --post-stop-handler` as the post-stop process, but that binary lives in Velopack's swap zone. When Velopack swapped `current/` during the upgrade window, the running post-stop process was stranded mid-sleep (launcher.log showed `sleeping 12s` at 19:28:32 but no follow-up log lines — confirmed killed/stranded). The recovery never fired, the service stayed Stopped until reboot.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.15"
+version = "0.1.25-beta.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.15"
+version = "0.1.25-beta.16"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.15"
+version = "0.1.25-beta.16"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.15"
+version = "0.1.25-beta.16"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.15",
+  "version": "0.1.25-beta.16",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Version bump 0.1.25-beta.15 → 0.1.25-beta.16. Carries §32 Part 4 (PR #55, `b8861ed`). Source half of the Part 4 smoke chain; pair with v0.1.25-beta.17 (queued next) as upgrade target.