### PR TITLE
feat: tray respawn after upgrade + server-reachability overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Standalone tray helper now respawns automatically after an in-app upgrade.** Previously, Velopack's swap of `current/` killed the running `ws-scrcpy-web-tray.exe` (file lock on `current/ws-scrcpy-web-tray.exe`) and the tray didn't come back until the user's next logon (HKLM\Run auto-start). Now: the post-stop bat writes `<dataRoot>/control/respawn-tray-after-upgrade` before `sc start`; the newly-spawned supervised launcher reads the flag in `supervisor::run` and uses the existing `user_session_spawn::spawn_in_active_user_session` machinery (the same WTSEnumerateSessions + WTSQueryUserToken + CreateProcessAsUserW dance from the v0.1.8 uninstall handoff) to land a fresh tray exe in the active interactive user's session. Best-effort: if no active user session is found (headless boot before any logon), the flag is left in place so a future launcher restart can retry. If spawn succeeds, the flag is deleted.
+- **Browser-side server-reachability overlay during in-app upgrades.** Replaces the OS-level "this site can't be reached" page with a branded "ws-scrcpy-web is updating — reconnecting…" overlay. Polls `/api/config` every 5s normally, every 2s when in recovery mode. Overlay appears after 2 consecutive failures (avoids false positives from network jitter). On recovery, reloads the page so the UI re-evaluates against post-restart state. Lives in `src/app/client/ServerReachabilityOverlay.ts` + `src/style/server-reachability.css`. Bootstrapped from `index.ts` at the end of `window.onload`.
+
 ## [0.1.25-beta.17] - 2026-05-20
 
 ## [0.1.25-beta.16] - 2026-05-20

--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -587,6 +587,19 @@ fn write_post_stop_bat(
     // Bat-file logic with paths and service name baked in at install time.
     // %~dp0 / %~1 are not needed — everything is interpolated. The bat is
     // self-contained and idempotent.
+    // §32 Part 4 follow-up: before `sc start`, drop a respawn-tray flag
+    // file. The supervised launcher reads it at startup (in supervisor::run)
+    // and uses user_session_spawn to land the standalone tray exe back in
+    // the user's interactive session. Without this, the tray was killed by
+    // Velopack's swap and didn't return until the user's next logon
+    // (HKLM\Run auto-start). User confirmed this gap on the v0.1.25-beta.16
+    // → beta.17 smoke; flag write here + supervisor pickup makes the tray
+    // self-heal across upgrades.
+    let respawn_tray_flag = data_root
+        .join("control")
+        .join("respawn-tray-after-upgrade");
+    let respawn_tray_flag_str = respawn_tray_flag.to_string_lossy();
+
     let bat = format!(
         "@echo off\r\n\
          REM ws-scrcpy-web post-stop handler (§32 Part 4).\r\n\
@@ -597,11 +610,15 @@ fn write_post_stop_bat(
          timeout /t {sleep} /nobreak >nul\r\n\
          if exist \"{marker}\" (\r\n\
          \x20\x20\x20\x20del \"{marker}\"\r\n\
+         \x20\x20\x20\x20REM Flag for the new supervised launcher to respawn the standalone tray helper\r\n\
+         \x20\x20\x20\x20REM in the active user session (Velopack killed the prior tray during swap).\r\n\
+         \x20\x20\x20\x20type nul > \"{tray_flag}\"\r\n\
          \x20\x20\x20\x20sc start {service}\r\n\
          )\r\n\
          exit /b 0\r\n",
         sleep = POST_STOP_SLEEP_SECS,
         marker = marker_path_str,
+        tray_flag = respawn_tray_flag_str,
         service = service_name,
     );
 

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -68,6 +68,20 @@ pub fn run() -> Result<i32> {
                 Ok(()) => log::info("supervisor: tray HKLM migration check complete"),
                 Err(e) => log::error(&format!("supervisor: tray HKLM migration: {e}")),
             }
+            // §32 Part 4 follow-up: respawn tray after upgrade. The
+            // post-stop bat writes a flag at <dataRoot>/control/
+            // respawn-tray-after-upgrade BEFORE sc start; this is the
+            // first thing the new service-mode launcher reads. If
+            // present, spawn the standalone tray helper into the active
+            // user session via the existing user_session_spawn machinery.
+            // Without this, the tray was killed by Velopack's current/ swap
+            // and didn't return until the user's next logon (HKLM\Run
+            // auto-start). The flag is deleted after spawn so subsequent
+            // startups don't double-spawn; if no active user session is
+            // found (e.g., headless boot before any logon), the flag stays
+            // and a later launcher restart will retry.
+            #[cfg(windows)]
+            try_respawn_tray_after_upgrade(&paths.install_root, &paths.data_root);
         }
     }
 
@@ -132,6 +146,71 @@ fn cleanup_stale_marker(marker: &Path) {
             Ok(()) => log::info(&format!("supervisor: removed stale marker {marker:?}")),
             Err(e) => log::error(&format!("supervisor: could not remove stale marker {marker:?}: {e}")),
         }
+    }
+}
+
+/// §32 Part 4 follow-up — respawn the standalone tray helper into the
+/// active user session if the post-stop bat wrote the
+/// `respawn-tray-after-upgrade` flag. Velopack's swap of `current/` kills
+/// the running tray (file lock on `current/ws-scrcpy-web-tray.exe`), and
+/// HKLM\Run only fires at user logon — so without explicit respawn here,
+/// the user has no tray icon until they log out + back in.
+///
+/// Best-effort: failures are logged but never block supervisor startup.
+/// If no active user session is found (e.g., headless boot before any
+/// interactive logon), the flag is LEFT IN PLACE so a future launcher
+/// restart can retry once a user session exists. If spawn succeeds, the
+/// flag is deleted so subsequent startups don't double-spawn.
+#[cfg(windows)]
+fn try_respawn_tray_after_upgrade(install_root: &Path, data_root: &Path) {
+    use crate::user_session_spawn::{spawn_in_active_user_session, SpawnUserLauncherArgs};
+
+    let flag = data_root.join("control").join("respawn-tray-after-upgrade");
+    if !flag.exists() {
+        return;
+    }
+
+    let tray_exe = install_root.join("current").join("ws-scrcpy-web-tray.exe");
+    if !tray_exe.exists() {
+        log::error(&format!(
+            "supervisor: respawn-tray flag present but tray helper missing at {tray_exe:?}; leaving flag for later retry"
+        ));
+        return;
+    }
+
+    let tray_path_str = match tray_exe.to_str() {
+        Some(s) => s.to_string(),
+        None => {
+            log::error(&format!(
+                "supervisor: tray path not valid UTF-8: {tray_exe:?}; leaving respawn flag"
+            ));
+            return;
+        }
+    };
+
+    log::info(&format!(
+        "supervisor: respawn-tray flag present — attempting cross-session spawn of {tray_path_str}"
+    ));
+    let r = spawn_in_active_user_session(&SpawnUserLauncherArgs {
+        launcher_path: tray_path_str,
+        launcher_args: vec![],
+    });
+    if r.ok {
+        log::info(&format!(
+            "supervisor: tray respawned in session {} (pid {}); clearing flag",
+            r.session_id, r.pid
+        ));
+        match std::fs::remove_file(&flag) {
+            Ok(()) => {}
+            Err(e) => log::error(&format!(
+                "supervisor: tray respawn succeeded but could not delete flag {flag:?}: {e} — may double-spawn on next launcher start"
+            )),
+        }
+    } else {
+        log::error(&format!(
+            "supervisor: tray respawn failed: {} — leaving flag for retry on next launcher start",
+            r.error_message.unwrap_or_default()
+        ));
     }
 }
 

--- a/src/app/client/ServerReachabilityOverlay.ts
+++ b/src/app/client/ServerReachabilityOverlay.ts
@@ -1,0 +1,177 @@
+/**
+ * Server-reachability overlay.
+ *
+ * During an in-app update (service-mode upgrade), the launcher exits + the
+ * port stops listening for ~12-15 seconds while Servy fires the post-stop
+ * bat (which delays + sc starts a fresh service launcher). Without
+ * intervention, the user's browser shows the OS-level "this site can't be
+ * reached" page — confusing UX, easy to misread as "app broke."
+ *
+ * This module mounts a persistent overlay that:
+ *   1. Polls a tiny endpoint at HEARTBEAT_INTERVAL_MS.
+ *   2. After CONSECUTIVE_FAILURES_BEFORE_OVERLAY consecutive failures,
+ *      shows the overlay ("ws-scrcpy-web is updating — reconnecting…").
+ *   3. While the overlay is up, polls more aggressively at
+ *      RECOVERY_POLL_INTERVAL_MS until the heartbeat succeeds.
+ *   4. On recovery, removes the overlay and reloads the page so the UI
+ *      re-evaluates against the freshly-restarted server (config, version,
+ *      etc. may have changed).
+ *
+ * The reload-on-recovery is the safest default — the alternative
+ * (just-remove-overlay-and-keep-going) would leave WebSocket connections,
+ * cached state, and any in-progress UI in stale-stranded form. Reload is
+ * one extra second the user wouldn't have seen anyway because they were
+ * staring at the overlay.
+ */
+
+const HEARTBEAT_ENDPOINT = '/api/config';
+// 5s normal heartbeat. Cheap enough to run continuously, slow enough that
+// network blips don't show false overlays.
+const HEARTBEAT_INTERVAL_MS = 5_000;
+// 2s during recovery — user is staring at the overlay, snappier feels
+// better. Server is fine with this load (one fetch per 2s is trivial).
+const RECOVERY_POLL_INTERVAL_MS = 2_000;
+// Show overlay only after this many consecutive failures. One missed
+// heartbeat is normal network jitter; two indicates the server is
+// genuinely down.
+const CONSECUTIVE_FAILURES_BEFORE_OVERLAY = 2;
+// Per-request fetch timeout. Aborts hanging connections so a TCP
+// half-open state (which Velopack swap can briefly produce) doesn't keep
+// us in pending-state forever.
+const FETCH_TIMEOUT_MS = 3_000;
+
+interface OverlayHandle {
+    overlay: HTMLDivElement;
+    detail: HTMLDivElement;
+}
+
+let consecutiveFailures = 0;
+let overlayHandle: OverlayHandle | null = null;
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let lastIntervalMs = 0;
+
+function buildOverlay(): OverlayHandle {
+    const overlay = document.createElement('div');
+    overlay.className = 'server-reachability-overlay';
+
+    const card = document.createElement('div');
+    card.className = 'server-reachability-card';
+
+    const heading = document.createElement('div');
+    heading.className = 'server-reachability-heading';
+    heading.textContent = 'ws-scrcpy-web is updating';
+
+    const detail = document.createElement('div');
+    detail.className = 'server-reachability-detail';
+    detail.textContent = 'reconnecting…';
+
+    const note = document.createElement('div');
+    note.className = 'server-reachability-note';
+    note.textContent = 'the page will reload automatically when the server is back';
+
+    card.appendChild(heading);
+    card.appendChild(detail);
+    card.appendChild(note);
+    overlay.appendChild(card);
+
+    return { overlay, detail };
+}
+
+function showOverlay(): void {
+    if (overlayHandle) return;
+    overlayHandle = buildOverlay();
+    document.body.appendChild(overlayHandle.overlay);
+}
+
+function hideOverlay(): void {
+    if (!overlayHandle) return;
+    overlayHandle.overlay.remove();
+    overlayHandle = null;
+}
+
+function setPollInterval(ms: number): void {
+    if (ms === lastIntervalMs && intervalHandle !== null) return;
+    if (intervalHandle !== null) clearInterval(intervalHandle);
+    lastIntervalMs = ms;
+    intervalHandle = setInterval(() => {
+        void heartbeatOnce();
+    }, ms);
+}
+
+async function heartbeatOnce(): Promise<void> {
+    let ok = false;
+    try {
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+        try {
+            const r = await fetch(HEARTBEAT_ENDPOINT, {
+                method: 'GET',
+                cache: 'no-store',
+                signal: ctrl.signal,
+            });
+            ok = r.ok;
+        } finally {
+            clearTimeout(t);
+        }
+    } catch {
+        ok = false;
+    }
+
+    if (ok) {
+        if (overlayHandle) {
+            // Recovery — server is back. Reload so the UI re-evaluates
+            // against post-restart state. Slight delay so the user sees
+            // the overlay finish acknowledging recovery.
+            if (overlayHandle.detail) {
+                overlayHandle.detail.textContent = 'reconnected — reloading…';
+            }
+            setTimeout(() => {
+                location.reload();
+            }, 400);
+        }
+        consecutiveFailures = 0;
+        if (lastIntervalMs !== HEARTBEAT_INTERVAL_MS) {
+            setPollInterval(HEARTBEAT_INTERVAL_MS);
+        }
+        return;
+    }
+
+    consecutiveFailures += 1;
+    if (consecutiveFailures >= CONSECUTIVE_FAILURES_BEFORE_OVERLAY) {
+        showOverlay();
+        // Once visible, poll harder until recovery.
+        if (lastIntervalMs !== RECOVERY_POLL_INTERVAL_MS) {
+            setPollInterval(RECOVERY_POLL_INTERVAL_MS);
+        }
+    }
+}
+
+/**
+ * Start the reachability watchdog. Safe to call multiple times; only
+ * starts the interval once.
+ */
+export function startServerReachabilityWatchdog(): void {
+    if (intervalHandle !== null) return;
+    // Don't show the overlay on the very first failure tick — the
+    // initial page load already established connectivity, so wait one
+    // poll cycle before counting failures. If the very first heartbeat
+    // fails (server died between page load and now), the second cycle
+    // crosses the threshold and the overlay shows ~10s later. Acceptable.
+    setPollInterval(HEARTBEAT_INTERVAL_MS);
+}
+
+/**
+ * Stop the watchdog and hide any visible overlay. Intended for tests
+ * and a hypothetical future explicit-shutdown path. Not currently
+ * wired from anywhere in production (the watchdog runs for the page's
+ * lifetime).
+ */
+export function stopServerReachabilityWatchdog(): void {
+    if (intervalHandle !== null) {
+        clearInterval(intervalHandle);
+        intervalHandle = null;
+    }
+    lastIntervalMs = 0;
+    consecutiveFailures = 0;
+    hideOverlay();
+}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -2,10 +2,12 @@ import '../style/app.css';
 import '../style/dependencies.css';
 import '../style/first-run-banner.css';
 import '../style/home.css';
+import '../style/server-reachability.css';
 import { DependencyPanel } from './client/DependencyPanel';
 import { FirstRunBanner } from './client/FirstRunBanner';
 import { HostTracker } from './client/HostTracker';
 import { NetworkDiscoveryPanel } from './client/NetworkDiscoveryPanel';
+import { startServerReachabilityWatchdog } from './client/ServerReachabilityOverlay';
 import { createSettingsHeader } from './client/SettingsHeader';
 import { createThemeToggle, initTheme } from './client/ThemeToggle';
 import { installThemeEmbedListener, notifyThemeReady } from './public/themeEmbed';
@@ -228,4 +230,11 @@ window.onload = async (): Promise<void> => {
     });
 
     HostTracker.start();
+
+    // Start the reachability watchdog AFTER the page is fully bootstrapped.
+    // When the server briefly goes unreachable (in-app upgrade window —
+    // §32 Part 4 has the server back in ~12-15s), the overlay covers the
+    // gap so the user doesn't see the OS-level "can't be reached" page.
+    // Auto-reloads on recovery.
+    startServerReachabilityWatchdog();
 };

--- a/src/style/server-reachability.css
+++ b/src/style/server-reachability.css
@@ -1,0 +1,73 @@
+/*
+ * Server-reachability overlay (ServerReachabilityOverlay.ts).
+ * Shown during an in-app upgrade window when the server is briefly
+ * unreachable. Replaces the OS-level "can't be reached" page with a
+ * branded "updating, reconnecting…" experience.
+ */
+
+.server-reachability-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 18, 26, 0.85);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    z-index: 99998;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    color: #f4f6fa;
+    padding: 2rem;
+    animation: server-reachability-fadein 0.18s ease-out;
+}
+
+@keyframes server-reachability-fadein {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.server-reachability-card {
+    max-width: 480px;
+    text-align: center;
+    background: rgba(31, 38, 52, 0.72);
+    border: 1px solid rgba(91, 154, 255, 0.35);
+    border-radius: 10px;
+    padding: 2rem 2.5rem;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+}
+
+.server-reachability-heading {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: #5b9aff;
+}
+
+.server-reachability-detail {
+    font-size: 1rem;
+    margin-bottom: 1.25rem;
+    color: #f4f6fa;
+}
+
+.server-reachability-detail::after {
+    /* Inline three-dot animation so we don't pull in an icon dep. */
+    content: '';
+    display: inline-block;
+    width: 1em;
+    text-align: left;
+    animation: server-reachability-dots 1.4s steps(4, end) infinite;
+}
+
+@keyframes server-reachability-dots {
+    0%   { content: ''; }
+    25%  { content: '.'; }
+    50%  { content: '..'; }
+    75%  { content: '...'; }
+    100% { content: ''; }
+}
+
+.server-reachability-note {
+    font-size: 0.85rem;
+    color: rgba(244, 246, 250, 0.65);
+    font-style: italic;
+}


### PR DESCRIPTION
## Summary

Two enhancements requested after §32 Part 4 (PR #55) was validated by the v0.1.25-beta.16 → beta.17 smoke. Both close UX gaps that surface during an in-app upgrade.

## 1. Tray respawn after upgrade

**Problem:** Velopack's swap of `current/` kills the running `ws-scrcpy-web-tray.exe` (file lock on `current/ws-scrcpy-web-tray.exe`). The tray doesn't come back until the user's next logon (HKLM\Run auto-start). Until then the user has no system tray icon.

**Fix:**
- `post-stop.bat` writes `<dataRoot>/control/respawn-tray-after-upgrade` flag BEFORE `sc start`
- New `supervisor::try_respawn_tray_after_upgrade()` reads the flag on launcher startup (service mode only)
- If present + tray exe exists → uses existing `user_session_spawn::spawn_in_active_user_session` to land tray exe in active interactive user's session (WTSEnumerateSessions + WTSQueryUserToken + CreateProcessAsUserW; same machinery as v0.1.8 uninstall handoff)
- Success → delete flag. Failure or no active session → leave flag for future launcher restart to retry.

## 2. Server-reachability overlay

**Problem:** During the ~12-15s upgrade window, browsers show OS-level "this site can't be reached" — looks broken, easy to misread as "app crashed."

**Fix:**
- New `src/app/client/ServerReachabilityOverlay.ts` + `src/style/server-reachability.css`
- Polls `/api/config` every 5s; switches to 2s during recovery
- Shows overlay after 2 consecutive failures (avoids false positives from network jitter)
- Branded "ws-scrcpy-web is updating — reconnecting…" message with animated dots
- Auto-reloads page on recovery so UI re-evaluates against post-restart state (config, version, etc.)
- Bootstrapped from `index.ts` at end of `window.onload`

## Test plan

- [x] Vitest 688/688 (re-measured on branch HEAD)
- [x] tsc --noEmit clean
- [ ] `build-and-test` green on this PR head
- [ ] Post-merge: cut v0.1.25-beta.18 (carrier) + v0.1.25-beta.19 (smoke target)
- [ ] VM smoke: install beta.18 fresh → service mode → opt-in → apply update to beta.19 → expect: (a) overlay appears in browser within ~10s of click, (b) page auto-reloads ~12-15s later, (c) tray icon reappears in system tray within ~15s, (d) launcher.log shows "supervisor: tray respawned in session N" line