### PR TITLE
chore(release): v0.1.25-beta.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.18] - 2026-05-20
+
 ### Added
 
 - **Standalone tray helper now respawns automatically after an in-app upgrade.** Previously, Velopack's swap of `current/` killed the running `ws-scrcpy-web-tray.exe` (file lock on `current/ws-scrcpy-web-tray.exe`) and the tray didn't come back until the user's next logon (HKLM\Run auto-start). Now: the post-stop bat writes `<dataRoot>/control/respawn-tray-after-upgrade` before `sc start`; the newly-spawned supervised launcher reads the flag in `supervisor::run` and uses the existing `user_session_spawn::spawn_in_active_user_session` machinery (the same WTSEnumerateSessions + WTSQueryUserToken + CreateProcessAsUserW dance from the v0.1.8 uninstall handoff) to land a fresh tray exe in the active interactive user's session. Best-effort: if no active user session is found (headless boot before any logon), the flag is left in place so a future launcher restart can retry. If spawn succeeds, the flag is deleted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.17"
+version = "0.1.25-beta.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.17"
+version = "0.1.25-beta.18"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.17"
+version = "0.1.25-beta.18"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.17"
+version = "0.1.25-beta.18"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.17",
+  "version": "0.1.25-beta.18",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Version bump 0.1.25-beta.17 → 0.1.25-beta.18. Carries PR #58 (tray respawn + reachability overlay). Source for the smoke chain; pair with beta.19.