### PR TITLE
chore(release): v0.1.25-beta.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.19] - 2026-05-20
+
 ## [0.1.25-beta.18] - 2026-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.18"
+version = "0.1.25-beta.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.18"
+version = "0.1.25-beta.19"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.18"
+version = "0.1.25-beta.19"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.18"
+version = "0.1.25-beta.19"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.18",
+  "version": "0.1.25-beta.19",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Version bump 0.1.25-beta.18 → 0.1.25-beta.19. No code changes. Destination for the tray-respawn + reachability-overlay smoke.