### PR TITLE
chore(release): v0.1.25-beta.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.20] - 2026-05-20
+
 ### Changed
 
 - **Tray lifecycle moved to launcher-owned polling.** §32 Part 5 — caught by v0.1.25-beta.18 → beta.19 smoke. Replaces the previous architecture (HKLM\Run auto-start at user logon + post-stop bat respawn flag) with a single owner: the launcher's new `tray_supervisor` background thread polls every 10 seconds, locates the active interactive user session via `WTSEnumerateSessionsW`, checks for `ws-scrcpy-web-tray.exe` in that session via `WTSEnumerateProcessesExW`, and spawns it via `user_session_spawn` if missing. The tray's per-session single-instance mutex handles dedup safely. Spawning passes `--launcher-spawn` argv, which signals the tray to surface a balloon notification on start: **"ws-scrcpy-web tray — tray started by launcher. to clear the tray, stop the ws-scrcpy-web service via Settings."** Sets correct expectation that the tray is intrinsic to service-mode operation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.19"
+version = "0.1.25-beta.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.19"
+version = "0.1.25-beta.20"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.19"
+version = "0.1.25-beta.20"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.19"
+version = "0.1.25-beta.20"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.19",
+  "version": "0.1.25-beta.20",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Version bump 0.1.25-beta.19 → 0.1.25-beta.20. Carries §32 Part 5 (PR #61, d9cbe40). Source for the Part 5 smoke chain.