### PR TITLE
chore(release): v0.1.25-beta.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.22] - 2026-05-20
+
 ### Fixed
 
 - **Service-mode in-app upgrade: "updating, please wait…" page now actually appears in the browser during the upgrade window, and survives the port-shift case where the new Node lands on a different port than the upgrade-server held.** §32 Part 5b — caught by v0.1.25-beta.20 → beta.21 smoke 2026-05-20. Two intertwined fixes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.21"
+version = "0.1.25-beta.22"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.21",
+  "version": "0.1.25-beta.22",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Cuts v0.1.25-beta.22, the first beta containing the §32 Part 5b fix (PR #64): pre-exit upgrade-server spawn + retry-bind + wind-down port-shift discovery. This becomes the SOURCE version for the smoke that validates the fix.