### PR TITLE
fix(install-flow): sync webPort after service-Node port-shift (§32 Part 5c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Service-mode opt-in: local Node now syncs its in-memory `webPort` to the actual port the service-Node bound, so subsequent local-Node writes can't clobber `config.json` back to the pre-install port.** §32 Part 5c — caught by v0.1.25-beta.22 → beta.23 smoke 2026-05-21. The user's clean-VM smoke installed beta.22 in local mode (port 8000), opted into service mode, and confirmed the browser correctly redirected to the new service-Node port (8001 after the install-time port shift). Two regressions followed from the same root cause:
+  - **Tray icon opened the wrong port.** After install, the tray re-read `config.json` on click (per `tray/src/main.rs:68-72` it does this every invocation) and got `webPort:8000`. Clicking opened `http://localhost:8000` — a dead address now that the service-Node was on 8001.
+  - **In-app upgrade "updating, please wait…" page never appeared.** During the apply-update window, the launcher's `--upgrade-server` subcommand (spawned pre-exit by §32 Part 5b) read `config.json` for its bind port (`launcher/src/upgrade_server.rs:107-109`) and got `webPort:8000`. It happily bound 8000 — but the browser was on 8001, so the browser's WebSocket-reconnect attempt hit ECONNREFUSED on 8001 for the entire upgrade window and never landed on the launcher's static page. The 25ms retry-bind loop and wind-down port-shift discovery from Part 5b worked correctly; they just couldn't help when the upgrade-server was bound to the wrong port to begin with.
+  - **Root cause: race write back to `config.json` from local Node's stale in-memory state.** During the ~5s window between `ServiceApi.handleInstall`'s redirect response and the scheduled `process.exit(0)`, local Node's `Config` singleton still had the pre-install `webPort:8000` in memory. Service-Node's `reconcileWebPort` had correctly written `webPort:8001` to disk, but any local-Node write during that window (browser-driven PATCH on a stale connection, periodic timer, etc.) used local Node's stale in-memory state and clobbered disk back to 8000.
+  - **Fix: `src/server/api/ServiceApi.ts:handleInstall`** now calls `cfg.setActualWebPort(parsedPort)` immediately after `discoverServicePort` returns a non-null URL — parses the port from `new URL(found).port`, validates the integer range [1024, 65535], updates local Node's in-memory `webPort` and writes `config.json` atomically via the existing `setActualWebPort` path. Any subsequent local-Node write now carries the correct port. Parse failures (host-only URL, etc.) log + continue without aborting the install response.
+
+Vitest 692/692 → 694/694 across 61 files (+2 from new `POST /install syncs local in-memory webPort to the service-Node port discovered on handoff (§32 Part 5c)` and `POST /install skips webPort sync when discovered URL has no parseable port` cases in `ServiceApi.test.ts`). `tsc --noEmit` clean.
+
 ## [0.1.25-beta.23] - 2026-05-20
 
 ## [0.1.25-beta.22] - 2026-05-20

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -232,6 +232,92 @@ describe('ServiceApi', () => {
         expect((installFn.mock.calls[0]?.[0] as { account?: unknown }).account).toBeUndefined();
     });
 
+    it('POST /install syncs local in-memory webPort to the service-Node port discovered on handoff (§32 Part 5c)', async () => {
+        // Regression for the v0.1.25-beta.22 → beta.23 smoke (2026-05-21):
+        // after a successful service install, local Node's in-memory
+        // webPort stayed at the pre-install value (8000) while the
+        // service-Node bound 8001 and persisted that to disk via
+        // reconcileWebPort. Any subsequent local-Node write (e.g., a
+        // browser-driven PATCH /api/config or /api/updater fired during
+        // the redirect window) would clobber config.json back to 8000,
+        // breaking both the tray icon (re-reads config.json on every
+        // click → opens dead 8000) AND the launcher's --upgrade-server
+        // (also reads config.json → binds 8000 while browser is on 8001
+        // → ECONNREFUSED for the entire upgrade window).
+        //
+        // The fix in ServiceApi.handleInstall calls cfg.setActualWebPort
+        // with the parsed port from the discovered URL right after
+        // discoverServicePort returns success. That synchronously
+        // updates in-memory webPort AND writes config.json, so any
+        // later local-Node write carries the correct port.
+        const client = fakeClient({
+            install: vi.fn(async () => undefined),
+            status: vi.fn(async () => 'running' as const),
+        });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(
+            () => factoryResult,
+            () => 'user',
+            () => true,
+            // discover stub: return a non-null URL on the first poll
+            // cycle so handleInstall takes the redirectTo +
+            // setActualWebPort path.
+            async () => 'http://localhost:8001',
+        );
+        const { req, res } = makeReqRes('/api/service/install', 'POST');
+        await api.handle(req, res);
+
+        expect((res as any).getStatus()).toBe(200);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.ok).toBe(true);
+        expect(body.redirectTo).toBe('http://localhost:8001');
+
+        // The crucial assertion. Without the fix, local Node's
+        // in-memory webPort would still be APP_CONFIG_DEFAULTS.webPort
+        // (8000) and any subsequent updateAppConfig / setActualWebPort
+        // call would write 8000 to disk.
+        expect(Config.getInstance().getAppConfig().webPort).toBe(8001);
+    });
+
+    it('POST /install skips webPort sync when discovered URL has no parseable port', async () => {
+        // Defensive coverage for the parse path in the §32 Part 5c sync.
+        // If discoverServicePort ever returns a URL whose port portion
+        // doesn't parse (host-only, weird scheme, etc.), the handler
+        // logs a warning and continues — it must NOT throw and abort
+        // the install response. We can't directly assert "no throw"
+        // beyond reaching the assertions below, but we DO assert that
+        // the response was still 200 and webPort stayed at the default.
+        const client = fakeClient({
+            install: vi.fn(async () => undefined),
+            status: vi.fn(async () => 'running' as const),
+        });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(
+            () => factoryResult,
+            () => 'user',
+            () => true,
+            // Host-only URL; new URL(...).port is '' which parses to NaN.
+            async () => 'http://localhost',
+        );
+        const { req, res } = makeReqRes('/api/service/install', 'POST');
+        await api.handle(req, res);
+
+        expect((res as any).getStatus()).toBe(200);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.ok).toBe(true);
+        expect(body.redirectTo).toBe('http://localhost');
+        // No sync attempted → in-memory webPort stays at the default.
+        expect(Config.getInstance().getAppConfig().webPort).toBe(8000);
+    });
+
     it('POST /install returns 403 when ServyClient throws ServiceInstallError with isUacDeclined=true', async () => {
         // v0.1.7: ServiceApi no longer guards on admin elevation up
         // front; instead, ServyClient.install() spawns an elevated

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -325,6 +325,30 @@ export class ServiceApi {
                 });
                 if (found) {
                     redirectTo = found;
+                    // §32 Part 5c — sync local Node's in-memory webPort to
+                    // the actual port the service-Node bound. Without this,
+                    // any local-Node write between now and process.exit
+                    // (e.g., a browser PATCH /api/config or /api/updater
+                    // fired during the redirect window) carries the stale
+                    // pre-install webPort in memory and clobbers the
+                    // correct value that service-Node already persisted
+                    // via reconcileWebPort. The clobbered config.json then
+                    // breaks BOTH the tray (re-reads stale port → opens a
+                    // dead address) AND the launcher's --upgrade-server
+                    // (binds stale port, browser sees ECONNREFUSED through
+                    // the entire upgrade window). Diagnosed via v0.1.25-
+                    // beta.22 → beta.23 smoke 2026-05-21.
+                    try {
+                        const parsedPort = Number.parseInt(new URL(found).port, 10);
+                        if (Number.isInteger(parsedPort) && parsedPort >= 1024 && parsedPort <= 65535) {
+                            cfg.setActualWebPort(parsedPort);
+                            log.info(`install-flow: synced local in-memory webPort to actual service port ${parsedPort}`);
+                        } else {
+                            log.warn(`install-flow: could not parse port from discovered URL ${found}; webPort sync skipped`);
+                        }
+                    } catch (err) {
+                        log.warn(`install-flow: webPort sync failed (continuing without it): ${(err as Error).message}`);
+                    }
                     // Schedule our own shutdown shortly after the
                     // response goes out. The user's browser will have
                     // navigated to `redirectTo` by then; killing this


### PR DESCRIPTION
## Summary

- Local Node's in-memory `webPort` was staying stale through the service-mode install handoff, letting any later local-Node write clobber `config.json` back to the pre-install port. The clobbered config broke both the tray and the launcher's `--upgrade-server` because both re-read `config.json` for their target port.
- `ServiceApi.handleInstall` now calls `cfg.setActualWebPort(parsedPort)` right after `discoverServicePort` returns a non-null URL — parses + range-validates the port and updates in-memory + disk atomically.
- +2 vitest regression cases in `ServiceApi.test.ts`; suite 692/692 → 694/694, `tsc --noEmit` clean.

Diagnosed via v0.1.25-beta.22 → beta.23 VM smoke 2026-05-21. See CHANGELOG entry for the full trace.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 694/694 across 61 files
- [ ] CI `build-and-test` green
- [ ] VM re-smoke beta.22 → beta.24 (cut after merge) — `config.json` should land at the actual service-Node port immediately after install, tray should open the correct port, "updating, please wait…" page should display through the upgrade window