### PR TITLE
chore(release): v0.1.25-beta.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.24] - 2026-05-20
+
 ### Fixed
 
 - **Service-mode opt-in: local Node now syncs its in-memory `webPort` to the actual port the service-Node bound, so subsequent local-Node writes can't clobber `config.json` back to the pre-install port.** §32 Part 5c — caught by v0.1.25-beta.22 → beta.23 smoke 2026-05-21. The user's clean-VM smoke installed beta.22 in local mode (port 8000), opted into service mode, and confirmed the browser correctly redirected to the new service-Node port (8001 after the install-time port shift). Two regressions followed from the same root cause:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.23"
+version = "0.1.25-beta.24"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.23",
+  "version": "0.1.25-beta.24",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.24 — the §32 Part 5c fix (`fix(install-flow): sync webPort after service-Node port-shift`, PR #67) shipped as a smoke target.
- Pairs with v0.1.25-beta.25 (no-op upgrade target, in flight) for the VM smoke that should validate both the tray-port-stale fix and the in-app upgrade "updating, please wait…" page now appearing on the correct port.

## Test plan

- [ ] CI `build-and-test` green
- [ ] release.yml run completes (prepare + build-windows + build-linux + publish jobs)
- [ ] GitHub release published with WsScrcpyWeb-beta.msi + .nupkg + Portable.zip + Linux AppImage
- [ ] VM re-smoke beta.24 → beta.25 — see PR #67 description for the full check sequence