### PR TITLE
chore(release): v0.1.25-beta.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.25] - 2026-05-20
+
 ## [0.1.25-beta.24] - 2026-05-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.24"
+version = "0.1.25-beta.25"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.24",
+  "version": "0.1.25-beta.25",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.25 — no-op upgrade target paired with v0.1.25-beta.24 (PR #68) for the §32 Part 5c VM smoke.
- Parallel cut from beta.24's branch HEAD; release.yml fires from the pushed tag in parallel with the auto-merge sequence. Same convention as the beta.22 + beta.23 pair (per todo).

## Test plan

- [ ] CI `build-and-test` green
- [ ] release.yml run completes (prepare + build-windows + build-linux + publish jobs)
- [ ] GitHub release published with WsScrcpyWeb-beta.msi + .nupkg + Portable.zip + Linux AppImage
- [ ] VM re-smoke beta.24 → beta.25 — see PR #67 description for the full check sequence