### PR TITLE
chore(release): v0.1.25-beta.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.26] - 2026-05-21
+
 ### Fixed
 
 - **Service-mode in-app upgrade: "updating, please wait…" page now actually appears in the browser during the upgrade window.** §32 Part 5e — caught by v0.1.25-beta.24 → beta.25 smoke 2026-05-21. The fix for §32 Part 5c (config.json port persistence) confirmed Bug A was solved, but the smoke also revealed Bug B was independent: the launcher's `--upgrade-server` correctly bound `0.0.0.0:8001` at `41.260`, logged ZERO `connection from …` lines, and logged no clean-exit message — Velopack's `Update.exe` terminated it within ~1s of bind because the process loaded `<installRoot>/current/ws-scrcpy-web-launcher.exe` as its image, and Velopack's apply phase needs to swap `current/`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.25"
+version = "0.1.25-beta.26"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.25",
+  "version": "0.1.25-beta.26",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.26 — the §32 Part 5e fix (`fix(updater): move upgrade-server spawn from Node to Servy post-stop bat`, PR #70) shipped as a smoke target.
- Pairs with v0.1.25-beta.27 (no-op upgrade target, to be cut after this merges) for the VM smoke that should validate the "updating, please wait…" page now appears during the upgrade window.

## Test plan

- [ ] CI `build-and-test` + cargo green
- [ ] release.yml run publishes WsScrcpyWeb-beta.msi + .nupkg + Portable.zip + Linux AppImage
- [ ] VM re-smoke beta.26 → beta.27: install beta.26 → opt into service mode → click Apply → expect updating page within ~200-300ms of clicking, persists through the ~12s upgrade window, auto-redirects to new version on completion