### PR TITLE
chore(release): v0.1.25-beta.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.27] - 2026-05-21
+
 ## [0.1.25-beta.26] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.26"
+version = "0.1.25-beta.27"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.26",
+  "version": "0.1.25-beta.27",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.27 — no-op upgrade target paired with v0.1.25-beta.26 (PR #71) for the §32 Part 5e VM smoke.

## Test plan

- [ ] CI `build-and-test` + cargo green
- [ ] release.yml run publishes WsScrcpyWeb-beta.msi + .nupkg + Portable.zip + Linux AppImage
- [ ] VM re-smoke beta.26 → beta.27 (full procedure in PR #70 description)