### PR TITLE
fix(updater): extend upgrade page architecture to local mode (§32 Part 5f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Local-mode in-app upgrade: "updating, please wait…" page now appears during the upgrade window too.** §32 Part 5f — extends the Part 5e upgrade-server architecture to local mode (when `installMode` is `null`/`'user'`/`'system'`, i.e., no Servy supervision). Part 5e fixed the page for service mode by spawning the upgrade-server from Servy's `--postStopPath` bat; local mode had no equivalent and the browser saw "this site can't be reached" for the ~3-8s Velopack-restart window. Part 5f extends the same dataRoot-helper + wind-down mechanism to local mode by spawning the upgrade-server from the launcher's own supervisor on clean Node exit.
+  - **`launcher/src/upgrade_server.rs`** — new `spawn_detached_helper(data_root)` function spawns `<dataRoot>/upgrade-server/ws-scrcpy-web-launcher.exe --upgrade-server` as a detached Windows process (DETACHED_PROCESS | CREATE_NO_WINDOW, stdio null'd). New `apply_update_pending_marker(data_root)` returns the canonical marker path so the supervisor and Node-side `Config.applyUpdatePendingMarkerPath` stay in sync.
+  - **`launcher/src/supervisor.rs`** — on Node clean exit (`decide_restart` returns None), if `apply_update_pending_marker` exists AND we're in local mode, delete the marker (so subsequent restart doesn't re-spawn on a stale marker) then call `spawn_detached_helper` before returning. Velopack's `restart=true` then relaunches the launcher; the next supervisor invocation writes the stop marker (now unconditional, was service-mode-only) and the upgrade-server's wind-down + port-shift discovery hands off cleanly. Service mode is gated OUT of this spawn path — the post-stop bat handles that, and racing the two would create bind contention.
+  - **`launcher/src/supervisor.rs`** — also drops the `is_service_mode()` gate on `refresh_helper_binary` at startup and on the upgrade-server stop-marker-write + `wait_for_port_free` block. Local mode launcher restart-on-apply needs all three to coordinate with the upgrade-server its previous incarnation spawned.
+  - **`src/server/UpdateService.ts::applyUpdate`** — moves `writeApplyUpdatePendingMarker()` out of the `if (isServiceMode)` block. Marker is now written in BOTH modes; it's the discriminator both the launcher supervisor (local) and the post-stop bat (service) use to tell apply-update from user-initiated stop (Ctrl+C, services.msc Stop, etc.).
+  - **`src/server/__tests__/UpdateService.test.ts`** — the existing Part 5e `applyUpdate (%s): does NOT spawn anything from Node` `it.each` (4 cases) now also asserts marker is written. Spy on `fs.promises.writeFile` + `mkdir` mocked as no-ops to avoid polluting real ProgramData. Renamed to `writes marker + does NOT spawn anything from Node (§32 Part 5f)`.
+
+Vitest 694/694 unchanged (test counts net zero — same `it.each` 4 cases, just gained additional assertions). `tsc --noEmit` clean. `cargo check --workspace` clean locally (now that VS 2026 Community + C++ workload is installed; Rust auto-detected MSVC via registry probing).
+
 ## [0.1.25-beta.27] - 2026-05-21
 
 ## [0.1.25-beta.26] - 2026-05-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.21"
+version = "0.1.25-beta.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.21"
+version = "0.1.25-beta.27"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.21"
+version = "0.1.25-beta.27"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -91,30 +91,37 @@ pub fn run() -> Result<i32> {
         }
 
         // §32 Part 5e — refresh the dataRoot copy of this launcher binary
-        // that the post-stop bat uses to spawn the upgrade-server. Copying
-        // outside `current/` lets the upgrade-server survive Velopack's
-        // swap of `current/` (Velopack terminated the pre-Part-5e in-
-        // current upgrade-server within ~1s of bind, per the beta.24 →
-        // beta.25 smoke). Refresh on every supervisor start so the helper
-        // tracks the installed launcher version. Best-effort.
-        if cfg.is_service_mode() {
-            match crate::upgrade_server::refresh_helper_binary(&paths.data_root) {
-                Ok(p) => log::info(&format!(
-                    "supervisor: refreshed upgrade-server helper at {p:?}"
-                )),
-                Err(e) => log::error(&format!(
-                    "supervisor: could not refresh upgrade-server helper (post-stop bat will spawn stale or fail): {e}"
-                )),
-            }
+        // that the upgrade-server is spawned from. Copying outside
+        // `current/` lets the upgrade-server survive Velopack's swap of
+        // `current/` (Velopack terminated the pre-Part-5e in-current
+        // upgrade-server within ~1s of bind, per the beta.24 → beta.25
+        // smoke). Refresh on every supervisor start so the helper tracks
+        // the installed launcher version. Best-effort.
+        //
+        // §32 Part 5f — refresh unconditionally (not just in service
+        // mode). Local-mode launcher also spawns the helper on apply-
+        // update path, so the helper must be current there too.
+        match crate::upgrade_server::refresh_helper_binary(&paths.data_root) {
+            Ok(p) => log::info(&format!(
+                "supervisor: refreshed upgrade-server helper at {p:?}"
+            )),
+            Err(e) => log::error(&format!(
+                "supervisor: could not refresh upgrade-server helper (upgrade-server spawn will use stale binary or fail): {e}"
+            )),
         }
 
         // §32 Part 5 — coordinate with any in-flight upgrade-server. If
-        // the post-stop bat spawned a `<launcher> --upgrade-server` to
-        // serve the updating page, it's bound to the port we're about to
-        // ask Node to bind. Write the stop marker + wait for the port to
-        // free up. Idempotent — if no upgrade-server is running, marker
-        // write is a no-op + port check returns immediately.
-        if cfg.is_service_mode() {
+        // an upgrade-server is currently bound to the port we're about
+        // to ask Node to bind (either spawned by service-mode post-stop
+        // bat OR by local-mode launcher on apply-update path), write
+        // the stop marker + wait for the port to free up. Idempotent —
+        // if no upgrade-server is running, marker write is a no-op and
+        // port check returns immediately.
+        //
+        // §32 Part 5f — runs unconditionally now (not just in service
+        // mode). Local-mode launcher restart-on-apply needs to coordinate
+        // with the upgrade-server its previous incarnation spawned.
+        {
             let port = cfg.web_port.unwrap_or(8000);
             if let Err(e) = crate::upgrade_server::write_stop_marker(&paths.data_root) {
                 log::error(&format!(
@@ -171,6 +178,42 @@ pub fn run() -> Result<i32> {
         match reason {
             None => {
                 log::info("supervisor: clean exit; not restarting");
+
+                // §32 Part 5f — local-mode upgrade page. If apply-update-
+                // pending marker is present AND we're in local mode, spawn
+                // the upgrade-server from the dataRoot helper before
+                // exiting. Velopack's restart=true (set by UpdateService
+                // for non-service-mode applyUpdate) will relaunch this
+                // launcher post-swap; the upgrade-server serves the
+                // updating page through that ~3-8s gap.
+                //
+                // In service mode the post-stop bat handles this same
+                // spawn — gating to local-mode-only here keeps the two
+                // architectures from racing for the bind. The marker is
+                // the discriminator between apply-update and user-
+                // initiated stop in BOTH modes; it's written by Node's
+                // UpdateService.applyUpdate (Part 5f drops the previous
+                // service-mode-only gate on the marker write).
+                let cfg_now = common::config::AppConfig::load(&paths.data_root);
+                if !cfg_now.is_service_mode() {
+                    let marker = crate::upgrade_server::apply_update_pending_marker(
+                        &paths.data_root,
+                    );
+                    if marker.exists() {
+                        log::info(
+                            "supervisor: apply-update-pending marker present (local mode); spawning upgrade-server before exit",
+                        );
+                        // Delete marker FIRST so a subsequent restart that
+                        // observes a stale marker doesn't re-spawn.
+                        if let Err(e) = std::fs::remove_file(&marker) {
+                            log::error(&format!(
+                                "supervisor: could not delete apply-update-pending marker (non-fatal): {e}"
+                            ));
+                        }
+                        crate::upgrade_server::spawn_detached_helper(&paths.data_root);
+                    }
+                }
+
                 return Ok(code);
             }
             Some(RestartReason::RestartMarker) => {

--- a/launcher/src/upgrade_server.rs
+++ b/launcher/src/upgrade_server.rs
@@ -455,6 +455,73 @@ pub fn helper_path_for(data_root: &Path) -> PathBuf {
     data_root.join("upgrade-server").join("ws-scrcpy-web-launcher.exe")
 }
 
+/// §32 Part 5f — spawn the dataRoot upgrade-server helper as a detached
+/// background process. Called by the launcher's supervisor on clean Node
+/// exit when an apply-update-pending marker is present (local mode). In
+/// service mode the post-stop bat handles the same spawn — both paths
+/// converge on the same helper binary + same wind-down handoff. Gating
+/// to local-mode-only at the call site keeps the two architectures from
+/// racing for the bind.
+///
+/// Best-effort: logs failure and returns. If the spawn fails (helper
+/// missing, permissions denied, etc.), the apply-update degrades to a
+/// brief "can't reach" gap during the upgrade window — the pre-Part-5f
+/// local-mode behavior. Stdio is explicitly null'd so the child doesn't
+/// inherit the launcher's handles (which become invalid after launcher
+/// exits).
+///
+/// Windows-only — on non-Windows the call is a no-op log line.
+pub fn spawn_detached_helper(data_root: &Path) {
+    let helper = helper_path_for(data_root);
+    if !helper.exists() {
+        log::error(&format!(
+            "upgrade-server: helper not present at {helper:?}, skipping spawn"
+        ));
+        return;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        use std::process::Stdio;
+        // DETACHED_PROCESS: child does not inherit calling process's console.
+        // CREATE_NO_WINDOW: child runs without console window (windows-subsystem
+        //   binary already has none, but belt-and-braces for parity with the
+        //   post-stop bat's `start "" /b` behavior).
+        const DETACHED_PROCESS: u32 = 0x00000008;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        match std::process::Command::new(&helper)
+            .arg("--upgrade-server")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
+            .spawn()
+        {
+            Ok(child) => log::info(&format!(
+                "upgrade-server: spawned helper (pid {})",
+                child.id()
+            )),
+            Err(e) => log::error(&format!("upgrade-server: spawn failed: {e}")),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = data_root; // silence unused-variable warning
+        log::info("upgrade-server: spawn_detached_helper skipped (non-Windows)");
+    }
+}
+
+/// Path of the apply-update-pending marker the launcher's supervisor
+/// reads on clean Node exit to decide whether to spawn the upgrade-
+/// server (local mode) before exiting. Same path the post-stop bat
+/// gates its spawn on (service mode). Written by Node's
+/// `UpdateService.applyUpdate` in both modes via
+/// `Config.applyUpdatePendingMarkerPath`.
+pub fn apply_update_pending_marker(data_root: &Path) -> PathBuf {
+    data_root.join("control").join("apply-update-pending")
+}
+
 /// Wait for the given TCP port to become bindable (i.e., the previous
 /// holder has released it). Polls `set_nonblocking` connects, NOT bind
 /// attempts (bind succeeds even if a previous bind is in TIME_WAIT). A

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -354,23 +354,26 @@ export class UpdateService {
         //     see §32 Part 3 in todo_ws_scrcpy_web.md.
         const installMode = Config.getInstance().getAppConfig().installMode;
         const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
-        if (isServiceMode) {
-            await this.writeApplyUpdatePendingMarker();
-            // §32 Part 5e — upgrade-server is no longer spawned from here.
-            // The pre-exit spawn (Part 5b) put the upgrade-server inside
-            // Velopack's process tree, loading
-            // `<installRoot>/current/ws-scrcpy-web-launcher.exe` as its
-            // image; Velopack's apply phase terminated it within ~1s of
-            // bind (v0.1.25-beta.24 → beta.25 smoke 2026-05-21).
-            //
-            // The upgrade-server is now spawned by the post-stop bat (Servy
-            // owns the bat; FireAndForget; no Job Object) from a dataRoot
-            // copy of the launcher at
-            // `<dataRoot>/upgrade-server/ws-scrcpy-web-launcher.exe`, which
-            // Velopack doesn't touch. See `launcher/src/upgrade_server.rs`
-            // (`refresh_helper_binary`, `helper_path_for`) and
-            // `launcher/src/elevated_runner.rs::write_post_stop_bat`.
-        }
+        // §32 Part 5e/5f — upgrade-server is no longer spawned from Node.
+        // The pre-exit spawn (Part 5b) put the upgrade-server inside
+        // Velopack's process tree, loading
+        // `<installRoot>/current/ws-scrcpy-web-launcher.exe` as its
+        // image; Velopack's apply phase terminated it within ~1s of
+        // bind (v0.1.25-beta.24 → beta.25 smoke 2026-05-21). The
+        // upgrade-server is now spawned by the launcher (Part 5f, local
+        // mode, on supervisor clean-exit path) or by the post-stop bat
+        // (Part 5e, service mode), both sourcing from
+        // `<dataRoot>/upgrade-server/ws-scrcpy-web-launcher.exe` which
+        // Velopack doesn't touch.
+        //
+        // §32 Part 5f — write the apply-update-pending marker in BOTH
+        // modes (was service-mode-only in Part 5e). The marker is the
+        // discriminator both the launcher's supervisor (local) and the
+        // post-stop bat (service) use on clean Node exit to decide
+        // whether to spawn the upgrade-server. Without the marker,
+        // neither side can tell apply-update from a user-initiated
+        // stop (Ctrl+C, services.msc Stop, etc.) and would over-spawn.
+        await this.writeApplyUpdatePendingMarker();
         this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, !isServiceMode);
     }
 

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -487,50 +487,86 @@ describe('UpdateService', () => {
         expect(args[2]).toBe(true);
     });
 
-    // §32 Part 5e: the upgrade-server is no longer spawned from Node. Part 5b
-    // tried a pre-exit spawn from `<installRoot>/current/ws-scrcpy-web-launcher.exe`
-    // to close the dead window between Node port-release and upgrade-server
-    // bind — but the upgrade-server loaded current/launcher.exe as its image,
-    // and Velopack's apply phase terminated it within ~1s (caught by v0.1.25-
-    // beta.24 → beta.25 smoke 2026-05-21). The upgrade-server is now spawned
-    // by Servy's --postStopPath bat from a dataRoot copy of the launcher,
-    // entirely outside Velopack's reach. applyUpdate's only side effects on
-    // Node side in service mode are: write the apply-update-pending marker
-    // and call waitExitThenApplyUpdate. Both code paths (local + service)
-    // share this assertion since neither spawns from Node now.
+    // §32 Part 5e/5f: the upgrade-server is no longer spawned from Node.
+    // Part 5b tried a pre-exit spawn from
+    // `<installRoot>/current/ws-scrcpy-web-launcher.exe` to close the dead
+    // window between Node port-release and upgrade-server bind — but the
+    // upgrade-server loaded current/launcher.exe as its image, and
+    // Velopack's apply phase terminated it within ~1s (caught by
+    // v0.1.25-beta.24 → beta.25 smoke 2026-05-21). The upgrade-server is
+    // now spawned by Servy's --postStopPath bat (Part 5e, service mode) or
+    // by the launcher's supervisor on clean Node exit (Part 5f, local
+    // mode), both sourcing from a dataRoot copy of the launcher entirely
+    // outside Velopack's reach.
+    //
+    // §32 Part 5f extends the apply-update-pending marker write to BOTH
+    // modes (was service-mode-only in Part 5e). Both the launcher
+    // supervisor (local) and the post-stop bat (service) use the marker
+    // as the discriminator between apply-update and user-initiated stop.
+    //
+    // applyUpdate's only side effects on Node side are: write the
+    // apply-update-pending marker (in BOTH modes) and call
+    // waitExitThenApplyUpdate. The marker-write spy below also locks in
+    // the Part 5f behavior — without it, local-mode would never get an
+    // upgrade page.
     it.each([
         ['user-service' as const],
         ['system-service' as const],
         ['user' as const],
         ['system' as const],
-    ])('applyUpdate (%s): does NOT spawn anything from Node (§32 Part 5e)', async (installMode) => {
+    ])('applyUpdate (%s): writes marker + does NOT spawn anything from Node (§32 Part 5f)', async (installMode) => {
         Config.getInstance().updateAppConfig({ autoUpdate: false, installMode });
-        const info = fakeUpdateInfo('0.2.0');
-        const applyFn = vi.fn();
-        const mgr = fakeMgr({
-            checkForUpdatesAsync: async () => info,
-            waitExitThenApplyUpdate: applyFn,
-        });
-        const svc = new UpdateService({
-            installRoot: '/fake-install-root',
-            existsSync: () => true,
-            updateManagerFactory: () => mgr,
-            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
-            clearIntervalFn: () => undefined,
-        });
-        svc.init();
-        await svc.checkForUpdates();
-        await svc.applyUpdate();
-        // UpdateService no longer exposes a spawnFn injection point;
-        // structurally, this is enforced by the TypeScript type system —
-        // UpdateServiceOptions has no `spawnFn` field. The behavioral
-        // assertion is that applyUpdate completes cleanly, the marker has
-        // been written (in service-mode), and waitExitThenApplyUpdate was
-        // invoked exactly once.
-        expect(applyFn).toHaveBeenCalledTimes(1);
-        const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
-        // restart=false in service mode, true in local mode.
-        expect(applyFn.mock.calls[0]![2]).toBe(!isServiceMode);
+        // Spy on fs.promises.writeFile + mkdir to capture the marker write
+        // without polluting real ProgramData. Mock as no-ops since we only
+        // care about the call shape, not the effect on disk.
+        const writeFileSpy = vi
+            .spyOn(fs.promises, 'writeFile')
+            .mockResolvedValue(undefined);
+        const mkdirSpy = vi
+            .spyOn(fs.promises, 'mkdir')
+            .mockResolvedValue(undefined);
+        try {
+            const info = fakeUpdateInfo('0.2.0');
+            const applyFn = vi.fn();
+            const mgr = fakeMgr({
+                checkForUpdatesAsync: async () => info,
+                waitExitThenApplyUpdate: applyFn,
+            });
+            const svc = new UpdateService({
+                installRoot: '/fake-install-root',
+                existsSync: () => true,
+                updateManagerFactory: () => mgr,
+                setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+                clearIntervalFn: () => undefined,
+            });
+            svc.init();
+            await svc.checkForUpdates();
+            await svc.applyUpdate();
+            // UpdateService no longer exposes a spawnFn injection point;
+            // structurally, this is enforced by the TypeScript type
+            // system — UpdateServiceOptions has no `spawnFn` field.
+            expect(applyFn).toHaveBeenCalledTimes(1);
+            const isServiceMode =
+                installMode === 'user-service' || installMode === 'system-service';
+            // restart=false in service mode, true in local mode.
+            expect(applyFn.mock.calls[0]![2]).toBe(!isServiceMode);
+
+            // §32 Part 5f — marker MUST be written in all four modes.
+            // Pre-Part-5f this was service-mode-only and local-mode
+            // launcher couldn't tell apply-update from user-initiated stop.
+            const markerCalls = writeFileSpy.mock.calls.filter(
+                (c) =>
+                    typeof c[0] === 'string' &&
+                    (c[0] as string).endsWith('apply-update-pending'),
+            );
+            expect(markerCalls).toHaveLength(1);
+            // mkdir should have been called for the marker's parent
+            // directory at least once.
+            expect(mkdirSpy).toHaveBeenCalled();
+        } finally {
+            writeFileSpy.mockRestore();
+            mkdirSpy.mockRestore();
+        }
     });
 
     // ── reconfigure ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Part 5e fixed the in-app upgrade "updating, please wait…" page for **service mode** by spawning the upgrade-server from Servy's `--postStopPath` bat (out of Velopack's process tree, from a dataRoot helper copy outside `current/`).
- **Local mode** (installMode null/user/system, no Servy) had no equivalent. The browser saw "this site can't be reached" for ~3–8s during Velopack's restart window.
- Part 5f closes that gap: the launcher's own supervisor spawns the upgrade-server on clean Node exit when an `apply-update-pending` marker is present, reusing the same dataRoot helper + wind-down + port-shift discovery mechanism.

## Architecture symmetry

| Mode | Marker writer | Spawn owner | Velopack relaunch trigger |
|---|---|---|---|
| **Service** | `UpdateService.applyUpdate` | post-stop bat (Servy `--postStopPath`) | `sc start` from bat |
| **Local** | `UpdateService.applyUpdate` | launcher supervisor (Part 5f) | `restart=true` in `waitExitThenApplyUpdate` |

Same helper binary, same wind-down + port-shift discovery, same `apply-update-pending` marker as the discriminator. Service mode is gated OUT of the launcher-spawn path so it doesn't race with the bat.

## Test plan

- [x] `cargo check --workspace` clean (local — VS 2026 + C++ workload now installed)
- [x] `tsc --noEmit` clean
- [x] vitest 694/694 across 61 files
- [ ] CI `build-and-test` + cargo green
- [ ] **VM smoke for local mode**: install beta.28 in default mode (no service opt-in) → confirm app loads → click Apply Update → expect updating page within ~3–8s (Velopack restart window) → page persists → auto-redirects to new version on launcher restart
- [ ] **VM smoke for service mode regression**: install beta.28 → opt into service mode → apply update → expect Part 5e behavior unchanged (updating page in ~200–300ms via post-stop bat)