### PR TITLE
chore(release): v0.1.25-beta.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.28] - 2026-05-21
+
 ### Added
 
 - **Local-mode in-app upgrade: "updating, please wait…" page now appears during the upgrade window too.** §32 Part 5f — extends the Part 5e upgrade-server architecture to local mode (when `installMode` is `null`/`'user'`/`'system'`, i.e., no Servy supervision). Part 5e fixed the page for service mode by spawning the upgrade-server from Servy's `--postStopPath` bat; local mode had no equivalent and the browser saw "this site can't be reached" for the ~3-8s Velopack-restart window. Part 5f extends the same dataRoot-helper + wind-down mechanism to local mode by spawning the upgrade-server from the launcher's own supervisor on clean Node exit.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.27"
+version = "0.1.25-beta.28"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.27",
+  "version": "0.1.25-beta.28",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.28 — the §32 Part 5f fix (`fix(updater): extend upgrade page architecture to local mode`, PR #73) shipped as a smoke source.
- Pairs with v0.1.25-beta.29 (no-op upgrade target, to be cut after this merges) for the VM smoke validating the local-mode upgrade page.

## Test plan

- [ ] CI `build-and-test` + cargo green
- [ ] release.yml publishes MSI + .nupkg + Portable.zip + Linux AppImage
- [ ] Local mode VM smoke beta.28 → beta.29: install beta.28, leave default (no service mode), click Apply → expect updating page within ~3-8s and through the Velopack restart window
- [ ] Service mode regression: install beta.28, opt into service mode, click Apply → expect Part 5e behavior unchanged (updating page in ~200-300ms)