### PR TITLE
fix(settings): unbreak install/uninstall service from Settings (double showModal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Settings → Install Service / Uninstall Service now works.** Pre-existing bug across many recent versions, surfaced by user-report 2026-05-21 while regression-testing §32 Part 5f: clicking "install service" in the Settings modal opened the "Administrative Privileges Required" confirmation dialog UNDERNEATH the Settings modal (couldn't reach without closing Settings), and clicking Continue did nothing. The Welcome modal's install path was unaffected because it bypasses `AdminConfirmModal` and calls `/api/service/install` directly.
+  - **Root cause:** `src/app/client/AdminConfirmModal.ts::confirm()` was calling `document.body.appendChild(dialog)` + `dialog.showModal()` **after** `new AdminConfirmModal(...)` — but the `Modal` base-class constructor (`src/app/ui/Modal.ts:84-85`) already appends + showModals during construction. The second `showModal()` on an already-`open` dialog throws `InvalidStateError` per HTML spec. That throw inside the Promise executor rejected the returned Promise; the user-visible dialog (rendered by the FIRST `showModal()`) appeared but Continue/Cancel handlers' `resolveAndClose()` called `resolve()` on an already-rejected Promise → no-op. Layering glitch was a side effect of the throw perturbing top-layer state.
+  - **Fix:** removed the redundant `appendChild` + `showModal` from `confirm()`. The base-class constructor handles both.
+  - **Why tests didn't catch it:** `src/app/client/__tests__/AdminConfirmModal.test.ts` stubbed `HTMLDialogElement.prototype.showModal` to just set the `open` attribute without throwing on double-call. Stub was too permissive vs the HTML spec. Updated the stub to throw `InvalidStateError` on already-`open` dialogs (spec-realistic) and added a regression test asserting `confirm()` calls `showModal` exactly once.
+
+Vitest 694/694 → 695/695 (+1 regression test: `calls showModal exactly once (no double-show throw)`). `tsc --noEmit` clean.
+
 ## [0.1.25-beta.29] - 2026-05-21
 
 ## [0.1.25-beta.28] - 2026-05-21

--- a/src/app/client/AdminConfirmModal.ts
+++ b/src/app/client/AdminConfirmModal.ts
@@ -21,9 +21,24 @@ export class AdminConfirmModal extends Modal {
 
     public static confirm(opts: AdminConfirmOptions): Promise<boolean> {
         return new Promise((resolve) => {
-            const modal = new AdminConfirmModal(opts, resolve);
-            document.body.appendChild((modal as unknown as { dialog: HTMLDialogElement }).dialog);
-            (modal as unknown as { dialog: HTMLDialogElement }).dialog.showModal();
+            // The Modal base-class constructor (src/app/ui/Modal.ts) already
+            // appends the dialog to document.body AND calls .showModal()
+            // during construction. Calling them again here throws
+            // InvalidStateError per HTML spec ("dialog already has 'open'
+            // attribute"). That throw rejects this Promise — which then
+            // silently breaks the Continue/Cancel handlers because
+            // resolveAndClose() calls resolve() on an already-rejected
+            // Promise (no-op). The dialog from the first showModal is still
+            // visible, so the user sees the modal but Continue does nothing.
+            //
+            // Asymmetry diagnosed via user-report 2026-05-21: only the
+            // Settings install/uninstall paths (which use this method) were
+            // broken; the Welcome modal's install path bypasses
+            // AdminConfirmModal and calls /api/service/install directly, so
+            // it always worked. The test stub for showModal didn't throw on
+            // double-call, so unit tests stayed green while the real browser
+            // throw broke production. Test stub is now spec-realistic.
+            new AdminConfirmModal(opts, resolve);
         });
     }
 

--- a/src/app/client/__tests__/AdminConfirmModal.test.ts
+++ b/src/app/client/__tests__/AdminConfirmModal.test.ts
@@ -3,9 +3,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AdminConfirmModal } from '../AdminConfirmModal';
 
-// JSDOM doesn't implement HTMLDialogElement.showModal() by default; stub it.
+// JSDOM doesn't implement HTMLDialogElement.showModal() by default; stub
+// it WITH the spec's InvalidStateError throw when called on a dialog that
+// already has the `open` attribute. Pre-2026-05-21 the stub silently
+// no-op'd the second call, which masked a real-browser bug:
+// AdminConfirmModal.confirm() used to fire showModal() twice (once via
+// the Modal base-class constructor, once explicitly afterwards). In a
+// real browser the second call threw, the Promise rejected, and the
+// Continue/Cancel handlers silently no-op'd (calling resolve() on an
+// already-rejected promise). Spec link:
+//   https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal
 beforeEach(() => {
     HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        if (this.hasAttribute('open')) {
+            throw new DOMException(
+                "Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.",
+                'InvalidStateError',
+            );
+        }
         this.setAttribute('open', '');
     });
     HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
@@ -87,5 +102,23 @@ describe('AdminConfirmModal.confirm', () => {
         // Resolve so the test cleans up.
         getButton('cancel').click();
         await promise;
+    });
+
+    // Regression for the 2026-05-21 fix: confirm() must call showModal()
+    // exactly ONCE. Pre-fix the method invoked showModal() twice (once via
+    // the Modal base-class constructor, once explicitly), which threw
+    // InvalidStateError on the second call in real browsers, rejecting the
+    // Promise and silently breaking the Continue/Cancel handlers. Settings →
+    // install was broken; Welcome modal worked because it bypasses
+    // AdminConfirmModal and calls /api/service/install directly.
+    it('calls showModal exactly once (no double-show throw)', async () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        const promise = AdminConfirmModal.confirm({ action: 'install service' });
+        await Promise.resolve();
+        expect(spy).toHaveBeenCalledTimes(1);
+        // The Promise must still resolve normally on Continue.
+        getButton('continue').click();
+        await expect(promise).resolves.toBe(true);
+        spy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary

- **Pre-existing bug** across many recent versions, surfaced 2026-05-21 while regression-testing §32 Part 5f. Settings → Install Service: confirmation dialog opened UNDERNEATH the Settings modal, Continue button did nothing.
- Welcome modal install path was unaffected (it bypasses AdminConfirmModal and POSTs `/api/service/install` directly) — that's why the bug went undetected across smokes that always opted into service mode via the Welcome flow.
- **Root cause:** `AdminConfirmModal.confirm()` fired `showModal()` twice (once via the `Modal` base-class constructor, once explicitly afterwards). Per HTML spec, calling `showModal()` on a dialog with the `open` attribute throws `InvalidStateError`. The throw rejected the Promise; Continue/Cancel handlers later called `resolve()` on that already-rejected Promise → no-op.
- **Fix:** removed the redundant `appendChild` + `showModal()` from `confirm()`. Modal base class already does both.
- **Test gap closed:** the stub for `HTMLDialogElement.prototype.showModal` was too permissive (didn't throw on double-call). Made it spec-realistic + added regression test asserting `showModal` called exactly once.

## Test plan

- [x] vitest 694/694 → 695/695 (+1 regression test)
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] **VM smoke for the actual bug**: install beta.30, dismiss the Welcome modal **without choosing service install**, open Settings → click Install Service → expect the confirmation dialog to appear ON TOP of Settings, click Continue → expect UAC prompt to fire
- [ ] Regression check on Welcome modal path: install beta.30 fresh → use the Welcome modal's "Install as service" → expect existing flow unchanged