### PR TITLE
chore(release): v0.1.25-beta.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.30] - 2026-05-21
+
 ### Fixed
 
 - **Settings → Install Service / Uninstall Service now works.** Pre-existing bug across many recent versions, surfaced by user-report 2026-05-21 while regression-testing §32 Part 5f: clicking "install service" in the Settings modal opened the "Administrative Privileges Required" confirmation dialog UNDERNEATH the Settings modal (couldn't reach without closing Settings), and clicking Continue did nothing. The Welcome modal's install path was unaffected because it bypasses `AdminConfirmModal` and calls `/api/service/install` directly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.29"
+version = "0.1.25-beta.30"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.29",
+  "version": "0.1.25-beta.30",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.30 — the AdminConfirmModal double-`showModal` fix (PR #76) shipped as a smoke source for the Settings → Install Service path.
- Pairs with v0.1.25-beta.31 (no-op upgrade target) for the smoke + upgrade-flow regression check.

## Test plan

- [ ] CI green
- [ ] release.yml publishes artifacts
- [ ] VM smoke beta.30: install fresh → DISMISS welcome modal without choosing service install → Settings → Install Service → expect confirmation on top of Settings + Continue triggers UAC
- [ ] Regression check: beta.30 → beta.31 in local and/or service mode → expect §32 Part 5e/5f upgrade page behavior unchanged