### PR TITLE
chore(release): v0.1.25-beta.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.32] - 2026-05-21
+
 ### Changed
 
 - **Tray architecture unified across local + service modes (§32 Part 5h).** Pre-Part-5h the tray ran differently per mode: service mode used a standalone `ws-scrcpy-web-tray.exe` process supervised by the launcher's `tray_supervisor.rs` poller (every 10s, cross-session WTS spawn from LocalSystem into the active user session); local mode used an in-process thread inside the launcher (`tray.rs::spawn`). The in-process thread had two failure modes with no recovery: (a) after a service install→uninstall handoff the new local launcher fires with `--local-takeover`, spawns its own tray thread, but a competing standalone tray.exe is still in the process of exiting → mutex/icon-registration collision, in-process thread silently dies, no recovery path; (b) double-clicking the desktop shortcut after the launcher exits and restarts can hit Windows Shell timing such that the tray icon never registers → no recovery. User-reported on beta.31 smoke 2026-05-21.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.31"
+version = "0.1.25-beta.32"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.31",
+  "version": "0.1.25-beta.32",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

- Cuts v0.1.25-beta.32 — the bundled tray refactor (§32 Part 5h) + welcome modal text fix (PR #79) shipped as the smoke source.
- Pairs with v0.1.25-beta.33 (no-op upgrade target).

## Test plan

- [ ] CI green
- [ ] release.yml publishes artifacts
- [ ] Smoke A: kill tray.exe in Task Manager (local mode) → expect respawn within ~10s
- [ ] Smoke B: service install → uninstall → expect local launcher fires AND tray returns
- [ ] Smoke C: welcome modal text on a port-shifted install (no "we auto-picked" sentence)
- [ ] Smoke D: beta.32 → beta.33 upgrade in both modes (§32 Part 5e/5f regression check)