### PR TITLE
fix(tray): mode-change detection + accurate local-mode balloon (§32 Part 5i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tray text now updates when installMode changes mid-session (§32 Part 5i).** Surfaced by beta.32 smoke 2026-05-21: opting into service mode from a fresh local-mode install left the tray text + balloon copy stuck at the local-mode values ("ws-scrcpy-web" / "Stop the server and quit?") even though the launcher and config.json had transitioned to service mode. Root cause was Part 5h reading `installMode` ONCE at `tray/src/main.rs` startup and baking the text into the static `common::tray::run` call. The URL provider was already mode-tracking (re-reads `config.json` per click), but tooltip + exit prompt + balloon text were frozen at spawn-time.
+  - **`tray/src/main.rs`** — new 5s-poll thread watches `config.json::installMode` for changes from the spawn-time value. On change, `std::process::exit(0)`; the launcher's tray-supervisor respawns within ~10s with mode-aware text picked up from the (now-current) config. Decision intentionally co-located with the tray process so the supervisor stays stateless.
+  - Brief icon-flicker on mode change (tray exits, supervisor respawns ~10s later) — same UX as the validated "kill tray.exe → 10s respawn" path from §32 Part 5h smoke.
+
+- **Local-mode tray balloon: dropped misleading "or Settings" clause.** Pre-2026-05-21 the local-mode launcher-spawn balloon read `"tray started by launcher. to clear the tray, stop the ws-scrcpy-web server via the tray exit or Settings."` — but local-mode Settings has no "stop server" affordance (only the service install/uninstall buttons). The tray menu's own exit option is the only intended path. Balloon now reads `"tray started by launcher. to clear the tray, use the exit option from the tray menu."`. Service-mode balloon unchanged (Settings DOES expose service stop there).
+
+### Known open issue (logging needed)
+
+- **Service uninstall fails after service-mode goes offline and back up** (reboot, in-app upgrade, any restart that recycles the service process). Pre-restart: 4-for-4 install/uninstall cycles succeed. Post-restart: uninstall fails, service stuck stopped-but-installed, tray doesn't respawn. Manual recovery via launching app → Settings → "stopped — uninstall?" works. Likely difference: tray.exe spawned via WTS cross-session post-restart vs Command::new same-session pre-restart — handoff polling thread / marker access / session token may differ. Triage pending logs from a failing flow.
+
+Vitest 695/695 unchanged. `tsc --noEmit` clean. `cargo check --workspace` clean.
+
 ## [0.1.25-beta.33] - 2026-05-21
 
 ## [0.1.25-beta.32] - 2026-05-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.31"
+version = "0.1.25-beta.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.31"
+version = "0.1.25-beta.33"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.31"
+version = "0.1.25-beta.33"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/tray/src/main.rs
+++ b/tray/src/main.rs
@@ -143,7 +143,10 @@ fn run_tray() -> Result<()> {
                 "ws-scrcpy-web",
                 "Exit ws-scrcpy-web?",
                 "Stop the server and quit?",
-                "tray started by launcher. to clear the tray, stop the ws-scrcpy-web server via the tray exit or Settings.",
+                // Local mode has no "stop server" affordance in Settings —
+                // only the service install/uninstall buttons. The only
+                // intended exit path is the tray's own context menu.
+                "tray started by launcher. to clear the tray, use the exit option from the tray menu.",
             )
         };
 
@@ -152,6 +155,38 @@ fn run_tray() -> Result<()> {
     } else {
         None
     };
+
+    // §32 Part 5i — mode-change detection thread. Watches config.json's
+    // installMode for changes from the spawn-time value (e.g., user opts
+    // INTO service mode from local, or uninstalls service while tray is
+    // alive). On change, exit the tray; the launcher's tray-supervisor
+    // respawns within ~10s with mode-aware text. Without this, the tray
+    // text + balloon stay frozen at the spawn-time mode (URL provider
+    // already re-reads per-click so the navigation target was already
+    // mode-tracking; this only fixes the static text).
+    //
+    // Polling intentionally lives in the tray process (not the launcher
+    // supervisor) so the supervisor stays stateless — the decision is
+    // co-located with the value being checked. 5s gives a snappy
+    // transition without spamming disk I/O.
+    {
+        let data_root_for_mode = config_dir.clone();
+        let initial_service_mode = is_service_mode_at_start;
+        std::thread::spawn(move || {
+            const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+            loop {
+                std::thread::sleep(POLL_INTERVAL);
+                let current = common::config::AppConfig::load(&data_root_for_mode).is_service_mode();
+                if current != initial_service_mode {
+                    eprintln!(
+                        "tray: installMode changed (was service={}, is service={}); exiting for tray-supervisor respawn with mode-aware text",
+                        initial_service_mode, current,
+                    );
+                    std::process::exit(0);
+                }
+            }
+        });
+    }
 
     let action = common::tray::run(
         ICON_BYTES,


### PR DESCRIPTION
## Summary

Two follow-ups from beta.32 smoke 2026-05-21:

1. **Tray text didn't update mid-session on mode change.** Pre-Part-5i `tray/src/main.rs` read `installMode` once at startup; opting into service mode left the tray text + balloon stuck at "ws-scrcpy-web" / "Stop the server and quit?" even after the launcher and config transitioned. Fix: 5s-poll thread in the tray watches `installMode`; on change → `std::process::exit(0)` and the tray-supervisor respawns within ~10s with correct text.
2. **Local-mode balloon text inaccurate.** Said `"stop the ws-scrcpy-web server via the tray exit or Settings"` — Settings has no "stop server" action in local mode. Now reads `"use the exit option from the tray menu."` Service-mode balloon unchanged.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `tsc --noEmit` clean
- [x] vitest 695/695 unchanged
- [ ] CI green
- [ ] **Smoke E (tray text local→service)**: install beta.34 → opt into service mode → tray icon-flickers within ~10s, comes back with "ws-scrcpy-web (service)" tooltip
- [ ] **Smoke F (tray text service→local via uninstall)**: from a service-mode install, uninstall service → tray flickers → comes back with "ws-scrcpy-web" tooltip
- [ ] **Smoke G (balloon copy)**: install beta.34, fresh local mode → expect launcher-spawn balloon to read "use the exit option from the tray menu." (no "Settings" reference)

## Open issue (logging for next pass)

Service uninstall fails after service-mode goes offline and back up (reboot, upgrade). Tracked as task — separate diagnosis once logs from a failing flow are available. Likely WTS-spawned vs Command::new-spawned tray behavior difference.