### PR TITLE
chore(release): v0.1.25-beta.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.34] - 2026-05-21
+
 ### Fixed
 
 - **Tray text now updates when installMode changes mid-session (§32 Part 5i).** Surfaced by beta.32 smoke 2026-05-21: opting into service mode from a fresh local-mode install left the tray text + balloon copy stuck at the local-mode values ("ws-scrcpy-web" / "Stop the server and quit?") even though the launcher and config.json had transitioned to service mode. Root cause was Part 5h reading `installMode` ONCE at `tray/src/main.rs` startup and baking the text into the static `common::tray::run` call. The URL provider was already mode-tracking (re-reads `config.json` per click), but tooltip + exit prompt + balloon text were frozen at spawn-time.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.33"
+version = "0.1.25-beta.34"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.33",
+  "version": "0.1.25-beta.34",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Cuts v0.1.25-beta.34 — §32 Part 5i (tray mode-change detection + accurate local-mode balloon, PR #82) shipped as smoke source. Pairs with v0.1.25-beta.35.