### PR TITLE
fix: correct service-mode tray balloon + Welcome modal copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`tray/src/main.rs`** — tuple grew from 4 to 5 elements to carry a mode-aware `balloon_title` (service: `"ws-scrcpy-web (service) tray"` mirroring the tooltip suffix; local: `"ws-scrcpy-web tray"` unchanged). Service-mode body now matches local-mode body verbatim: `"tray started by launcher. to clear the tray, use the exit option from the tray menu."`. Body literal duplicated across both branches intentionally (preserves if/else symmetry; can diverge later if needed). The "tray menu is the only exit" comment moved from inside the local-mode branch to above the if/else, since the rationale now applies to both modes.
   - **`launcher/src/tray_supervisor.rs`** — user-killed-tray comment block rewritten: dropped the verbatim quote of the old body and the "intrinsic to service-mode" framing, replaced with a mode-neutral description of the respawn-on-death contract + the actual Settings-can-uninstall-but-not-stop reality.
 
+- **Welcome modal "change later" hint made specific.** Below the "run as a service?" yes/no buttons, the hint previously read `"you can change this later in settings."` — `"this"` was ambiguous (port? service decision? scope?). Now reads `"you can install/uninstall the service later in settings."`, which names the actual reversible decision and matches the Settings UI vocabulary. The port-config hint at the top of the modal (line 81) is unchanged.
+
 ## [0.1.25-beta.35] - 2026-05-21
 
 ## [0.1.25-beta.34] - 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Service-mode tray balloon title + body corrected.** The service-mode launcher-spawn balloon previously read `title: "ws-scrcpy-web tray"` / `body: "tray started by launcher. to clear the tray, stop the ws-scrcpy-web service via Settings."` — but Settings only exposes uninstall, not stop, so the body directed users to a UI action that doesn't exist. The tray menu's own exit option is the only intended exit path in both modes.
+  - **`tray/src/main.rs`** — tuple grew from 4 to 5 elements to carry a mode-aware `balloon_title` (service: `"ws-scrcpy-web (service) tray"` mirroring the tooltip suffix; local: `"ws-scrcpy-web tray"` unchanged). Service-mode body now matches local-mode body verbatim: `"tray started by launcher. to clear the tray, use the exit option from the tray menu."`. Body literal duplicated across both branches intentionally (preserves if/else symmetry; can diverge later if needed). The "tray menu is the only exit" comment moved from inside the local-mode branch to above the if/else, since the rationale now applies to both modes.
+  - **`launcher/src/tray_supervisor.rs`** — user-killed-tray comment block rewritten: dropped the verbatim quote of the old body and the "intrinsic to service-mode" framing, replaced with a mode-neutral description of the respawn-on-death contract + the actual Settings-can-uninstall-but-not-stop reality.
+
 ## [0.1.25-beta.35] - 2026-05-21
 
 ## [0.1.25-beta.34] - 2026-05-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.33"
+version = "0.1.25-beta.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.33"
+version = "0.1.25-beta.35"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.33"
+version = "0.1.25-beta.35"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/launcher/src/tray_supervisor.rs
+++ b/launcher/src/tray_supervisor.rs
@@ -29,10 +29,12 @@
 //   - The tray helper does NOT have a "user-suppress" marker. If the user
 //     kills the tray (e.g., via Task Manager), the launcher polls within
 //     TRAY_POLL_INTERVAL_SECS and respawns it WITH the balloon notification
-//     explaining "to clear the tray, stop the ws-scrcpy-web service via
-//     Settings." This matches the user's design intent: the tray is
-//     intrinsic to service-mode operation; closing it requires stopping
-//     the service.
+//     directing users to the tray's own exit menu. The tray is the only
+//     user-facing handle on the launcher in both modes (service mode runs
+//     windowless under Servy; local mode hides its console), so closing
+//     it requires the explicit tray-menu exit path. Settings can uninstall
+//     the service (which tears down both service and tray) but has no
+//     "stop service" or "stop server" action.
 
 #![cfg(windows)]
 

--- a/src/app/client/WelcomeModal.ts
+++ b/src/app/client/WelcomeModal.ts
@@ -139,7 +139,7 @@ export class WelcomeModal extends Modal {
 
         const later = document.createElement('p');
         later.style.cssText = 'margin: 0 0 16px; color: var(--text-color-light); font-size: 13px;';
-        later.textContent = 'you can change this later in settings.';
+        later.textContent = 'you can install/uninstall the service later in settings.';
         container.appendChild(later);
 
         // v0.1.9 bookmark hint. ws-scrcpy-web is a web app served from

--- a/tray/src/main.rs
+++ b/tray/src/main.rs
@@ -130,28 +130,33 @@ fn run_tray() -> Result<()> {
 
     let is_service_mode_at_start =
         common::config::AppConfig::load(&config_dir).is_service_mode();
-    let (tooltip, exit_title, exit_msg, balloon_text): (&str, &str, &str, &str) =
+    // The tray menu's exit option is the only intended path to clear the
+    // tray in either mode. Service-mode Settings exposes uninstall (which
+    // tears down service + tray) but no "stop service" action; local-mode
+    // Settings has no server-lifecycle affordances at all. The balloon
+    // body is identical for both modes for this reason; the title carries
+    // the service suffix to mirror the tooltip.
+    let (tooltip, exit_title, exit_msg, balloon_title, balloon_text): (&str, &str, &str, &str, &str) =
         if is_service_mode_at_start {
             (
                 "ws-scrcpy-web (service)",
                 "Exit ws-scrcpy-web?",
                 "Stop the service and quit?",
-                "tray started by launcher. to clear the tray, stop the ws-scrcpy-web service via Settings.",
+                "ws-scrcpy-web (service) tray",
+                "tray started by launcher. to clear the tray, use the exit option from the tray menu.",
             )
         } else {
             (
                 "ws-scrcpy-web",
                 "Exit ws-scrcpy-web?",
                 "Stop the server and quit?",
-                // Local mode has no "stop server" affordance in Settings —
-                // only the service install/uninstall buttons. The only
-                // intended exit path is the tray's own context menu.
+                "ws-scrcpy-web tray",
                 "tray started by launcher. to clear the tray, use the exit option from the tray menu.",
             )
         };
 
     let balloon: Option<(&str, &str)> = if show_launcher_balloon {
-        Some(("ws-scrcpy-web tray", balloon_text))
+        Some((balloon_title, balloon_text))
     } else {
         None
     };


### PR DESCRIPTION
## Summary

Two related UX-copy corrections in the service-mode user-facing surfaces. Settings exposes uninstall (which tears down both service and tray) but no stop-service action — the old copy directed users to UI actions that don't exist.

| Surface | Before | After |
|---|---|---|
| Service-mode toast title | `ws-scrcpy-web tray` | `ws-scrcpy-web (service) tray` |
| Service-mode toast body | `…stop the ws-scrcpy-web service via Settings.` | `…use the exit option from the tray menu.` |
| Welcome modal "change later" hint | `you can change this later in settings.` | `you can install/uninstall the service later in settings.` |

Tooltip, exit-confirm dialog, menu labels, port-config hint, and local-mode toast all unchanged.

## Files

- **`tray/src/main.rs`** — tuple grows from 4 to 5 elements to carry a mode-aware `balloon_title`. Body literal duplicated across both branches intentionally (preserves if/else symmetry with the other mode-specific strings; can diverge later if needed). The "tray menu is the only exit" comment moved from inside the local-mode branch to above the if/else, since the rationale now applies to both modes.
- **`launcher/src/tray_supervisor.rs`** — user-killed-tray comment block rewritten. Dropped the verbatim quote of the old body and the "intrinsic to service-mode" framing; replaced with mode-neutral description.
- **`src/app/client/WelcomeModal.ts:142`** — "change later" hint now names the actual reversible decision (install/uninstall the service). Port-config hint at line 81 untouched.
- **`CHANGELOG.md`** `[Unreleased]` — two entries under Changed (tray balloon, Welcome modal).
- **`Cargo.lock`** — version-stamped beta.33 → beta.35 to match Cargo.toml (lockfile lag from the beta.34/.35 release cut; cargo check refreshed it during pre-commit verification). Independent of the copy changes.

## Commits

- `64d40d8` `fix(tray): correct service-mode balloon title + body`
- `0822f45` `fix(welcome): name the actual reversible decision in "change later" hint`

## Test plan

- [x] `cargo check --workspace` clean
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 695/695 across 61 files (baseline matches beta.34 CHANGELOG entry, no fixtures touched these strings)
- [ ] VM smoke: clean install → Welcome modal shows new "install/uninstall the service" hint
- [ ] VM smoke: install service → tooltip flips to `(service)` AND balloon (if visible at supervisor respawn) shows new title `"ws-scrcpy-web (service) tray"` + new body
- [ ] VM smoke: uninstall service → tooltip flips back to local-mode `ws-scrcpy-web`

Smoke validation queued behind the broader beta.34/.35 walkthrough (which targets the open "service uninstall fails after restart" bug).