### PR TITLE
chore(release): v0.1.25-beta.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.36] - 2026-05-22
+
 ### Changed
 
 - **Service-mode tray balloon title + body corrected.** The service-mode launcher-spawn balloon previously read `title: "ws-scrcpy-web tray"` / `body: "tray started by launcher. to clear the tray, stop the ws-scrcpy-web service via Settings."` — but Settings only exposes uninstall, not stop, so the body directed users to a UI action that doesn't exist. The tray menu's own exit option is the only intended exit path in both modes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.35"
+version = "0.1.25-beta.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.35"
+version = "0.1.25-beta.36"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.35"
+version = "0.1.25-beta.36"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.35"
+version = "0.1.25-beta.36"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.35",
+  "version": "0.1.25-beta.36",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

Version bump to **v0.1.25-beta.36**. Carries the §33 service-uninstall fix from PR #88 (merge commit `e1f8967`).

## What landed in main since beta.35

- **PR #85** (`c77d911`) — service-mode tray balloon copy + Welcome modal "change later" hint
- **PR #88** (`e1f8967`) — §33 Bug A + Bug B service-uninstall bundled fix

## Files

- `package.json` 0.1.25-beta.35 → 0.1.25-beta.36
- `Cargo.toml` workspace.version 0.1.25-beta.35 → 0.1.25-beta.36
- `Cargo.lock` internal-crate version stamps refreshed
- `CHANGELOG.md` `[Unreleased]` → `[0.1.25-beta.36] - 2026-05-22` section header

## Test plan

- [x] `cargo check --workspace` clean
- [ ] CI re-validates on PR (build-and-test, CodeQL ×4, Scorecard)
- [ ] Post-merge: tag `v0.1.25-beta.36` pushed → release.yml publishes MSI + Portable + AppImage + nupkg
- [ ] Followed by beta.37 cut (upgrade-test target per user direction 2026-05-22)
- [ ] User VM smoke against the published release: clean install → install service → uninstall ×5 pre-reboot → reboot + idle 15+ min → uninstall post-reboot. Bug A should pass 5/5; Bug B should succeed without manual recovery.

Auto-merge will be enabled. Smoke happens against the published beta.36 (or beta.37 for upgrade flow), not on the PR itself.