### PR TITLE
chore(release): v0.1.25-beta.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.37] - 2026-05-22
+
 ## [0.1.25-beta.36] - 2026-05-22
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.36"
+version = "0.1.25-beta.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.36"
+version = "0.1.25-beta.37"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.36"
+version = "0.1.25-beta.37"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.36"
+version = "0.1.25-beta.37"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.36",
+  "version": "0.1.25-beta.37",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary

No-op version bump to **v0.1.25-beta.37**. Cut as the upgrade-test target per user direction 2026-05-22 — lets the user validate the in-app updater on the §33-fixed code (install beta.36 → in-app upgrade to beta.37 → verify handoff + restart flows work cleanly).

## What this PR carries

Pure version stamp bump. No code changes beyond `package.json`, `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` section header.

## Test plan

- [x] `cargo check --workspace` clean
- [ ] CI re-validates on PR
- [ ] Post-merge: tag `v0.1.25-beta.37` pushed → release.yml publishes
- [ ] User VM smoke: clean install beta.36 (which has §33 fix) → install service → uninstall pre-reboot ×5 → reboot + idle 15+ min → uninstall post-reboot → in-app upgrade beta.36 → beta.37 → re-test install/uninstall flow on beta.37

Auto-merge enabled.