### PR TITLE
chore(launcher): post-Phase-1 cleanup sweep — operation-server naming consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.38"
+version = "0.1.25-beta.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.38"
+version = "0.1.25-beta.39"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.38"
+version = "0.1.25-beta.39"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -1,6 +1,11 @@
 // §32 Part 5 — launcher-served "updating, please wait…" page during the
 // in-app upgrade window.
 //
+// (Phase 1 rearchitecture renamed this subsystem `upgrade-server` →
+// `operation-server` to reflect its broader role; the legacy
+// `--upgrade-server` CLI flag is kept as a read-time alias for ~2 release
+// cycles so existing post-stop.bat files keep working.)
+//
 // Background: §32 Part 4 (the cmd.exe + bat post-stop architecture) closed
 // the service-restart race so that the new Node binds the port reliably
 // within ~15s of clicking Apply. But during that ~15s window, browsers
@@ -14,16 +19,17 @@
 // one — user explicitly rejected Service Workers as fragile.
 //
 // Architecture:
-//   1. Post-stop bat spawns `<launcher> --upgrade-server` AFTER Node
+//   1. Post-stop bat spawns `<launcher> --operation-server` AFTER Node
 //      exits but BEFORE `sc start`. The bat fire-and-forget-spawns, then
 //      continues to its `timeout` + `sc start` sequence.
-//   2. Upgrade-server reads the web port from config.json, binds it,
+//   2. Operation-server reads the web port from config.json, binds it,
 //      serves a static "updating" HTML page on all paths (200 for root,
 //      503 for /api/*). HTML page has inline JS that polls /api/config
 //      every 1s, reloads the page when real app responds with 200 JSON.
-//   3. Upgrade-server self-exits on either:
-//      - <dataRoot>/control/upgrade-server-stop marker present (the new
-//        supervised launcher writes this before spawning Node)
+//   3. Operation-server self-exits on either:
+//      - <dataRoot>/control/operation-server-stop marker present (the new
+//        supervised launcher writes this before spawning Node) — legacy
+//        `upgrade-server-stop` marker also honored at read time.
 //      - 30 seconds elapsed (safety cap; if Node isn't up by then, the
 //        user is hitting a deeper problem the upgrade page can't paper
 //        over)
@@ -31,7 +37,8 @@
 //      Connection count during a typical upgrade is single-digit;
 //      no need for async.
 //
-// Subcommand argv: `<launcher> --upgrade-server`
+// Subcommand argv: `<launcher> --operation-server` (canonical;
+// `--upgrade-server` accepted as legacy alias)
 //   - No positional args (port resolved from config.json)
 //   - Self-exits cleanly; no shutdown handshake required from caller
 //
@@ -556,7 +563,7 @@ pub fn spawn_detached_helper(data_root: &Path) {
         const DETACHED_PROCESS: u32 = 0x00000008;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         match std::process::Command::new(&helper)
-            .arg("--upgrade-server")
+            .arg("--operation-server")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -132,10 +132,10 @@ pub fn run() -> Result<i32> {
         // update path, so the helper must be current there too.
         match crate::operation_server::refresh_helper_binary(&paths.data_root) {
             Ok(p) => log::info(&format!(
-                "supervisor: refreshed upgrade-server helper at {p:?}"
+                "supervisor: refreshed operation-server helper at {p:?}"
             )),
             Err(e) => log::error(&format!(
-                "supervisor: could not refresh upgrade-server helper (upgrade-server spawn will use stale binary or fail): {e}"
+                "supervisor: could not refresh operation-server helper (operation-server spawn will use stale binary or fail): {e}"
             )),
         }
 
@@ -154,7 +154,7 @@ pub fn run() -> Result<i32> {
             let port = cfg.web_port.unwrap_or(8000);
             if let Err(e) = crate::operation_server::write_stop_marker(&paths.data_root) {
                 log::error(&format!(
-                    "supervisor: could not write upgrade-server stop marker (non-fatal): {e}"
+                    "supervisor: could not write operation-server stop marker (non-fatal): {e}"
                 ));
             }
             crate::operation_server::wait_for_port_free(
@@ -230,7 +230,7 @@ pub fn run() -> Result<i32> {
                     );
                     if marker.exists() {
                         log::info(
-                            "supervisor: apply-update-pending marker present (local mode); spawning upgrade-server before exit",
+                            "supervisor: apply-update-pending marker present (local mode); spawning operation-server before exit",
                         );
                         // Delete marker FIRST so a subsequent restart that
                         // observes a stale marker doesn't re-spawn.


### PR DESCRIPTION
## Summary

Post-Phase-1 cleanup sweep. Three naming-consistency items the PR #93 final reviewer flagged as Minor (out-of-scope for Phase 1, surfaced for tracking) — none breaking because the Phase 1 dual-name compat papered over them, but worth resolving before Phase 2 starts so the codebase reads cleanly.

- **`spawn_detached_helper` flag (`launcher/src/operation_server.rs` ~559):** detached-spawn now passes `--operation-server` instead of the legacy `--upgrade-server` alias. Brings the local-mode apply-update path in line with `post-stop.bat` (PR #93 commit `81a01ae`). Helper accepts both flags, so this is a consistency fix not a correctness fix.
- **Four production-log strings in `launcher/src/supervisor.rs` (lines 135, 138, 157, 233):** now say `operation-server` instead of `upgrade-server`. These are runtime-visible in `logs/launcher.log` and matter for post-merge log archaeology on Phase 2-5 smokes.
- **Top-of-file architecture comment block in `launcher/src/operation_server.rs`:** subcommand argv example uses `--operation-server` (canonical) with `--upgrade-server` noted as the legacy alias; marker filename example uses `operation-server-stop` with `upgrade-server-stop` noted as legacy-honored-at-read-time.
- **Bonus:** `Cargo.lock` synced to the beta.39 workspace version. PR #94 bumped the manifests but did not update the lockfile — the first `cargo build/test` on the new version regenerates it. Locking it in here so the drift doesn't surface on every subsequent branch's first build.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 42 common + 71 launcher unit + 1 launcher integration + 4 tray = 118 passed, 0 failed
- [x] `npm test` — vitest 695/695 unchanged

No new tests added (pure naming/comment changes). No behavior change.

Next: Phase 2 (launcher uninstall capability, dormant) → beta.40.
