### PR TITLE
chore(release): v0.1.25-beta.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.40] - 2026-05-23
+
 ### Added
 
 - **Launcher uninstall capability via operation-server (dormant)** — Phase 2 of the operation-server rearchitecture per `docs/superpowers/specs/2026-05-23-operation-server-rearchitecture-design.md`. `--spawn-user-launcher` subcommand wraps existing WTS cross-session spawn (`spawn_in_active_user_session`). post-stop.bat broadened from two-state (apply-update / no-op) to three-state (apply-update / uninstall / no-op) using marker discriminators in `<dataRoot>/control/` — `apply-update-pending` (existing) and `uninstall-pending` (new). Operation-server detects variant at spawn time via `detect_operation_variant` and serves per-variant page text via `render_operation_page` (template-token substitution: `__OPERATION_TITLE__` + `__OPERATION_BODY__` in the HTML asset). **No user-visible behavior change** — no Node-side marker writer for uninstall yet (Phase 4 activates the user-visible flip).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.39"
+version = "0.1.25-beta.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.39"
+version = "0.1.25-beta.40"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.39"
+version = "0.1.25-beta.40"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.39"
+version = "0.1.25-beta.40"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.39",
+  "version": "0.1.25-beta.40",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Phase 2 of operation-server rearchitecture (launcher uninstall capability, dormant). See PR #96 for details.