### PR TITLE
fix(deps): dev-mode dep update gate + installNodejs rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dev mode no longer crashes on Update Node click.** Per-dep `requiresLauncher` flag gates the in-app dep updater. In dev mode, `nodejs` and `adb` show a disabled "update (dev)" button with a tooltip pointing at `scripts/fetch-node.mjs`. `scrcpy-server` remains updatable in dev (no launcher needed). `POST /api/dependencies/:name/update` returns HTTP 503 with `reason: 'launcher-required'` for the dev-mode refusal. `autoInstallMissing` skips launcher-required deps when launcher unavailable, breaking the restart loop that occurred after a failed manual update left `node.exe` renamed to `node.exe.old`.
+
+- **`installNodejs` no longer leaves Node missing on failed updates.** Reordered to extract to `tmpDir` first (non-destructive); only after extract succeeds does it rename `node.exe` to `node.exe.old` and copy new files. On copy failure, the rename is rolled back so `node.exe` remains the prior version. Applies to production failure modes (network-zip-corrupt, disk-full, AV-quarantine, malformed archive).
+
+Tests: vitest 708/708 (was 695/695 pre-fix; +13 new tests across dependencyDefinitions, dependencyManager, dependencyManager.update, dependencyManager.autoInstallMissing, dependencyApi.update suites).
+
 ## [0.1.25-beta.40] - 2026-05-23
 
 ### Added

--- a/docs/superpowers/plans/2026-05-24-dev-mode-dep-update-gate.md
+++ b/docs/superpowers/plans/2026-05-24-dev-mode-dep-update-gate.md
@@ -1,0 +1,1173 @@
+# Dev-mode dep update gate + installNodejs rollback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the design from `docs/superpowers/specs/2026-05-24-dev-mode-dep-update-gate-design.md` — gate the in-app dep update flow per-dep so dev mode no longer hits the launcher-only `extractZip` path, and reorder `installNodejs` to extract-first-then-rename so production extract/copy failures cannot leave Node missing.
+
+**Architecture:** Per-dep `requiresLauncher` on `DependencyDefinition`. `DependencyInfo.canUpdate = !requiresLauncher || launcherIsAvailable()` recomputed each `getAll()`. `update()` early-bails with typed `reason: 'launcher-required'` when the gate trips, surfaced as HTTP 503 by `DependencyApi`. `installNodejs` extracts to `tmpDir` first, then performs the destructive rename + copy with a tight rollback if copy fails.
+
+**Tech Stack:** TypeScript, vitest (server-side unit tests), webpack-bundled Node.js server + custom-element frontend. Local-Dependencies-Only architecture (CLAUDE.md).
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `src/common/DependencyTypes.ts` | modify | Add `canUpdate` to `DependencyInfo`, `reason` to `UpdateResult` |
+| `src/server/DependencyDefinitions.ts` | modify | Add `requiresLauncher` to interface + per-dep values |
+| `src/server/DependencyManager.ts` | modify | `getAll()` recomputes canUpdate; `update()` guard; `autoInstallMissing()` skip; `installNodejs` reorder + rollback |
+| `src/server/api/DependencyApi.ts` | modify | Map `result.reason === 'launcher-required'` to HTTP 503 |
+| `src/app/client/DependencyPanel.ts` | modify | `actionButton` renders disabled `update (dev)` when `!canUpdate`; lowercase labels |
+| `src/server/__tests__/dependencyDefinitions.test.ts` | modify | Add requiresLauncher value test |
+| `src/server/__tests__/dependencyManager.test.ts` | modify | Add canUpdate tests (mock elevatedRunner) |
+| `src/server/__tests__/dependencyManager.update.test.ts` | modify | Add guard tests + installNodejs rollback tests |
+| `src/server/__tests__/dependencyManager.autoInstallMissing.test.ts` | modify | Add launcher-required-skip test |
+| `src/server/__tests__/dependencyApi.update.test.ts` | create | NEW — 503 routing tests |
+| `CHANGELOG.md` | modify | Unreleased entry (final task) |
+
+**Working branch:** `fix/dev-mode-dep-update-gate` (already created, spec committed at `390a4de`).
+
+**Commands you will use frequently:**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" status
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add <files>
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "..."
+
+# Run tests (all)
+cd C:/Users/jscha/source/repos/ws-scrcpy-web
+npm test
+
+# Run one test file
+npx vitest run src/server/__tests__/<file>.test.ts
+
+# Type check only
+npx tsc --noEmit
+```
+
+> **cwd discipline (CLAUDE.md):** prefer `git -C "<absolute-path>"` for git operations to keep cross-session-safe. For `npm test` / `npx tsc`, the test runner needs to be in the repo root — `cd` once at the start of an implementation session and stay there for the duration. Do NOT `cd` if a parallel session might be in this repo.
+
+---
+
+## Task 1: Extend shared types
+
+**Files:**
+- Modify: `src/common/DependencyTypes.ts`
+- Modify: `src/server/DependencyManager.ts:42-54` (constructor state initialization)
+
+This task is type-only — it adds the fields and initializes them in the one place that constructs `DependencyInfo`. No new test cases yet; existing 695 tests must still pass.
+
+- [ ] **Step 1: Add fields to `DependencyTypes.ts`**
+
+Replace lines 10-27 of `src/common/DependencyTypes.ts` with:
+
+```ts
+export interface DependencyInfo {
+    name: string;
+    displayName: string;
+    installedVersion: string | null;
+    latestVersion: string | null;
+    status: DependencyStatus;
+    description: string;
+    errorMessage?: string | undefined;
+    requiresRestart: boolean;
+    pairedWith?: string | undefined;
+    canUpdate: boolean;
+}
+
+export interface UpdateResult {
+    success: boolean;
+    newVersion?: string | undefined;
+    errorMessage?: string | undefined;
+    requiresRestart: boolean;
+    reason?: 'launcher-required' | undefined;
+}
+```
+
+(Two new fields: `canUpdate: boolean` required on `DependencyInfo`; `reason?: 'launcher-required'` optional on `UpdateResult`. Existing fields unchanged. The `?: T | undefined` pattern matches existing fields, satisfying `exactOptionalPropertyTypes`.)
+
+- [ ] **Step 2: Initialize `canUpdate` in `DependencyManager` constructor**
+
+In `src/server/DependencyManager.ts`, find the constructor's state initialization loop (around lines 43-54):
+
+```ts
+for (const def of this.definitions) {
+    this.state.set(def.name, {
+        name: def.name,
+        displayName: def.displayName,
+        installedVersion: null,
+        latestVersion: null,
+        status: DependencyStatus.Unknown,
+        description: def.description,
+        requiresRestart: def.requiresRestart,
+        pairedWith: def.pairedWith,
+    });
+}
+```
+
+Add `canUpdate: false` to the object literal (it will be recomputed by `getAll()` in Task 3):
+
+```ts
+for (const def of this.definitions) {
+    this.state.set(def.name, {
+        name: def.name,
+        displayName: def.displayName,
+        installedVersion: null,
+        latestVersion: null,
+        status: DependencyStatus.Unknown,
+        description: def.description,
+        requiresRestart: def.requiresRestart,
+        pairedWith: def.pairedWith,
+        canUpdate: false,
+    });
+}
+```
+
+- [ ] **Step 3: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: clean (no errors). If any errors surface from other DependencyInfo construction sites, surface them — those would be unexpected.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test`
+Expected: 695/695 pass (unchanged from baseline).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/common/DependencyTypes.ts src/server/DependencyManager.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(deps): add canUpdate + launcher-required reason to DependencyInfo/UpdateResult"
+```
+
+---
+
+## Task 2: Add `requiresLauncher` to dependency definitions
+
+**Files:**
+- Modify: `src/server/DependencyDefinitions.ts` (interface at line 48-57; definitions at lines 74-173)
+- Modify: `src/server/__tests__/dependencyDefinitions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add this test block to `src/server/__tests__/dependencyDefinitions.test.ts` (after the existing `scrcpy-server does not require restart` test, around line 51):
+
+```ts
+    it('nodejs and adb require the launcher (extractZip path); scrcpy-server does not', () => {
+        const defs = getDependencyDefinitions('/tmp/test-deps');
+        const node = defs.find((d) => d.name === 'nodejs');
+        const adb = defs.find((d) => d.name === 'adb');
+        const scrcpy = defs.find((d) => d.name === 'scrcpy-server');
+        expect(node?.requiresLauncher).toBe(true);
+        expect(adb?.requiresLauncher).toBe(true);
+        expect(scrcpy?.requiresLauncher).toBe(false);
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/dependencyDefinitions.test.ts`
+Expected: FAIL on the new test (`requiresLauncher` undefined on all defs). Other tests in file: pass.
+
+- [ ] **Step 3: Add `requiresLauncher` field to the interface**
+
+In `src/server/DependencyDefinitions.ts`, find the `DependencyDefinition` interface (around line 48-57) and add `requiresLauncher`:
+
+```ts
+export interface DependencyDefinition {
+    name: string;
+    displayName: string;
+    description: string;
+    requiresRestart: boolean;
+    pairedWith?: string;
+    requiresLauncher: boolean;
+    checkInstalled: (depsPath: string) => Promise<string | null>;
+    checkLatest: () => Promise<string | null>;
+    getDownloadUrl: (version: string) => string;
+}
+```
+
+- [ ] **Step 4: Set `requiresLauncher` on each definition**
+
+In `src/server/DependencyDefinitions.ts`, find `getDependencyDefinitions` (around line 69 onward). For each of the three definitions, add `requiresLauncher`:
+
+- **nodejs** (around line 74-121): add `requiresLauncher: true` after `pairedWith: 'node-pty'`.
+- **adb** (around line 122-146): add `requiresLauncher: true` after `requiresRestart: false`.
+- **scrcpy-server** (around line 147-173): add `requiresLauncher: false` after `requiresRestart: false`.
+
+Example for the nodejs section (the new field is the last line shown):
+
+```ts
+{
+    name: 'nodejs',
+    displayName: 'Node.js',
+    description: 'JavaScript runtime that runs the ws-scrcpy-web server',
+    requiresRestart: true,
+    pairedWith: 'node-pty',
+    requiresLauncher: true,
+    checkInstalled: async (depsPath) => {
+        // ... existing body unchanged
+    },
+    // ...
+},
+```
+
+Apply the analogous one-line addition to the other two definitions.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/dependencyDefinitions.test.ts`
+Expected: all tests pass, including the new `requiresLauncher` assertion.
+
+- [ ] **Step 6: Run full suite**
+
+Run: `npm test`
+Expected: 696/696 (1 new test, all existing still pass).
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/DependencyDefinitions.ts src/server/__tests__/dependencyDefinitions.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(deps): add requiresLauncher to DependencyDefinition (true for nodejs/adb, false for scrcpy-server)"
+```
+
+---
+
+## Task 3: Compute `canUpdate` in `getAll()`
+
+**Files:**
+- Modify: `src/server/DependencyManager.ts:57-59` (getAll method)
+- Modify: `src/server/__tests__/dependencyManager.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this describe block to `src/server/__tests__/dependencyManager.test.ts` (after the existing `describe('DependencyManager', ...)` block, before `describe('DependencyManager.requestRestart', ...)`):
+
+```ts
+describe('DependencyManager.getAll() canUpdate', () => {
+    it('reports canUpdate=true for all deps when launcher is available', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => true,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        // Re-import after mock to pick up the stubbed module
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const mgr = new Mgr('/tmp/test-deps-canupdate-yes');
+        const deps = mgr.getAll();
+        for (const dep of deps) {
+            expect(dep.canUpdate).toBe(true);
+        }
+        vi.doUnmock('../service/elevatedRunner');
+    });
+
+    it('reports canUpdate=false for launcher-required deps when launcher is unavailable', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const mgr = new Mgr('/tmp/test-deps-canupdate-no');
+        const byName = Object.fromEntries(mgr.getAll().map((d) => [d.name, d]));
+        expect(byName.nodejs?.canUpdate).toBe(false);
+        expect(byName.adb?.canUpdate).toBe(false);
+        expect(byName['scrcpy-server']?.canUpdate).toBe(true);
+        vi.doUnmock('../service/elevatedRunner');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.test.ts`
+Expected: both new tests FAIL (canUpdate is always false from Task 1's constructor init; getAll doesn't recompute yet).
+
+- [ ] **Step 3: Implement `getAll()` recomputation**
+
+In `src/server/DependencyManager.ts`, replace the existing `getAll()` (around lines 57-59):
+
+```ts
+public getAll(): DependencyInfo[] {
+    return Array.from(this.state.values());
+}
+```
+
+with:
+
+```ts
+public getAll(): DependencyInfo[] {
+    const launcherAvail = launcherIsAvailable();
+    return Array.from(this.state.values()).map((info) => {
+        const def = this.definitions.find((d) => d.name === info.name);
+        return { ...info, canUpdate: !def?.requiresLauncher || launcherAvail };
+    });
+}
+```
+
+(`launcherIsAvailable` is already imported at the top of the file via `import { launcherIsAvailable, resolveLauncherPath } from './service/elevatedRunner';` — confirm the import line exists at line 21; if missing, add it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.test.ts`
+Expected: both new tests pass.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: 698/698 (2 new tests added; baseline grows from 696).
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/DependencyManager.ts src/server/__tests__/dependencyManager.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(deps): getAll() computes canUpdate per launcher availability"
+```
+
+---
+
+## Task 4: `update()` early-bail with `reason: 'launcher-required'`
+
+**Files:**
+- Modify: `src/server/DependencyManager.ts:122-192` (update method)
+- Modify: `src/server/__tests__/dependencyManager.update.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this describe block to `src/server/__tests__/dependencyManager.update.test.ts` (after the existing `describe('DependencyManager.update("scrcpy-server") — loop fix', ...)` block):
+
+```ts
+describe('DependencyManager.update() launcher-required gate', () => {
+    afterEach(() => {
+        vi.doUnmock('../service/elevatedRunner');
+    });
+
+    it('returns reason=launcher-required for nodejs when launcher is unavailable', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-gate-'));
+        try {
+            const mgr = new Mgr(tmp);
+            const result = await mgr.update('nodejs');
+            expect(result.success).toBe(false);
+            expect(result.reason).toBe('launcher-required');
+            expect(result.errorMessage).toMatch(/installed build/);
+            expect(result.requiresRestart).toBe(false);
+            // Status MUST remain UpdateAvailable / Unknown — NOT transition to Updating or Error.
+            const info = mgr.getByName('nodejs')!;
+            expect(info.status).not.toBe(DependencyStatus.Updating);
+            expect(info.status).not.toBe(DependencyStatus.Error);
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('does not gate scrcpy-server (no launcher needed)', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-gate-scrcpy-'));
+        const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+            const url = typeof input === 'string' ? input : input.toString();
+            if (url.includes('api.github.com')) {
+                return new Response(JSON.stringify({ tag_name: 'v4.0' }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                });
+            }
+            return new Response('fake-jar-bytes', { status: 200 });
+        });
+        try {
+            const mgr = new Mgr(tmp);
+            const info = mgr.getByName('scrcpy-server')!;
+            info.installedVersion = '3.3.4';
+            info.latestVersion = '4.0';
+            const result = await mgr.update('scrcpy-server');
+            expect(result.success).toBe(true);
+            expect(result.reason).toBeUndefined();
+        } finally {
+            fetchSpy.mockRestore();
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+});
+```
+
+(This block reuses the existing `fs`, `os`, `path`, `vi`, `describe`, `expect`, `it`, `DependencyStatus` imports at the top of the file — no new imports needed.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.update.test.ts`
+Expected: nodejs gate test FAILS (no guard exists, update proceeds and hits extractZip which then throws a different way, so the assertion on `result.reason` fails). scrcpy-server test may pass already (no launcher path).
+
+- [ ] **Step 3: Implement the guard**
+
+In `src/server/DependencyManager.ts`, find `update(name)` (around line 122). Insert the guard immediately after the "Unknown dependency" early return, BEFORE `info.status = DependencyStatus.Updating`:
+
+```ts
+public async update(name: string): Promise<UpdateResult> {
+    const def = this.definitions.find((d) => d.name === name);
+    const info = this.state.get(name);
+    if (!def || !info) {
+        return { success: false, errorMessage: `Unknown dependency: ${name}`, requiresRestart: false };
+    }
+    if (def.requiresLauncher && !launcherIsAvailable()) {
+        return {
+            success: false,
+            reason: 'launcher-required',
+            errorMessage:
+                `${def.displayName} updates require an installed build. ` +
+                `In dev mode, populate dependencies/ via scripts/fetch-node.mjs.`,
+            requiresRestart: false,
+        };
+    }
+
+    info.status = DependencyStatus.Updating;
+    // ... existing body unchanged from here onward
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.update.test.ts`
+Expected: both new tests pass; existing scrcpy-server loop-fix test still passes.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: 700/700.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/DependencyManager.ts src/server/__tests__/dependencyManager.update.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(deps): update() early-bails with reason=launcher-required when launcher unavailable"
+```
+
+---
+
+## Task 5: `autoInstallMissing()` skips launcher-required deps in dev
+
+**Files:**
+- Modify: `src/server/DependencyManager.ts:194-215` (autoInstallMissing method)
+- Modify: `src/server/__tests__/dependencyManager.autoInstallMissing.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add this test to the existing `describe('DependencyManager.autoInstallMissing', ...)` block in `src/server/__tests__/dependencyManager.autoInstallMissing.test.ts` (insert after the last `it(...)` at line 80):
+
+```ts
+    it('skips launcher-required deps in dev mode (no launcher available)', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const localMgr = new Mgr('/tmp/test-deps-skip');
+        const localUpdateSpy = vi.spyOn(localMgr, 'update').mockResolvedValue({
+            success: true,
+            newVersion: 'stub',
+            requiresRestart: false,
+        });
+
+        const nodejs = localMgr.getByName('nodejs')!;
+        nodejs.installedVersion = null;
+        nodejs.latestVersion = '24.15.0';
+
+        const scrcpy = localMgr.getByName('scrcpy-server')!;
+        scrcpy.installedVersion = null;
+        scrcpy.latestVersion = '4.0';
+
+        await localMgr.autoInstallMissing();
+
+        // nodejs is skipped (requiresLauncher && !launcherIsAvailable)
+        expect(localUpdateSpy).not.toHaveBeenCalledWith('nodejs');
+        // scrcpy-server still gets installed (no launcher needed)
+        expect(localUpdateSpy).toHaveBeenCalledWith('scrcpy-server');
+
+        localUpdateSpy.mockRestore();
+        vi.doUnmock('../service/elevatedRunner');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.autoInstallMissing.test.ts`
+Expected: new test FAILS (autoInstallMissing currently calls update for both nodejs and scrcpy-server when both are missing).
+
+- [ ] **Step 3: Implement the skip**
+
+In `src/server/DependencyManager.ts`, replace `autoInstallMissing` (around lines 194-215) with:
+
+```ts
+public async autoInstallMissing(): Promise<void> {
+    // v0.1.9: try the seed-promotion path before any network
+    // download. If we ship scrcpy-server as a seed (in
+    // <install>/seed/scrcpy-server/scrcpy-server), copy it into
+    // <deps>/scrcpy-server/scrcpy-server so the runtime path
+    // (DeviceProbe / ScrcpyConnection) can read it. Idempotent —
+    // if the dest already exists, the promotion is a no-op.
+    // Network download still runs after, in case the seed is
+    // missing or the user has an updater-managed newer version.
+    try {
+        this.promoteSeedScrcpyServer();
+    } catch (err) {
+        log.warn(`seed-promote scrcpy-server failed: ${(err as Error).message}`);
+    }
+
+    const launcherAvail = launcherIsAvailable();
+    for (const info of this.state.values()) {
+        if (info.installedVersion === null && info.latestVersion !== null) {
+            const def = this.definitions.find((d) => d.name === info.name);
+            if (def?.requiresLauncher && !launcherAvail) {
+                log.info(`Skipping auto-install of ${info.name} in dev mode (no launcher)`);
+                continue;
+            }
+            log.info(`First-run: auto-installing ${info.name}`);
+            await this.update(info.name);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.autoInstallMissing.test.ts`
+Expected: all tests pass including the new skip test.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: 701/701.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/DependencyManager.ts src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(deps): autoInstallMissing skips launcher-required deps when launcher unavailable"
+```
+
+---
+
+## Task 6: DependencyApi returns 503 for `launcher-required`
+
+**Files:**
+- Modify: `src/server/api/DependencyApi.ts:34-42` (update endpoint handler)
+- Create: `src/server/__tests__/dependencyApi.update.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/server/__tests__/dependencyApi.update.test.ts` with:
+
+```ts
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { EventEmitter } from 'events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DependencyApi } from '../api/DependencyApi';
+import { DependencyManager } from '../DependencyManager';
+
+interface MockRes {
+    statusCode?: number;
+    body?: string;
+    writeHead: (...args: unknown[]) => unknown;
+    end: (...args: unknown[]) => unknown;
+    setHeader: (...args: unknown[]) => unknown;
+}
+
+function makeMockRes() {
+    const res = Object.assign(new EventEmitter(), {
+        statusCode: undefined as number | undefined,
+        body: undefined as string | undefined,
+        setHeader: vi.fn(),
+        writeHead: vi.fn(),
+        end: vi.fn(),
+    }) as MockRes;
+    (res.writeHead as ReturnType<typeof vi.fn>).mockImplementation((code: number) => {
+        res.statusCode = code;
+    });
+    (res.end as ReturnType<typeof vi.fn>).mockImplementation((body: string) => {
+        res.body = body;
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    return res as any;
+}
+
+function makeReq(method: string, url: string) {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    return { method, url } as any;
+}
+
+describe('DependencyApi.update endpoint', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns 503 when update result has reason=launcher-required', async () => {
+        const mgr = new DependencyManager('/tmp/test-api-503');
+        vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: false,
+            reason: 'launcher-required',
+            errorMessage: 'Node.js updates require an installed build.',
+            requiresRestart: false,
+        });
+        const api = new DependencyApi(mgr);
+        const req = makeReq('POST', '/api/dependencies/nodejs/update');
+        const res = makeMockRes();
+
+        const handled = await api.handle(req, res);
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(503);
+        const body = JSON.parse(res.body!);
+        expect(body.success).toBe(false);
+        expect(body.reason).toBe('launcher-required');
+    });
+
+    it('returns 200 when update succeeds (no launcher gate)', async () => {
+        const mgr = new DependencyManager('/tmp/test-api-200');
+        vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: true,
+            newVersion: '4.0',
+            requiresRestart: false,
+        });
+        const api = new DependencyApi(mgr);
+        const req = makeReq('POST', '/api/dependencies/scrcpy-server/update');
+        const res = makeMockRes();
+
+        const handled = await api.handle(req, res);
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        const body = JSON.parse(res.body!);
+        expect(body.success).toBe(true);
+    });
+
+    it('returns 500 for non-gate update failures', async () => {
+        const mgr = new DependencyManager('/tmp/test-api-500');
+        vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: false,
+            errorMessage: 'Download failed: HTTP 500',
+            requiresRestart: false,
+        });
+        const api = new DependencyApi(mgr);
+        const req = makeReq('POST', '/api/dependencies/nodejs/update');
+        const res = makeMockRes();
+
+        await api.handle(req, res);
+
+        expect(res.statusCode).toBe(500);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/dependencyApi.update.test.ts`
+Expected: 503 test FAILS (currently returns 500 for any !success); 200 + 500 tests pass.
+
+- [ ] **Step 3: Implement the 503 branch**
+
+In `src/server/api/DependencyApi.ts`, find the update endpoint block (around lines 34-42):
+
+```ts
+// POST /api/dependencies/:name/update — update specific dependency
+const updateMatch = url.match(/^\/api\/dependencies\/([a-z-]+)\/update$/);
+if (req.method === 'POST' && updateMatch) {
+    const name = updateMatch[1]!;
+    const result = await this.manager.update(name);
+    res.writeHead(result.success ? 200 : 500);
+    res.end(JSON.stringify(result));
+    return true;
+}
+```
+
+Replace the `res.writeHead(...)` line so the 503 case is checked first:
+
+```ts
+// POST /api/dependencies/:name/update — update specific dependency
+const updateMatch = url.match(/^\/api\/dependencies\/([a-z-]+)\/update$/);
+if (req.method === 'POST' && updateMatch) {
+    const name = updateMatch[1]!;
+    const result = await this.manager.update(name);
+    if (result.reason === 'launcher-required') {
+        res.writeHead(503);
+    } else {
+        res.writeHead(result.success ? 200 : 500);
+    }
+    res.end(JSON.stringify(result));
+    return true;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/__tests__/dependencyApi.update.test.ts`
+Expected: all 3 tests pass.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: 704/704.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/DependencyApi.ts src/server/__tests__/dependencyApi.update.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(deps): DependencyApi POST /:name/update returns 503 for launcher-required refusals"
+```
+
+---
+
+## Task 7: `installNodejs` reorder + rollback
+
+**Files:**
+- Modify: `src/server/DependencyManager.ts:322-367` (installNodejs method)
+- Modify: `src/server/__tests__/dependencyManager.update.test.ts`
+
+This task fixes Bug #2 — destructive rename before failed extract leaves Node missing. New order: extract first (non-destructive), then rename + copy with tight rollback.
+
+- [ ] **Step 1: Write failing tests**
+
+Add this describe block to `src/server/__tests__/dependencyManager.update.test.ts` (after the gate tests from Task 4):
+
+```ts
+describe('DependencyManager.installNodejs rollback', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-nodeinstall-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    async function callInstallNodejs(
+        mgr: DependencyManager,
+        downloadPath: string,
+        version: string,
+        installTmp: string,
+        platform: 'win32' | 'linux',
+    ): Promise<void> {
+        // installNodejs is private — invoke via a typed cast for the test only.
+        // biome-ignore lint/suspicious/noExplicitAny: invoke private method
+        await (mgr as any).installNodejs(downloadPath, version, installTmp, platform);
+    }
+
+    it('win32: extract failure leaves destDir untouched (original node.exe intact)', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNodeExe = path.join(destDir, 'node.exe');
+        fs.writeFileSync(originalNodeExe, 'ORIGINAL-NODE-BYTES');
+
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
+
+        // Mock extractZip to throw
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'extractZip').mockRejectedValue(new Error('mock extract fail'));
+
+        await expect(
+            callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32'),
+        ).rejects.toThrow('mock extract fail');
+
+        // Original node.exe must be intact; no .old created.
+        expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('ORIGINAL-NODE-BYTES');
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(false);
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+
+    it('win32: copy failure restores .old back to .exe (rollback)', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNodeExe = path.join(destDir, 'node.exe');
+        fs.writeFileSync(originalNodeExe, 'ORIGINAL-NODE-BYTES');
+
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
+        // Simulate a successful extract: write the expected archive layout.
+        const archiveRoot = path.join(extractTmp, 'node-v24.15.0-win-x64');
+        fs.mkdirSync(archiveRoot, { recursive: true });
+        fs.writeFileSync(path.join(archiveRoot, 'node.exe'), 'NEW-NODE-BYTES');
+
+        // extractZip mock succeeds (no-op — the layout is pre-populated).
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'extractZip').mockResolvedValue(undefined);
+        // copyDirContents mock throws partway.
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'copyDirContents').mockImplementation(() => {
+            throw new Error('mock copy fail');
+        });
+
+        await expect(
+            callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32'),
+        ).rejects.toThrow('mock copy fail');
+
+        // node.exe must be restored from .old; .old must no longer exist after restore.
+        expect(fs.existsSync(originalNodeExe)).toBe(true);
+        expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('ORIGINAL-NODE-BYTES');
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(false);
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+
+    it('win32: full success replaces node.exe (and leaves node.exe.old per current behavior)', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNodeExe = path.join(destDir, 'node.exe');
+        fs.writeFileSync(originalNodeExe, 'ORIGINAL-NODE-BYTES');
+
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
+        const archiveRoot = path.join(extractTmp, 'node-v24.15.0-win-x64');
+        fs.mkdirSync(archiveRoot, { recursive: true });
+        fs.writeFileSync(path.join(archiveRoot, 'node.exe'), 'NEW-NODE-BYTES');
+        fs.writeFileSync(path.join(archiveRoot, 'npm.cmd'), 'NPM-CMD-BYTES');
+
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'extractZip').mockResolvedValue(undefined);
+        // Don't mock copyDirContents — let it run for real on the pre-populated archive.
+
+        await callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32');
+
+        expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('NEW-NODE-BYTES');
+        expect(fs.readFileSync(path.join(destDir, 'npm.cmd'), 'utf8')).toBe('NPM-CMD-BYTES');
+        // Current behavior: node.exe.old lingers post-success (cleanup is a separate non-goal).
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(true);
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+
+    it('linux: extract failure leaves destDir untouched', async () => {
+        // The Linux branch uses execFileAsync('tar', ...) directly, not extractZip.
+        // Mocking the actual tar call is tricky; instead verify by checking that
+        // after a failure, destDir state is unchanged from initial.
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNode = path.join(destDir, 'node');
+        fs.writeFileSync(originalNode, 'ORIGINAL-LINUX-NODE');
+
+        // Point download at a non-existent file so tar will fail.
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-linux-'));
+
+        await expect(
+            callInstallNodejs(mgr, '/does/not/exist.tar.gz', '24.15.0', extractTmp, 'linux'),
+        ).rejects.toThrow();
+
+        // Linux destDir state unchanged.
+        expect(fs.readFileSync(originalNode, 'utf8')).toBe('ORIGINAL-LINUX-NODE');
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.update.test.ts`
+Expected: the 4 new rollback tests FAIL in characteristic ways:
+- win32 extract-failure: probably FAILS because the current code renames node.exe → node.exe.old BEFORE extractZip throws, so the assertion `fs.readFileSync(originalNodeExe, 'utf8')).toBe('ORIGINAL-NODE-BYTES')` fails (file no longer exists at `originalNodeExe`).
+- win32 copy-failure: FAILS because no rollback path exists.
+- win32 success: may pass — depends on whether current code can complete with the mock setup.
+- linux: probably FAILS because the test path uses a non-existent file but the current code may write something to destDir before the tar call fails. Adjust test if it surfaces a different real-bug shape.
+
+- [ ] **Step 3: Implement the reordered installNodejs**
+
+In `src/server/DependencyManager.ts`, replace `installNodejs` entirely (around lines 322-367):
+
+```ts
+private async installNodejs(
+    downloadPath: string,
+    _version: string,
+    tmpDir: string,
+    platform: 'win32' | 'linux',
+): Promise<void> {
+    const destDir = path.join(this.depsPath, 'node');
+    fs.mkdirSync(destDir, { recursive: true });
+
+    // 1. Non-destructive: extract to tmpDir (both platforms).
+    if (platform === 'win32') {
+        await this.extractZip(downloadPath, tmpDir, platform);
+    } else {
+        await execFileAsync('tar', ['xzf', downloadPath, '-C', tmpDir]);
+    }
+    const archiveDir = fs.readdirSync(tmpDir).find((d) => d.startsWith('node-v'));
+    if (!archiveDir) {
+        throw new Error('Could not find Node.js directory in extracted archive');
+    }
+    const extractedPath = path.join(tmpDir, archiveDir);
+
+    // 2. Destructive (Windows only): rename + copy with rollback.
+    if (platform === 'win32') {
+        const runningExe = path.join(destDir, 'node.exe');
+        const oldExe = path.join(destDir, 'node.exe.old');
+        let renamed = false;
+        if (fs.existsSync(runningExe)) {
+            try {
+                fs.renameSync(runningExe, oldExe);
+                renamed = true;
+            } catch {
+                // May fail if not the managed node — proceed without rollback safety net.
+            }
+        }
+        try {
+            this.copyDirContents(extractedPath, destDir);
+        } catch (err) {
+            if (renamed && !fs.existsSync(runningExe)) {
+                try {
+                    fs.renameSync(oldExe, runningExe);
+                } catch {
+                    // Best-effort rollback. Original error bubbles up regardless.
+                }
+            }
+            throw err;
+        }
+    } else {
+        this.copyDirContents(extractedPath, destDir);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/__tests__/dependencyManager.update.test.ts`
+Expected: all rollback tests pass. The pre-existing scrcpy-server loop-fix + Task 4 gate tests still pass.
+
+If the linux extract-failure test behaves differently than expected (e.g., the mkdirSync runs before tar fails, leaving destDir in a "created but empty" state), adjust the test assertion to verify that no NEW files appear in destDir, rather than asserting that `originalNode` is untouched (which it would be regardless).
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: 708/708.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/DependencyManager.ts src/server/__tests__/dependencyManager.update.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(deps): installNodejs reorder (extract-first) + rollback on copy failure"
+```
+
+---
+
+## Task 8: Frontend gated `update (dev)` button
+
+**Files:**
+- Modify: `src/app/client/DependencyPanel.ts:218-226` (actionButton method) and lines 210-212 (badge text — lowercase consistency)
+
+No frontend test harness exists for `DependencyPanel`; this is a pure rendering change verified by manual smoke (Task 9).
+
+- [ ] **Step 1: Modify `actionButton` and lowercase status badges**
+
+In `src/app/client/DependencyPanel.ts`, find `actionButton` (around lines 218-226):
+
+```ts
+private actionButton(dep: DependencyInfo): string {
+    if (dep.status === 'update-available') {
+        return `<button class="dep-btn dep-update" data-update="${dep.name}">Update</button>`;
+    }
+    if (dep.status === 'updating') {
+        return '<button class="dep-btn" disabled>Updating...</button>';
+    }
+    return '';
+}
+```
+
+Replace with:
+
+```ts
+private actionButton(dep: DependencyInfo): string {
+    if (dep.status === 'update-available') {
+        if (!dep.canUpdate) {
+            const tooltip = 'In-app updates require an installed build. ' +
+                'In dev mode, populate dependencies/ via scripts/fetch-node.mjs.';
+            return `<button class="dep-btn dep-update" disabled title="${tooltip}">` +
+                `update (dev)</button>`;
+        }
+        return `<button class="dep-btn dep-update" data-update="${dep.name}">update</button>`;
+    }
+    if (dep.status === 'updating') {
+        return '<button class="dep-btn" disabled>updating...</button>';
+    }
+    return '';
+}
+```
+
+- [ ] **Step 2: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: clean — `dep.canUpdate` is now a known field on `DependencyInfo` from Task 1.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `npm test`
+Expected: 708/708 (no test changes; existing tests unaffected).
+
+- [ ] **Step 4: Build the frontend bundle**
+
+The dev server uses webpack to bundle the frontend. Rebuild before manual smoke:
+
+```powershell
+npm run build
+```
+
+Expected: build completes with no errors. Output in `dist/`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/DependencyPanel.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(ui): DependencyPanel disables update button for launcher-required deps in dev (lowercase labels)"
+```
+
+---
+
+## Task 9: Manual smoke + CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+This task closes the loop: confirm the fix works end-to-end in dev mode (and ideally also against a deployed install), then write the CHANGELOG entry with the actual measured test counts.
+
+### Manual smoke
+
+The fix is initially landed in dev only. The deployed-mode validation comes when the next beta ships (out of scope for this plan). The dev-mode smoke is sufficient gate for merge.
+
+- [ ] **Step 1: Recover from the broken Node state (if not already done)**
+
+In PowerShell:
+
+```powershell
+Move-Item "C:\ProgramData\WsScrcpyWeb\dependencies\node\node.exe.old" "C:\ProgramData\WsScrcpyWeb\dependencies\node\node.exe"
+```
+
+(Skip this step if Node was already recovered earlier, or if Node was never broken in this session.)
+
+- [ ] **Step 2: Start the dev server**
+
+```powershell
+cd C:/Users/jscha/source/repos/ws-scrcpy-web
+npm start
+```
+
+Watch the server log. Confirm: no `[DependencyManager] ERROR Update nodejs failed: extractZip requires the packaged launcher binary` line on startup. If autoInstallMissing would previously have re-fired for missing nodejs, you should now see `[DependencyManager] INFO Skipping auto-install of nodejs in dev mode (no launcher)`.
+
+- [ ] **Step 3: Open the app + check the dep panel**
+
+Navigate to `http://localhost:8000/` → Settings → Dependencies panel.
+
+Verify:
+- **nodejs:** "update available" badge, action column shows a **disabled** "update (dev)" button. Hover shows the tooltip: "In-app updates require an installed build. In dev mode, populate dependencies/ via scripts/fetch-node.mjs."
+- **adb:** same shape as nodejs.
+- **scrcpy-server:** if an update is available, the action column shows an **enabled** "update" button (no launcher needed for this dep).
+
+- [ ] **Step 4: Verify the disabled button does not fire**
+
+Click the disabled "update (dev)" button on the nodejs row. Confirm:
+- Nothing happens (the disabled attribute blocks the click).
+- No POST request appears in DevTools Network tab.
+- Server log shows no new ERROR lines.
+
+- [ ] **Step 5: Verify the 503 path via direct API call**
+
+In DevTools console:
+
+```js
+const r = await fetch('/api/dependencies/nodejs/update', { method: 'POST' });
+console.log('status:', r.status);
+console.log('body:', await r.json());
+```
+
+Expected:
+- `status: 503`
+- `body: { success: false, reason: 'launcher-required', errorMessage: 'Node.js updates require an installed build. In dev mode, populate dependencies/ via scripts/fetch-node.mjs.', requiresRestart: false }`
+
+Server log shows no ERROR — the guard returns cleanly, no destructive code path entered.
+
+- [ ] **Step 6: Verify scrcpy-server update still works in dev**
+
+Click the (enabled) "update" button on the scrcpy-server row. If an update is available, it should download and install. Confirm:
+- Status transitions update-available → updating → up-to-date (or stays update-available if checkLatest matches installed).
+- No errors.
+- (If no update is currently available, this step is a no-op — skip and document below.)
+
+- [ ] **Step 7: Stop the dev server**
+
+Ctrl+C in the npm start terminal. Wait for clean shutdown.
+
+### CHANGELOG entry
+
+- [ ] **Step 8: Remeasure final test counts**
+
+Run: `npm test`
+Expected: ~708/708. Note the exact number for the CHANGELOG entry.
+
+- [ ] **Step 9: Add the CHANGELOG entry**
+
+Open `CHANGELOG.md`. Under the most recent `## [Unreleased]` section (create it if it doesn't exist, at the top of the file under the `# Changelog` header), add:
+
+```markdown
+### Fixed
+
+- **Dev mode no longer crashes on Update Node click.** Per-dep `requiresLauncher` flag gates the in-app dep updater. In dev mode, `nodejs` and `adb` show a disabled "update (dev)" button with a tooltip pointing at `scripts/fetch-node.mjs`. `scrcpy-server` remains updatable in dev (no launcher needed). `POST /api/dependencies/:name/update` returns HTTP 503 with `reason: 'launcher-required'` for the dev-mode refusal.
+
+- **`installNodejs` no longer leaves Node missing on failed updates.** Reordered to extract to `tmpDir` first (non-destructive); only after extract succeeds does it rename `node.exe` → `node.exe.old` and copy new files. On copy failure, the rename is rolled back so `node.exe` remains the prior version. Reachable in production via any extract/copy failure mode (network-zip-corrupt, disk-full, AV-quarantine, malformed archive).
+
+- **`autoInstallMissing` no longer restart-loops in dev.** Skips deps where `requiresLauncher && !launcherIsAvailable()` with a log line. Previously: a failed manual update that renamed `node.exe` → `node.exe.old` made `checkInstalled` return null, which fired `autoInstallMissing` on every dev startup, which re-threw the same launcher-missing error on every restart.
+
+Tests: vitest <NNN>/<NNN> (was 695/695 pre-fix; +<N> new tests across dependencyDefinitions, dependencyManager, dependencyManager.update, dependencyManager.autoInstallMissing, dependencyApi.update suites).
+```
+
+Fill in `<NNN>/<NNN>` and `<N>` from the measurement in Step 8.
+
+- [ ] **Step 10: Commit the CHANGELOG entry**
+
+```powershell
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add CHANGELOG.md
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "docs(changelog): dev-mode dep update gate + installNodejs rollback"
+```
+
+### Optional: version bump + tag (out of plan)
+
+Per `reference_wsscrcpy_version_bump.md`, releases use `npm run version:bump <ver>`. This is intentionally out of plan — surfacing it as a separate operation that you'll run at PR-merge time or as part of the next beta cut. The breadcrumb in `todo_ws_scrcpy_web.md` reserves `v0.1.25-beta.41` for Phase 3 of the operation-server arc; this fix would naturally land as a separate beta (e.g., `v0.1.25-beta.42` or pulled forward as `.41` if the user prioritizes it).
+
+Surface to the user when implementation is complete:
+
+> Plan executed. PR is on branch `fix/dev-mode-dep-update-gate` with N commits ahead of main. Final test count: NNN/NNN. Want to bump the version + tag + open a PR now, or fold into a later beta cut?
+
+---
+
+## Self-review
+
+Spec coverage:
+
+| Spec section | Task |
+| --- | --- |
+| Data model: DependencyInfo.canUpdate | Task 1 |
+| Data model: UpdateResult.reason | Task 1 |
+| Data model: DependencyDefinition.requiresLauncher | Task 2 |
+| Server: getAll() recompute | Task 3 |
+| Server: update() guard | Task 4 |
+| Server: autoInstallMissing skip | Task 5 |
+| Server: DependencyApi 503 | Task 6 |
+| Server: installNodejs rollback | Task 7 |
+| Frontend: actionButton gate + lowercase | Task 8 |
+| Testing: 6.1 definitions test | Task 2 |
+| Testing: 6.2 manager canUpdate tests | Task 3 |
+| Testing: 6.3 update guard tests | Task 4 |
+| Testing: 6.4 autoInstallMissing skip test | Task 5 |
+| Testing: 6.5 dependencyApi.update.test.ts NEW | Task 6 |
+| Testing: 6.6 rollback tests | Task 7 |
+| Testing: 6.7 baseline-no-regress | All tasks (full suite at each commit) |
+| Risks: stringly-vs-typed reason | Resolved by typed `reason` in Task 1 |
+| Risks: rollback-fails-too | Best-effort try/catch in Task 7 |
+| Manual smoke per spec 6 | Task 9 |
+| CHANGELOG entry | Task 9 |
+| Out of scope: version bump | Documented in Task 9 epilogue |
+
+All spec sections have an implementing task. No placeholders. Type names match across tasks (`canUpdate`, `reason: 'launcher-required'`, `requiresLauncher`). Method signatures match between definition and consumer (Task 1's interface fields used in Task 3's getAll, Task 4's update, Task 8's actionButton).

--- a/docs/superpowers/specs/2026-05-24-dev-mode-dep-update-gate-design.md
+++ b/docs/superpowers/specs/2026-05-24-dev-mode-dep-update-gate-design.md
@@ -1,0 +1,386 @@
+# Dev-mode dep update gate + installNodejs rollback
+
+**Status:** Design approved 2026-05-24 via brainstorming session.
+**Targets:** post-v0.1.25-beta.40, before the next stable cut.
+**Scope:** Two bug fixes shipped together. Both surfaced during dev-mode testing after commit `92f8c2a` (`fix(config): align Windows dev resolveDependenciesPath with launcher`, 2026-05-14) made the in-app dep updater reachable in dev mode without making it work for launcher-gated extract paths.
+
+---
+
+## Background
+
+### Bug #1 — dev-mode dep update trigger trap
+
+User clicks "Update Node" in Settings while running the dev server (`npm start`). The server logs:
+
+```
+[DependencyManager] ERROR Update nodejs failed: extractZip requires the packaged launcher binary at C:\Users\jscha\source\repos\ws-scrcpy-web\ws-scrcpy-web-launcher.exe. Dev mode should populate dependencies/ via scripts/fetch-node.mjs (Node) or by pre-seeding from a prior install; the dependency-manager's autoInstall extractZip path is intended for Velopack-installed deployments only.
+```
+
+Root cause: `DependencyManager.extractZip` (`src/server/DependencyManager.ts:418-425`) requires the Rust launcher at `<cwd>/ws-scrcpy-web-launcher.exe` for its `--unzip` subcommand. In dev that path is the repo root, where no compiled launcher exists. `launcherIsAvailable()` returns false; `extractZip` throws.
+
+Before commit `92f8c2a`, the dev `dependencies/` path was different from the deployed one, so `DependencyManager.checkInstalled('nodejs')` returned null in dev and the updater never reported `UpdateAvailable`. After the alignment, dev mirrors deployed at `<dataRoot>/dependencies/node/node.exe`, so the updater sees a stale Node, offers Update, and crashes on click.
+
+### Bug #2 — `installNodejs` lacks rollback on failure
+
+`installNodejs` (`src/server/DependencyManager.ts:322-367`) renames `node.exe` -> `node.exe.old` BEFORE calling the throwing `extractZip`. The catch block in `update()` re-throws — no rollback path. After the failed update: `node.exe.old` exists, `node.exe` does not.
+
+On the next dev server start:
+
+1. `checkInstalled('nodejs')` runs `node.exe --version` — file does not exist — returns null.
+2. `installedVersion === null` -> status `Unknown`.
+3. `autoInstallMissing()` (`DependencyManager.ts:209-214`) fires because `installedVersion === null && latestVersion !== null`.
+4. Calls `update('nodejs')` -> same `extractZip` throw -> status `Error`.
+5. Restart loop: every dev startup re-attempts and re-fails.
+
+The rollback gap is also reachable in production (deployed) on any extract/copy failure mode: network-zip-corrupt, disk-full, antivirus quarantine, malformed archive. Production users would be left with no `node.exe` and a service that cannot restart.
+
+### Why fix both together
+
+Bug #1 prevents the dev-mode trigger of the rename-before-extract code path. But Bug #2 is reachable in production via any other failure mode in `extractZip` or `copyDirContents`. A failed Node update on a real user's machine that leaves them with no Node is a P0. Per CLAUDE.md no-accepted-tech-debt + `feedback_no_low_priority_on_packaging_paths.md`, this is release-gating tech.
+
+---
+
+## Goals
+
+1. In dev mode, the dep panel accurately shows which deps can be updated in-app (per-dep `canUpdate`). Deps that need the launcher are surfaced as a disabled button with a tooltip pointing at the dev-mode workaround (`scripts/fetch-node.mjs`).
+2. `POST /api/dependencies/:name/update` returns a clean 503 with a typed `reason: 'launcher-required'` when a launcher-required dep is requested in dev. The endpoint never enters the destructive install path in that case.
+3. `installNodejs` is robust: either the new files are in place after the call, OR the previous `node.exe` is intact. The window where neither holds is reduced to "copy fails mid-operation" with a best-effort rollback.
+4. The dev-mode restart loop (`autoInstallMissing` re-fires the failing update on every startup) cannot occur — `autoInstallMissing` skips launcher-required deps when the launcher is unavailable.
+
+## Non-goals (YAGNI)
+
+- Pure-JS extract fallback for dev mode (rejected option B — two code paths, masks production bugs).
+- Building the Rust launcher into dev startup (rejected option D — slow startup, Rust prerequisite for all devs).
+- Extending `scripts/fetch-node.mjs` to populate `<dataRoot>/dependencies/` directly (rejected option C — UX worse than option A, plus A's gate is wanted regardless).
+- Refactoring `installAdb` (uses the same `extractZip` path but is not the reported failure; separate TODO if/when triaged).
+- Cleaning up stale `node.exe.old` files after successful updates (separate TODO).
+- Changes to the Velopack/installed update flow.
+- Frontend testing harness for `DependencyPanel.actionButton` — manual smoke check covers the 3-line conditional.
+
+---
+
+## Design
+
+### Data model
+
+**`DependencyDefinition`** (`src/server/DependencyDefinitions.ts`) — one new field:
+
+```ts
+export interface DependencyDefinition {
+    name: string;
+    displayName: string;
+    description: string;
+    requiresRestart: boolean;
+    pairedWith?: string;
+    requiresLauncher: boolean;       // NEW
+    checkInstalled: (depsPath: string) => Promise<string | null>;
+    checkLatest: () => Promise<string | null>;
+    getDownloadUrl: (version: string) => string;
+}
+```
+
+Values per dep:
+
+| Dep | `requiresLauncher` | Why |
+| --- | --- | --- |
+| `nodejs` | `true` | Uses `extractZip` (launcher `--unzip`) |
+| `adb` | `true` | Uses `extractZip` (launcher `--unzip`) |
+| `scrcpy-server` | `false` | Single-file `fs.copyFileSync` only |
+
+**`DependencyInfo`** (`src/common/DependencyTypes.ts`) — one new field:
+
+```ts
+export interface DependencyInfo {
+    name: string;
+    displayName: string;
+    installedVersion: string | null;
+    latestVersion: string | null;
+    status: DependencyStatus;
+    description: string;
+    requiresRestart: boolean;
+    pairedWith?: string;
+    errorMessage?: string;
+    canUpdate: boolean;              // NEW — computed each getAll() call
+}
+```
+
+`canUpdate` is computed (not persisted state) — recalculated on every `getAll()` so a launcher that appears mid-session (e.g., dev manually copies it in) is reflected immediately.
+
+**`UpdateResult`** (`src/common/DependencyTypes.ts`) — one new optional field:
+
+```ts
+export interface UpdateResult {
+    success: boolean;
+    newVersion?: string;
+    errorMessage?: string;
+    requiresRestart: boolean;
+    reason?: 'launcher-required';    // NEW
+}
+```
+
+Typed instead of stringly — easier to extend with more refusal reasons later (e.g., `'offline'`, `'concurrent-update'`).
+
+No new API endpoints. No shape changes to existing endpoints beyond the added fields.
+
+### Server-side changes
+
+#### `src/server/DependencyDefinitions.ts`
+
+Add `requiresLauncher: true` to nodejs and adb definitions; `requiresLauncher: false` to scrcpy-server. No other changes.
+
+#### `src/server/DependencyManager.ts`
+
+**`getAll()`** — recompute `canUpdate` on each call:
+
+```ts
+public getAll(): DependencyInfo[] {
+    const launcherAvail = launcherIsAvailable();
+    return Array.from(this.state.values()).map((info) => {
+        const def = this.definitions.find((d) => d.name === info.name);
+        return { ...info, canUpdate: !def?.requiresLauncher || launcherAvail };
+    });
+}
+```
+
+**`update(name)`** — early bail when launcher unavailable for a `requiresLauncher` dep. New guard at the top, before any state mutation:
+
+```ts
+public async update(name: string): Promise<UpdateResult> {
+    const def = this.definitions.find((d) => d.name === name);
+    const info = this.state.get(name);
+    if (!def || !info) {
+        return { success: false, errorMessage: `Unknown dependency: ${name}`, requiresRestart: false };
+    }
+    if (def.requiresLauncher && !launcherIsAvailable()) {
+        return {
+            success: false,
+            reason: 'launcher-required',
+            errorMessage:
+                `${def.displayName} updates require an installed build. ` +
+                `In dev mode, populate dependencies/ via scripts/fetch-node.mjs.`,
+            requiresRestart: false,
+        };
+    }
+    // ... existing body unchanged
+}
+```
+
+Status stays `UpdateAvailable` (no transition through `Updating` -> `Error`). The dep panel sees a clean refusal and remains in its current state.
+
+**`autoInstallMissing()`** — skip launcher-required deps when launcher unavailable. Prevents the dev-mode restart loop:
+
+```ts
+public async autoInstallMissing(): Promise<void> {
+    try {
+        this.promoteSeedScrcpyServer();
+    } catch (err) {
+        log.warn(`seed-promote scrcpy-server failed: ${(err as Error).message}`);
+    }
+
+    const launcherAvail = launcherIsAvailable();
+    for (const info of this.state.values()) {
+        if (info.installedVersion === null && info.latestVersion !== null) {
+            const def = this.definitions.find((d) => d.name === info.name);
+            if (def?.requiresLauncher && !launcherAvail) {
+                log.info(`Skipping auto-install of ${info.name} in dev mode (no launcher)`);
+                continue;
+            }
+            log.info(`First-run: auto-installing ${info.name}`);
+            await this.update(info.name);
+        }
+    }
+}
+```
+
+#### `src/server/api/DependencyApi.ts`
+
+`POST /:name/update` returns 503 specifically when the guard fires (typed by `result.reason`):
+
+```ts
+if (req.method === 'POST' && updateMatch) {
+    const name = updateMatch[1]!;
+    const result = await this.manager.update(name);
+    if (result.reason === 'launcher-required') {
+        res.writeHead(503);
+    } else {
+        res.writeHead(result.success ? 200 : 500);
+    }
+    res.end(JSON.stringify(result));
+    return true;
+}
+```
+
+Other endpoints (`GET /api/dependencies`, `POST /check`, `POST /restart`, `POST /retry-install`) require no changes — they return whatever `getAll()` produces, which now includes `canUpdate`.
+
+### Frontend changes
+
+**`src/app/client/DependencyPanel.ts`** — `actionButton()` (lines 218-226) gains a gated case:
+
+```ts
+private actionButton(dep: DependencyInfo): string {
+    if (dep.status === 'update-available') {
+        if (!dep.canUpdate) {
+            const tooltip = 'In-app updates require an installed build. ' +
+                'In dev mode, populate dependencies/ via scripts/fetch-node.mjs.';
+            return `<button class="dep-btn dep-update" disabled title="${tooltip}">` +
+                `update (dev)</button>`;
+        }
+        return `<button class="dep-btn dep-update" data-update="${dep.name}">update</button>`;
+    }
+    if (dep.status === 'updating') {
+        return '<button class="dep-btn" disabled>updating...</button>';
+    }
+    return '';
+}
+```
+
+Two changes alongside the gate, both within `feedback_ui_color_scheme.md` ("lowercase text"):
+
+- Button labels lowercased (`update`, `updating...`) — minor consistency drift on lines already touched.
+- Disabled variant keeps the `dep-update` class so it inherits the warn-state styling; `disabled` attribute provides the visual cue via the browser default.
+
+No click-handler change required. The 503 path is unreachable from the disabled button; it remains as belt-and-suspenders for direct API calls (e.g., during integration testing).
+
+Status badge unchanged. "Update available" still displays — accurate info; only the action is gated.
+
+### `installNodejs` rollback (Bug #2)
+
+**`src/server/DependencyManager.ts:322-367`** — reorder: extract first, then rename + copy with tight rollback.
+
+```ts
+private async installNodejs(
+    downloadPath: string,
+    _version: string,
+    tmpDir: string,
+    platform: 'win32' | 'linux',
+): Promise<void> {
+    const destDir = path.join(this.depsPath, 'node');
+    fs.mkdirSync(destDir, { recursive: true });
+
+    // 1. Non-destructive: extract to tmpDir (both platforms).
+    if (platform === 'win32') {
+        await this.extractZip(downloadPath, tmpDir, platform);
+    } else {
+        await execFileAsync('tar', ['xzf', downloadPath, '-C', tmpDir]);
+    }
+    const archiveDir = fs.readdirSync(tmpDir).find((d) => d.startsWith('node-v'));
+    if (!archiveDir) {
+        throw new Error('Could not find Node.js directory in extracted archive');
+    }
+    const extractedPath = path.join(tmpDir, archiveDir);
+
+    // 2. Destructive (Windows only): rename + copy with rollback.
+    if (platform === 'win32') {
+        const runningExe = path.join(destDir, 'node.exe');
+        const oldExe = path.join(destDir, 'node.exe.old');
+        let renamed = false;
+        if (fs.existsSync(runningExe)) {
+            try {
+                fs.renameSync(runningExe, oldExe);
+                renamed = true;
+            } catch {
+                // May fail if not the managed node — proceed without rollback safety net.
+            }
+        }
+        try {
+            this.copyDirContents(extractedPath, destDir);
+        } catch (err) {
+            if (renamed && !fs.existsSync(runningExe)) {
+                try {
+                    fs.renameSync(oldExe, runningExe);
+                } catch {
+                    // Best-effort rollback. Original error bubbles up regardless.
+                }
+            }
+            throw err;
+        }
+    } else {
+        this.copyDirContents(extractedPath, destDir);
+    }
+}
+```
+
+**Key invariants:**
+
+- Extract failure -> destDir untouched (rename hadn't happened yet) -> next start sees prior `node.exe` and reports prior version.
+- Copy failure -> tight rollback restores `.old` -> `.exe`. Best-effort; if rollback itself fails, original error bubbles up so the user sees what really went wrong.
+- Successful path -> new files in destDir, `node.exe.old` lingers (current behavior, deferred cleanup).
+- The early-return guard from `update()` means this function never runs in dev. Bug #2 rollback is belt-and-suspenders for production failure modes (network-zip-corrupt, disk-full, AV-quarantine, malformed archive, mid-copy fault).
+
+---
+
+## Testing
+
+### Test plan
+
+| Test file | Status | Adds |
+| --- | --- | --- |
+| `dependencyDefinitions.test.ts` | existing | 1 test: each definition has correct `requiresLauncher` value |
+| `dependencyManager.test.ts` | existing | 2 tests: `getAll()` returns `canUpdate` correctly per launcher availability and per dep |
+| `dependencyManager.update.test.ts` | existing | 2 tests: nodejs early-bails with `reason: 'launcher-required'`; scrcpy-server succeeds without launcher. Plus install-rollback tests (see below). Existing test fixtures gain `requiresLauncher` field. |
+| `dependencyManager.autoInstallMissing.test.ts` | existing | 1 test: skip-and-log path for `requiresLauncher && !launcherIsAvailable` |
+| `dependencyApi.update.test.ts` | NEW | 2 tests: nodejs POST returns 503 + reason; scrcpy-server POST returns 200 without launcher |
+
+### `installNodejs` rollback tests
+
+Added to `dependencyManager.update.test.ts` (or a new `dependencyManager.installNodejs.test.ts` if size warrants). Real tempdir + fs (no memfs) — small surface, easier than mocking layered `fs` calls.
+
+| Scenario | Expectation |
+| --- | --- |
+| Win32 extract failure | destDir state unchanged: original `node.exe` intact, no `node.exe.old` |
+| Win32 copy failure | `node.exe` restored from `.old` rollback; original error bubbles |
+| Win32 full success | new `node.exe`; `node.exe.old` lingers (current behavior, separate-cleanup non-goal) |
+| Linux extract failure | destDir state unchanged |
+
+Launcher-availability toggle: `vi.mock('../service/elevatedRunner', ...)` — same pattern as existing `UpdatesApi.test.ts` mocks `UpdateService`.
+
+### Baseline
+
+Current `npm test`: 695/695. Target post-implementation: ~702-705. No existing tests regress; fixture adaptations add fields but do not change behavior assertions.
+
+### Manual smoke
+
+After implementation:
+
+1. **Recovery from current broken state:** rename `C:\ProgramData\WsScrcpyWeb\dependencies\node\node.exe.old` -> `node.exe` (or use Mode A reinstall on a clean VM).
+2. **Dev mode (npm start):** dep panel shows "update available" for nodejs and adb with the disabled "update (dev)" button + tooltip. scrcpy-server's "update" button remains enabled.
+3. **POST to API directly** (`curl` or DevTools) for nodejs/update in dev: 503 + body `{"success":false,"reason":"launcher-required","errorMessage":"Node.js updates require an installed build. In dev mode, populate dependencies/ via scripts/fetch-node.mjs.","requiresRestart":false}`.
+4. **Restart dev server** with node.exe missing: no `autoInstallMissing` -> `update` loop. Log line `Skipping auto-install of nodejs in dev mode (no launcher)` appears.
+5. **Deployed mode (VM Mode A install):** all three deps show enabled "update" buttons. Clicking nodejs update goes through the new install path; rollback path is exercised only on injected failure.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| `launcherIsAvailable()` returns false during a deployed-mode launch race where the file is briefly missing | Recompute per `getAll()` call; transient false reads correct themselves on the next status poll. The `update()` re-check at call time catches stale `canUpdate`. |
+| Frontend caches the `canUpdate` field across polls | `DependencyPanel.refresh()` re-fetches `/api/dependencies` on each check-for-updates click; no client-side state survives. |
+| Stringly-typed `errorMessage` substring matching breaks if message wording drifts | Switched to typed `reason: 'launcher-required'` field; API check is `result.reason === 'launcher-required'`, immune to wording changes. |
+| Rollback fails too (rename `.old` -> `.exe` throws) | Best-effort; original error still throws to the caller, status -> `Error`, user sees the original failure with no silent masking. |
+| Win32 `fs.renameSync` semantics under AV scanner holding the file open | Existing code already handled this with `try/catch` around the rename; we preserve that pattern. |
+
+---
+
+## Implementation order (suggested phasing for plan)
+
+1. **Types first** (`common/DependencyTypes.ts`) — add `canUpdate`, `reason`. Cheap, enables typed callsites downstream.
+2. **Definitions** (`DependencyDefinitions.ts`) — add `requiresLauncher` per dep. Update existing definition tests.
+3. **Manager — `getAll()` + `update()` guard + `autoInstallMissing()` skip** (`DependencyManager.ts`). Update existing manager tests.
+4. **Rollback fix** in `installNodejs` (`DependencyManager.ts`). Add rollback tests.
+5. **API** (`DependencyApi.ts`) — 503 branch. New `dependencyApi.update.test.ts` file.
+6. **Frontend** (`DependencyPanel.ts`) — gated action button + lowercase labels.
+7. **Manual smoke** — dev mode + deployed mode + direct API path.
+8. **CHANGELOG.md** entry + version bump (post-plan, separate PR or bundled).
+
+Each phase is independently testable; the order above means tests pass at every commit boundary.
+
+---
+
+## Out of scope (explicit deferrals — surface as separate TODOs)
+
+- Cleanup of stale `node.exe.old` after successful Node updates.
+- `installAdb` rollback parity with `installNodejs` (uses `extractZip` but isn't the reported failure; same pattern would apply if triaged).
+- Linux equivalent of the dev-mode `dependencies/` alignment that triggered Bug #1 (separate item `§19 v0.5.0 Linux Phase-1-equivalent dataRoot` in `todo_ws_scrcpy_web.md`).
+- Tighter ACL on `<dataRoot>/dependencies/` (separate item `§1d`).
+- Pure-JS extract fallback (rejected option B).

--- a/src/app/client/DependencyPanel.ts
+++ b/src/app/client/DependencyPanel.ts
@@ -217,10 +217,16 @@ export class DependencyPanel {
 
     private actionButton(dep: DependencyInfo): string {
         if (dep.status === 'update-available') {
-            return `<button class="dep-btn dep-update" data-update="${dep.name}">Update</button>`;
+            if (!dep.canUpdate) {
+                const tooltip = 'In-app updates require an installed build. ' +
+                    'In dev mode, populate dependencies/ via scripts/fetch-node.mjs.';
+                return `<button class="dep-btn dep-update" disabled title="${tooltip}">` +
+                    `update (dev)</button>`;
+            }
+            return `<button class="dep-btn dep-update" data-update="${dep.name}">update</button>`;
         }
         if (dep.status === 'updating') {
-            return '<button class="dep-btn" disabled>Updating...</button>';
+            return '<button class="dep-btn" disabled>updating...</button>';
         }
         return '';
     }

--- a/src/common/DependencyTypes.ts
+++ b/src/common/DependencyTypes.ts
@@ -17,6 +17,7 @@ export interface DependencyInfo {
     errorMessage?: string | undefined;
     requiresRestart: boolean;
     pairedWith?: string | undefined;
+    canUpdate: boolean;
 }
 
 export interface UpdateResult {
@@ -24,6 +25,7 @@ export interface UpdateResult {
     newVersion?: string | undefined;
     errorMessage?: string | undefined;
     requiresRestart: boolean;
+    reason?: 'launcher-required' | undefined;
 }
 
 export function compareVersions(a: string | null, b: string | null): number {

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -51,6 +51,7 @@ export interface DependencyDefinition {
     description: string;
     requiresRestart: boolean;
     pairedWith?: string;
+    requiresLauncher: boolean;
     checkInstalled: (depsPath: string) => Promise<string | null>;
     checkLatest: () => Promise<string | null>;
     getDownloadUrl: (version: string) => string;
@@ -77,6 +78,7 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             description: 'JavaScript runtime that runs the ws-scrcpy-web server',
             requiresRestart: true,
             pairedWith: 'node-pty',
+            requiresLauncher: true,
             checkInstalled: async (depsPath) => {
                 const ext = platform === 'win32' ? '.exe' : '';
                 const exe = path.join(depsPath, 'node', `node${ext}`);
@@ -124,6 +126,7 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             displayName: 'ADB (Android Debug Bridge)',
             description: 'Communicates with Android devices (push, shell, tunnel)',
             requiresRestart: false,
+            requiresLauncher: true,
             checkInstalled: async (depsPath) => {
                 const ext = platform === 'win32' ? '.exe' : '';
                 const exe = path.join(depsPath, 'adb', `adb${ext}`);
@@ -149,6 +152,7 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             displayName: 'scrcpy-server',
             description: 'Runs on Android device to capture screen, audio, and accept input',
             requiresRestart: false,
+            requiresLauncher: false,
             checkInstalled: async (depsPath) => {
                 // The JAR file presence gates "installed at all"; the actual version
                 // comes from the .version marker (or SERVER_VERSION as fallback for

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -133,6 +133,16 @@ export class DependencyManager {
         if (!def || !info) {
             return { success: false, errorMessage: `Unknown dependency: ${name}`, requiresRestart: false };
         }
+        if (def.requiresLauncher && !launcherIsAvailable()) {
+            return {
+                success: false,
+                reason: 'launcher-required',
+                errorMessage:
+                    `${def.displayName} updates require an installed build. ` +
+                    `In dev mode, populate dependencies/ via scripts/fetch-node.mjs.`,
+                requiresRestart: false,
+            };
+        }
 
         info.status = DependencyStatus.Updating;
         const fromVersion = info.installedVersion ?? 'not installed';

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -224,8 +224,14 @@ export class DependencyManager {
             log.warn(`seed-promote scrcpy-server failed: ${(err as Error).message}`);
         }
 
+        const launcherAvail = launcherIsAvailable();
         for (const info of this.state.values()) {
             if (info.installedVersion === null && info.latestVersion !== null) {
+                const def = this.definitions.find((d) => d.name === info.name);
+                if (def?.requiresLauncher && !launcherAvail) {
+                    log.info(`Skipping auto-install of ${info.name} in dev mode (no launcher)`);
+                    continue;
+                }
                 log.info(`First-run: auto-installing ${info.name}`);
                 await this.update(info.name);
             }

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -50,6 +50,7 @@ export class DependencyManager {
                 description: def.description,
                 requiresRestart: def.requiresRestart,
                 pairedWith: def.pairedWith,
+                canUpdate: false,
             });
         }
     }

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -352,40 +352,44 @@ export class DependencyManager {
         const destDir = path.join(this.depsPath, 'node');
         fs.mkdirSync(destDir, { recursive: true });
 
+        // 1. Non-destructive: extract to tmpDir (both platforms).
         if (platform === 'win32') {
-            // On Windows, rename running node.exe to node.exe.old before replacing
+            await this.extractZip(downloadPath, tmpDir, platform);
+        } else {
+            await execFileAsync('tar', ['xzf', downloadPath, '-C', tmpDir]);
+        }
+        const archiveDir = fs.readdirSync(tmpDir).find((d) => d.startsWith('node-v'));
+        if (!archiveDir) {
+            throw new Error('Could not find Node.js directory in extracted archive');
+        }
+        const extractedPath = path.join(tmpDir, archiveDir);
+
+        // 2. Destructive (Windows only): rename + copy with rollback.
+        if (platform === 'win32') {
             const runningExe = path.join(destDir, 'node.exe');
             const oldExe = path.join(destDir, 'node.exe.old');
+            let renamed = false;
             if (fs.existsSync(runningExe)) {
                 try {
                     fs.renameSync(runningExe, oldExe);
+                    renamed = true;
                 } catch {
-                    // May fail if not the managed node
+                    // May fail if not the managed node — proceed without rollback safety net.
                 }
             }
-
-            // Extract zip using PowerShell
-            await this.extractZip(downloadPath, tmpDir, platform);
-
-            // Node.js archives contain a top-level dir like node-v24.14.1-win-x64/
-            const archiveDir = fs.readdirSync(tmpDir).find((d) => d.startsWith('node-v'));
-            if (!archiveDir) {
-                throw new Error('Could not find Node.js directory in extracted archive');
+            try {
+                this.copyDirContents(extractedPath, destDir);
+            } catch (err) {
+                if (renamed && !fs.existsSync(runningExe)) {
+                    try {
+                        fs.renameSync(oldExe, runningExe);
+                    } catch {
+                        // Best-effort rollback. Original error bubbles up regardless.
+                    }
+                }
+                throw err;
             }
-            const extractedPath = path.join(tmpDir, archiveDir);
-
-            // Copy contents to destination
-            this.copyDirContents(extractedPath, destDir);
         } else {
-            // Extract tar.gz
-            await execFileAsync('tar', ['xzf', downloadPath, '-C', tmpDir]);
-
-            const archiveDir = fs.readdirSync(tmpDir).find((d) => d.startsWith('node-v'));
-            if (!archiveDir) {
-                throw new Error('Could not find Node.js directory in extracted archive');
-            }
-            const extractedPath = path.join(tmpDir, archiveDir);
-
             this.copyDirContents(extractedPath, destDir);
         }
     }

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -56,6 +56,13 @@ export class DependencyManager {
     }
 
     public getAll(): DependencyInfo[] {
+        const launcherAvail = launcherIsAvailable();
+        // In-place mutation: callers (incl. getByName) hold references to state
+        // entries and mutate them; spread copies would orphan those mutations.
+        for (const info of this.state.values()) {
+            const def = this.definitions.find((d) => d.name === info.name);
+            info.canUpdate = !def?.requiresLauncher || launcherAvail;
+        }
         return Array.from(this.state.values());
     }
 

--- a/src/server/__tests__/dependencyApi.update.test.ts
+++ b/src/server/__tests__/dependencyApi.update.test.ts
@@ -1,0 +1,98 @@
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { EventEmitter } from 'events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DependencyApi } from '../api/DependencyApi';
+import { DependencyManager } from '../DependencyManager';
+
+interface MockRes {
+    statusCode?: number;
+    body?: string;
+    writeHead: (...args: unknown[]) => unknown;
+    end: (...args: unknown[]) => unknown;
+    setHeader: (...args: unknown[]) => unknown;
+}
+
+function makeMockRes() {
+    const res = Object.assign(new EventEmitter(), {
+        statusCode: undefined as number | undefined,
+        body: undefined as string | undefined,
+        setHeader: vi.fn(),
+        writeHead: vi.fn(),
+        end: vi.fn(),
+    }) as MockRes;
+    (res.writeHead as ReturnType<typeof vi.fn>).mockImplementation((code: number) => {
+        res.statusCode = code;
+    });
+    (res.end as ReturnType<typeof vi.fn>).mockImplementation((body: string) => {
+        res.body = body;
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    return res as any;
+}
+
+function makeReq(method: string, url: string) {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    return { method, url } as any;
+}
+
+describe('DependencyApi.update endpoint', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns 503 when update result has reason=launcher-required', async () => {
+        const mgr = new DependencyManager('/tmp/test-api-503');
+        vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: false,
+            reason: 'launcher-required',
+            errorMessage: 'Node.js updates require an installed build.',
+            requiresRestart: false,
+        });
+        const api = new DependencyApi(mgr);
+        const req = makeReq('POST', '/api/dependencies/nodejs/update');
+        const res = makeMockRes();
+
+        const handled = await api.handle(req, res);
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(503);
+        const body = JSON.parse(res.body!);
+        expect(body.success).toBe(false);
+        expect(body.reason).toBe('launcher-required');
+    });
+
+    it('returns 200 when update succeeds (no launcher gate)', async () => {
+        const mgr = new DependencyManager('/tmp/test-api-200');
+        vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: true,
+            newVersion: '4.0',
+            requiresRestart: false,
+        });
+        const api = new DependencyApi(mgr);
+        const req = makeReq('POST', '/api/dependencies/scrcpy-server/update');
+        const res = makeMockRes();
+
+        const handled = await api.handle(req, res);
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        const body = JSON.parse(res.body!);
+        expect(body.success).toBe(true);
+    });
+
+    it('returns 500 for non-gate update failures', async () => {
+        const mgr = new DependencyManager('/tmp/test-api-500');
+        vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: false,
+            errorMessage: 'Download failed: HTTP 500',
+            requiresRestart: false,
+        });
+        const api = new DependencyApi(mgr);
+        const req = makeReq('POST', '/api/dependencies/nodejs/update');
+        const res = makeMockRes();
+
+        await api.handle(req, res);
+
+        expect(res.statusCode).toBe(500);
+    });
+});

--- a/src/server/__tests__/dependencyDefinitions.test.ts
+++ b/src/server/__tests__/dependencyDefinitions.test.ts
@@ -48,6 +48,16 @@ describe('getDependencyDefinitions', () => {
         const scrcpy = defs.find((d) => d.name === 'scrcpy-server');
         expect(scrcpy?.requiresRestart).toBe(false);
     });
+
+    it('nodejs and adb require the launcher (extractZip path); scrcpy-server does not', () => {
+        const defs = getDependencyDefinitions('/tmp/test-deps');
+        const node = defs.find((d) => d.name === 'nodejs');
+        const adb = defs.find((d) => d.name === 'adb');
+        const scrcpy = defs.find((d) => d.name === 'scrcpy-server');
+        expect(node?.requiresLauncher).toBe(true);
+        expect(adb?.requiresLauncher).toBe(true);
+        expect(scrcpy?.requiresLauncher).toBe(false);
+    });
 });
 
 describe('scrcpy-server.checkInstalled (v0.1.10 regression fix)', () => {

--- a/src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
+++ b/src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DependencyStatus } from '../../common/DependencyTypes';
+import * as elevatedRunnerModule from '../service/elevatedRunner';
 import { DependencyManager } from '../DependencyManager';
+
+vi.mock('../service/elevatedRunner', () => ({
+    launcherIsAvailable: vi.fn(() => true),
+    resolveLauncherPath: () => '/fake/launcher.exe',
+}));
 
 describe('DependencyManager.autoInstallMissing', () => {
     let mgr: DependencyManager;
@@ -77,5 +83,26 @@ describe('DependencyManager.autoInstallMissing', () => {
         expect(updateSpy).toHaveBeenCalledTimes(2);
         expect(updateSpy).toHaveBeenCalledWith('adb');
         expect(updateSpy).toHaveBeenCalledWith('scrcpy-server');
+    });
+
+    it('skips launcher-required deps in dev mode (no launcher available)', async () => {
+        vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockReturnValue(false);
+
+        const nodejs = mgr.getByName('nodejs')!;
+        nodejs.installedVersion = null;
+        nodejs.latestVersion = '24.15.0';
+
+        const scrcpy = mgr.getByName('scrcpy-server')!;
+        scrcpy.installedVersion = null;
+        scrcpy.latestVersion = '4.0';
+
+        await mgr.autoInstallMissing();
+
+        // nodejs is skipped (requiresLauncher && !launcherIsAvailable)
+        expect(updateSpy).not.toHaveBeenCalledWith('nodejs');
+        // scrcpy-server still gets installed (no launcher needed)
+        expect(updateSpy).toHaveBeenCalledWith('scrcpy-server');
+
+        vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockReturnValue(true);
     });
 });

--- a/src/server/__tests__/dependencyManager.test.ts
+++ b/src/server/__tests__/dependencyManager.test.ts
@@ -38,6 +38,39 @@ describe('DependencyManager', () => {
     });
 });
 
+describe('DependencyManager.getAll() canUpdate', () => {
+    it('reports canUpdate=true for all deps when launcher is available', async () => {
+        vi.resetModules();
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => true,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        // Re-import after mock to pick up the stubbed module
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const mgr = new Mgr('/tmp/test-deps-canupdate-yes');
+        const deps = mgr.getAll();
+        for (const dep of deps) {
+            expect(dep.canUpdate).toBe(true);
+        }
+        vi.resetModules();
+    });
+
+    it('reports canUpdate=false for launcher-required deps when launcher is unavailable', async () => {
+        vi.resetModules();
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const mgr = new Mgr('/tmp/test-deps-canupdate-no');
+        const byName = Object.fromEntries(mgr.getAll().map((d) => [d.name, d]));
+        expect(byName['nodejs']?.canUpdate).toBe(false);
+        expect(byName['adb']?.canUpdate).toBe(false);
+        expect(byName['scrcpy-server']?.canUpdate).toBe(true);
+        vi.resetModules();
+    });
+});
+
 describe('DependencyManager.requestRestart', () => {
     let tmpDir: string;
     let exitSpy: ReturnType<typeof vi.spyOn>;

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -70,3 +70,63 @@ describe('DependencyManager.update("scrcpy-server") — loop fix', () => {
         expect(mgr.getByName('scrcpy-server')!.installedVersion).toBe('4.0');
     });
 });
+
+describe('DependencyManager.update() launcher-required gate', () => {
+    afterEach(() => {
+        vi.doUnmock('../service/elevatedRunner');
+    });
+
+    it('returns reason=launcher-required for nodejs when launcher is unavailable', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-gate-'));
+        try {
+            const mgr = new Mgr(tmp);
+            const result = await mgr.update('nodejs');
+            expect(result.success).toBe(false);
+            expect(result.reason).toBe('launcher-required');
+            expect(result.errorMessage).toMatch(/installed build/);
+            expect(result.requiresRestart).toBe(false);
+            // Status MUST remain UpdateAvailable / Unknown — NOT transition to Updating or Error.
+            const info = mgr.getByName('nodejs')!;
+            expect(info.status).not.toBe(DependencyStatus.Updating);
+            expect(info.status).not.toBe(DependencyStatus.Error);
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('does not gate scrcpy-server (no launcher needed)', async () => {
+        vi.doMock('../service/elevatedRunner', () => ({
+            launcherIsAvailable: () => false,
+            resolveLauncherPath: () => '/fake/launcher.exe',
+        }));
+        const { DependencyManager: Mgr } = await import('../DependencyManager');
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-gate-scrcpy-'));
+        const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+            const url = typeof input === 'string' ? input : input.toString();
+            if (url.includes('api.github.com')) {
+                return new Response(JSON.stringify({ tag_name: 'v4.0' }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                });
+            }
+            return new Response('fake-jar-bytes', { status: 200 });
+        });
+        try {
+            const mgr = new Mgr(tmp);
+            const info = mgr.getByName('scrcpy-server')!;
+            info.installedVersion = '3.3.4';
+            info.latestVersion = '4.0';
+            const result = await mgr.update('scrcpy-server');
+            expect(result.success).toBe(true);
+            expect(result.reason).toBeUndefined();
+        } finally {
+            fetchSpy.mockRestore();
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -130,3 +130,133 @@ describe('DependencyManager.update() launcher-required gate', () => {
         }
     });
 });
+
+describe('DependencyManager.installNodejs rollback', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-nodeinstall-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    async function callInstallNodejs(
+        mgr: DependencyManager,
+        downloadPath: string,
+        version: string,
+        installTmp: string,
+        platform: 'win32' | 'linux',
+    ): Promise<void> {
+        // installNodejs is private — invoke via a typed cast for the test only.
+        // biome-ignore lint/suspicious/noExplicitAny: invoke private method
+        await (mgr as any).installNodejs(downloadPath, version, installTmp, platform);
+    }
+
+    it('win32: extract failure leaves destDir untouched (original node.exe intact)', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNodeExe = path.join(destDir, 'node.exe');
+        fs.writeFileSync(originalNodeExe, 'ORIGINAL-NODE-BYTES');
+
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
+
+        // Mock extractZip to throw
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'extractZip').mockRejectedValue(new Error('mock extract fail'));
+
+        await expect(
+            callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32'),
+        ).rejects.toThrow('mock extract fail');
+
+        // Original node.exe must be intact; no .old created.
+        expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('ORIGINAL-NODE-BYTES');
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(false);
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+
+    it('win32: copy failure restores .old back to .exe (rollback)', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNodeExe = path.join(destDir, 'node.exe');
+        fs.writeFileSync(originalNodeExe, 'ORIGINAL-NODE-BYTES');
+
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
+        // Simulate a successful extract: write the expected archive layout.
+        const archiveRoot = path.join(extractTmp, 'node-v24.15.0-win-x64');
+        fs.mkdirSync(archiveRoot, { recursive: true });
+        fs.writeFileSync(path.join(archiveRoot, 'node.exe'), 'NEW-NODE-BYTES');
+
+        // extractZip mock succeeds (no-op — the layout is pre-populated).
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'extractZip').mockResolvedValue(undefined);
+        // copyDirContents mock throws partway.
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'copyDirContents').mockImplementation(() => {
+            throw new Error('mock copy fail');
+        });
+
+        await expect(
+            callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32'),
+        ).rejects.toThrow('mock copy fail');
+
+        // node.exe must be restored from .old; .old must no longer exist after restore.
+        expect(fs.existsSync(originalNodeExe)).toBe(true);
+        expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('ORIGINAL-NODE-BYTES');
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(false);
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+
+    it('win32: full success replaces node.exe (and leaves node.exe.old per current behavior)', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNodeExe = path.join(destDir, 'node.exe');
+        fs.writeFileSync(originalNodeExe, 'ORIGINAL-NODE-BYTES');
+
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
+        const archiveRoot = path.join(extractTmp, 'node-v24.15.0-win-x64');
+        fs.mkdirSync(archiveRoot, { recursive: true });
+        fs.writeFileSync(path.join(archiveRoot, 'node.exe'), 'NEW-NODE-BYTES');
+        fs.writeFileSync(path.join(archiveRoot, 'npm.cmd'), 'NPM-CMD-BYTES');
+
+        // biome-ignore lint/suspicious/noExplicitAny: private method spy
+        vi.spyOn(mgr as any, 'extractZip').mockResolvedValue(undefined);
+        // Don't mock copyDirContents — let it run for real on the pre-populated archive.
+
+        await callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32');
+
+        expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('NEW-NODE-BYTES');
+        expect(fs.readFileSync(path.join(destDir, 'npm.cmd'), 'utf8')).toBe('NPM-CMD-BYTES');
+        // Current behavior: node.exe.old lingers post-success (cleanup is a separate non-goal).
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(true);
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+
+    it('linux: extract failure leaves destDir untouched', async () => {
+        const mgr = new DependencyManager(tmpDir);
+        const destDir = path.join(tmpDir, 'node');
+        fs.mkdirSync(destDir, { recursive: true });
+        const originalNode = path.join(destDir, 'node');
+        fs.writeFileSync(originalNode, 'ORIGINAL-LINUX-NODE');
+
+        // Point download at a non-existent file so tar will fail.
+        const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-linux-'));
+
+        await expect(
+            callInstallNodejs(mgr, '/does/not/exist.tar.gz', '24.15.0', extractTmp, 'linux'),
+        ).rejects.toThrow();
+
+        // Linux destDir state unchanged.
+        expect(fs.readFileSync(originalNode, 'utf8')).toBe('ORIGINAL-LINUX-NODE');
+
+        fs.rmSync(extractTmp, { recursive: true, force: true });
+    });
+});

--- a/src/server/api/DependencyApi.ts
+++ b/src/server/api/DependencyApi.ts
@@ -36,7 +36,11 @@ export class DependencyApi {
             if (req.method === 'POST' && updateMatch) {
                 const name = updateMatch[1]!;
                 const result = await this.manager.update(name);
-                res.writeHead(result.success ? 200 : 500);
+                if (result.reason === 'launcher-required') {
+                    res.writeHead(503);
+                } else {
+                    res.writeHead(result.success ? 200 : 500);
+                }
                 res.end(JSON.stringify(result));
                 return true;
             }


### PR DESCRIPTION
## Summary

- **Dev-mode dep update gate:** per-dep `requiresLauncher` flag gates the in-app updater. In dev mode, `nodejs` and `adb` show a disabled "update (dev)" button with tooltip pointing at `scripts/fetch-node.mjs`. `scrcpy-server` remains updatable (no launcher needed). `POST /api/dependencies/:name/update` returns HTTP 503 with `reason: 'launcher-required'` for the refusal. `autoInstallMissing` skips launcher-required deps when launcher unavailable, breaking the restart loop.

- **`installNodejs` rollback:** reordered to extract-first (non-destructive), then rename + copy with tight rollback on copy failure. Applies to production failure modes (disk-full, AV-quarantine, corrupt archive).

- **Tests:** vitest 695 -> 708 (+13 new tests across dependencyDefinitions, dependencyManager, dependencyManager.update, dependencyManager.autoInstallMissing, dependencyApi.update suites). tsc clean.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` 708/708
- [x] Manual smoke: dev server — nodejs/adb show disabled "update (dev)" button, scrcpy-server shows enabled "update", direct POST returns 503
- [x] Manual smoke: `autoInstallMissing` log shows "Skipping auto-install of nodejs in dev mode (no launcher)"

Spec: `docs/superpowers/specs/2026-05-24-dev-mode-dep-update-gate-design.md`
Plan: `docs/superpowers/plans/2026-05-24-dev-mode-dep-update-gate.md`