### PR TITLE
fix(launcher): migrate post-stop.bat to control/ on update + clean up old dirs

### DIFF
--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -557,7 +557,7 @@ pub fn unregister_tray_run_key() -> Result<(), String> {
 /// install time — no arg-passing needed at run time.
 ///
 /// Returns the full path of the written bat on success.
-fn write_post_stop_bat(
+pub(crate) fn write_post_stop_bat(
     data_root: &std::path::Path,
     service_name: &str,
     servy_path: &str,

--- a/launcher/src/hooks.rs
+++ b/launcher/src/hooks.rs
@@ -339,6 +339,55 @@ fn on_updated(install_root: &Path, data_root: &Path) -> i32 {
         return 0;
     }
 
+    // Migration: bat exists at pre-consolidation path but not at the new
+    // control/ path. Regenerate at BOTH paths — new path so this check passes
+    // on subsequent updates, old path because Servy's postStopPath config
+    // (set at the original install_service time) still references it.
+    let old_post_stop_bat = data_root.join("post-stop").join("post-stop.bat");
+    if old_post_stop_bat.exists() {
+        let servy_path = install_root.join("current").join("servy-cli.exe");
+        let launcher_path = install_root.join("current").join("ws-scrcpy-web-launcher.exe");
+        match crate::elevated_runner::write_post_stop_bat(
+            data_root,
+            "WsScrcpyWeb",
+            &servy_path.to_string_lossy(),
+            &launcher_path.to_string_lossy(),
+        ) {
+            Ok(new_bat_path) => {
+                log::info(&format!(
+                    "hook(updated): migrated post-stop bat to {new_bat_path:?}"
+                ));
+                if let Err(e) = std::fs::copy(&new_bat_path, &old_post_stop_bat) {
+                    log::error(&format!(
+                        "hook(updated): could not copy bat to legacy path {old_post_stop_bat:?}: {e}"
+                    ));
+                }
+                // Clean up old pre-consolidation helper dirs (supervisor already
+                // refreshes to control/ paths on every startup).
+                for old_dir in ["operation-server", "upgrade-server"] {
+                    let old_path = data_root.join(old_dir);
+                    let new_path = data_root.join("control").join(old_dir);
+                    if old_path.exists() && new_path.exists() {
+                        match std::fs::remove_dir_all(&old_path) {
+                            Ok(()) => log::info(&format!(
+                                "hook(updated): removed legacy {old_path:?}"
+                            )),
+                            Err(e) => log::error(&format!(
+                                "hook(updated): could not remove legacy {old_path:?}: {e}"
+                            )),
+                        }
+                    }
+                }
+                return 0;
+            }
+            Err(e) => {
+                log::error(&format!(
+                    "hook(updated): post-stop bat migration failed: {e} — falling through to legacy bridge"
+                ));
+            }
+        }
+    }
+
     log::info(&format!(
         "hook(updated): post-stop bat absent at {post_stop_bat:?} — firing legacy synchronous servy-cli restart bridge"
     ));


### PR DESCRIPTION
## Summary

- On `hook(updated)`, if the post-stop bat exists at the pre-consolidation path (`<dataRoot>/post-stop/`) but not at the new `control/post-stop/` path, regenerate it at BOTH paths using current code (new helper paths + diagnostic logging).
- The old-path copy is needed because Servy's `--postStopPath` config (set at the original service-install) still references the old path until the service is reinstalled.
- Cleans up old `<dataRoot>/operation-server/` and `<dataRoot>/upgrade-server/` directories (supervisor already refreshes to `control/` paths on every startup).
- Made `write_post_stop_bat` pub(crate) so hooks.rs can call it.

## Test plan

- [x] `cargo test --workspace`: 130/130
- [ ] VM smoke: update from beta.42 → beta.43 → verify bat exists at `control/post-stop/`, old dirs cleaned up, `sc stop` produces `post-stop.log`