### PR TITLE
feat: Phase 4 — service uninstall via operation-server + console flash suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Service uninstall now uses operation-server pattern (Phase 4 user-visible flip).** Replaces the Theory D handoff dance. New flow: service-Node writes `uninstall-pending` marker, spawns operation-server (detached), returns `shutting-down` status, exits; post-stop.bat runs `servy-cli uninstall` + spawns fresh user-session launcher; operation-server serves "Uninstalling service, please wait..." page throughout. Frontend `ServiceOperationModal` stays open during transition. **No more UAC prompt during uninstall.** `handoffUninstallToUserSession` function body remains as dead code; deletion in Phase 5.
+- **Console window flashes eliminated during service install/uninstall.** `silent_command` helper in `elevated_runner.rs` sets `CREATE_NO_WINDOW` on servy-cli, taskkill, and reg.exe spawns.
+
 ## [0.1.25-beta.43] - 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.47] - 2026-05-25
+
 ## [0.1.25-beta.46] - 2026-05-25
 
 ## [0.1.25-beta.45] - 2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.50] - 2026-05-25
+
 ## [0.1.25-beta.49] - 2026-05-25
 
 ## [0.1.25-beta.48] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.51] - 2026-05-25
+
 ## [0.1.25-beta.50] - 2026-05-25
 
 ## [0.1.25-beta.49] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.48] - 2026-05-25
+
 ## [0.1.25-beta.47] - 2026-05-25
 
 ## [0.1.25-beta.46] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.46] - 2026-05-25
+
 ## [0.1.25-beta.45] - 2026-05-24
 
 ## [0.1.25-beta.44] - 2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.49] - 2026-05-25
+
 ## [0.1.25-beta.48] - 2026-05-25
 
 ## [0.1.25-beta.47] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.45] - 2026-05-24
+
 ## [0.1.25-beta.44] - 2026-05-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.44] - 2026-05-24
+
 ### Changed
 
 - **Service uninstall now uses operation-server pattern (Phase 4 user-visible flip).** Replaces the Theory D handoff dance. New flow: service-Node writes `uninstall-pending` marker, spawns operation-server (detached), returns `shutting-down` status, exits; post-stop.bat runs `servy-cli uninstall` + spawns fresh user-session launcher; operation-server serves "Uninstalling service, please wait..." page throughout. Frontend `ServiceOperationModal` stays open during transition. **No more UAC prompt during uninstall.** `handoffUninstallToUserSession` function body remains as dead code; deletion in Phase 5.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.43"
+version = "0.1.25-beta.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.43"
+version = "0.1.25-beta.49"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.43"
+version = "0.1.25-beta.49"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.25-beta.40"
+version = "0.1.25-beta.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.25-beta.40"
+version = "0.1.25-beta.43"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.25-beta.40"
+version = "0.1.25-beta.43"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.43"
+version = "0.1.25-beta.44"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.47"
+version = "0.1.25-beta.48"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.46"
+version = "0.1.25-beta.47"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.48"
+version = "0.1.25-beta.49"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.44"
+version = "0.1.25-beta.45"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.49"
+version = "0.1.25-beta.50"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.50"
+version = "0.1.25-beta.51"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.45"
+version = "0.1.25-beta.46"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/docs/superpowers/plans/2026-05-24-phase-4-node-activation.md
+++ b/docs/superpowers/plans/2026-05-24-phase-4-node-activation.md
@@ -1,0 +1,831 @@
+# Phase 4 — Node Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Every task that edits existing code embeds the verbatim current source (per `feedback_subagent_code_specificity`); subagents MUST match the embedded source exactly when locating edits — do NOT paraphrase or describe-by-name. If you see modifications you don't expect in files OUTSIDE your task's scope, STOP and ASK — never silently revert or assume they're pre-existing user changes.
+
+**Goal:** Activate the operation-server pattern for service-uninstall by wiring the Node-side marker write + pre-exit operation-server spawn + frontend modal keep-alive, and suppress console window flashes from servy-cli/taskkill/reg.exe spawns.
+
+**Architecture:** Service-Node writes `uninstall-pending` marker, spawns operation-server (detached, retry-loops on port), returns `200 { status: 'shutting-down' }`, then schedules `process.exit(0)`. Operation-server grabs port ~25ms after exit. Frontend keeps the ServiceOperationModal open via a `keepModalOpen` flag. Post-stop.bat runs `servy-cli uninstall` + `--spawn-user-launcher`. Console window flashes eliminated via `silent_command` helper in `elevated_runner.rs`.
+
+**Tech Stack:** Node.js + TypeScript (server), vitest (Node + frontend tests), Rust 1.x (launcher workspace), cargo test (Rust tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md`
+
+**Branching strategy:** Single PR branch off `main`, squash-merge per CLAUDE.md rule (`required_signatures` on main). Beta.44 cut after smoke.
+
+**Repo absolute path:** `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+**IMPORTANT — multi-session cwd discipline:** ALL git commands MUST use `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`. ALL file paths MUST be absolute. NO `cd` into the repo.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `src/common/ServiceEvents.ts` | Modify line 12 | Add `'shutting-down'` to `ServiceStatus` union |
+| `src/server/Config.ts` | Modify after line 531 | Add `uninstallPendingMarkerPath` getter |
+| `src/server/__tests__/Config.test.ts` | Modify — append test | Test the new getter |
+| `src/server/api/ServiceApi.ts` | Modify lines 1 (import) + 419-446 (branch rewrite) | `spawn` import + operation-server activation flow |
+| `src/server/__tests__/ServiceApi.test.ts` | Modify — append describe block | 5 tests for the new flow |
+| `src/app/client/SettingsModal.ts` | Modify lines 909-931 | `keepModalOpen` flag + `'shutting-down'` check |
+| `launcher/src/elevated_runner.rs` | Modify — add helper + swap 3 callsites | `silent_command` helper |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Verify clean state and pull latest main.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" status -sb
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" checkout main
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" pull origin main
+```
+
+Expected: `## main...origin/main` (clean tree). Pull succeeds.
+
+- [ ] **Step 2: Create branch.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" checkout -b feat/phase-4-node-activation
+```
+
+- [ ] **Step 3: Commit spec (already on main, verify present).**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" log --oneline -3
+```
+
+Expected: spec commit `3fe224d` visible in recent history.
+
+---
+
+### Task 2: Add `'shutting-down'` to `ServiceStatus` type
+
+**Files:**
+- Modify: `src/common/ServiceEvents.ts:12`
+
+- [ ] **Step 1: Edit the type.**
+
+Current text at line 12:
+
+```typescript
+export type ServiceStatus = 'running' | 'stopped' | 'not-installed';
+```
+
+Replace with:
+
+```typescript
+export type ServiceStatus = 'running' | 'stopped' | 'not-installed' | 'shutting-down';
+```
+
+- [ ] **Step 2: Type-check.**
+
+```powershell
+npx tsc --noEmit --project "C:/Users/jscha/source/repos/ws-scrcpy-web/tsconfig.json"
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/common/ServiceEvents.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(common): add 'shutting-down' to ServiceStatus type"
+```
+
+---
+
+### Task 3: Add `Config.uninstallPendingMarkerPath` getter + test
+
+**Files:**
+- Modify: `src/server/Config.ts` (add getter after line 531)
+- Modify: `src/server/__tests__/Config.test.ts` (append test)
+
+- [ ] **Step 1: Write the failing test.**
+
+Append to the bottom of `src/server/__tests__/Config.test.ts`, INSIDE the existing `describe('Config — AppConfig extension', () => { ... })` block, just before the final `});`:
+
+```typescript
+    it('uninstallPendingMarkerPath returns <dataRoot>/control/uninstall-pending', () => {
+        setup({});
+        const cfg = Config.getInstance();
+        const depsDir = process.env['DEPS_PATH']!;
+        const expectedBase = path.dirname(depsDir);
+        expect(cfg.uninstallPendingMarkerPath).toBe(
+            path.join(expectedBase, 'control', 'uninstall-pending'),
+        );
+    });
+```
+
+- [ ] **Step 2: Run test, verify failure.**
+
+```powershell
+npx vitest run "C:/Users/jscha/source/repos/ws-scrcpy-web/src/server/__tests__/Config.test.ts" -t "uninstallPendingMarkerPath"
+```
+
+Expected: FAIL — `uninstallPendingMarkerPath` does not exist on Config.
+
+- [ ] **Step 3: Add the getter to `Config.ts`.**
+
+Current text at lines 526-531 of `src/server/Config.ts`:
+
+```typescript
+    public get applyUpdatePendingMarkerPath(): string {
+        const base = this._dataRoot !== null
+            ? this._dataRoot
+            : path.dirname(this._dependenciesPath);
+        return path.join(base, 'control', 'apply-update-pending');
+    }
+```
+
+Add immediately after (after line 531, before the blank line):
+
+```typescript
+
+    public get uninstallPendingMarkerPath(): string {
+        const base = this._dataRoot !== null
+            ? this._dataRoot
+            : path.dirname(this._dependenciesPath);
+        return path.join(base, 'control', 'uninstall-pending');
+    }
+```
+
+- [ ] **Step 4: Run test, verify pass.**
+
+```powershell
+npx vitest run "C:/Users/jscha/source/repos/ws-scrcpy-web/src/server/__tests__/Config.test.ts" -t "uninstallPendingMarkerPath"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/Config.ts src/server/__tests__/Config.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(server): Config.uninstallPendingMarkerPath getter"
+```
+
+---
+
+### Task 4: Rewrite `handleUninstall` service+LocalSystem branch + tests
+
+**Files:**
+- Modify: `src/server/api/ServiceApi.ts` (add `spawn` import at line 3; replace lines 419-446)
+- Modify: `src/server/__tests__/ServiceApi.test.ts` (append new describe block)
+
+This is the core activation. TDD: write 5 failing tests first, then rewrite the branch, then verify all pass.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append the following `describe` block to `src/server/__tests__/ServiceApi.test.ts`, INSIDE the existing `describe('ServiceApi', () => { ... })` block, just before its closing `});`:
+
+```typescript
+    describe('handleUninstall — operation-server flow (Phase 4)', () => {
+        it('writes uninstall-pending marker when service+LocalSystem on Windows', async () => {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(true);
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            const cfg = Config.getInstance();
+            expect(fs.existsSync(cfg.uninstallPendingMarkerPath)).toBe(true);
+        });
+
+        it('returns 200 with status=shutting-down and no redirectTo', async () => {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(true);
+            Config.getInstance().updateAppConfig({ installMode: 'system-service' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
+            expect(body.installMode).toBe('system-service');
+            expect(body.redirectTo).toBeUndefined();
+        });
+
+        it('schedules process.exit(0) after 5s', async () => {
+            vi.useFakeTimers();
+            const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+            try {
+                const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+                const factoryResult: ServiceClientFactoryResult = {
+                    client,
+                    supported: true,
+                    platform: 'win32',
+                };
+                const api = new ServiceApi(() => factoryResult, () => 'user');
+                vi.spyOn(
+                    api as unknown as { isLikelyLocalSystem: () => boolean },
+                    'isLikelyLocalSystem',
+                ).mockReturnValue(true);
+                Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+                const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+                await api.handle(req, res);
+
+                expect(exitSpy).not.toHaveBeenCalled();
+                vi.advanceTimersByTime(5000);
+                expect(exitSpy).toHaveBeenCalledWith(0);
+            } finally {
+                exitSpy.mockRestore();
+                vi.useRealTimers();
+            }
+        });
+
+        it('does NOT write marker in local mode', async () => {
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'not-installed' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(false);
+            Config.getInstance().updateAppConfig({ installMode: 'user' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            const cfg = Config.getInstance();
+            expect(fs.existsSync(cfg.uninstallPendingMarkerPath)).toBe(false);
+        });
+
+        it('does NOT write marker when isLikelyLocalSystem is false in service mode', async () => {
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'not-installed' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(false);
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            const cfg = Config.getInstance();
+            expect(fs.existsSync(cfg.uninstallPendingMarkerPath)).toBe(false);
+        });
+    });
+```
+
+- [ ] **Step 2: Run tests, verify all 5 fail.**
+
+```powershell
+npx vitest run "C:/Users/jscha/source/repos/ws-scrcpy-web/src/server/__tests__/ServiceApi.test.ts" -t "operation-server flow"
+```
+
+Expected: 5 failures. The first two hit the old `handoffUninstallToUserSession` code path; the last two hit the direct uninstall path (no marker written in either case).
+
+- [ ] **Step 3: Add `spawn` import to `ServiceApi.ts`.**
+
+Current text at lines 1-4 of `src/server/api/ServiceApi.ts`:
+
+```typescript
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import type { IncomingMessage, ServerResponse } from 'http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+```
+
+Replace with:
+
+```typescript
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import type { IncomingMessage, ServerResponse } from 'http';
+import { spawn } from 'child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+```
+
+- [ ] **Step 4: Rewrite the service+LocalSystem branch.**
+
+Current verbatim text at lines 419-446 of `src/server/api/ServiceApi.ts`:
+
+```typescript
+        } else {
+            // No resume token → could be a direct click from the
+            // local UI, OR could be a click from the service UI that
+            // hasn't been redirected yet. Detect the service-context
+            // case and do the handoff.
+            const installMode = cfg.getAppConfig().installMode;
+            const runningAsService = installMode === 'user-service' || installMode === 'system-service';
+            const isWindows = result.platform === 'win32';
+
+            if (isWindows && runningAsService && this.isLikelyLocalSystem()) {
+                const handoff = await this.handoffUninstallToUserSession(cfg.dependenciesPath, res);
+                if (handoff) return true;
+                // Handoff failed AND we're running as LocalSystem. We CANNOT fall
+                // through to direct runElevated() here — PowerShell Start-Process
+                // -Verb RunAs from LocalSystem has no interactive desktop to show
+                // the UAC prompt on, so it silently fails. Return a clear error
+                // and let the user retry (per spec
+                // docs/superpowers/specs/2026-04-30-service-mode-admin-uac-ux-design.md).
+                const body: ServiceActionFailure = {
+                    ok: false,
+                    error: "Couldn't reach the user session to relay the uninstall request. Make sure ws-scrcpy-web is running for your user, then try again.",
+                    reason: 'handoff-timeout',
+                };
+                res.writeHead(503);
+                res.end(JSON.stringify(body));
+                return true;
+            }
+        }
+```
+
+Replace with:
+
+```typescript
+        } else {
+            const installMode = cfg.getAppConfig().installMode;
+            const runningAsService = installMode === 'user-service' || installMode === 'system-service';
+            const isWindows = result.platform === 'win32';
+
+            if (isWindows && runningAsService && this.isLikelyLocalSystem()) {
+                try {
+                    await fs.promises.mkdir(path.dirname(cfg.uninstallPendingMarkerPath), { recursive: true });
+                    await fs.promises.writeFile(cfg.uninstallPendingMarkerPath, '', 'utf8');
+                    log.info(`uninstall: wrote uninstall-pending marker at ${cfg.uninstallPendingMarkerPath}`);
+                } catch (err) {
+                    log.error(`uninstall: failed to write uninstall-pending marker: ${(err as Error).message}`);
+                    const body: ServiceActionFailure = {
+                        ok: false,
+                        error: `failed to write uninstall-pending marker: ${(err as Error).message}`,
+                        reason: 'unknown',
+                    };
+                    res.writeHead(500);
+                    res.end(JSON.stringify(body));
+                    return true;
+                }
+
+                const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+                const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+                try {
+                    const child = spawn(helperPath, ['--operation-server'], {
+                        detached: true,
+                        stdio: 'ignore',
+                        windowsHide: true,
+                        env: { ...process.env, WS_SCRCPY_DATA_ROOT: dataRoot },
+                    });
+                    child.unref();
+                    log.info(`uninstall: spawned operation-server at ${helperPath}`);
+                } catch (err) {
+                    log.warn(`uninstall: failed to spawn operation-server (bat will handle it): ${(err as Error).message}`);
+                }
+
+                setTimeout(() => {
+                    log.info('uninstall: scheduled exit firing (post-stop.bat takes over)');
+                    process.exit(0);
+                }, 5000).unref();
+
+                const body: ServiceActionSuccess = {
+                    ok: true,
+                    status: 'shutting-down',
+                    installMode,
+                };
+                res.writeHead(200);
+                res.end(JSON.stringify(body));
+                return true;
+            }
+        }
+```
+
+- [ ] **Step 5: Run the 5 new tests, verify pass.**
+
+```powershell
+npx vitest run "C:/Users/jscha/source/repos/ws-scrcpy-web/src/server/__tests__/ServiceApi.test.ts" -t "operation-server flow"
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 6: Run the existing handoff-timeout test, verify it changed behavior.**
+
+The existing test at line 645 (`returns 503 with reason=handoff-timeout when LocalSystem handoff fails`) mocks `handoffUninstallToUserSession` to return false, then asserts 503. With Phase 4, `handoffUninstallToUserSession` is never called. The test needs updating: change its assertions to expect `200` with `status: 'shutting-down'` (since the code now writes the marker instead of calling handoff).
+
+Current test text at lines 645-679 of `src/server/__tests__/ServiceApi.test.ts`:
+
+```typescript
+    it('returns 503 with reason=handoff-timeout when LocalSystem handoff fails (does NOT direct-uninstall)', async () => {
+        const uninstallSpy = vi.fn(async () => undefined);
+        const client = fakeClient({
+            uninstall: uninstallSpy,
+            status: vi.fn(async () => 'running' as const),
+        });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user');
+        // Force isLikelyLocalSystem() to return true.
+        vi.spyOn(
+            api as unknown as { isLikelyLocalSystem: () => boolean },
+            'isLikelyLocalSystem',
+        ).mockReturnValue(true);
+        // Force the handoff to fail (resolve false synchronously).
+        vi.spyOn(
+            api as unknown as { handoffUninstallToUserSession: (...args: unknown[]) => Promise<boolean> },
+            'handoffUninstallToUserSession',
+        ).mockResolvedValue(false);
+        // Set installMode to 'system-service' so the running-as-service branch fires.
+        Config.getInstance().updateAppConfig({ installMode: 'system-service' });
+
+        const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+        await api.handle(req, res);
+
+        expect((res as any).getStatus()).toBe(503);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.ok).toBe(false);
+        expect(body.reason).toBe('handoff-timeout');
+        // Critical: the direct uninstall path must NOT have been attempted.
+        expect(uninstallSpy).not.toHaveBeenCalled();
+    });
+```
+
+Replace with:
+
+```typescript
+    it('service+LocalSystem uninstall writes marker and returns shutting-down (Phase 4 replaces handoff)', async () => {
+        const uninstallSpy = vi.fn(async () => undefined);
+        const client = fakeClient({
+            uninstall: uninstallSpy,
+            status: vi.fn(async () => 'running' as const),
+        });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user');
+        vi.spyOn(
+            api as unknown as { isLikelyLocalSystem: () => boolean },
+            'isLikelyLocalSystem',
+        ).mockReturnValue(true);
+        Config.getInstance().updateAppConfig({ installMode: 'system-service' });
+
+        const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+        await api.handle(req, res);
+
+        expect((res as any).getStatus()).toBe(200);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.ok).toBe(true);
+        expect(body.status).toBe('shutting-down');
+        expect(uninstallSpy).not.toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 7: Run full ServiceApi test suite.**
+
+```powershell
+npx vitest run "C:/Users/jscha/source/repos/ws-scrcpy-web/src/server/__tests__/ServiceApi.test.ts"
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/ServiceApi.ts src/server/__tests__/ServiceApi.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(server): handleUninstall uses operation-server flow for service+LocalSystem"
+```
+
+---
+
+### Task 5: Frontend modal keep-alive for `'shutting-down'` status
+
+**Files:**
+- Modify: `src/app/client/SettingsModal.ts` (lines 909-931)
+
+- [ ] **Step 1: Add the `keepModalOpen` flag and `'shutting-down'` check.**
+
+Current verbatim text at lines 909-931 of `src/app/client/SettingsModal.ts`:
+
+```typescript
+        const modal = new ServiceOperationModal({ operation: 'uninstall' });
+        using _closeModal = { [Symbol.dispose](): void { modal.close(); } };
+        try {
+            const r = await fetch('/api/service/uninstall', { method: 'POST' });
+            const data = (await r.json().catch(() => null)) as ServiceUninstallResponse | null;
+            if (!r.ok || !data || data.ok !== true) {
+                const errMsg = data && data.ok === false
+                    ? SettingsModal.reasonToUserMessage(data.reason, data.error)
+                    : `uninstall failed (${r.status})`;
+                this.renderServiceError(errMsg, () => void this.refreshService());
+                return;
+            }
+            if (data.redirectTo) {
+                btn.textContent = '→ user mode (uninstall)…';
+                setTimeout(() => {
+                    window.location.href = data.redirectTo!;
+                }, 500);
+                return;
+            }
+            await this.refreshService();
+        } catch {
+            this.renderServiceError("couldn't reach server", () => void this.refreshService());
+        }
+```
+
+Replace with:
+
+```typescript
+        let keepModalOpen = false;
+        const modal = new ServiceOperationModal({ operation: 'uninstall' });
+        using _closeModal = { [Symbol.dispose](): void { if (!keepModalOpen) modal.close(); } };
+        try {
+            const r = await fetch('/api/service/uninstall', { method: 'POST' });
+            const data = (await r.json().catch(() => null)) as ServiceUninstallResponse | null;
+            if (!r.ok || !data || data.ok !== true) {
+                const errMsg = data && data.ok === false
+                    ? SettingsModal.reasonToUserMessage(data.reason, data.error)
+                    : `uninstall failed (${r.status})`;
+                this.renderServiceError(errMsg, () => void this.refreshService());
+                return;
+            }
+            if (data.status === 'shutting-down') {
+                keepModalOpen = true;
+                return;
+            }
+            if (data.redirectTo) {
+                btn.textContent = '→ user mode (uninstall)…';
+                setTimeout(() => {
+                    window.location.href = data.redirectTo!;
+                }, 500);
+                return;
+            }
+            await this.refreshService();
+        } catch {
+            this.renderServiceError("couldn't reach server", () => void this.refreshService());
+        }
+```
+
+- [ ] **Step 2: Type-check.**
+
+```powershell
+npx tsc --noEmit --project "C:/Users/jscha/source/repos/ws-scrcpy-web/tsconfig.json"
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/SettingsModal.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(frontend): keep ServiceOperationModal open on shutting-down status"
+```
+
+---
+
+### Task 6: `silent_command` helper in `elevated_runner.rs`
+
+**Files:**
+- Modify: `launcher/src/elevated_runner.rs`
+
+- [ ] **Step 1: Add the `silent_command` helper.**
+
+Add the following just ABOVE the existing `run_capture` function (which starts at line 470):
+
+```rust
+#[cfg(windows)]
+fn silent_command(exe: &str) -> Command {
+    use std::os::windows::process::CommandExt;
+    let mut cmd = Command::new(exe);
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    cmd
+}
+
+#[cfg(not(windows))]
+fn silent_command(exe: &str) -> Command {
+    Command::new(exe)
+}
+
+```
+
+- [ ] **Step 2: Update `run_capture` to use `silent_command`.**
+
+Current verbatim text at lines 470-474 of `launcher/src/elevated_runner.rs`:
+
+```rust
+fn run_capture(exe: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Result<CapturedOutput, String> {
+    let output = Command::new(exe)
+        .args(args)
+        .output()
+        .map_err(|e| e.to_string())?;
+```
+
+Replace with:
+
+```rust
+fn run_capture(exe: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Result<CapturedOutput, String> {
+    let output = silent_command(exe)
+        .args(args)
+        .output()
+        .map_err(|e| e.to_string())?;
+```
+
+- [ ] **Step 3: Update the `taskkill` call in `uninstall_service`.**
+
+Current verbatim text at lines 429-431 of `launcher/src/elevated_runner.rs`:
+
+```rust
+    match Command::new("taskkill")
+        .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
+        .output()
+```
+
+Replace with:
+
+```rust
+    match silent_command("taskkill")
+        .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
+        .output()
+```
+
+- [ ] **Step 4: Update the `reg.exe` call in `reg_delete_value_best_effort`.**
+
+Current verbatim text at lines 515-518 of `launcher/src/elevated_runner.rs`:
+
+```rust
+    let out = Command::new("reg.exe")
+        .args(["delete", key, "/v", value, "/f"])
+        .output()
+        .map_err(|e| e.to_string())?;
+```
+
+Replace with:
+
+```rust
+    let out = silent_command("reg.exe")
+        .args(["delete", key, "/v", value, "/f"])
+        .output()
+        .map_err(|e| e.to_string())?;
+```
+
+- [ ] **Step 5: Run cargo test.**
+
+```powershell
+cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml"
+```
+
+Expected: 130/130 pass (existing tests unchanged — `silent_command` is a transparent wrapper).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/elevated_runner.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(launcher): suppress console window flashes from servy-cli/taskkill/reg.exe spawns"
+```
+
+---
+
+### Task 7: Full test suite + type-check gate
+
+- [ ] **Step 1: Run full vitest.**
+
+```powershell
+cd "C:/Users/jscha/source/repos/ws-scrcpy-web" ; npm test
+```
+
+Expected: 714 + new tests, all pass.
+
+- [ ] **Step 2: Run full cargo test.**
+
+```powershell
+cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml"
+```
+
+Expected: 130/130 pass.
+
+- [ ] **Step 3: Run tsc.**
+
+```powershell
+npx tsc --noEmit --project "C:/Users/jscha/source/repos/ws-scrcpy-web/tsconfig.json"
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Record test counts.**
+
+Note the exact vitest count (should be 714 + 6 new = 720) and cargo count (130 unchanged) for the CHANGELOG.
+
+---
+
+### Task 8: CHANGELOG + push + open PR
+
+- [ ] **Step 1: Add CHANGELOG entry.**
+
+Add under `[Unreleased]` → `### Changed` in `CHANGELOG.md`:
+
+```markdown
+- **Service uninstall now uses operation-server pattern (Phase 4 user-visible flip).** Replaces the Theory D handoff dance. New flow: service-Node writes `uninstall-pending` marker, spawns operation-server (detached), returns `shutting-down` status, exits; post-stop.bat runs `servy-cli uninstall` + spawns fresh user-session launcher; operation-server serves "Uninstalling service, please wait..." page throughout. Frontend `ServiceOperationModal` stays open during transition. **No more UAC prompt during uninstall.** `handoffUninstallToUserSession` function body remains as dead code; deletion in Phase 5.
+- **Console window flashes eliminated during service install/uninstall.** `silent_command` helper in `elevated_runner.rs` sets `CREATE_NO_WINDOW` on servy-cli, taskkill, and reg.exe spawns.
+```
+
+- [ ] **Step 2: Commit CHANGELOG.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add CHANGELOG.md
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "docs(changelog): Phase 4 node activation + console flash suppression"
+```
+
+- [ ] **Step 3: Push + open PR (DO NOT auto-merge — smoke required).**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" push -u origin feat/phase-4-node-activation
+```
+
+```bash
+gh -R bilbospocketses/ws-scrcpy-web pr create --title "feat: Phase 4 — service uninstall via operation-server + console flash suppression" --body "$(cat <<'EOF'
+## Summary
+
+**Phase 4 of operation-server rearchitecture — the user-visible flip.**
+
+- `ServiceStatus` type gains `'shutting-down'` variant
+- `Config.uninstallPendingMarkerPath` getter added
+- `handleUninstall` service+LocalSystem path: writes uninstall-pending marker, spawns operation-server (detached, retry-loops on port), returns `{ status: 'shutting-down' }`, schedules `process.exit(0)`
+- Frontend `ServiceOperationModal` stays open via `keepModalOpen` flag on `shutting-down` status
+- `silent_command` helper in `elevated_runner.rs` suppresses console window flashes from servy-cli/taskkill/reg.exe
+- `handoffUninstallToUserSession` body LEFT in place (Phase 5 deletes it)
+
+## Test plan
+
+- [x] vitest — all green (baseline + new tests)
+- [x] cargo test — 130/130 unchanged
+- [x] tsc --noEmit — clean
+- [ ] **REQUIRED before merge: full clean-VM smoke** per spec smoke plan:
+  - Install service (no console flash)
+  - Uninstall x3 pre-reboot (modal stays, no UAC, op-server page, redirect to local)
+  - Post-reboot uninstall
+  - Post-idle (15+ min) uninstall
+
+## Spec
+`docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md`
+EOF
+)" --base main
+```
+
+---
+
+### Task 9: Clean-VM smoke (THE CRITICAL VALIDATION)
+
+Manual validation on a Hyper-V VM. See spec smoke plan for full matrix.
+
+- [ ] **Step 1: Cut a smoke-target beta.**
+
+Version bump to `0.1.25-beta.44`, commit, tag, push tag. Wait for release.yml to publish.
+
+- [ ] **Step 2: Fresh VM — install beta.44 via MSI.**
+
+- [ ] **Step 3: Install service — verify no console window flash.**
+
+- [ ] **Step 4: Uninstall service x3 (pre-reboot) — verify modal stays, no UAC, op-server page, redirect to local.**
+
+- [ ] **Step 5: Reboot → uninstall.**
+
+- [ ] **Step 6: Reboot → idle 15+ min → uninstall.**
+
+- [ ] **Step 7: If all pass — enable auto-merge.**
+
+```bash
+gh -R bilbospocketses/ws-scrcpy-web pr merge feat/phase-4-node-activation --squash --delete-branch --auto
+```
+
+- [ ] **Step 8: If any fail — diagnose, fix on branch, re-cut RC, re-smoke.**

--- a/docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md
+++ b/docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md
@@ -187,7 +187,7 @@ New code:
         const body: ServiceActionSuccess = {
             ok: true,
             status: 'shutting-down',
-            installMode: 'user-service',
+            installMode,
         };
         res.writeHead(200);
         res.end(JSON.stringify(body));

--- a/docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md
+++ b/docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md
@@ -1,0 +1,306 @@
+# Phase 4 — Node Activation (Operation-Server Rearchitecture)
+
+> **Standalone spec for Phase 4.** Phases 1-3 SHIPPED (beta.39-42). Bat migration fix SHIPPED (beta.43). This spec supersedes the Phase 4 section of the original plan (`2026-05-23-operation-server-rearchitecture.md` lines 2053-2449) with three design revisions: (1) pre-exit operation-server spawn from Node, (2) `'shutting-down'` response status + frontend modal keep-alive, (3) `silent_command` helper for console window flash suppression.
+
+## Goal
+
+Wire Node-side to write the `uninstall-pending` marker, spawn the operation-server, and exit cleanly — replacing the Theory D handoff for the service+LocalSystem context. This is the activation that makes the operation-server pattern fire for real on service-uninstall. Also eliminates console window flashes during install/uninstall operations.
+
+## Architecture overview
+
+```
+Browser ──POST /api/service/uninstall──▶ Service-Node (LocalSystem)
+                                              │
+                                     1. Write uninstall-pending marker
+                                     2. Spawn operation-server (detached)
+                                     3. Return 200 { status: 'shutting-down' }
+                                     4. Schedule process.exit(0) in 5s
+                                              │
+                                              ▼
+                              Service exits → op-server grabs port (~25ms)
+                                              │
+                                              ▼
+                              Browser connection drops → page reloads
+                              → hits operation-server "Uninstalling service..."
+                                              │
+                                              ▼
+                              Servy fires post-stop.bat
+                              → bat sees uninstall-pending marker
+                              → bat's op-server spawn fails (port bound) — harmless
+                              → servy-cli uninstall
+                              → --spawn-user-launcher
+                                              │
+                                              ▼
+                              Op-server wind-down detects new Node
+                              → serves redirect → browser lands on local-mode app
+```
+
+## Design decisions
+
+### Pre-exit operation-server spawn (vs bat-only spawn)
+
+The original plan had Node write a marker and exit, leaving the bat to spawn the operation-server. This creates a timing gap: after the service exits, the port is unbound until the bat spawns the operation-server. The browser's page dies and has nowhere to reload to.
+
+**Chosen approach:** Node spawns the operation-server as a detached child BEFORE exiting. The operation-server retry-loops on the config port; when the service releases it ~5s later, it binds within 25ms. The browser's stale page reloads directly into the "Uninstalling service" page.
+
+The bat's redundant `start "" /b "<helper>" --operation-server` sees the port already bound, times out after 10s, and exits harmlessly. The bat's other commands (`servy-cli uninstall`, `--spawn-user-launcher`) run independently and are unaffected.
+
+This mirrors the proven apply-update pre-exit spawn pattern from Part 5b (which was later moved to the bat for Velopack process-tree reasons that don't apply to uninstall).
+
+### Frontend modal keep-alive (vs redirectTo)
+
+The original plan returned `redirectTo` pointing at the service's own port. Since the service is still alive for ~5s, the browser would reload the full app, which then dies — cosmetically jarring.
+
+**Chosen approach:** Return `status: 'shutting-down'` with NO `redirectTo`. The frontend checks for this status and keeps the `ServiceOperationModal` open (via a `keepModalOpen` flag that suppresses the `using _closeModal` disposal). The modal stays visible with its "uninstalling service" spinner until the page reloads into the operation-server's HTML.
+
+### Console window flash suppression
+
+`elevated_runner.rs::run_capture` uses bare `Command::new().output()` for servy-cli and reg.exe calls. Since the elevated runner launches via `ShellExecuteExW(verb="runas")` (no parent console), each spawn creates a visible console window that flashes briefly.
+
+**Fix:** A `silent_command(exe)` helper that sets `CREATE_NO_WINDOW` (0x08000000) on Windows. Applied to all three console-app spawn sites in `elevated_runner.rs`.
+
+## Files modified
+
+### Node (server)
+
+| File | Change |
+|------|--------|
+| `src/common/ServiceEvents.ts` | Add `'shutting-down'` to `ServiceStatus` union type |
+| `src/server/Config.ts` | Add `uninstallPendingMarkerPath` getter mirroring `applyUpdatePendingMarkerPath` |
+| `src/server/api/ServiceApi.ts` | Add `import { spawn } from 'child_process'`. Replace `handleUninstall` service+LocalSystem branch (lines 419-446): write marker, spawn operation-server, return `'shutting-down'`, schedule exit. `handoffUninstallToUserSession` body stays (dead code for Phase 5). |
+| `src/server/__tests__/Config.test.ts` | One new test for the getter |
+| `src/server/__tests__/ServiceApi.test.ts` | ~5 new tests for the marker-write + spawn + response shape |
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `src/app/client/SettingsModal.ts` | Uninstall handler: check `data.status === 'shutting-down'` before `redirectTo` check; set `keepModalOpen` flag to suppress modal disposal |
+
+### Rust (launcher)
+
+| File | Change |
+|------|--------|
+| `launcher/src/elevated_runner.rs` | Add `silent_command` helper; swap 3 callsites from `Command::new` to `silent_command` (lines 471, 429, 515) |
+
+## Detailed changes
+
+### ServiceEvents.ts — `ServiceStatus` type extension
+
+Add `'shutting-down'` to the union (line 12):
+
+```typescript
+export type ServiceStatus = 'running' | 'stopped' | 'not-installed' | 'shutting-down';
+```
+
+### Config.ts — `uninstallPendingMarkerPath` getter
+
+Mirrors `applyUpdatePendingMarkerPath` (line 526). Added immediately after it:
+
+```typescript
+public get uninstallPendingMarkerPath(): string {
+    const base = this._dataRoot !== null
+        ? this._dataRoot
+        : path.dirname(this._dependenciesPath);
+    return path.join(base, 'control', 'uninstall-pending');
+}
+```
+
+### ServiceApi.ts — `handleUninstall` rewrite
+
+**New import needed:** `import { spawn } from 'child_process';` (matches existing pattern in `AdbClient.ts`, `openBrowser.ts`, etc.).
+
+The `else` branch at lines 419-446 (service+LocalSystem context) is replaced. Current code:
+
+```typescript
+} else {
+    const installMode = cfg.getAppConfig().installMode;
+    const runningAsService = installMode === 'user-service' || installMode === 'system-service';
+    const isWindows = result.platform === 'win32';
+
+    if (isWindows && runningAsService && this.isLikelyLocalSystem()) {
+        const handoff = await this.handoffUninstallToUserSession(cfg.dependenciesPath, res);
+        if (handoff) return true;
+        const body: ServiceActionFailure = {
+            ok: false,
+            error: "Couldn't reach the user session to relay the uninstall request. ...",
+            reason: 'handoff-timeout',
+        };
+        res.writeHead(503);
+        res.end(JSON.stringify(body));
+        return true;
+    }
+}
+```
+
+New code:
+
+```typescript
+} else {
+    const installMode = cfg.getAppConfig().installMode;
+    const runningAsService = installMode === 'user-service' || installMode === 'system-service';
+    const isWindows = result.platform === 'win32';
+
+    if (isWindows && runningAsService && this.isLikelyLocalSystem()) {
+        // Phase 4 operation-server flow: write uninstall-pending marker,
+        // spawn operation-server (detached, retry-loops on port), return
+        // 'shutting-down' status, schedule process.exit(0).
+        try {
+            await fs.promises.mkdir(path.dirname(cfg.uninstallPendingMarkerPath), { recursive: true });
+            await fs.promises.writeFile(cfg.uninstallPendingMarkerPath, '', 'utf8');
+            log.info(`uninstall: wrote uninstall-pending marker at ${cfg.uninstallPendingMarkerPath}`);
+        } catch (err) {
+            log.error(`uninstall: failed to write uninstall-pending marker: ${(err as Error).message}`);
+            const body: ServiceActionFailure = {
+                ok: false,
+                error: `failed to write uninstall-pending marker: ${(err as Error).message}`,
+                reason: 'unknown',
+            };
+            res.writeHead(500);
+            res.end(JSON.stringify(body));
+            return true;
+        }
+
+        // Spawn operation-server so it's retry-looping on the port before
+        // we exit. It grabs the port within ~25ms of service exit.
+        // cfg.dataRoot is string | null; fall back to deps parent.
+        const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+        try {
+            const child = spawn(helperPath, ['--operation-server'], {
+                detached: true,
+                stdio: 'ignore',
+                windowsHide: true,
+                env: { ...process.env, WS_SCRCPY_DATA_ROOT: dataRoot },
+            });
+            child.unref();
+            log.info(`uninstall: spawned operation-server at ${helperPath}`);
+        } catch (err) {
+            log.warn(`uninstall: failed to spawn operation-server (bat will handle it): ${(err as Error).message}`);
+        }
+
+        setTimeout(() => {
+            log.info('uninstall: scheduled exit firing (post-stop.bat takes over)');
+            process.exit(0);
+        }, 5000).unref();
+
+        const body: ServiceActionSuccess = {
+            ok: true,
+            status: 'shutting-down',
+            installMode: 'user-service',
+        };
+        res.writeHead(200);
+        res.end(JSON.stringify(body));
+        return true;
+    }
+}
+```
+
+**Note:** `handoffUninstallToUserSession` function body stays untouched as dead code. Phase 5 deletes it.
+
+**Note:** The operation-server spawn is best-effort (catch + warn). If it fails, the bat's spawn takes over — same as if we hadn't tried. The bat's spawn will succeed because the port will be free by then (service already exited). The only cost is a brief gap where the port is unbound.
+
+### SettingsModal.ts — modal keep-alive
+
+In the uninstall handler (~line 909-928), add a `keepModalOpen` flag:
+
+```typescript
+let keepModalOpen = false;
+const modal = new ServiceOperationModal({ operation: 'uninstall' });
+using _closeModal = { [Symbol.dispose](): void { if (!keepModalOpen) modal.close(); } };
+try {
+    const r = await fetch('/api/service/uninstall', { method: 'POST' });
+    const data = (await r.json().catch(() => null)) as ServiceUninstallResponse | null;
+    if (!r.ok || !data || data.ok !== true) {
+        // ... existing error handling unchanged ...
+        return;
+    }
+    if (data.status === 'shutting-down') {
+        keepModalOpen = true;
+        return;
+    }
+    if (data.redirectTo) {
+        // ... existing redirect handling unchanged ...
+        return;
+    }
+    await this.refreshService();
+} catch {
+    this.renderServiceError("couldn't reach server", () => void this.refreshService());
+}
+```
+
+### elevated_runner.rs — `silent_command` helper
+
+```rust
+/// Build a `Command` that suppresses console window creation on Windows.
+/// Used for servy-cli, taskkill, reg.exe — any console app spawned from the
+/// elevated runner (which has no parent console due to ShellExecuteExW).
+#[cfg(windows)]
+fn silent_command(exe: &str) -> Command {
+    use std::os::windows::process::CommandExt;
+    let mut cmd = Command::new(exe);
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    cmd
+}
+
+#[cfg(not(windows))]
+fn silent_command(exe: &str) -> Command {
+    Command::new(exe)
+}
+```
+
+Three callsites updated:
+
+1. `run_capture` (line 471): `Command::new(exe)` → `silent_command(exe)`
+2. `uninstall_service` taskkill (line 429): `Command::new("taskkill")` → `silent_command("taskkill")`
+3. `reg_delete_value_best_effort` (line 515): `Command::new("reg.exe")` → `silent_command("reg.exe")`
+
+## Tests
+
+### vitest (Node)
+
+**Config.test.ts:**
+- `Config.uninstallPendingMarkerPath` returns `<dataRoot>/control/uninstall-pending`
+
+**ServiceApi.test.ts** — new `describe('handleUninstall — operation-server flow')`:
+- Writes `uninstall-pending` marker when service+LocalSystem on Windows
+- Spawns operation-server helper (spy on `child_process.spawn`)
+- Returns `200 { ok: true, status: 'shutting-down' }` with no `redirectTo`
+- Schedules `process.exit(0)` after 5s (fake timers)
+- Does NOT write marker or spawn in local mode
+
+### cargo test (Rust)
+
+**elevated_runner.rs:**
+- `silent_command` returns a Command (compile-time verification is sufficient; the creation flag is a u32 constant with no runtime failure mode)
+
+### vitest (frontend)
+
+**SettingsModal tests:**
+- `status: 'shutting-down'` response keeps modal open (verify `modal.close()` not called)
+- Normal response still closes modal
+
+## Smoke plan (clean VM, mandatory)
+
+| # | Scenario | Pass criteria |
+|---|----------|---------------|
+| 1 | Install Service | Phase 3 modal visible. **No console window flash.** Browser lands on service-mode UI. |
+| 2 | Uninstall Service x3 (pre-reboot) | "Uninstalling service" modal stays visible. **No UAC prompt.** Page reloads to operation-server page, then redirects to local-mode Node. Re-install between iterations. |
+| 3 | Reboot → Uninstall | Succeeds across reboot boundary. |
+| 4 | Reboot → idle 15+ min → Uninstall | Old Bug B aggravation case. Must succeed. |
+
+**Log capture per uninstall:**
+- `launcher.log`: `operation-server: starting` + `variant=Uninstall` + `bound 0.0.0.0:<port>`
+- `post-stop.log`: `uninstall-pending marker found, firing uninstall branch`
+- `ws-scrcpy-web.log`: `uninstall: wrote uninstall-pending marker` + `spawned operation-server` + `scheduled exit firing`
+- Verify `control/uninstall-pending` marker is GONE post-uninstall
+
+**Pass gate:** 3/3 pre-reboot + 1 post-reboot + 1 post-idle, all clean with no console flashes and no UAC prompts during uninstall.
+
+## Phase 5 (next, out of scope)
+
+Dead-code sweep: delete `handoffUninstallToUserSession` body + associated imports (`consumeToken`, `issueToken`, `writeUninstallHandoffMarker`, `resolveActiveSessionId`, `resolveLauncherPathForElevation`). Audit each for other callers before deletion.
+
+## Relationship to original plan
+
+This spec supersedes `docs/superpowers/plans/2026-05-23-operation-server-rearchitecture.md` Phase 4 (lines 2053-2449). The original plan's Task 4.2 (Config getter), Task 4.3 (handleUninstall rewrite), Task 4.4 (CHANGELOG + PR), Task 4.5 (smoke), Task 4.6 (beta cut) remain structurally valid but with the three design revisions documented above. Beta numbering shifts: Phase 4 ships as beta.44 (not beta.42 as originally planned).

--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -426,7 +426,7 @@ fn uninstall_service(args: &UninstallServiceArgs) -> ElevatedResult {
     // current session. Best-effort — no tray process means no kill,
     // not an error.
     log::info("uninstall-service: invoking taskkill /F /IM ws-scrcpy-web-tray.exe");
-    match Command::new("taskkill")
+    match silent_command("taskkill")
         .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
         .output()
     {
@@ -467,8 +467,21 @@ impl CapturedOutput {
     }
 }
 
+#[cfg(windows)]
+fn silent_command(exe: &str) -> Command {
+    use std::os::windows::process::CommandExt;
+    let mut cmd = Command::new(exe);
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    cmd
+}
+
+#[cfg(not(windows))]
+fn silent_command(exe: &str) -> Command {
+    Command::new(exe)
+}
+
 fn run_capture(exe: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Result<CapturedOutput, String> {
-    let output = Command::new(exe)
+    let output = silent_command(exe)
         .args(args)
         .output()
         .map_err(|e| e.to_string())?;
@@ -512,7 +525,7 @@ fn classify_reg_delete_outcome(status_code: Option<i32>, stderr: &[u8]) -> Resul
 /// caveats around what exit 1 actually means). Other non-zero exits are
 /// propagated with stderr in the error payload.
 fn reg_delete_value_best_effort(key: &str, value: &str) -> Result<(), String> {
-    let out = Command::new("reg.exe")
+    let out = silent_command("reg.exe")
         .args(["delete", key, "/v", value, "/f"])
         .output()
         .map_err(|e| e.to_string())?;

--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -290,14 +290,6 @@ fn install_service(args: &InstallServiceArgs) -> ElevatedResult {
     let start_out = run_capture(&args.servy_path, &["start", "--name", &args.name])
         .unwrap_or_else(|e| CapturedOutput::error_only(&format!("servy-cli start spawn failed: {e}")));
 
-    // §32 Part 5: HKLM\Run registration removed — launcher owns tray
-    // lifecycle now via the tray_supervisor background poller (runs every
-    // 10s, spawns into active interactive user session as needed).
-    // Cleanup of ANY existing HKLM\Run\WsScrcpyWebTray entry happens
-    // here AND at supervisor startup (defensive for legacy installs).
-    let _ = unregister_tray_run_key();
-    let _ = cleanup_stale_hkcu_tray_run_key();
-
     // Spawn the tray detached so the installing admin immediately gets
     // a tray icon for their session. The tray_supervisor polling thread
     // will also start firing from the now-running service launcher;
@@ -409,17 +401,7 @@ fn uninstall_service(args: &UninstallServiceArgs) -> ElevatedResult {
         };
     }
 
-    // Tray Run-key cleanup — best-effort.
-    log::info("uninstall-service: invoking unregister_tray_run_key (HKLM\\Run cleanup)");
-    match unregister_tray_run_key() {
-        Ok(()) => log::info("uninstall-service: unregister_tray_run_key result Ok"),
-        Err(e) => log::error(&format!(
-            "uninstall-service: unregister_tray_run_key result Err (non-fatal): {e}"
-        )),
-    }
-
     // v0.1.8: also kill the running tray helper process if any. The
-    // Run-key removal above only prevents auto-start on next login;
     // the currently-running tray icon would otherwise sit there
     // pointing at a service that no longer exists. taskkill /F /IM
     // hits both elevated and non-elevated tray instances in the
@@ -493,65 +475,16 @@ fn run_capture(exe: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Result<Captur
     })
 }
 
-const TRAY_RUN_KEY: &str = r"HKLM\Software\Microsoft\Windows\CurrentVersion\Run";
-const TRAY_RUN_VALUE: &str = "WsScrcpyWebTray";
-
-/// Pre-v0.1.25 the tray was registered under HKCU\...\Run from the
-/// elevated install context, which only wrote to the installing admin's
-/// hive. We keep this path constant so install upgrades can clean up
-/// that stale value. Other users' hives never had it written, so the
-/// cleanup is intentionally limited to the elevated user's HKCU.
-const STALE_HKCU_TRAY_RUN_KEY: &str = r"HKCU\Software\Microsoft\Windows\CurrentVersion\Run";
-
-/// Classify the outcome of a `reg.exe delete` command based on its exit code.
-/// Exit code 0 = clean success. Exit code 1 = generic non-fatal failure (value
-/// not found is the dominant case here, but reg.exe also returns 1 for some
-/// other recoverable conditions like access-denied on a key the caller can't
-/// write — the actual reason is in stderr, which is locale-dependent).
-/// We accept exit 1 as no-op success because (a) the previous English-only
-/// stderr substring match was strictly worse on non-English Windows, and
-/// (b) callers wrap this in `let _ =` for best-effort cleanup, so a swallowed
-/// access-denied here would be swallowed under the old logic too. Other
-/// codes = real errors; stderr propagated for the caller to log.
-fn classify_reg_delete_outcome(status_code: Option<i32>, stderr: &[u8]) -> Result<(), String> {
-    match status_code {
-        Some(0) | Some(1) => Ok(()),
-        _ => Err(String::from_utf8_lossy(stderr).into_owned()),
-    }
-}
-
-/// Run `reg.exe delete <key> /v <value> /f` for a best-effort cleanup. Treats
-/// exit code 1 as no-op success (see `classify_reg_delete_outcome` for the
-/// caveats around what exit 1 actually means). Other non-zero exits are
-/// propagated with stderr in the error payload.
-fn reg_delete_value_best_effort(key: &str, value: &str) -> Result<(), String> {
-    let out = silent_command("reg.exe")
-        .args(["delete", key, "/v", value, "/f"])
-        .output()
-        .map_err(|e| e.to_string())?;
-    classify_reg_delete_outcome(out.status.code(), &out.stderr)
-}
-
-// §32 Part 5: HKLM\Run registration removed entirely (replaced by
-// launcher-owned tray polling via tray_supervisor). The following
-// functions were dropped along with that architecture:
-//   - register_tray_run_key (HKLM\Run add)
-//   - migrate_tray_run_key_for_service (startup self-heal)
-//   - is_hklm_already_migrated (helper for the above)
-// Only `unregister_tray_run_key` remains, used at supervisor::run start +
-// install_service time to clean up legacy entries from beta.18-and-earlier
-// installs.
-
-/// Unregister the tray from the HKLM Run key. Exit code 1 (value not found)
-/// is treated as success — the desired post-state is that the value is absent.
-pub fn unregister_tray_run_key() -> Result<(), String> {
-    reg_delete_value_best_effort(TRAY_RUN_KEY, TRAY_RUN_VALUE)
-}
-
-/// Best-effort delete of the pre-v0.1.25 HKCU tray Run-key value, run
-/// during install to clean up upgrades from the HKCU era. Exit code 1
-/// (value not found) is treated as success — fresh installs have nothing
-/// to clean up, and that's the expected post-state.
+// §32 Part 5 / Phase 4: HKLM\Run + HKCU\Run tray registration removed
+// entirely. Tray lifecycle is now owned by the tray_supervisor background
+// poller. The following legacy cleanup functions were dropped:
+//   - register_tray_run_key, migrate_tray_run_key_for_service,
+//     is_hklm_already_migrated (dropped in §32 Part 5)
+//   - unregister_tray_run_key, cleanup_stale_hkcu_tray_run_key,
+//     reg_delete_value_best_effort, classify_reg_delete_outcome,
+//     TRAY_RUN_KEY, TRAY_RUN_VALUE, STALE_HKCU_TRAY_RUN_KEY
+//     (dropped in Phase 4 — 30+ betas with tray_supervisor means any
+//     stale Run-key entries have already been cleaned up)
 /// §32 Part 4 — write the post-stop bat file at `<data_root>/post-stop/post-stop.bat`.
 /// This bat is invoked by Servy via `--postStopPath` every time the supervised
 /// launcher exits. The bat:
@@ -661,10 +594,6 @@ pub(crate) fn write_post_stop_bat(
     Ok(bat_path)
 }
 
-fn cleanup_stale_hkcu_tray_run_key() -> Result<(), String> {
-    reg_delete_value_best_effort(STALE_HKCU_TRAY_RUN_KEY, TRAY_RUN_VALUE)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -743,51 +672,6 @@ mod tests {
     }
 
     #[test]
-    fn tray_run_key_targets_hklm() {
-        // Auto-start for the service-mode tray must be machine-wide so
-        // every user (not only the installing admin) gets a tray at logon.
-        // See docs/superpowers/specs/2026-04-30-tray-autostart-machine-wide-design.md.
-        assert!(
-            TRAY_RUN_KEY.starts_with(r"HKLM\"),
-            "TRAY_RUN_KEY must target HKLM, got: {TRAY_RUN_KEY}"
-        );
-    }
-
-    #[test]
-    fn classify_reg_delete_outcome_success_status_returns_ok() {
-        let result = classify_reg_delete_outcome(Some(0), b"");
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn classify_reg_delete_outcome_value_not_found_status_returns_ok() {
-        // Exit code 1 is the locale-stable "value not found" path;
-        // this is the bug fix — replacing English-only stderr matching.
-        let result = classify_reg_delete_outcome(Some(1), b"any stderr");
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn classify_reg_delete_outcome_other_failure_propagates_stderr() {
-        let stderr_text = b"some error message";
-        let result = classify_reg_delete_outcome(Some(5), stderr_text);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("some error message"));
-    }
-
-    #[test]
-    fn classify_reg_delete_outcome_killed_by_signal_propagates_stderr() {
-        // None from status.code() means the process was killed by a signal.
-        let stderr_text = b"killed";
-        let result = classify_reg_delete_outcome(None, stderr_text);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("killed"));
-    }
-
-    // §32 Part 5: `is_hklm_already_migrated_*` tests removed along with the
-    // `is_hklm_already_migrated` function (HKLM\Run registration architecture
-    // replaced by launcher-owned tray polling).
-
     #[test]
     fn write_post_stop_bat_uses_operation_server_flag() {
         let tmp = tempdir().unwrap();

--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -672,7 +672,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn write_post_stop_bat_uses_operation_server_flag() {
         let tmp = tempdir().unwrap();
         let bat_path = super::write_post_stop_bat(

--- a/launcher/src/hooks.rs
+++ b/launcher/src/hooks.rs
@@ -432,13 +432,6 @@ fn on_uninstall(install_root: &Path, data_root: &Path) -> i32 {
     //     renamed file).
     //   - leaves an HKCU\...\Run\WsScrcpyWebTray entry pointing at a
     //     non-existent path, which is benign on next login but messy.
-    // Best-effort, unconditional within service mode (the only path that
-    // ever registered a standalone tray helper in the first place).
-    if let Err(e) = crate::elevated_runner::unregister_tray_run_key() {
-        log::error(&format!("hook(uninstall): tray Run-key cleanup: {e}"));
-    } else {
-        log::info("hook(uninstall): tray Run-key cleared");
-    }
     let _ = std::process::Command::new("taskkill")
         .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
         .stdout(std::process::Stdio::null())

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -80,7 +80,6 @@ pub fn run() -> Result<i32> {
         // token (which fails) — user left with no tray after the service
         // goes away.
         let local_takeover_override = std::env::args().any(|a| a == "--local-takeover");
-        let is_service_mode = cfg.is_service_mode() && !local_takeover_override;
         if local_takeover_override && cfg.is_service_mode() {
             log::info(
                 "supervisor: --local-takeover override; forcing is_service_mode=false for tray-supervisor",
@@ -98,6 +97,7 @@ pub fn run() -> Result<i32> {
         // tray with no recovery. Polls every 10s and respawns if missing.
         #[cfg(windows)]
         {
+            let is_service_mode = cfg.is_service_mode() && !local_takeover_override;
             let _stop = crate::tray_supervisor::start_background(
                 &paths.install_root,
                 &paths.data_root,

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -87,16 +87,6 @@ pub fn run() -> Result<i32> {
             );
         }
 
-        if is_service_mode {
-            // One-time legacy cleanup (drops HKLM\Run\WsScrcpyWebTray
-            // left over from beta.18 and earlier installs that registered
-            // it at install_service time). Service-mode-only because
-            // that's where the legacy Run entry was registered.
-            if let Err(e) = crate::elevated_runner::unregister_tray_run_key() {
-                log::error(&format!("supervisor: legacy HKLM\\Run cleanup: {e}"));
-            }
-        }
-
         // §32 Part 5h — tray-supervisor runs in BOTH modes (was service-
         // mode-only pre-Part-5h). Mode-aware spawn dispatch inside the
         // supervisor: WTS cross-session for service mode (LocalSystem ->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.47",
+  "version": "0.1.25-beta.48",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.48",
+  "version": "0.1.25-beta.49",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.44",
+  "version": "0.1.25-beta.45",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.49",
+  "version": "0.1.25-beta.50",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.50",
+  "version": "0.1.25-beta.51",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.46",
+  "version": "0.1.25-beta.47",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.45",
+  "version": "0.1.25-beta.46",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.43",
+  "version": "0.1.25-beta.44",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -906,8 +906,9 @@ export class SettingsModal extends Modal {
             },
         };
 
+        let keepModalOpen = false;
         const modal = new ServiceOperationModal({ operation: 'uninstall' });
-        using _closeModal = { [Symbol.dispose](): void { modal.close(); } };
+        using _closeModal = { [Symbol.dispose](): void { if (!keepModalOpen) modal.close(); } };
         try {
             const r = await fetch('/api/service/uninstall', { method: 'POST' });
             const data = (await r.json().catch(() => null)) as ServiceUninstallResponse | null;
@@ -916,6 +917,10 @@ export class SettingsModal extends Modal {
                     ? SettingsModal.reasonToUserMessage(data.reason, data.error)
                     : `uninstall failed (${r.status})`;
                 this.renderServiceError(errMsg, () => void this.refreshService());
+                return;
+            }
+            if (data.status === 'shutting-down') {
+                keepModalOpen = true;
                 return;
             }
             if (data.redirectTo) {

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -921,6 +921,9 @@ export class SettingsModal extends Modal {
             }
             if (data.status === 'shutting-down') {
                 keepModalOpen = true;
+                setTimeout(() => {
+                    window.location.reload();
+                }, 8000);
                 return;
             }
             if (data.redirectTo) {

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -9,7 +9,7 @@
  * ServyClient, SystemdClient) and `src/server/api/ServiceApi.ts`.
  */
 
-export type ServiceStatus = 'running' | 'stopped' | 'not-installed';
+export type ServiceStatus = 'running' | 'stopped' | 'not-installed' | 'shutting-down';
 
 /**
  * Response shape for `GET /api/service/status`.

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -530,6 +530,13 @@ export class Config {
         return path.join(base, 'control', 'apply-update-pending');
     }
 
+    public get uninstallPendingMarkerPath(): string {
+        const base = this._dataRoot !== null
+            ? this._dataRoot
+            : path.dirname(this._dependenciesPath);
+        return path.join(base, 'control', 'uninstall-pending');
+    }
+
     public get scanConcurrency(): number { return this._scanConcurrency; }
     public get scanTcpTimeoutMs(): number { return this._scanTcpTimeoutMs; }
     public get scanAdbConnectTimeoutMs(): number { return this._scanAdbConnectTimeoutMs; }

--- a/src/server/__tests__/Config.test.ts
+++ b/src/server/__tests__/Config.test.ts
@@ -150,4 +150,13 @@ describe('Config — AppConfig extension', () => {
         const cfg = Config.getInstance();
         expect(() => cfg.updateAppConfig({ installMode: 'bogus' as 'user' })).toThrow(ConfigValidationError);
     });
+
+    it('uninstallPendingMarkerPath returns <base>/control/uninstall-pending', () => {
+        setup({});
+        const cfg = Config.getInstance();
+        const base = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        expect(cfg.uninstallPendingMarkerPath).toBe(
+            path.join(base, 'control', 'uninstall-pending'),
+        );
+    });
 });

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -85,6 +85,10 @@ describe('ServiceApi', () => {
     });
 
     afterEach(() => {
+        // Capture paths that need cleanup BEFORE resetting the Config singleton.
+        let uninstallMarkerPath: string | undefined;
+        try { uninstallMarkerPath = Config.getInstance().uninstallPendingMarkerPath; } catch { /* no singleton */ }
+
         Config._resetForTest();
         if (savedEnv.CONFIG === undefined) delete process.env[EnvName.CONFIG_PATH];
         else process.env[EnvName.CONFIG_PATH] = savedEnv.CONFIG;
@@ -97,6 +101,11 @@ describe('ServiceApi', () => {
             } catch {
                 /* best-effort */
             }
+        }
+        // Clean up the uninstall-pending marker (may live outside tmpDirs on
+        // Windows when dataRoot resolves to ProgramData rather than the tmp dir).
+        if (uninstallMarkerPath) {
+            try { fs.rmSync(uninstallMarkerPath, { force: true }); } catch { /* best-effort */ }
         }
     });
 
@@ -642,7 +651,7 @@ describe('ServiceApi', () => {
 
     // ── reason discriminator + no-direct-uninstall guard (v0.1.25) ──────────
 
-    it('returns 503 with reason=handoff-timeout when LocalSystem handoff fails (does NOT direct-uninstall)', async () => {
+    it('service+LocalSystem uninstall writes marker and returns shutting-down (Phase 4 replaces handoff)', async () => {
         const uninstallSpy = vi.fn(async () => undefined);
         const client = fakeClient({
             uninstall: uninstallSpy,
@@ -654,27 +663,19 @@ describe('ServiceApi', () => {
             platform: 'win32',
         };
         const api = new ServiceApi(() => factoryResult, () => 'user');
-        // Force isLikelyLocalSystem() to return true.
         vi.spyOn(
             api as unknown as { isLikelyLocalSystem: () => boolean },
             'isLikelyLocalSystem',
         ).mockReturnValue(true);
-        // Force the handoff to fail (resolve false synchronously).
-        vi.spyOn(
-            api as unknown as { handoffUninstallToUserSession: (...args: unknown[]) => Promise<boolean> },
-            'handoffUninstallToUserSession',
-        ).mockResolvedValue(false);
-        // Set installMode to 'system-service' so the running-as-service branch fires.
         Config.getInstance().updateAppConfig({ installMode: 'system-service' });
 
         const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
         await api.handle(req, res);
 
-        expect((res as any).getStatus()).toBe(503);
+        expect((res as any).getStatus()).toBe(200);
         const body = JSON.parse((res as any).getBody());
-        expect(body.ok).toBe(false);
-        expect(body.reason).toBe('handoff-timeout');
-        // Critical: the direct uninstall path must NOT have been attempted.
+        expect(body.ok).toBe(true);
+        expect(body.status).toBe('shutting-down');
         expect(uninstallSpy).not.toHaveBeenCalled();
     });
 
@@ -763,5 +764,130 @@ describe('ServiceApi', () => {
         const body = JSON.parse((res as any).getBody());
         expect(body.ok).toBe(false);
         expect(body.reason).toBe('servy-failure');
+    });
+
+    describe('handleUninstall — operation-server flow (Phase 4)', () => {
+        it('writes uninstall-pending marker when service+LocalSystem on Windows', async () => {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(true);
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            const cfg = Config.getInstance();
+            expect(fs.existsSync(cfg.uninstallPendingMarkerPath)).toBe(true);
+        });
+
+        it('returns 200 with status=shutting-down and no redirectTo', async () => {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(true);
+            Config.getInstance().updateAppConfig({ installMode: 'system-service' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
+            expect(body.installMode).toBe('system-service');
+            expect(body.redirectTo).toBeUndefined();
+        });
+
+        it('schedules process.exit(0) after 5s', async () => {
+            vi.useFakeTimers();
+            const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+            try {
+                const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+                const factoryResult: ServiceClientFactoryResult = {
+                    client,
+                    supported: true,
+                    platform: 'win32',
+                };
+                const api = new ServiceApi(() => factoryResult, () => 'user');
+                vi.spyOn(
+                    api as unknown as { isLikelyLocalSystem: () => boolean },
+                    'isLikelyLocalSystem',
+                ).mockReturnValue(true);
+                Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+                const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+                await api.handle(req, res);
+
+                expect(exitSpy).not.toHaveBeenCalled();
+                vi.advanceTimersByTime(5000);
+                expect(exitSpy).toHaveBeenCalledWith(0);
+            } finally {
+                exitSpy.mockRestore();
+                vi.useRealTimers();
+            }
+        });
+
+        it('does NOT write marker in local mode', async () => {
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'not-installed' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(false);
+            Config.getInstance().updateAppConfig({ installMode: 'user' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            const cfg = Config.getInstance();
+            expect(fs.existsSync(cfg.uninstallPendingMarkerPath)).toBe(false);
+        });
+
+        it('does NOT write marker when isLikelyLocalSystem is false in service mode', async () => {
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'not-installed' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(false);
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            const cfg = Config.getInstance();
+            expect(fs.existsSync(cfg.uninstallPendingMarkerPath)).toBe(false);
+        });
     });
 });

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -809,7 +809,7 @@ describe('ServiceApi', () => {
             const body = JSON.parse((res as any).getBody());
             expect(body.ok).toBe(true);
             expect(body.status).toBe('shutting-down');
-            expect(body.installMode).toBe('system-service');
+            expect(body.installMode).toBe('system');
             expect(body.redirectTo).toBeUndefined();
         });
 

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -1,5 +1,6 @@
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
+import { spawn } from 'child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { InstallMode } from '../../common/ConfigEvents';
@@ -417,29 +418,58 @@ export class ServiceApi {
             // instance from the service-context handoff. Proceed
             // directly with the uninstall (no second handoff).
         } else {
-            // No resume token → could be a direct click from the
-            // local UI, OR could be a click from the service UI that
-            // hasn't been redirected yet. Detect the service-context
-            // case and do the handoff.
             const installMode = cfg.getAppConfig().installMode;
             const runningAsService = installMode === 'user-service' || installMode === 'system-service';
             const isWindows = result.platform === 'win32';
 
             if (isWindows && runningAsService && this.isLikelyLocalSystem()) {
-                const handoff = await this.handoffUninstallToUserSession(cfg.dependenciesPath, res);
-                if (handoff) return true;
-                // Handoff failed AND we're running as LocalSystem. We CANNOT fall
-                // through to direct runElevated() here — PowerShell Start-Process
-                // -Verb RunAs from LocalSystem has no interactive desktop to show
-                // the UAC prompt on, so it silently fails. Return a clear error
-                // and let the user retry (per spec
-                // docs/superpowers/specs/2026-04-30-service-mode-admin-uac-ux-design.md).
-                const body: ServiceActionFailure = {
-                    ok: false,
-                    error: "Couldn't reach the user session to relay the uninstall request. Make sure ws-scrcpy-web is running for your user, then try again.",
-                    reason: 'handoff-timeout',
+                try {
+                    await fs.promises.mkdir(path.dirname(cfg.uninstallPendingMarkerPath), { recursive: true });
+                    await fs.promises.writeFile(cfg.uninstallPendingMarkerPath, '', 'utf8');
+                    log.info(`uninstall: wrote uninstall-pending marker at ${cfg.uninstallPendingMarkerPath}`);
+                } catch (err) {
+                    log.error(`uninstall: failed to write uninstall-pending marker: ${(err as Error).message}`);
+                    const body: ServiceActionFailure = {
+                        ok: false,
+                        error: `failed to write uninstall-pending marker: ${(err as Error).message}`,
+                        reason: 'unknown',
+                    };
+                    res.writeHead(500);
+                    res.end(JSON.stringify(body));
+                    return true;
+                }
+
+                const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+                const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+                try {
+                    const child = spawn(helperPath, ['--operation-server'], {
+                        detached: true,
+                        stdio: 'ignore',
+                        windowsHide: true,
+                        env: { ...process.env, WS_SCRCPY_DATA_ROOT: dataRoot },
+                    });
+                    // Absorb the async 'error' event (e.g. ENOENT when the helper
+                    // isn't yet on disk) so it doesn't become an unhandled rejection.
+                    child.on('error', (err) => {
+                        log.warn(`uninstall: operation-server child error (bat will handle it): ${err.message}`);
+                    });
+                    child.unref();
+                    log.info(`uninstall: spawned operation-server at ${helperPath}`);
+                } catch (err) {
+                    log.warn(`uninstall: failed to spawn operation-server (bat will handle it): ${(err as Error).message}`);
+                }
+
+                setTimeout(() => {
+                    log.info('uninstall: scheduled exit firing (post-stop.bat takes over)');
+                    process.exit(0);
+                }, 5000).unref();
+
+                const body: ServiceActionSuccess = {
+                    ok: true,
+                    status: 'shutting-down',
+                    installMode,
                 };
-                res.writeHead(503);
+                res.writeHead(200);
                 res.end(JSON.stringify(body));
                 return true;
             }

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -423,6 +423,22 @@ export class ServiceApi {
             const isWindows = result.platform === 'win32';
 
             if (isWindows && runningAsService && this.isLikelyLocalSystem()) {
+                // Revert installMode BEFORE exiting so the freshly spawned
+                // launcher (from --spawn-user-launcher in post-stop.bat)
+                // reads local mode from config.json, not the stale service
+                // mode. Without this, the fresh launcher enters service mode,
+                // its tray supervisor tries WTSQueryUserToken (needs
+                // SeTcbPrivilege), but the launcher runs as the regular user
+                // → tray spawn fails forever with 0x80070522.
+                let newMode: InstallMode = 'user';
+                if (installMode === 'system-service') newMode = 'system';
+                try {
+                    cfg.updateAppConfig({ installMode: newMode });
+                    log.info(`uninstall: reverted installMode ${installMode} → ${newMode}`);
+                } catch (err) {
+                    log.warn(`uninstall: installMode revert failed (continuing): ${(err as Error).message}`);
+                }
+
                 try {
                     await fs.promises.mkdir(path.dirname(cfg.uninstallPendingMarkerPath), { recursive: true });
                     await fs.promises.writeFile(cfg.uninstallPendingMarkerPath, '', 'utf8');
@@ -467,7 +483,7 @@ export class ServiceApi {
                 const body: ServiceActionSuccess = {
                     ok: true,
                     status: 'shutting-down',
-                    installMode,
+                    installMode: newMode,
                 };
                 res.writeHead(200);
                 res.end(JSON.stringify(body));

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -535,14 +535,13 @@ export class ServiceApi {
     }
 
     /**
-     * Theory D handoff: write a control marker that the user-session
-     * tray helper polls; the helper spawns the local launcher in its
-     * own session natively (no cross-session WTS APIs). Then poll for
-     * the new launcher's port, issue a resume token, and return the
-     * redirect response. Returns `true` if the handoff succeeded and
-     * the response was sent; `false` if any step failed (caller falls
-     * back to direct uninstall).
+     * Theory D handoff — DEAD CODE after Phase 4. Kept for Phase 5
+     * sweep; no callers remain. Delete the entire method + its imports
+     * (`consumeToken`, `issueToken`, `writeUninstallHandoffMarker`,
+     * `resolveActiveSessionId`, `resolveLauncherPathForElevation`) in
+     * the Phase 5 dead-code PR.
      */
+    // @ts-ignore TS6133 — intentional dead code, Phase 5 deletes this
     private async handoffUninstallToUserSession(
         installRoot: string,
         res: ServerResponse,


### PR DESCRIPTION
## Summary

**Phase 4 of operation-server rearchitecture — the user-visible flip.**

- `ServiceStatus` type gains `'shutting-down'` variant
- `Config.uninstallPendingMarkerPath` getter added
- `handleUninstall` service+LocalSystem path: writes uninstall-pending marker, spawns operation-server (detached, retry-loops on port), returns `{ status: 'shutting-down' }`, schedules `process.exit(0)`
- Frontend `ServiceOperationModal` stays open via `keepModalOpen` flag on `shutting-down` status
- `silent_command` helper in `elevated_runner.rs` suppresses console window flashes from servy-cli/taskkill/reg.exe
- `handoffUninstallToUserSession` body LEFT in place (Phase 5 deletes it)

## Test plan

- [x] vitest — 720/720 (714 baseline + 6 new)
- [x] cargo test — 130/130 unchanged
- [x] tsc --noEmit — clean
- [ ] **REQUIRED before merge: full clean-VM smoke** per spec smoke plan:
  - Install service (no console flash)
  - Uninstall x3 pre-reboot (modal stays, no UAC, op-server page, redirect to local)
  - Post-reboot uninstall
  - Post-idle (15+ min) uninstall

## Spec
`docs/superpowers/specs/2026-05-24-phase-4-node-activation-design.md`