### PR TITLE
fix(deps): installAdb rollback parity — rename-before-copy with rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`installAdb` rollback parity.** Applied the same rename-before-copy + rollback pattern from `installNodejs` (PR #98). On Windows, `adb.exe` is now renamed to `adb.exe.old` before `copyDirContents`; if copy fails, `adb.exe` is restored. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.
+
 ### Removed
 
 - **Dead Theory D handoff code (Phase 5 sweep).** Deleted `handoffUninstallToUserSession` method + `issueToken`, `writeUninstallHandoffMarker`, `resolveActiveSessionId`, `resolveLauncherPathForElevation` imports from `ServiceApi.ts` (-99 lines). `consumeToken` retained (still referenced by the resume-token validation block). No behavior change.

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -409,16 +409,41 @@ export class DependencyManager {
             }
         }
 
-        // Extract zip (ADB is always a zip on both platforms)
+        // 1. Non-destructive: extract to tmpDir.
         await this.extractZip(downloadPath, tmpDir, platform);
 
-        // ADB archives contain a platform-tools/ subfolder
         const platformToolsDir = path.join(tmpDir, 'platform-tools');
         if (!fs.existsSync(platformToolsDir)) {
             throw new Error('Could not find platform-tools directory in extracted archive');
         }
 
-        this.copyDirContents(platformToolsDir, destDir);
+        // 2. Destructive (Windows only): rename + copy with rollback.
+        if (platform === 'win32') {
+            const oldExe = path.join(destDir, 'adb.exe.old');
+            let renamed = false;
+            if (fs.existsSync(adbExe)) {
+                try {
+                    fs.renameSync(adbExe, oldExe);
+                    renamed = true;
+                } catch {
+                    // May fail if adb server didn't fully stop — proceed without rollback safety net.
+                }
+            }
+            try {
+                this.copyDirContents(platformToolsDir, destDir);
+            } catch (err) {
+                if (renamed && !fs.existsSync(adbExe)) {
+                    try {
+                        fs.renameSync(oldExe, adbExe);
+                    } catch {
+                        // Best-effort rollback.
+                    }
+                }
+                throw err;
+            }
+        } else {
+            this.copyDirContents(platformToolsDir, destDir);
+        }
     }
 
     private async installScrcpyServer(downloadPath: string, version: string): Promise<void> {


### PR DESCRIPTION
## Summary

Applies the same rename-before-copy + rollback pattern from `installNodejs` (PR #98) to `installAdb`. On Windows, `adb.exe` is renamed to `adb.exe.old` before `copyDirContents`; if copy fails mid-operation, `adb.exe` is restored from the `.old` file. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.

## Test plan

- [x] tsc --noEmit clean
- [x] DependencyManager tests 27/27