### PR TITLE
fix(deps): clean up stale .old files after successful Node/ADB updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Stale `.old` files cleaned up after successful Node/ADB updates.** `node.exe.old` and `adb.exe.old` (created by the rename-before-copy rollback pattern) are now deleted after `copyDirContents` succeeds. Previously they lingered indefinitely.
 - **`installAdb` rollback parity.** Applied the same rename-before-copy + rollback pattern from `installNodejs` (PR #98). On Windows, `adb.exe` is now renamed to `adb.exe.old` before `copyDirContents`; if copy fails, `adb.exe` is restored. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.
 
 ### Removed

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -389,6 +389,9 @@ export class DependencyManager {
                 }
                 throw err;
             }
+            if (renamed) {
+                try { fs.unlinkSync(oldExe); } catch { /* best-effort cleanup */ }
+            }
         } else {
             this.copyDirContents(extractedPath, destDir);
         }
@@ -440,6 +443,9 @@ export class DependencyManager {
                     }
                 }
                 throw err;
+            }
+            if (renamed) {
+                try { fs.unlinkSync(oldExe); } catch { /* best-effort cleanup */ }
             }
         } else {
             this.copyDirContents(platformToolsDir, destDir);


### PR DESCRIPTION
## Summary

After `installNodejs` and `installAdb` rename the running exe to `.old` for rollback safety, the `.old` file was never deleted on success. Added `fs.unlinkSync` cleanup after `copyDirContents` succeeds in both methods.

## Test plan

- [x] tsc --noEmit clean