### PR TITLE
fix(frontend): poll-based transition on service uninstall (replaces blind 8s reload)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Uninstall modal-to-operation-server transition.** Replaced the blind 8s `window.location.reload()` with a poll loop that detects when the service dies, then waits for the operation-server to bind the port before reloading. Modal stays visible throughout; transition is as fast as the operation-server starts.
 - **`installAdb` rollback parity.** Applied the same rename-before-copy + rollback pattern from `installNodejs` (PR #98). On Windows, `adb.exe` is now renamed to `adb.exe.old` before `copyDirContents`; if copy fails, `adb.exe` is restored. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.
 
 ### Removed

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -921,9 +921,18 @@ export class SettingsModal extends Modal {
             }
             if (data.status === 'shutting-down') {
                 keepModalOpen = true;
-                setTimeout(() => {
-                    window.location.reload();
-                }, 8000);
+                let serviceDied = false;
+                const poll = setInterval(async () => {
+                    try {
+                        await fetch('/api/service/status', { signal: AbortSignal.timeout(2000) });
+                        if (serviceDied) {
+                            clearInterval(poll);
+                            window.location.reload();
+                        }
+                    } catch {
+                        serviceDied = true;
+                    }
+                }, 1000);
                 return;
             }
             if (data.redirectTo) {


### PR DESCRIPTION
## Summary

Replaces the 8s `setTimeout(() => window.location.reload())` with a two-phase poll:
1. Poll `/api/service/status` every 1s until it fails (service died)
2. Keep polling until it succeeds again (operation-server bound the port)
3. Reload — lands directly on the operation-server page

Modal stays visible throughout. Transition adapts to actual timing instead of a fixed delay.

## Test plan

- [x] tsc --noEmit clean
- [ ] VM smoke: uninstall service, observe modal stays visible, page reloads to operation-server without the old 8s blind gap