### PR TITLE
fix(frontend): first-run modal dismissal survives port shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **All console window flashes eliminated.** Full audit of every `Command::new` in the launcher: `silent_command` (with `CREATE_NO_WINDOW`) now covers icacls (×2 in hooks.rs), taskkill (hooks.rs + tray_supervisor.rs), servy-cli (hooks.rs run_servy), and the tray spawn in elevated_runner. `silent_command` promoted to `pub(crate)` and signature widened to `impl AsRef<OsStr>`.
 - **Uninstall modal-to-operation-server transition.** Replaced the blind 8s `window.location.reload()` with a poll loop that detects when the service dies, then waits for the operation-server to bind the port before reloading. Modal stays visible throughout; transition is as fast as the operation-server starts.
+- **First-run modal dismissal survives port shifts.** On page load, server-side `firstRunComplete` / `serviceFirstRunSeen` flags (already dual-written when modals are dismissed) are now synced into localStorage before the modal gate check runs. Previously, navigating to a new port (different origin) cleared localStorage flags, causing dismissed modals to re-fire.
 - **`installAdb` rollback parity.** Applied the same rename-before-copy + rollback pattern from `installNodejs` (PR #98). On Windows, `adb.exe` is now renamed to `adb.exe.old` before `copyDirContents`; if copy fails, `adb.exe` is restored. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.
 
 ### Removed

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -107,6 +107,12 @@ function maybeShowWelcomeModal(): void {
             // Only one modal at a time — bookmark modal yields to either
             // first-run modal so we don't pile dialogs on first contact.
             const gate = await import('./client/firstRunGate');
+            if (config.firstRunComplete && !gate.isWelcomeDismissed()) {
+                gate.setWelcomeDismissed();
+            }
+            if (config.serviceFirstRunSeen && !gate.isServiceFirstRunDismissed()) {
+                gate.setServiceFirstRunDismissed();
+            }
             if (isServiceInstance) {
                 if (!gate.isServiceFirstRunDismissed()) {
                     void import('./client/ServiceFirstRunModal').then(({ ServiceFirstRunModal }) => {


### PR DESCRIPTION
## Summary

Syncs server-side `firstRunComplete` / `serviceFirstRunSeen` flags from the `/api/config` response into localStorage before the modal gate checks run. The modals already dual-write these flags to the server when dismissed; this adds the read-back path so a new-port origin picks up the dismissal state from config.json.

4-line change in `src/app/index.ts`.

## Test plan

- [x] tsc --noEmit clean
- [ ] VM smoke: dismiss Welcome modal on port 8000, install service (shifts to 8001), verify Welcome modal does NOT re-fire on 8001