### PR TITLE
fix(launcher): eliminate all console window flashes — full Command::new audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **All console window flashes eliminated.** Full audit of every `Command::new` in the launcher: `silent_command` (with `CREATE_NO_WINDOW`) now covers icacls (×2 in hooks.rs), taskkill (hooks.rs + tray_supervisor.rs), servy-cli (hooks.rs run_servy), and the tray spawn in elevated_runner. `silent_command` promoted to `pub(crate)` and signature widened to `impl AsRef<OsStr>`.
 - **Uninstall modal-to-operation-server transition.** Replaced the blind 8s `window.location.reload()` with a poll loop that detects when the service dies, then waits for the operation-server to bind the port before reloading. Modal stays visible throughout; transition is as fast as the operation-server starts.
 - **`installAdb` rollback parity.** Applied the same rename-before-copy + rollback pattern from `installNodejs` (PR #98). On Windows, `adb.exe` is now renamed to `adb.exe.old` before `copyDirContents`; if copy fails, `adb.exe` is restored. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.
 

--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -296,7 +296,7 @@ fn install_service(args: &InstallServiceArgs) -> ElevatedResult {
     // dedup via the per-session single-instance mutex.
     if let Some(tray) = &args.tray_helper_path {
         if std::path::Path::new(tray).exists() {
-            let _ = Command::new(tray).spawn();
+            let _ = silent_command(tray).spawn();
         }
     }
 
@@ -450,7 +450,7 @@ impl CapturedOutput {
 }
 
 #[cfg(windows)]
-fn silent_command(exe: &str) -> Command {
+pub(crate) fn silent_command(exe: impl AsRef<std::ffi::OsStr>) -> Command {
     use std::os::windows::process::CommandExt;
     let mut cmd = Command::new(exe);
     cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
@@ -458,7 +458,7 @@ fn silent_command(exe: &str) -> Command {
 }
 
 #[cfg(not(windows))]
-fn silent_command(exe: &str) -> Command {
+pub(crate) fn silent_command(exe: impl AsRef<std::ffi::OsStr>) -> Command {
     Command::new(exe)
 }
 

--- a/launcher/src/hooks.rs
+++ b/launcher/src/hooks.rs
@@ -16,7 +16,7 @@
 // missing servy-cli would block the update from completing.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+
 
 use common::config::AppConfig;
 
@@ -229,7 +229,7 @@ fn grant_data_root_acl(data_root: &Path) {
     // /C = continue on per-file errors (defensive).
     // /Q = suppress success spam.
     let target = data_root.as_os_str();
-    let result = Command::new("icacls")
+    let result = crate::elevated_runner::silent_command("icacls")
         .arg(target)
         .args(["/grant", "*S-1-5-11:(OI)(CI)M", "/T", "/C", "/Q"])
         // Suppress icacls's "Successfully processed N files" chatter —
@@ -277,7 +277,7 @@ fn grant_data_root_acl(_data_root: &Path) {
 #[cfg(windows)]
 fn grant_install_root_acl(install_root: &Path) {
     let target = install_root.as_os_str();
-    let result = Command::new("icacls")
+    let result = crate::elevated_runner::silent_command("icacls")
         .arg(target)
         .args(["/grant", "*S-1-5-11:(OI)(CI)M", "/T", "/C", "/Q"])
         .stdout(std::process::Stdio::null())
@@ -432,7 +432,7 @@ fn on_uninstall(install_root: &Path, data_root: &Path) -> i32 {
     //     renamed file).
     //   - leaves an HKCU\...\Run\WsScrcpyWebTray entry pointing at a
     //     non-existent path, which is benign on next login but messy.
-    let _ = std::process::Command::new("taskkill")
+    let _ = crate::elevated_runner::silent_command("taskkill")
         .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -453,7 +453,7 @@ fn run_servy(install_root: &Path, args: &[&str], tag: &str) -> i32 {
         return 0;
     }
     log::info(&format!("hook({tag}): invoking {servy:?} {args:?}"));
-    match Command::new(&servy).args(args).status() {
+    match crate::elevated_runner::silent_command(&servy).args(args).status() {
         Ok(status) => {
             let code = status.code().unwrap_or(1);
             log::info(&format!("hook({tag}): servy exited with {code}"));

--- a/launcher/src/tray_supervisor.rs
+++ b/launcher/src/tray_supervisor.rs
@@ -137,7 +137,7 @@ fn tray_supervisor_loop(
                     if persisted_mode { "service" } else { "local" },
                     if cfg_install_mode { "service" } else { "local" },
                 ));
-                let _ = std::process::Command::new("taskkill")
+                let _ = crate::elevated_runner::silent_command("taskkill")
                     .args(["/F", "/IM", TRAY_PROCESS_NAME])
                     .output();
             }


### PR DESCRIPTION
## Summary

Full audit of every `Command::new` in the launcher crate. All console-app spawn sites now use `silent_command` (sets `CREATE_NO_WINDOW` on Windows):

- `hooks.rs`: icacls (×2), taskkill, servy-cli via `run_servy`
- `tray_supervisor.rs`: taskkill for stale tray kill
- `elevated_runner.rs`: tray spawn in `install_service`

`silent_command` promoted to `pub(crate)`, signature widened from `&str` to `impl AsRef<OsStr>` for PathBuf compatibility.

## Test plan

- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test 125/125