### PR TITLE
fix(deps): clean up stale .old files after successful Node/ADB updates (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **All console window flashes eliminated.** Full audit of every `Command::new` in the launcher: `silent_command` (with `CREATE_NO_WINDOW`) now covers icacls (×2 in hooks.rs), taskkill (hooks.rs + tray_supervisor.rs), servy-cli (hooks.rs run_servy), and the tray spawn in elevated_runner. `silent_command` promoted to `pub(crate)` and signature widened to `impl AsRef<OsStr>`.
 - **Uninstall modal-to-operation-server transition.** Replaced the blind 8s `window.location.reload()` with a poll loop that detects when the service dies, then waits for the operation-server to bind the port before reloading. Modal stays visible throughout; transition is as fast as the operation-server starts.
+- **Stale `.old` files cleaned up after successful Node/ADB updates.** `node.exe.old` and `adb.exe.old` (created by the rename-before-copy rollback pattern) are now deleted after `copyDirContents` succeeds.
 - **`installAdb` rollback parity.** Applied the same rename-before-copy + rollback pattern from `installNodejs` (PR #98). On Windows, `adb.exe` is now renamed to `adb.exe.old` before `copyDirContents`; if copy fails, `adb.exe` is restored. Prevents a partial-update state where `adb.exe` is missing after a failed ADB update.
 
 ### Removed

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -389,6 +389,9 @@ export class DependencyManager {
                 }
                 throw err;
             }
+            if (renamed) {
+                try { fs.unlinkSync(oldExe); } catch { /* best-effort cleanup */ }
+            }
         } else {
             this.copyDirContents(extractedPath, destDir);
         }
@@ -440,6 +443,9 @@ export class DependencyManager {
                     }
                 }
                 throw err;
+            }
+            if (renamed) {
+                try { fs.unlinkSync(oldExe); } catch { /* best-effort cleanup */ }
             }
         } else {
             this.copyDirContents(platformToolsDir, destDir);

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -234,8 +234,7 @@ describe('DependencyManager.installNodejs rollback', () => {
 
         expect(fs.readFileSync(originalNodeExe, 'utf8')).toBe('NEW-NODE-BYTES');
         expect(fs.readFileSync(path.join(destDir, 'npm.cmd'), 'utf8')).toBe('NPM-CMD-BYTES');
-        // Current behavior: node.exe.old lingers post-success (cleanup is a separate non-goal).
-        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(true);
+        expect(fs.existsSync(path.join(destDir, 'node.exe.old'))).toBe(false);
 
         fs.rmSync(extractTmp, { recursive: true, force: true });
     });


### PR DESCRIPTION
## Summary

Recreated from closed #111 (CI fail + rebase conflicts). Same fix: `fs.unlinkSync` cleanup after `copyDirContents` succeeds in both `installNodejs` and `installAdb`. Test updated to expect `.old` absent after success.

## Test plan

- [x] dependencyManager.update.test.ts 7/7