### PR TITLE
chore(release): beta.61 + beta.62 — localStorage cleanup + reset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.62] - 2026-05-25
+
 ## [0.1.25-beta.61] - 2026-05-25
 
 ## [0.1.25-beta.60] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.61] - 2026-05-25
+
 ## [0.1.25-beta.60] - 2026-05-25
 
 ## [0.1.25-beta.59] - 2026-05-25

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.61"
+version = "0.1.25-beta.62"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.60"
+version = "0.1.25-beta.61"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.61",
+  "version": "0.1.25-beta.62",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.60",
+  "version": "0.1.25-beta.61",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/client/ServiceFirstRunModal.ts
+++ b/src/app/client/ServiceFirstRunModal.ts
@@ -1,5 +1,5 @@
 import { Modal } from '../ui/Modal';
-import { setBookmarkDismissedPort, setServiceFirstRunDismissed } from './firstRunGate';
+import { setBookmarkDismissedPort } from './firstRunGate';
 
 /**
  * One-shot informational modal shown on the FIRST page load of a
@@ -117,19 +117,8 @@ export class ServiceFirstRunModal extends Modal {
     private async dismiss(): Promise<void> {
         if (this.dismissBtn) this.dismissBtn.disabled = true;
         if (this.dontShowCheckbox?.checked) {
-            setServiceFirstRunDismissed();
-            // v0.1.11: same rationale as WelcomeModal — this modal already
-            // shows bookmark copy ("bookmark this URL now"), so dismissing
-            // with the checkbox covers the bookmark prompt for this port.
-            // Without this, PortChangeModal redundantly fired on the next
-            // page load.
             setBookmarkDismissedPort(this.opts.webPort);
         }
-        // Keep persisting serviceFirstRunSeen on the server too — other
-        // code paths (e.g., the resume-token UX overlay) may still read
-        // it for reasons unrelated to modal-gating. localStorage is now
-        // the modal authority; the server flag is non-load-bearing for
-        // gating but harmless to maintain.
         try {
             await fetch('/api/config', {
                 method: 'PATCH',

--- a/src/app/client/WelcomeModal.ts
+++ b/src/app/client/WelcomeModal.ts
@@ -1,6 +1,6 @@
 import { Modal } from '../ui/Modal';
 import type { ServiceStatusResponse, ServiceInstallResponse } from '../../common/ServiceEvents';
-import { setBookmarkDismissedPort, setWelcomeDismissed } from './firstRunGate';
+import { setBookmarkDismissedPort } from './firstRunGate';
 import { ServiceOperationModal } from './ServiceOperationModal';
 
 export type WelcomeChoice = 'service' | 'on-demand';
@@ -374,19 +374,7 @@ export class WelcomeModal extends Modal {
             this.setBusy(false);
             return;
         }
-        // v0.1.10: only suppress future first-run modal when the user
-        // explicitly opts out via the checkbox. Without this gate the
-        // modal would still keep firing because firstRunComplete server
-        // state alone was load-bearing-but-broken across uninstall cycles
-        // — the localStorage flag is the new authority.
         if (this.dontShowCheckbox.checked) {
-            setWelcomeDismissed();
-            // v0.1.11: WelcomeModal already shows bookmark copy in its
-            // info-callout, so dismissing it with the checkbox legitimately
-            // covers the bookmark prompt for this port too. Without this,
-            // PortChangeModal fired on the very next page load even though
-            // the user had just acknowledged a bookmark hint two seconds
-            // earlier — redundant noise.
             setBookmarkDismissedPort(this.opts.webPort);
         }
         this.opts.onDecision('on-demand');

--- a/src/app/client/__tests__/firstRunGate.test.ts
+++ b/src/app/client/__tests__/firstRunGate.test.ts
@@ -3,12 +3,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
     getBookmarkDismissedPort,
-    isServiceFirstRunDismissed,
-    isWelcomeDismissed,
     resetAllDismissals,
     setBookmarkDismissedPort,
-    setServiceFirstRunDismissed,
-    setWelcomeDismissed,
 } from '../firstRunGate';
 
 describe('firstRunGate', () => {
@@ -18,38 +14,6 @@ describe('firstRunGate', () => {
 
     afterEach(() => {
         window.localStorage.clear();
-    });
-
-    describe('welcomeDismissed flag', () => {
-        it('returns false when never set', () => {
-            expect(isWelcomeDismissed()).toBe(false);
-        });
-
-        it('returns true after setWelcomeDismissed', () => {
-            setWelcomeDismissed();
-            expect(isWelcomeDismissed()).toBe(true);
-        });
-
-        it('is independent from serviceFirstRunDismissed', () => {
-            setWelcomeDismissed();
-            expect(isServiceFirstRunDismissed()).toBe(false);
-        });
-    });
-
-    describe('serviceFirstRunDismissed flag', () => {
-        it('returns false when never set', () => {
-            expect(isServiceFirstRunDismissed()).toBe(false);
-        });
-
-        it('returns true after setServiceFirstRunDismissed', () => {
-            setServiceFirstRunDismissed();
-            expect(isServiceFirstRunDismissed()).toBe(true);
-        });
-
-        it('is independent from welcomeDismissed', () => {
-            setServiceFirstRunDismissed();
-            expect(isWelcomeDismissed()).toBe(false);
-        });
     });
 
     describe('bookmarkDismissedPort flag', () => {
@@ -74,41 +38,32 @@ describe('firstRunGate', () => {
         });
 
         it('mismatching saved port vs current is the trigger to re-show modal', () => {
-            // Mirrors maybeShowPortChangeModal's gating: dismissedFor !== currentPort.
             setBookmarkDismissedPort(8000);
             const currentPort = 9090;
             expect(getBookmarkDismissedPort() !== currentPort).toBe(true);
         });
     });
 
-    describe('resetAllDismissals (v0.1.12)', () => {
-        it('clears all three flags', () => {
-            setWelcomeDismissed();
-            setServiceFirstRunDismissed();
+    describe('resetAllDismissals', () => {
+        it('clears bookmark flag', () => {
             setBookmarkDismissedPort(8000);
-
             resetAllDismissals();
-
-            expect(isWelcomeDismissed()).toBe(false);
-            expect(isServiceFirstRunDismissed()).toBe(false);
             expect(getBookmarkDismissedPort()).toBeNull();
         });
 
         it('does not touch unrelated localStorage keys', () => {
             window.localStorage.setItem('audio.preferredBitrate', '128');
             window.localStorage.setItem('theme.mode', 'dark');
-            setWelcomeDismissed();
+            setBookmarkDismissedPort(8000);
 
             resetAllDismissals();
 
             expect(window.localStorage.getItem('audio.preferredBitrate')).toBe('128');
             expect(window.localStorage.getItem('theme.mode')).toBe('dark');
-            expect(isWelcomeDismissed()).toBe(false);
         });
 
         it('is idempotent — calling on a clean state is a no-op', () => {
             expect(() => resetAllDismissals()).not.toThrow();
-            expect(isWelcomeDismissed()).toBe(false);
         });
     });
 });

--- a/src/app/client/firstRunGate.ts
+++ b/src/app/client/firstRunGate.ts
@@ -1,34 +1,16 @@
 /**
- * v0.1.10: client-side modal gating via localStorage.
+ * Client-side bookmark-port tracking via localStorage.
  *
- * Pre-v0.1.10 the WelcomeModal and ServiceFirstRunModal gated on
- * server-side config flags (firstRunComplete, serviceFirstRunSeen).
- * That meant uninstalling and re-installing the service re-triggered
- * the "welcome to service mode" modal because the new install reset
- * (or never persisted) the flag — even though the same user had
- * already dismissed the modal once.
+ * Welcome and ServiceFirstRun modal gating moved to config.json
+ * (server-side) in v0.1.25-beta.59. The bookmark-port flag stays
+ * in localStorage because it's inherently per-origin — a port
+ * change IS the trigger for re-showing the bookmark reminder.
  *
- * v0.1.10 moves dismissal tracking entirely to localStorage. Each
- * modal now ships a "don't show again" checkbox, and the flag is
- * only persisted when the user checks that checkbox AND clicks the
- * commit button. The flags are independent — dismissing the local
- * (Welcome) modal does not dismiss the service (ServiceFirstRun)
- * modal and vice versa, mirroring the user's mental model: "I have
- * been told what I need to know on this side."
- *
- * The bookmark-port flag is keyed on a port number, not a boolean.
- * On page load, if the saved port differs from the current port,
- * the bookmark reminder shows again — over-reminding a user about
- * a NEW URL is the right tradeoff vs. silently letting them lose
- * their bookmark.
- *
- * The only way to clear any of these flags is for the user to clear
- * browser storage. There is no in-app reset button by design — the
- * flags exist to stop noise, not to be re-armed.
+ * resetAllDismissals clears the bookmark localStorage key; the
+ * config.json flags (firstRunComplete, serviceFirstRunSeen) are
+ * reset by the Settings button's PATCH call, not here.
  */
 
-const KEY_WELCOME = 'wsScrcpy.welcomeDismissed';
-const KEY_SERVICE_FIRST_RUN = 'wsScrcpy.serviceFirstRunDismissed';
 const KEY_BOOKMARK_PORT = 'wsScrcpy.bookmarkDismissedForPort';
 
 function safeGet(key: string): string | null {
@@ -44,24 +26,7 @@ function safeSet(key: string, value: string): void {
         window.localStorage.setItem(key, value);
     } catch {
         // Private mode / quota exceeded / disabled — fall through.
-        // The modal will show again next load; that is acceptable.
     }
-}
-
-export function isWelcomeDismissed(): boolean {
-    return safeGet(KEY_WELCOME) === '1';
-}
-
-export function setWelcomeDismissed(): void {
-    safeSet(KEY_WELCOME, '1');
-}
-
-export function isServiceFirstRunDismissed(): boolean {
-    return safeGet(KEY_SERVICE_FIRST_RUN) === '1';
-}
-
-export function setServiceFirstRunDismissed(): void {
-    safeSet(KEY_SERVICE_FIRST_RUN, '1');
 }
 
 export function getBookmarkDismissedPort(): number | null {
@@ -76,17 +41,12 @@ export function setBookmarkDismissedPort(port: number): void {
 }
 
 /**
- * v0.1.12: clear all first-run / bookmark dismissal flags. Used by the
- * Settings → "Reset welcome prompts" button so the user can re-see the
- * WelcomeModal / ServiceFirstRunModal / PortChangeModal without having to
- * clear their entire browser cache. Does NOT touch other localStorage
- * keys (audio prefs, theme, scan history) — narrowly scoped to the
- * three first-run gates.
+ * Clear the bookmark-port localStorage flag. Called by Settings →
+ * "Reset welcome prompts" alongside the config.json PATCH that
+ * resets firstRunComplete + serviceFirstRunSeen.
  */
 export function resetAllDismissals(): void {
     try {
-        window.localStorage.removeItem(KEY_WELCOME);
-        window.localStorage.removeItem(KEY_SERVICE_FIRST_RUN);
         window.localStorage.removeItem(KEY_BOOKMARK_PORT);
     } catch {
         // Private mode / quota / disabled — silent fall-through.


### PR DESCRIPTION
Orphan cleanup (dead localStorage writes removed from firstRunGate/WelcomeModal/ServiceFirstRunModal) + version bumps. beta.61 = smoke target, beta.62 = upgrade target.