### PR TITLE
fix(frontend): only set dismissal flags when checkbox checked + beta.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25-beta.64] - 2026-05-25
+
 ## [0.1.25-beta.63] - 2026-05-25
 
 ## [0.1.25-beta.62] - 2026-05-25

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.25-beta.63"
+version = "0.1.25-beta.64"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.25-beta.63",
+  "version": "0.1.25-beta.64",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/client/ServiceFirstRunModal.ts
+++ b/src/app/client/ServiceFirstRunModal.ts
@@ -118,15 +118,15 @@ export class ServiceFirstRunModal extends Modal {
         if (this.dismissBtn) this.dismissBtn.disabled = true;
         if (this.dontShowCheckbox?.checked) {
             setBookmarkDismissedPort(this.opts.webPort);
-        }
-        try {
-            await fetch('/api/config', {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ serviceFirstRunSeen: true }),
-            });
-        } catch {
-            /* fall-through: still close */
+            try {
+                await fetch('/api/config', {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ serviceFirstRunSeen: true }),
+                });
+            } catch {
+                /* fall-through: still close */
+            }
         }
         this.opts.onDismissed?.();
         this.close();

--- a/src/app/client/WelcomeModal.ts
+++ b/src/app/client/WelcomeModal.ts
@@ -299,7 +299,9 @@ export class WelcomeModal extends Modal {
                 statusResp.unsupportedReason ||
                 'service mode is not supported on this platform.';
             this.setStatus(`${reason} falling back to on-demand mode…`);
-            const ok = await this.patchConfig({ installMode: 'user', firstRunComplete: true });
+            const patch: Record<string, unknown> = { installMode: 'user' };
+            if (this.dontShowCheckbox.checked) patch['firstRunComplete'] = true;
+            const ok = await this.patchConfig(patch);
             if (!ok) {
                 this.setStatus("couldn't save preference. try again?", true);
                 this.setBusy(false);
@@ -335,11 +337,9 @@ export class WelcomeModal extends Modal {
                 this.setBusy(false);
                 return;
             }
-            // Server has updated installMode on success. Defensively also PATCH
-            // firstRunComplete so the welcome modal does not re-appear on next
-            // load even if the backend's /install handler omits that flag.
-            // Failure here is non-fatal — install itself succeeded.
-            await this.patchConfig({ firstRunComplete: true });
+            if (this.dontShowCheckbox.checked) {
+                await this.patchConfig({ firstRunComplete: true });
+            }
 
             // v0.1.8: if the server discovered a new service-instance
             // port and asked us to redirect, hand off cleanly. The
@@ -368,7 +368,9 @@ export class WelcomeModal extends Modal {
     private async onNo(): Promise<void> {
         this.setBusy(true);
         this.setStatus('saving…');
-        const ok = await this.patchConfig({ installMode: 'user', firstRunComplete: true });
+        const patch: Record<string, unknown> = { installMode: 'user' };
+        if (this.dontShowCheckbox.checked) patch['firstRunComplete'] = true;
+        const ok = await this.patchConfig(patch);
         if (!ok) {
             this.setStatus("couldn't save preference. try again?", true);
             this.setBusy(false);


### PR DESCRIPTION
## Summary

Config.json dismissal flags (`firstRunComplete`, `serviceFirstRunSeen`) were being set unconditionally on every modal dismiss, ignoring the "don't show again" checkbox. Now they're only PATCHed when the checkbox is checked.

Four callsites fixed: WelcomeModal onNo(), onYes() install success, unsupported platform fallback; ServiceFirstRunModal dismiss().

Includes beta.64 version bump.

## Test plan

- [x] tsc --noEmit clean
- [ ] VM smoke: dismiss Welcome WITHOUT checkbox → refresh → Welcome re-fires
- [ ] VM smoke: dismiss Welcome WITH checkbox → refresh → Welcome stays dismissed