### PR TITLE
refactor(§25): final TS6 pass — convert last 4 test try/finally to using

### DIFF
--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -766,30 +766,27 @@ describe('ServiceApi', () => {
         it('schedules process.exit(0) after 5s', async () => {
             vi.useFakeTimers();
             const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
-            try {
-                const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
-                const factoryResult: ServiceClientFactoryResult = {
-                    client,
-                    supported: true,
-                    platform: 'win32',
-                };
-                const api = new ServiceApi(() => factoryResult, () => 'user');
-                vi.spyOn(
-                    api as unknown as { isLikelyLocalSystem: () => boolean },
-                    'isLikelyLocalSystem',
-                ).mockReturnValue(true);
-                Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+            using _restore = { [Symbol.dispose]() { exitSpy.mockRestore(); vi.useRealTimers(); } };
 
-                const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
-                await api.handle(req, res);
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            vi.spyOn(
+                api as unknown as { isLikelyLocalSystem: () => boolean },
+                'isLikelyLocalSystem',
+            ).mockReturnValue(true);
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
 
-                expect(exitSpy).not.toHaveBeenCalled();
-                vi.advanceTimersByTime(5000);
-                expect(exitSpy).toHaveBeenCalledWith(0);
-            } finally {
-                exitSpy.mockRestore();
-                vi.useRealTimers();
-            }
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            expect(exitSpy).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(5000);
+            expect(exitSpy).toHaveBeenCalledWith(0);
         });
 
         it('does NOT write marker in local mode', async () => {

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -525,48 +525,36 @@ describe('UpdateService', () => {
         const mkdirSpy = vi
             .spyOn(fs.promises, 'mkdir')
             .mockResolvedValue(undefined);
-        try {
-            const info = fakeUpdateInfo('0.2.0');
-            const applyFn = vi.fn();
-            const mgr = fakeMgr({
-                checkForUpdatesAsync: async () => info,
-                waitExitThenApplyUpdate: applyFn,
-            });
-            const svc = new UpdateService({
-                installRoot: '/fake-install-root',
-                existsSync: () => true,
-                updateManagerFactory: () => mgr,
-                setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
-                clearIntervalFn: () => undefined,
-            });
-            svc.init();
-            await svc.checkForUpdates();
-            await svc.applyUpdate();
-            // UpdateService no longer exposes a spawnFn injection point;
-            // structurally, this is enforced by the TypeScript type
-            // system — UpdateServiceOptions has no `spawnFn` field.
-            expect(applyFn).toHaveBeenCalledTimes(1);
-            const isServiceMode =
-                installMode === 'user-service' || installMode === 'system-service';
-            // restart=false in service mode, true in local mode.
-            expect(applyFn.mock.calls[0]![2]).toBe(!isServiceMode);
+        using _restore = { [Symbol.dispose]() { writeFileSpy.mockRestore(); mkdirSpy.mockRestore(); } };
 
-            // §32 Part 5f — marker MUST be written in all four modes.
-            // Pre-Part-5f this was service-mode-only and local-mode
-            // launcher couldn't tell apply-update from user-initiated stop.
-            const markerCalls = writeFileSpy.mock.calls.filter(
-                (c) =>
-                    typeof c[0] === 'string' &&
-                    (c[0] as string).endsWith('apply-update-pending'),
-            );
-            expect(markerCalls).toHaveLength(1);
-            // mkdir should have been called for the marker's parent
-            // directory at least once.
-            expect(mkdirSpy).toHaveBeenCalled();
-        } finally {
-            writeFileSpy.mockRestore();
-            mkdirSpy.mockRestore();
-        }
+        const info = fakeUpdateInfo('0.2.0');
+        const applyFn = vi.fn();
+        const mgr = fakeMgr({
+            checkForUpdatesAsync: async () => info,
+            waitExitThenApplyUpdate: applyFn,
+        });
+        const svc = new UpdateService({
+            installRoot: '/fake-install-root',
+            existsSync: () => true,
+            updateManagerFactory: () => mgr,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+        });
+        svc.init();
+        await svc.checkForUpdates();
+        await svc.applyUpdate();
+        expect(applyFn).toHaveBeenCalledTimes(1);
+        const isServiceMode =
+            installMode === 'user-service' || installMode === 'system-service';
+        expect(applyFn.mock.calls[0]![2]).toBe(!isServiceMode);
+
+        const markerCalls = writeFileSpy.mock.calls.filter(
+            (c) =>
+                typeof c[0] === 'string' &&
+                (c[0] as string).endsWith('apply-update-pending'),
+        );
+        expect(markerCalls).toHaveLength(1);
+        expect(mkdirSpy).toHaveBeenCalled();
     });
 
     // ── reconfigure ─────────────────────────────────────────────────────

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -83,20 +83,16 @@ describe('DependencyManager.update() launcher-required gate', () => {
         }));
         const { DependencyManager: Mgr } = await import('../DependencyManager');
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-gate-'));
-        try {
-            const mgr = new Mgr(tmp);
-            const result = await mgr.update('nodejs');
-            expect(result.success).toBe(false);
-            expect(result.reason).toBe('launcher-required');
-            expect(result.errorMessage).toMatch(/installed build/);
-            expect(result.requiresRestart).toBe(false);
-            // Status MUST remain UpdateAvailable / Unknown — NOT transition to Updating or Error.
-            const info = mgr.getByName('nodejs')!;
-            expect(info.status).not.toBe(DependencyStatus.Updating);
-            expect(info.status).not.toBe(DependencyStatus.Error);
-        } finally {
-            fs.rmSync(tmp, { recursive: true, force: true });
-        }
+        using _cleanup = { [Symbol.dispose]() { fs.rmSync(tmp, { recursive: true, force: true }); } };
+        const mgr = new Mgr(tmp);
+        const result = await mgr.update('nodejs');
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('launcher-required');
+        expect(result.errorMessage).toMatch(/installed build/);
+        expect(result.requiresRestart).toBe(false);
+        const info = mgr.getByName('nodejs')!;
+        expect(info.status).not.toBe(DependencyStatus.Updating);
+        expect(info.status).not.toBe(DependencyStatus.Error);
     });
 
     it('does not gate scrcpy-server (no launcher needed)', async () => {
@@ -106,6 +102,7 @@ describe('DependencyManager.update() launcher-required gate', () => {
         }));
         const { DependencyManager: Mgr } = await import('../DependencyManager');
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-gate-scrcpy-'));
+        using _cleanup = { [Symbol.dispose]() { fs.rmSync(tmp, { recursive: true, force: true }); } };
         const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
             const url = typeof input === 'string' ? input : input.toString();
             if (url.includes('api.github.com')) {
@@ -116,18 +113,14 @@ describe('DependencyManager.update() launcher-required gate', () => {
             }
             return new Response('fake-jar-bytes', { status: 200 });
         });
-        try {
-            const mgr = new Mgr(tmp);
-            const info = mgr.getByName('scrcpy-server')!;
-            info.installedVersion = '3.3.4';
-            info.latestVersion = '4.0';
-            const result = await mgr.update('scrcpy-server');
-            expect(result.success).toBe(true);
-            expect(result.reason).toBeUndefined();
-        } finally {
-            fetchSpy.mockRestore();
-            fs.rmSync(tmp, { recursive: true, force: true });
-        }
+        using _restoreFetch = { [Symbol.dispose]() { fetchSpy.mockRestore(); } };
+        const mgr = new Mgr(tmp);
+        const info = mgr.getByName('scrcpy-server')!;
+        info.installedVersion = '3.3.4';
+        info.latestVersion = '4.0';
+        const result = await mgr.update('scrcpy-server');
+        expect(result.success).toBe(true);
+        expect(result.reason).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
Final audit pass on §25 TS6 compliance. Converts the last 4 remaining try/finally blocks in test files to using declarations. Zero try/finally blocks remain in src/ after this.