### PR TITLE
fix(§8): resolve FileListingClient FIXMEs

### DIFF
--- a/src/app/googDevice/client/FileListingClient.ts
+++ b/src/app/googDevice/client/FileListingClient.ts
@@ -40,11 +40,13 @@ type Upload = { row: HTMLElement; progressEl: HTMLElement; anchor: HTMLElement; 
 enum Foreground {
     Drop = 'drop-target',
     Connect = 'connect',
+    Error = 'error',
 }
 
 const Message: Record<Foreground, string> = {
     [Foreground.Drop]: 'Drop files here',
     [Foreground.Connect]: 'Connection lost',
+    [Foreground.Error]: 'An error occurred',
 };
 
 export class FileListingClient extends ManagerClient<ParamsFileListing, never> implements DragAndPushListener {
@@ -104,6 +106,15 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
         this.path = this.params.path;
         this.openNewConnection();
         this.setBodyClass('file-listing');
+        window.addEventListener('hashchange', () => {
+            const hash = location.hash.replace(/#!/, '');
+            const params = new URLSearchParams(hash);
+            if (params.get('action') !== ACTION.FILE_LISTING) return;
+            const hashPath = params.get('path');
+            if (hashPath && hashPath !== this.path) {
+                this.loadContent(hashPath);
+            }
+        });
         this.name = `${TAG} [${this.serial}]`;
         this.tableBodyId = `${Util.escapeUdid(this.serial)}_list`;
         this.wrapperId = `wrapper_${this.tableBodyId}`;
@@ -243,7 +254,10 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
         }
     }
     public onError(error: string | Error): void {
-        console.error(this.name, 'FIXME: implement', error);
+        const msg = typeof error === 'string' ? error : error.message;
+        console.error(this.name, msg);
+        this.removeForeground(Foreground.Error);
+        this.addForeground(Foreground.Error);
     }
 
     private addForeground(type: Foreground): void {
@@ -350,7 +364,6 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
         }
         this.toggleQuickLinks(this.path);
 
-        // FIXME: should do over way around: load content on hash change
         const hash = location.hash.replace(/#!/, '');
         const params = new URLSearchParams(hash);
         if (params.get('action') === ACTION.FILE_LISTING) {
@@ -411,9 +424,10 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
                 const mtime = statView.getUint32(8, true);
                 const nameString = basename(download.path);
                 if (mode === 0) {
-                    console.error('FIXME: show error in UI');
-                    console.error(`Error: no entity "${download.path}"`);
+                    console.error(this.name, `no entity "${download.path}"`);
                     this.channels.delete(channel);
+                    this.removeForeground(Foreground.Error);
+                    this.addForeground(Foreground.Error);
                     this.loadContent(tempPath);
                     return;
                 }

--- a/src/style/listfiles.css
+++ b/src/style/listfiles.css
@@ -1,3 +1,33 @@
+/* ── Foreground overlays (error, connection lost, drop target) ── */
+.foreground {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    pointer-events: none;
+}
+
+.foreground.drop-target {
+    background: rgba(30, 60, 120, 0.85);
+}
+
+.foreground.connect {
+    background: rgba(40, 40, 40, 0.9);
+}
+
+.foreground.error {
+    background: rgba(80, 20, 20, 0.9);
+}
+
+.foreground-message {
+    color: #fff;
+    font-size: 1.25rem;
+    text-align: center;
+    padding: 1rem 2rem;
+}
+
 /* ── Icon sizing via CSS custom property ── */
 .list-files-modal .file-icon {
     display: inline-flex;


### PR DESCRIPTION
## Summary

- FIXME #1 (line 246): `onError` now shows a visual error overlay instead of just console.error
- FIXME #2 (line 353): Added hashchange listener for navigation — browsing via back/forward now drives content load
- FIXME #3 (line 414): "No entity" error now shows the error overlay instead of just console.error
- Added CSS for the foreground overlay system (was wired in JS but had no styles — upstream inherited gap)

All three FIXMEs removed. §8 closed.