### PR TITLE
fix(§40): local-mode in-app update relaunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local-mode in-app updates now work.** Velopack's `restart=true` silently failed under non-elevated user identity — `current/` swapped but the app was never relaunched. Fix: `restart=false` for all modes + a local-post-stop.bat (sleeps 12s for Velopack swap, then launches the new launcher). Mirrors the proven service-mode post-stop.bat pattern.
+
 ## [0.1.27] - 2026-05-25
 
 ### Fixed

--- a/docs/superpowers/plans/2026-05-26-local-mode-update-relaunch.md
+++ b/docs/superpowers/plans/2026-05-26-local-mode-update-relaunch.md
@@ -1,0 +1,267 @@
+# §40 Local-Mode Update Relaunch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix silent local-mode update failure by switching to `restart=false` + our own bat-based relaunch.
+
+**Architecture:** Change `waitExitThenApplyUpdate` to `restart=false` for all modes. Add a local-post-stop.bat (generated on-the-fly by the supervisor) that sleeps 12s then launches the new `current/ws-scrcpy-web-launcher.exe`. Mirrors the proven service-mode post-stop pattern.
+
+**Tech Stack:** TypeScript (one-line change), Rust (bat generation + spawn)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/server/UpdateService.ts` | Modify (1 line) | `restart` param: `!isServiceMode` → `false` |
+| `src/server/__tests__/UpdateService.test.ts` | Modify | Update test assertions for `restart=false` in all modes |
+| `launcher/src/supervisor.rs` | Modify (~20 lines) | Write + spawn local-post-stop.bat in apply-update branch |
+
+---
+
+### Task 1: Change restart param to false for all modes
+
+**Files:**
+- Modify: `src/server/UpdateService.ts:377`
+- Modify: `src/server/__tests__/UpdateService.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/server/__tests__/UpdateService.test.ts`, find the existing `it.each` block that tests `applyUpdate` across all four installModes. The test currently asserts that the third argument to `waitExitThenApplyUpdate` is `!isServiceMode` (true for user/system, false for service modes). Update the assertion to expect `false` for ALL modes:
+
+Find the assertion that looks like:
+```typescript
+expect(applyFn.mock.calls[0]![2]).toBe(!isServiceMode);
+```
+
+Change it to:
+```typescript
+expect(applyFn.mock.calls[0]![2]).toBe(false);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts` from `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+Expected: FAIL — user and system modes pass `true` but test expects `false`.
+
+- [ ] **Step 3: Change the restart param**
+
+In `src/server/UpdateService.ts`, line 377, change:
+
+```typescript
+this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, !isServiceMode);
+```
+
+to:
+
+```typescript
+this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts`
+
+Expected: ALL tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/UpdateService.ts src/server/__tests__/UpdateService.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(§40): set restart=false for all modes — we own the relaunch"
+```
+
+---
+
+### Task 2: Add local-post-stop.bat generation + spawn to supervisor
+
+**Files:**
+- Modify: `launcher/src/supervisor.rs`
+
+- [ ] **Step 1: Write a unit test for the bat content generator**
+
+Add to the test module in `supervisor.rs` (or create one if it doesn't exist):
+
+```rust
+#[test]
+fn local_post_stop_bat_contains_launcher_path_and_sleep() {
+    let install_root = std::path::Path::new(r"C:\Program Files\WsScrcpyWeb");
+    let bat = build_local_post_stop_bat(install_root);
+    assert!(bat.contains("timeout /t 12 /nobreak"));
+    assert!(bat.contains(r"C:\Program Files\WsScrcpyWeb\current\ws-scrcpy-web-launcher.exe"));
+    assert!(bat.contains("exit /b 0"));
+}
+```
+
+- [ ] **Step 2: Run cargo test to verify it fails**
+
+Run: `cargo test -p ws-scrcpy-web-launcher` from `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+Expected: FAIL — `build_local_post_stop_bat` doesn't exist.
+
+- [ ] **Step 3: Implement the bat content generator**
+
+Add this function to `supervisor.rs`:
+
+```rust
+/// Generate a one-shot bat that sleeps through the Velopack swap window,
+/// then launches the new launcher from `current/`. Written on-the-fly
+/// and spawned detached by the supervisor during local-mode updates.
+fn build_local_post_stop_bat(install_root: &Path) -> String {
+    let launcher = install_root.join("current").join("ws-scrcpy-web-launcher.exe");
+    let launcher_str = launcher.to_string_lossy();
+    format!(
+        "@echo off\r\n\
+         timeout /t 12 /nobreak >nul\r\n\
+         start \"\" \"{launcher_str}\"\r\n\
+         exit /b 0\r\n"
+    )
+}
+```
+
+- [ ] **Step 4: Run cargo test to verify it passes**
+
+Run: `cargo test -p ws-scrcpy-web-launcher`
+
+Expected: PASS
+
+- [ ] **Step 5: Wire the bat spawn into the apply-update branch**
+
+In `supervisor.rs`, inside the `if marker.exists()` block (around line 221), AFTER the `spawn_detached_helper` call (line 232), add the bat write + spawn:
+
+```rust
+// §40 — local-mode relaunch. Write + spawn a one-shot bat that
+// sleeps through the Velopack swap window, then launches the
+// new current/launcher.exe. Mirrors the service-mode post-stop
+// bat pattern (12s sleep + sc start → 12s sleep + start launcher).
+let bat_dir = paths.data_root.join("control");
+let bat_path = bat_dir.join("local-post-stop.bat");
+let bat_content = build_local_post_stop_bat(&paths.install_root);
+match std::fs::write(&bat_path, &bat_content) {
+    Ok(()) => {
+        log::info(&format!(
+            "supervisor: wrote local-post-stop.bat at {bat_path:?}"
+        ));
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            use std::process::Stdio;
+            const DETACHED_PROCESS: u32 = 0x00000008;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            match std::process::Command::new(r"C:\Windows\System32\cmd.exe")
+                .args(["/c", &bat_path.to_string_lossy()])
+                .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+            {
+                Ok(child) => log::info(&format!(
+                    "supervisor: spawned local-post-stop.bat (pid {})",
+                    child.id()
+                )),
+                Err(e) => log::error(&format!(
+                    "supervisor: failed to spawn local-post-stop.bat: {e}"
+                )),
+            }
+        }
+    }
+    Err(e) => log::error(&format!(
+        "supervisor: failed to write local-post-stop.bat: {e}"
+    )),
+}
+```
+
+- [ ] **Step 6: Update the comment block above the apply-update branch**
+
+Replace the existing comment (lines 201-215) that says "Velopack's restart=true ... will relaunch this launcher post-swap" with accurate language:
+
+```rust
+// §40 — local-mode update relaunch. If apply-update-pending
+// marker is present AND we're in local mode:
+//   1. Spawn operation-server (serves "updating" page)
+//   2. Write + spawn local-post-stop.bat (sleeps 12s, then
+//      launches the new current/launcher.exe post-swap)
+//   3. Exit — Velopack Update.exe swaps current/ (restart=false,
+//      we own the relaunch via the bat)
+//
+// In service mode, Servy's post-stop.bat handles both the
+// operation-server spawn and the sc start relaunch — gating
+// to local-mode-only here keeps the two architectures from
+// racing.
+```
+
+- [ ] **Step 7: Run full cargo test**
+
+Run: `cargo test` from `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/supervisor.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(§40): add local-post-stop.bat for local-mode update relaunch"
+```
+
+---
+
+### Task 3: Full verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run tsc --noEmit**
+
+Run: `npx tsc --noEmit` from `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+Expected: clean.
+
+- [ ] **Step 2: Run full vitest suite**
+
+Run: `npx vitest run` from `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run full cargo test**
+
+Run: `cargo test` from `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+Expected: all tests pass.
+
+---
+
+### Task 4: CHANGELOG + version bump + beta cut
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`, `Cargo.toml` (via `npm run version:bump`)
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Under `## [Unreleased]`:
+
+```markdown
+### Fixed
+
+- **Local-mode in-app updates now work.** Velopack's `restart=true` silently failed under non-elevated user identity — the `current/` swap completed but the app was never relaunched. Fix: `restart=false` for all modes + a local-post-stop.bat (sleeps 12s for Velopack swap, then launches the new launcher). Mirrors the proven service-mode post-stop.bat pattern.
+```
+
+- [ ] **Step 2: Version bump**
+
+Check the latest tag and bump accordingly.
+
+- [ ] **Step 3: Commit + push + PR + tag**
+
+Branch → push → PR → auto-merge → tag → release pipeline.
+
+---
+
+### Task 5: Deploy smoke test
+
+**Smoke matrix (3 items, all local mode on Windows):**
+
+1. **Local-mode update (same channel):** install v0.1.27 stable, trigger update to v0.1.28 → operation-server page appears → 12s later app relaunches on new version
+2. **Local-mode update (cross-channel):** install a beta, switch channel to stable, update → same flow, new version
+3. **Service-mode update (regression check):** install service, trigger update → existing flow still works (no regression from restart=false change — service mode was already restart=false)

--- a/docs/superpowers/specs/2026-05-26-local-mode-update-relaunch-design.md
+++ b/docs/superpowers/specs/2026-05-26-local-mode-update-relaunch-design.md
@@ -1,0 +1,72 @@
+# §40 — Local-mode update relaunch
+
+## Problem
+
+`waitExitThenApplyUpdate(restart=true)` fails silently in local mode. Velopack's Update.exe cannot relaunch the app under a non-elevated user identity — the `current/` swap either fails or completes but Update.exe can't start the new binary. The app comes back on the old version with no error. Service mode works because `restart=false` + Servy's post-stop.bat handles the relaunch under LocalSystem.
+
+## Solution
+
+Make local mode work like service mode: `restart=false` for all modes + our own relaunch mechanism.
+
+### Change 1: UpdateService.ts
+
+Change line 377 from:
+```typescript
+this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, !isServiceMode);
+```
+to:
+```typescript
+this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+```
+
+`restart=false` for ALL modes. We own the relaunch in both service mode (post-stop.bat + `sc start`) and local mode (new local-post-stop.bat).
+
+### Change 2: supervisor.rs
+
+In the local-mode apply-update branch (the block that checks `!cfg_now.is_service_mode()` + marker exists), after spawning the operation-server, generate and spawn a local-post-stop.bat:
+
+```bat
+@echo off
+timeout /t 12 /nobreak >nul
+start "" "<install_root>\current\ws-scrcpy-web-launcher.exe"
+exit /b 0
+```
+
+- Written on-the-fly to `<dataRoot>/control/local-post-stop.bat` (Velopack-untouchable location)
+- Spawned detached via `cmd.exe /c` (fire-and-forget)
+- The 12s sleep matches the service-mode post-stop bat's proven timing
+- After the sleep, `current/` has been swapped by Update.exe → bat launches the NEW launcher
+- New launcher starts → writes operation-server stop marker → operation-server winds down → browser navigates
+
+### What doesn't change
+
+- **Operation-server** — still spawned by the supervisor, still serves "updating, please wait" page, still winds down on stop marker from the new launcher
+- **Service-mode flow** — completely untouched (Servy's post-stop.bat + `sc start`)
+- **Frontend** — no changes (upgrade-server page works the same)
+- **Marker lifecycle** — apply-update-pending marker still deleted by supervisor before spawning (existing code)
+
+### Sequence (local mode, after fix)
+
+```
+t=0s    Node calls waitExitThenApplyUpdate(restart=false)
+t=0s    Node exits cleanly
+t=0s    Supervisor: sees clean exit + apply-update marker
+t=0s    Supervisor: deletes marker
+t=0s    Supervisor: spawns operation-server (binds port 8000)
+t=0s    Supervisor: writes + spawns local-post-stop.bat
+t=0s    Supervisor: exits
+t=~1s   Velopack Update.exe calls --veloapp-obsolete (old binary)
+t=1-3s  Update.exe swaps current/ (no relaunch — restart=false)
+t=0-12s Operation-server serves "updating, please wait" page
+t=12s   local-post-stop.bat sleep finishes → launches current/launcher.exe (NEW version)
+t=12s   New launcher starts → writes stop marker
+t=12s   Operation-server detects stop marker → enters wind-down
+t=~15s  New Node starts, binds port → operation-server navigates browser
+```
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/server/UpdateService.ts` | `restart` param: `!isServiceMode` → `false` |
+| `launcher/src/supervisor.rs` | Write + spawn local-post-stop.bat in apply-update branch |

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -198,21 +198,18 @@ pub fn run() -> Result<i32> {
             None => {
                 log::info("supervisor: clean exit; not restarting");
 
-                // §32 Part 5f — local-mode upgrade page. If apply-update-
-                // pending marker is present AND we're in local mode, spawn
-                // the upgrade-server from the dataRoot helper before
-                // exiting. Velopack's restart=true (set by UpdateService
-                // for non-service-mode applyUpdate) will relaunch this
-                // launcher post-swap; the upgrade-server serves the
-                // updating page through that ~3-8s gap.
+                // §40 — local-mode update relaunch. If apply-update-pending
+                // marker is present AND we're in local mode:
+                //   1. Spawn operation-server (serves "updating" page)
+                //   2. Write + spawn local-post-stop.bat (sleeps 12s, then
+                //      launches the new current/launcher.exe post-swap)
+                //   3. Exit — Velopack Update.exe swaps current/ (restart=false,
+                //      we own the relaunch via the bat)
                 //
-                // In service mode the post-stop bat handles this same
-                // spawn — gating to local-mode-only here keeps the two
-                // architectures from racing for the bind. The marker is
-                // the discriminator between apply-update and user-
-                // initiated stop in BOTH modes; it's written by Node's
-                // UpdateService.applyUpdate (Part 5f drops the previous
-                // service-mode-only gate on the marker write).
+                // In service mode, Servy's post-stop.bat handles both the
+                // operation-server spawn and the sc start relaunch — gating
+                // to local-mode-only here keeps the two architectures from
+                // racing.
                 let cfg_now = common::config::AppConfig::load(&paths.data_root);
                 if !cfg_now.is_service_mode() {
                     let marker = crate::operation_server::apply_update_pending_marker(
@@ -230,6 +227,46 @@ pub fn run() -> Result<i32> {
                             ));
                         }
                         crate::operation_server::spawn_detached_helper(&paths.data_root);
+
+                        // §40 — local-mode relaunch. Write + spawn a bat that
+                        // sleeps through the Velopack swap window, then launches
+                        // the new current/launcher.exe.
+                        let bat_dir = paths.data_root.join("control");
+                        let bat_path = bat_dir.join("local-post-stop.bat");
+                        let bat_content = build_local_post_stop_bat(&paths.install_root);
+                        match std::fs::write(&bat_path, &bat_content) {
+                            Ok(()) => {
+                                log::info(&format!(
+                                    "supervisor: wrote local-post-stop.bat at {bat_path:?}"
+                                ));
+                                #[cfg(windows)]
+                                {
+                                    use std::os::windows::process::CommandExt;
+                                    use std::process::Stdio;
+                                    const DETACHED_PROCESS: u32 = 0x00000008;
+                                    const CREATE_NO_WINDOW: u32 = 0x08000000;
+                                    match std::process::Command::new(r"C:\Windows\System32\cmd.exe")
+                                        .args(["/c", &bat_path.to_string_lossy()])
+                                        .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
+                                        .stdin(Stdio::null())
+                                        .stdout(Stdio::null())
+                                        .stderr(Stdio::null())
+                                        .spawn()
+                                    {
+                                        Ok(child) => log::info(&format!(
+                                            "supervisor: spawned local-post-stop.bat (pid {})",
+                                            child.id()
+                                        )),
+                                        Err(e) => log::error(&format!(
+                                            "supervisor: failed to spawn local-post-stop.bat: {e}"
+                                        )),
+                                    }
+                                }
+                            }
+                            Err(e) => log::error(&format!(
+                                "supervisor: failed to write local-post-stop.bat: {e}"
+                            )),
+                        }
                     }
                 }
 
@@ -246,6 +283,17 @@ pub fn run() -> Result<i32> {
 
         thread::sleep(RESTART_DELAY);
     }
+}
+
+fn build_local_post_stop_bat(install_root: &Path) -> String {
+    let launcher = install_root.join("current").join("ws-scrcpy-web-launcher.exe");
+    let launcher_str = launcher.to_string_lossy();
+    format!(
+        "@echo off\r\n\
+         timeout /t 12 /nobreak >nul\r\n\
+         start \"\" \"{launcher_str}\"\r\n\
+         exit /b 0\r\n"
+    )
 }
 
 fn cleanup_stale_marker(marker: &Path) {
@@ -322,5 +370,14 @@ mod tests {
         // If both signals are present, marker wins (matches start.cmd's
         // ordering — marker checked before exit code).
         assert_eq!(decide_restart(75, true), Some(RestartReason::RestartMarker));
+    }
+
+    #[test]
+    fn local_post_stop_bat_contains_launcher_path_and_sleep() {
+        let install_root = std::path::Path::new(r"C:\Program Files\WsScrcpyWeb");
+        let bat = build_local_post_stop_bat(install_root);
+        assert!(bat.contains("timeout /t 12 /nobreak"));
+        assert!(bat.contains(r"C:\Program Files\WsScrcpyWeb\current\ws-scrcpy-web-launcher.exe"));
+        assert!(bat.contains("exit /b 0"));
     }
 }

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -373,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn local_post_stop_bat_contains_launcher_path_and_sleep() {
         let install_root = std::path::Path::new(r"C:\Program Files\WsScrcpyWeb");
         let bat = build_local_post_stop_bat(install_root);

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -337,10 +337,10 @@ export class UpdateService {
         // silent=true (no UI from Velopack updater).
         //
         // restart semantics depend on install mode:
-        //   - local mode (installMode in {null, 'user', 'system'}): restart=true so
+        //   - local mode: restart=false. Supervisor writes + spawns a
         //     Velopack relaunches the user-mode launcher post-swap. Unchanged
         //     behavior from v0.1.x stable.
-        //   - service mode (installMode in {'user-service', 'system-service'}): restart=false.
+        //   - service mode: restart=false. Servy's post-stop.bat handles sc start.
         //     Velopack's stub-relaunch would spawn a parallel LocalSystem launcher
         //     outside Servy (inherits the LocalSystem token from Update.exe's parent
         //     chain, grabs the single-instance mutex, starves out Servy's recovery
@@ -352,8 +352,6 @@ export class UpdateService {
         //     to launch a fresh launcher — by which point Velopack is long gone.
         //     v0.1.25-beta.8 / beta.10 / beta.11 smokes caught the prior approaches;
         //     see §32 Part 3 in todo_ws_scrcpy_web.md.
-        const installMode = Config.getInstance().getAppConfig().installMode;
-        const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
         // §32 Part 5e/5f — upgrade-server is no longer spawned from Node.
         // The pre-exit spawn (Part 5b) put the upgrade-server inside
         // Velopack's process tree, loading
@@ -374,7 +372,7 @@ export class UpdateService {
         // neither side can tell apply-update from a user-initiated
         // stop (Ctrl+C, services.msc Stop, etc.) and would over-spawn.
         await this.writeApplyUpdatePendingMarker();
-        this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, !isServiceMode);
+        this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
     }
 
     /**

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -389,9 +389,9 @@ describe('UpdateService', () => {
         await expect(svc.applyUpdate()).rejects.toThrow(/apply not allowed in current state/);
     });
 
-    it('applyUpdate (local mode): waitExitThenApplyUpdate called with restart=true', async () => {
+    it('applyUpdate (local mode): waitExitThenApplyUpdate called with restart=false', async () => {
         // Default installMode is null after Config._resetForTest + empty config.json,
-        // which is treated as local mode (Velopack relaunches the user-mode launcher).
+        // which is treated as local mode. restart=false — we own the relaunch.
         Config.getInstance().updateAppConfig({ autoUpdate: false });
         const info = fakeUpdateInfo('0.2.0');
         const applyFn = vi.fn();
@@ -417,8 +417,8 @@ describe('UpdateService', () => {
         const args = applyFn.mock.calls[0]!;
         expect(args[0]).toBe(info);
         expect(args[1]).toBe(true);
-        // restart=true in local mode (Velopack relaunches us post-swap).
-        expect(args[2]).toBe(true);
+        // restart=false in all modes — launcher supervisor handles relaunch.
+        expect(args[2]).toBe(false);
     });
 
     // v0.1.25-beta.8 smoke A.2 regression: when installMode is a service mode,
@@ -459,11 +459,11 @@ describe('UpdateService', () => {
     });
 
     // Symmetry check: local-mode variants other than the default null should also
-    // get restart=true. Keeps the boolean wiring honest if someone widens InstallMode later.
+    // get restart=false. All modes use restart=false — we own the relaunch.
     it.each([
         ['user' as const],
         ['system' as const],
-    ])('applyUpdate (%s): waitExitThenApplyUpdate called with restart=true', async (installMode) => {
+    ])('applyUpdate (%s): waitExitThenApplyUpdate called with restart=false', async (installMode) => {
         Config.getInstance().updateAppConfig({ autoUpdate: false, installMode });
         const info = fakeUpdateInfo('0.2.0');
         const applyFn = vi.fn();
@@ -484,7 +484,7 @@ describe('UpdateService', () => {
         await svc.applyUpdate();
         expect(applyFn).toHaveBeenCalledTimes(1);
         const args = applyFn.mock.calls[0]!;
-        expect(args[2]).toBe(true);
+        expect(args[2]).toBe(false);
     });
 
     // §32 Part 5e/5f: the upgrade-server is no longer spawned from Node.
@@ -544,9 +544,7 @@ describe('UpdateService', () => {
         await svc.checkForUpdates();
         await svc.applyUpdate();
         expect(applyFn).toHaveBeenCalledTimes(1);
-        const isServiceMode =
-            installMode === 'user-service' || installMode === 'system-service';
-        expect(applyFn.mock.calls[0]![2]).toBe(!isServiceMode);
+        expect(applyFn.mock.calls[0]![2]).toBe(false);
 
         const markerCalls = writeFileSpy.mock.calls.filter(
             (c) =>


### PR DESCRIPTION
Local-mode updates silently failed — Velopack restart=true doesn't work under non-elevated identity. Fix: restart=false for all modes + local-post-stop.bat (sleeps 12s, launches new launcher). Mirrors service-mode pattern.