### PR TITLE
fix(§40): bat owns Velopack apply in local mode

### DIFF
--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -286,11 +286,15 @@ pub fn run() -> Result<i32> {
 }
 
 fn build_local_post_stop_bat(install_root: &Path) -> String {
+    let update_exe = install_root.join("Update.exe");
+    let update_str = update_exe.to_string_lossy();
     let launcher = install_root.join("current").join("ws-scrcpy-web-launcher.exe");
     let launcher_str = launcher.to_string_lossy();
     format!(
         "@echo off\r\n\
-         timeout /t 12 /nobreak >nul\r\n\
+         timeout /t 5 /nobreak >nul\r\n\
+         \"{update_str}\" apply --silent\r\n\
+         timeout /t 2 /nobreak >nul\r\n\
          start \"\" \"{launcher_str}\"\r\n\
          exit /b 0\r\n"
     )
@@ -374,10 +378,12 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn local_post_stop_bat_contains_launcher_path_and_sleep() {
+    fn local_post_stop_bat_contains_update_exe_and_launcher() {
         let install_root = std::path::Path::new(r"C:\Program Files\WsScrcpyWeb");
         let bat = build_local_post_stop_bat(install_root);
-        assert!(bat.contains("timeout /t 12 /nobreak"));
+        assert!(bat.contains("timeout /t 5 /nobreak"));
+        assert!(bat.contains(r"Update.exe"));
+        assert!(bat.contains("apply --silent"));
         assert!(bat.contains(r"C:\Program Files\WsScrcpyWeb\current\ws-scrcpy-web-launcher.exe"));
         assert!(bat.contains("exit /b 0"));
     }

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -352,6 +352,9 @@ export class UpdateService {
         //     to launch a fresh launcher — by which point Velopack is long gone.
         //     v0.1.25-beta.8 / beta.10 / beta.11 smokes caught the prior approaches;
         //     see §32 Part 3 in todo_ws_scrcpy_web.md.
+        const installMode = Config.getInstance().getAppConfig().installMode;
+        const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
+
         // §32 Part 5e/5f — upgrade-server is no longer spawned from Node.
         // The pre-exit spawn (Part 5b) put the upgrade-server inside
         // Velopack's process tree, loading
@@ -372,7 +375,18 @@ export class UpdateService {
         // neither side can tell apply-update from a user-initiated
         // stop (Ctrl+C, services.msc Stop, etc.) and would over-spawn.
         await this.writeApplyUpdatePendingMarker();
-        this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+
+        if (isServiceMode) {
+            // Service mode: Velopack applies under LocalSystem via Servy's
+            // post-stop.bat which calls sc start after the swap.
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+        }
+        // Local mode: do NOT call waitExitThenApplyUpdate. That spawns
+        // Update.exe watching our PID, which kills the launcher's process
+        // tree before the supervisor can spawn the operation-server + bat.
+        // Instead: write the marker, exit cleanly. The supervisor's
+        // local-post-stop.bat calls Update.exe apply --silent after
+        // everything has exited.
     }
 
     /**

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -413,12 +413,9 @@ describe('UpdateService', () => {
         // (adb kill-server + Windows taskkill + 250ms settle). Hygiene
         // failures are swallowed so the test still drives waitExitThenApplyUpdate.
         await svc.applyUpdate();
-        expect(applyFn).toHaveBeenCalledTimes(1);
-        const args = applyFn.mock.calls[0]!;
-        expect(args[0]).toBe(info);
-        expect(args[1]).toBe(true);
-        // restart=false in all modes — launcher supervisor handles relaunch.
-        expect(args[2]).toBe(false);
+        // §40: local mode does NOT call waitExitThenApplyUpdate — the
+        // supervisor's local-post-stop.bat calls Update.exe apply directly.
+        expect(applyFn).not.toHaveBeenCalled();
     });
 
     // v0.1.25-beta.8 smoke A.2 regression: when installMode is a service mode,
@@ -458,12 +455,12 @@ describe('UpdateService', () => {
         expect(args[2]).toBe(false);
     });
 
-    // Symmetry check: local-mode variants other than the default null should also
-    // get restart=false. All modes use restart=false — we own the relaunch.
+    // §40: local-mode variants (user/system) also skip waitExitThenApplyUpdate.
+    // The supervisor's local-post-stop.bat calls Update.exe apply directly.
     it.each([
         ['user' as const],
         ['system' as const],
-    ])('applyUpdate (%s): waitExitThenApplyUpdate called with restart=false', async (installMode) => {
+    ])('applyUpdate (%s): does NOT call waitExitThenApplyUpdate (local mode)', async (installMode) => {
         Config.getInstance().updateAppConfig({ autoUpdate: false, installMode });
         const info = fakeUpdateInfo('0.2.0');
         const applyFn = vi.fn();
@@ -482,9 +479,7 @@ describe('UpdateService', () => {
         await svc.checkForUpdates();
         expect(svc.getStatus().status).toBe('ready');
         await svc.applyUpdate();
-        expect(applyFn).toHaveBeenCalledTimes(1);
-        const args = applyFn.mock.calls[0]!;
-        expect(args[2]).toBe(false);
+        expect(applyFn).not.toHaveBeenCalled();
     });
 
     // §32 Part 5e/5f: the upgrade-server is no longer spawned from Node.
@@ -543,8 +538,13 @@ describe('UpdateService', () => {
         svc.init();
         await svc.checkForUpdates();
         await svc.applyUpdate();
-        expect(applyFn).toHaveBeenCalledTimes(1);
-        expect(applyFn.mock.calls[0]![2]).toBe(false);
+        const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
+        if (isServiceMode) {
+            expect(applyFn).toHaveBeenCalledTimes(1);
+            expect(applyFn.mock.calls[0]![2]).toBe(false);
+        } else {
+            expect(applyFn).not.toHaveBeenCalled();
+        }
 
         const markerCalls = writeFileSpy.mock.calls.filter(
             (c) =>


### PR DESCRIPTION
Revised fix: local mode skips waitExitThenApplyUpdate entirely (it kills the process tree before supervisor can spawn operation-server). Instead, local-post-stop.bat calls Update.exe apply --silent directly after the launcher exits. No race, no process-tree kill.