### PR TITLE
fix(§40): break current/ CWD handle lock on update

### DIFF
--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -662,6 +662,7 @@ pub fn spawn_detached_helper(data_root: &Path) {
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         match std::process::Command::new(&helper)
             .arg("--operation-server")
+            .current_dir(data_root)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -247,6 +247,7 @@ pub fn run() -> Result<i32> {
                                     const CREATE_NO_WINDOW: u32 = 0x08000000;
                                     match std::process::Command::new(r"C:\Windows\System32\cmd.exe")
                                         .args(["/c", &bat_path.to_string_lossy()])
+                                        .current_dir(&paths.data_root)
                                         .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
                                         .stdin(Stdio::null())
                                         .stdout(Stdio::null())


### PR DESCRIPTION
Root cause: operation-server + bat's cmd.exe inherited current/ as CWD from the launcher. Their CWD handles blocked Update.exe from renaming current/ during the swap. Fix: .current_dir(data_root) on both spawns.