### PR TITLE
fix(§40): direct nupkg extraction — no Update.exe, no bat

### DIFF
--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -173,6 +173,70 @@ pub fn should_exit_for_stop_marker(data_root: &Path) -> bool {
     dir.join(STOP_MARKER_FILENAME).exists() || dir.join(LEGACY_STOP_MARKER_FILENAME).exists()
 }
 
+/// Find the latest full nupkg in `packages_dir` and extract its `lib/app/`
+/// contents into `current_dir` (overwrite). Returns the version string on
+/// success. This replaces Update.exe for local-mode updates — no rename
+/// dance, no process-tree scanning, no CWD handle locks.
+fn find_and_extract_nupkg(packages_dir: &Path, current_dir: &Path) -> Result<String, String> {
+    let entry = std::fs::read_dir(packages_dir)
+        .map_err(|e| format!("cannot read packages dir: {e}"))?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let s = name.to_string_lossy();
+            s.ends_with("-full.nupkg")
+        })
+        .max_by_key(|e| e.file_name());
+
+    let nupkg_path = entry
+        .ok_or_else(|| "no *-full.nupkg found in packages dir".to_string())?
+        .path();
+
+    let version = nupkg_path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    log::info(&format!("operation-server: extracting {nupkg_path:?}"));
+
+    let file = std::fs::File::open(&nupkg_path)
+        .map_err(|e| format!("cannot open nupkg: {e}"))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|e| format!("cannot read nupkg as zip: {e}"))?;
+
+    let prefix = "lib/app/";
+    let mut extracted = 0u32;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)
+            .map_err(|e| format!("zip entry {i}: {e}"))?;
+        let raw_name = entry.name().to_string();
+        if !raw_name.starts_with(prefix) {
+            continue;
+        }
+        let relative = &raw_name[prefix.len()..];
+        if relative.is_empty() {
+            continue;
+        }
+        let dest = current_dir.join(relative);
+        if raw_name.ends_with('/') {
+            let _ = std::fs::create_dir_all(&dest);
+        } else {
+            if let Some(parent) = dest.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let mut out = std::fs::File::create(&dest)
+                .map_err(|e| format!("cannot create {dest:?}: {e}"))?;
+            std::io::copy(&mut entry, &mut out)
+                .map_err(|e| format!("cannot write {dest:?}: {e}"))?;
+            extracted += 1;
+        }
+    }
+
+    log::info(&format!("operation-server: extracted {extracted} files"));
+    Ok(version)
+}
+
 fn run() -> i32 {
     log::info("operation-server: starting");
 
@@ -237,17 +301,78 @@ fn run() -> i32 {
         "operation-server: bound 0.0.0.0:{port}, serving updating page (max lifetime {MAX_LIFETIME_SECS}s)"
     ));
 
+    // §40 — local-mode update: extract nupkg + relaunch, all from this
+    // process (no Update.exe, no bat). Triggered by WS_SCRCPY_INSTALL_ROOT
+    // env var set by the supervisor for local-mode apply-update only.
+    if variant == OperationVariant::ApplyUpdate {
+        if let Ok(install_root) = std::env::var("WS_SCRCPY_INSTALL_ROOT") {
+            let install_root = PathBuf::from(install_root);
+            // Serve the page on a background thread while we do the apply.
+            let bg_listener = listener.try_clone().expect("clone listener");
+            let bg_redirect: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+            let bg_redirect2 = bg_redirect.clone();
+            let page_thread = thread::spawn(move || {
+                loop {
+                    accept_one(&bg_listener, &bg_redirect2, OperationVariant::ApplyUpdate);
+                }
+            });
+
+            log::info("operation-server: local-mode apply — killing tray");
+            #[cfg(windows)]
+            {
+                let _ = std::process::Command::new(r"C:\Windows\System32\taskkill.exe")
+                    .args(["/F", "/IM", "ws-scrcpy-web-tray.exe", "/T"])
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+            thread::sleep(Duration::from_secs(3));
+
+            let packages_dir = install_root.join("packages");
+            let current_dir = install_root.join("current");
+            match find_and_extract_nupkg(&packages_dir, &current_dir) {
+                Ok(ver) => log::info(&format!("operation-server: extracted {ver} into current/")),
+                Err(e) => {
+                    log::error(&format!("operation-server: nupkg extraction failed: {e}"));
+                    return 4;
+                }
+            }
+
+            thread::sleep(Duration::from_secs(1));
+            log::info("operation-server: launching new launcher");
+            let launcher = current_dir.join("ws-scrcpy-web-launcher.exe");
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                const DETACHED_PROCESS: u32 = 0x00000008;
+                const CREATE_NO_WINDOW: u32 = 0x08000000;
+                match std::process::Command::new(&launcher)
+                    .current_dir(&install_root)
+                    .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                {
+                    Ok(child) => log::info(&format!(
+                        "operation-server: launched new launcher (pid {})", child.id()
+                    )),
+                    Err(e) => log::error(&format!(
+                        "operation-server: failed to launch new launcher: {e}"
+                    )),
+                }
+            }
+            // Fall through to normal stop-marker loop — new launcher will
+            // write it, triggering wind-down + browser redirect.
+            drop(page_thread);
+        }
+    }
+
     let stop_flag = Arc::new(AtomicBool::new(false));
-    // Shared redirect state — populated by the wind-down probe thread when
-    // the real Node is found on a different port than the upgrade-server is
-    // holding. Connection handlers check it on every request and switch
-    // /api/config from 503 (still upgrading) to 200 + redirect JSON when set.
     let redirect_state: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let started_at = Instant::now();
 
-    // Normal serving phase — runs until stop marker observed or max lifetime
-    // hits. After stop marker, control transfers to wind_down() which keeps
-    // the listener open while probing for the new Node's port.
     loop {
         if stop_flag.load(Ordering::SeqCst) {
             log::info("operation-server: stop_flag observed, exiting");

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -341,9 +341,9 @@ fn run() -> i32 {
 
             thread::sleep(Duration::from_secs(1));
             log::info("operation-server: launching new launcher");
-            let launcher = current_dir.join("ws-scrcpy-web-launcher.exe");
             #[cfg(windows)]
             {
+                let launcher = current_dir.join("ws-scrcpy-web-launcher.exe");
                 use std::os::windows::process::CommandExt;
                 const DETACHED_PROCESS: u32 = 0x00000008;
                 const CREATE_NO_WINDOW: u32 = 0x08000000;

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -219,55 +219,15 @@ pub fn run() -> Result<i32> {
                         log::info(
                             "supervisor: apply-update-pending marker present (local mode); spawning operation-server before exit",
                         );
-                        // Delete marker FIRST so a subsequent restart that
-                        // observes a stale marker doesn't re-spawn.
                         if let Err(e) = std::fs::remove_file(&marker) {
                             log::error(&format!(
                                 "supervisor: could not delete apply-update-pending marker (non-fatal): {e}"
                             ));
                         }
+                        // §40 — pass install_root so the operation-server
+                        // can extract the nupkg into current/ and relaunch.
+                        std::env::set_var("WS_SCRCPY_INSTALL_ROOT", &paths.install_root);
                         crate::operation_server::spawn_detached_helper(&paths.data_root);
-
-                        // §40 — local-mode relaunch. Write + spawn a bat that
-                        // sleeps through the Velopack swap window, then launches
-                        // the new current/launcher.exe.
-                        let bat_dir = paths.data_root.join("control");
-                        let bat_path = bat_dir.join("local-post-stop.bat");
-                        let bat_content = build_local_post_stop_bat(&paths.install_root, &paths.data_root);
-                        match std::fs::write(&bat_path, &bat_content) {
-                            Ok(()) => {
-                                log::info(&format!(
-                                    "supervisor: wrote local-post-stop.bat at {bat_path:?}"
-                                ));
-                                #[cfg(windows)]
-                                {
-                                    use std::os::windows::process::CommandExt;
-                                    use std::process::Stdio;
-                                    const DETACHED_PROCESS: u32 = 0x00000008;
-                                    const CREATE_NO_WINDOW: u32 = 0x08000000;
-                                    match std::process::Command::new(r"C:\Windows\System32\cmd.exe")
-                                        .args(["/c", &bat_path.to_string_lossy()])
-                                        .current_dir(&paths.data_root)
-                                        .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
-                                        .stdin(Stdio::null())
-                                        .stdout(Stdio::null())
-                                        .stderr(Stdio::null())
-                                        .spawn()
-                                    {
-                                        Ok(child) => log::info(&format!(
-                                            "supervisor: spawned local-post-stop.bat (pid {})",
-                                            child.id()
-                                        )),
-                                        Err(e) => log::error(&format!(
-                                            "supervisor: failed to spawn local-post-stop.bat: {e}"
-                                        )),
-                                    }
-                                }
-                            }
-                            Err(e) => log::error(&format!(
-                                "supervisor: failed to write local-post-stop.bat: {e}"
-                            )),
-                        }
                     }
                 }
 
@@ -284,28 +244,6 @@ pub fn run() -> Result<i32> {
 
         thread::sleep(RESTART_DELAY);
     }
-}
-
-fn build_local_post_stop_bat(install_root: &Path, data_root: &Path) -> String {
-    let update_exe = install_root.join("Update.exe");
-    let update_str = update_exe.to_string_lossy();
-    let launcher = install_root.join("current").join("ws-scrcpy-web-launcher.exe");
-    let launcher_str = launcher.to_string_lossy();
-    let log_path = data_root.join("logs").join("update-apply.log");
-    let log_str = log_path.to_string_lossy();
-    // ping loopback is the classic silent-wait trick for bat files.
-    // timeout.exe shows a visible countdown window even under
-    // CREATE_NO_WINDOW; ping -n N waits (N-1) seconds silently.
-    format!(
-        "@echo off\r\n\
-         ping -n 6 127.0.0.1 >nul\r\n\
-         C:\\Windows\\System32\\taskkill.exe /F /IM ws-scrcpy-web-tray.exe /T >nul 2>&1\r\n\
-         ping -n 4 127.0.0.1 >nul\r\n\
-         \"{update_str}\" apply --silent --norestart --log \"{log_str}\"\r\n\
-         ping -n 3 127.0.0.1 >nul\r\n\
-         start \"\" \"{launcher_str}\"\r\n\
-         exit /b 0\r\n"
-    )
 }
 
 fn cleanup_stale_marker(marker: &Path) {
@@ -384,19 +322,4 @@ mod tests {
         assert_eq!(decide_restart(75, true), Some(RestartReason::RestartMarker));
     }
 
-    #[test]
-    #[cfg(windows)]
-    fn local_post_stop_bat_contains_update_exe_and_launcher() {
-        let install_root = std::path::Path::new(r"C:\Program Files\WsScrcpyWeb");
-        let data_root = std::path::Path::new(r"C:\ProgramData\WsScrcpyWeb");
-        let bat = build_local_post_stop_bat(install_root, data_root);
-        assert!(bat.contains("ping -n 6 127.0.0.1"));
-        assert!(bat.contains("taskkill.exe /F /IM ws-scrcpy-web-tray.exe"));
-        assert!(bat.contains("ping -n 4 127.0.0.1"));
-        assert!(bat.contains(r"Update.exe"));
-        assert!(bat.contains("apply --silent --norestart"));
-        assert!(bat.contains("update-apply.log"));
-        assert!(bat.contains(r"C:\Program Files\WsScrcpyWeb\current\ws-scrcpy-web-launcher.exe"));
-        assert!(bat.contains("exit /b 0"));
-    }
 }


### PR DESCRIPTION
Replaces the bat + Update.exe approach with direct nupkg extraction in the operation-server:

1. Operation-server detects local-mode apply via WS_SCRCPY_INSTALL_ROOT env var
2. Kills tray (taskkill by image name)
3. Extracts nupkg lib/app/* contents directly into current/ (overwrite)
4. Launches new launcher from current/
5. Falls through to normal stop-marker loop for browser redirect

No Update.exe (no process-tree kill race). No bat (no CWD handle inheritance, no visible windows). No rename dance (overwrite in place). Bat code + test removed.