### PR TITLE
chore: bump to v0.1.28-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28-beta.13] - 2026-05-26
+
 ## [0.1.28-beta.12] - 2026-05-26
 
 ## [0.1.28-beta.11] - 2026-05-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.28-beta.12"
+version = "0.1.28-beta.13"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.28-beta.12",
+  "version": "0.1.28-beta.13",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary
- Version bump to v0.1.28-beta.13
- Includes PR #164 (tray shutdown diagnostic logging)

## Test plan
- [ ] CI green
- [ ] Release publishes
- [ ] Upgrade from beta.12, reproduce tray exit regression, check tray.log