### PR TITLE
chore: bump to v0.1.28-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28-beta.14] - 2026-05-26
+
 ## [0.1.28-beta.13] - 2026-05-26
 
 ## [0.1.28-beta.12] - 2026-05-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.28-beta.13"
+version = "0.1.28-beta.14"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.28-beta.13",
+  "version": "0.1.28-beta.14",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
## Summary
- No-op version bump target so beta.13→14 upgrade exercises the tray shutdown diagnostic logging from PR #164

## Test plan
- [ ] Install beta.13 fresh on VM
- [ ] Upgrade to beta.14 via in-app updater
- [ ] Click tray exit → Yes
- [ ] Read `C:\ProgramData\WsScrcpyWeb\logs\tray.log` for diagnostic lines