### PR TITLE
fix(§40): exit operation-server after local-mode relaunch

### DIFF
--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -311,7 +311,7 @@ fn run() -> i32 {
             let bg_listener = listener.try_clone().expect("clone listener");
             let bg_redirect: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
             let bg_redirect2 = bg_redirect.clone();
-            let page_thread = thread::spawn(move || {
+            let _page_thread = thread::spawn(move || {
                 loop {
                     accept_one(&bg_listener, &bg_redirect2, OperationVariant::ApplyUpdate);
                 }
@@ -366,9 +366,15 @@ fn run() -> i32 {
                     )),
                 }
             }
-            // Fall through to normal stop-marker loop — new launcher will
-            // write it, triggering wind-down + browser redirect.
-            drop(page_thread);
+            // Exit immediately so the new launcher gets a clean port
+            // bind. The wind-down + probe redirect loop is for the
+            // service-mode bat case; in §40 the operation-server owns
+            // the whole update and its job is done once the new launcher
+            // is spawned. Holding the port through wind-down causes
+            // Node to bind IPv6-only (dual-stack conflict with our
+            // IPv4 listener), leaving 127.0.0.1 unreachable.
+            log::info("operation-server: local-mode apply complete, exiting");
+            return 0;
         }
     }
 


### PR DESCRIPTION
## Summary
- After extracting nupkg + launching the new launcher, the operation-server fell through to the 15s wind-down loop, holding `0.0.0.0:8000`
- New Node's dual-stack bind to `::8000` got only the IPv6 socket — `127.0.0.1` unreachable
- Tray's ureq POST to `127.0.0.1:8000` timed out (os error 10060) instead of reaching ServerShutdownApi
- Fix: `return 0` immediately after spawning the new launcher in the §40 path

## Root cause
Confirmed via tray.log diagnostics (PR #164): pre-update POST returns `200 OK`; post-update POST times out with `WSAETIMEDOUT`. Killing + restarting the launcher (clean dual-stack bind) fixes it.

## Test plan
- [ ] Cut beta.15 (this fix) + beta.16 (upgrade target)
- [ ] Install beta.15 on VM
- [ ] Upgrade to beta.16
- [ ] Click tray exit → should shut down server cleanly
- [ ] Verify tray.log shows `200 OK`