### PR TITLE
fix(§40): local-mode update redesign — separate port for operation-server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,14 @@ jobs:
           # channel won't see beta releases because their feed file lists
           # only stable assets. See feedback_velopack_permachine_lessons.md
           # Gotcha 5 for the full diagnosis.
+          #
+          # make_latest: 'legacy' lets GitHub determine Latest via its
+          # own SemVer + creation-date algorithm instead of every new
+          # release forcibly stealing the badge. Fixes the releases page
+          # sort order (betas were appearing in the middle instead of at
+          # the top because each publish force-set Latest and GitHub
+          # sorted non-Latest entries by commit date not publish date).
+          make_latest: 'legacy'
           body_path: release-notes.md
           files: |
             artifacts/windows-final/*.msi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28-beta.17] - 2026-05-26
+
 ### Fixed
 
 - **Local-mode update redesign (§40).** Operation-server now binds `config_port + 1` (probing upward) instead of competing with Node for `config_port`. Eliminates the IPv4-dead / dual-stack corruption bug where `127.0.0.1:8000` became unreachable after updates while `[::1]:8000` worked. Three stacked bugs fixed: port conflict (separate port), stale helper binary (neutralized — old code fails gracefully), Node resolution (`spawn_server` now resolves from `dependencies/node/` before falling back to `seed/node/`). Browser redirect flow: Node spawns operation-server → poll-reads port file → serves redirect to browser → operation-server probes for new Node → redirects browser back.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,42 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`resolve_node_with` relaxed.** When `deps_path` is set but the node binary isn't there yet (first-run bootstrap), resolution now falls through to `seed/node/node.exe` instead of hard-failing. `spawn_server` passes `deps_path` directly instead of reading `DEPS_PATH` from process env.
 - **Supervisor §40 path simplified.** `wait_for_port_free` + stop-marker coordination is now service-mode only. Node spawns the operation-server directly (moved from supervisor). Supervisor's clean-exit path no longer needs to detect the apply-update marker.
 - **Updating page JS rewritten.** Polls `/api/discover` on the operation-server's own port (was `/api/config` on the shared port). 60-second timeout with error message.
+- **Releases page sort fix.** `make_latest: 'legacy'` in release.yml so GitHub uses SemVer-aware sorting instead of each beta forcibly stealing the Latest badge.
+
+### Removed
+
+- **v0.1.28-beta.1 through beta.14 releases deleted.** All were iterations on the §40 local-mode update bug — none produced a working local-mode update flow. beta.15 and beta.16 are the last two pre-redesign betas retained for reference. Orphaned git tags remain (tag protection ruleset blocks deletion); they point to valid commits on main but have no associated GitHub Release.
 
 ## [0.1.28-beta.16] - 2026-05-26
 
 ## [0.1.28-beta.15] - 2026-05-26
 
-## [0.1.28-beta.14] - 2026-05-26
-
-## [0.1.28-beta.13] - 2026-05-26
-
-## [0.1.28-beta.12] - 2026-05-26
-
-## [0.1.28-beta.11] - 2026-05-26
-
-## [0.1.28-beta.10] - 2026-05-26
-
-## [0.1.28-beta.9] - 2026-05-26
-
-## [0.1.28-beta.8] - 2026-05-26
-
-## [0.1.28-beta.7] - 2026-05-26
-
-## [0.1.28-beta.6] - 2026-05-26
-
-## [0.1.28-beta.5] - 2026-05-26
-
-## [0.1.28-beta.4] - 2026-05-26
-
-## [0.1.28-beta.3] - 2026-05-26
-
-## [0.1.28-beta.2] - 2026-05-25
-
-## [0.1.28-beta.1] - 2026-05-25
-
-### Fixed
-
-- **Local-mode in-app updates now work.** Velopack's `restart=true` silently failed under non-elevated user identity — `current/` swapped but the app was never relaunched. Fix: `restart=false` for all modes + a local-post-stop.bat (sleeps 12s for Velopack swap, then launches the new launcher). Mirrors the proven service-mode post-stop.bat pattern.
+## [0.1.28-beta.16] and [0.1.28-beta.15] are the last pre-redesign betas.
+## beta.1 through beta.14 were §40 iteration artifacts — releases deleted,
+## orphaned tags remain in git. See beta.17's Removed section for context.
 
 ## [0.1.27] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local-mode update redesign (§40).** Operation-server now binds `config_port + 1` (probing upward) instead of competing with Node for `config_port`. Eliminates the IPv4-dead / dual-stack corruption bug where `127.0.0.1:8000` became unreachable after updates while `[::1]:8000` worked. Three stacked bugs fixed: port conflict (separate port), stale helper binary (neutralized — old code fails gracefully), Node resolution (`spawn_server` now resolves from `dependencies/node/` before falling back to `seed/node/`). Browser redirect flow: Node spawns operation-server → poll-reads port file → serves redirect to browser → operation-server probes for new Node → redirects browser back.
+
+### Changed
+
+- **`resolve_node_with` relaxed.** When `deps_path` is set but the node binary isn't there yet (first-run bootstrap), resolution now falls through to `seed/node/node.exe` instead of hard-failing. `spawn_server` passes `deps_path` directly instead of reading `DEPS_PATH` from process env.
+- **Supervisor §40 path simplified.** `wait_for_port_free` + stop-marker coordination is now service-mode only. Node spawns the operation-server directly (moved from supervisor). Supervisor's clean-exit path no longer needs to detect the apply-update marker.
+- **Updating page JS rewritten.** Polls `/api/discover` on the operation-server's own port (was `/api/config` on the shared port). 60-second timeout with error message.
+
 ## [0.1.28-beta.16] - 2026-05-26
 
 ## [0.1.28-beta.15] - 2026-05-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.28-beta.10"
+version = "0.1.28-beta.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.28-beta.10"
+version = "0.1.28-beta.16"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.28-beta.10"
+version = "0.1.28-beta.16"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.28-beta.16"
+version = "0.1.28-beta.17"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/docs/superpowers/plans/2026-05-26-local-mode-update-redesign.md
+++ b/docs/superpowers/plans/2026-05-26-local-mode-update-redesign.md
@@ -1,0 +1,996 @@
+# Local-Mode Update Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the port conflict, stale-binary, and seed-node bugs in the §40 local-mode update flow by having the operation-server bind a separate port from Node.
+
+**Architecture:** The operation-server binds `config_port + 1` (probing upward) instead of `config_port`. Node spawns the operation-server, poll-reads a port file to discover its port, and serves a redirect to the browser. The operation-server probes for the new Node after extraction + relaunch and relays a redirect URL back to the browser via `/api/discover`. The `resolve_node_with` function is relaxed to fall through to seed when deps_path is set but node isn't there yet.
+
+**Tech Stack:** Rust (launcher), TypeScript (Node server), HTML/JS (updating page)
+
+**Spec:** `docs/superpowers/specs/2026-05-26-local-mode-update-redesign-design.md`
+
+**Repo:** `C:/Users/jscha/source/repos/ws-scrcpy-web`
+
+**Test commands:**
+- Rust: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml"`
+- Node: `npm test --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web"`
+- Type-check: `npx --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" tsc --noEmit`
+
+---
+
+### Task 1: Relax `resolve_node_with` strict mode (spawn.rs)
+
+**Files:**
+- Modify: `launcher/src/spawn.rs:26-49` (resolve_node_with + resolve_node)
+- Modify: `launcher/src/spawn.rs:196-240` (tests)
+
+- [ ] **Step 1: Update the failing test to expect fallback behavior**
+
+Change the existing `resolve_node_strict_fails_when_deps_path_missing` test to verify that when `deps_path` is set but the node binary doesn't exist there, resolution falls through to seed:
+
+```rust
+#[test]
+fn resolve_node_falls_back_to_seed_when_deps_path_set_but_node_missing() {
+    let dir = tempdir().unwrap();
+    let exe_dir = dir.path().join("exe");
+    let seed = exe_dir.join("seed").join("node").join("node.exe");
+    touch(&seed);
+
+    let bogus_deps = dir.path().join("deps-empty");
+    std::fs::create_dir_all(&bogus_deps).unwrap();
+
+    let resolved = resolve_node_with(Some(bogus_deps.to_str().unwrap()), &exe_dir).unwrap();
+    assert_eq!(resolved, seed);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml" resolve_node_falls_back_to_seed_when_deps_path_set_but_node_missing -- --nocapture`
+
+Expected: FAIL — `resolve_node_with` currently calls `bail!` when deps_path is set but node is missing.
+
+- [ ] **Step 3: Add test for the error case (both paths missing)**
+
+```rust
+#[test]
+fn resolve_node_errors_when_deps_and_seed_both_missing() {
+    let dir = tempdir().unwrap();
+    let exe_dir = dir.path().join("exe");
+    std::fs::create_dir_all(&exe_dir).unwrap();
+
+    let bogus_deps = dir.path().join("deps-empty");
+    std::fs::create_dir_all(&bogus_deps).unwrap();
+
+    let err = resolve_node_with(Some(bogus_deps.to_str().unwrap()), &exe_dir).unwrap_err();
+    assert!(err.to_string().contains("Node not found"));
+}
+```
+
+- [ ] **Step 4: Implement the relaxed `resolve_node_with`**
+
+Replace `launcher/src/spawn.rs:26-49`:
+
+```rust
+/// Pure resolution: given an optional DEPS_PATH and an exe directory,
+/// return the Node binary path or an error.
+///
+/// Priority: deps_path/node/node.exe > exe_dir/seed/node/node.exe > error.
+/// When deps_path is set but node isn't there yet (first-run before
+/// DependencyManager populates it), falls through to seed gracefully.
+pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<PathBuf> {
+    if let Some(deps) = deps_path {
+        let candidate = Path::new(deps).join("node").join("node.exe");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    let seed = exe_dir.join("seed").join("node").join("node.exe");
+    if seed.exists() {
+        return Ok(seed);
+    }
+
+    bail!(
+        "Node not found at deps or seed (deps_path={:?}, seed={:?})",
+        deps_path,
+        seed
+    )
+}
+```
+
+- [ ] **Step 5: Update `spawn_server` to pass `deps_path` through**
+
+Replace `launcher/src/spawn.rs:117` (`let node = resolve_node()?;` in the `#[cfg(windows)]` block) with:
+
+```rust
+let exe = std::env::current_exe().context("could not determine current exe path")?;
+let exe_dir = exe.parent().context("exe has no parent dir")?.to_path_buf();
+let node = resolve_node_with(
+    deps_path.to_str().map(Some).unwrap_or(None),
+    &exe_dir,
+)?;
+```
+
+And replace `launcher/src/spawn.rs:158` (`let node = resolve_node()?;` in the `#[cfg(not(windows))]` block) with the same pattern:
+
+```rust
+let exe = std::env::current_exe().context("could not determine current exe path")?;
+let exe_dir = exe.parent().context("exe has no parent dir")?.to_path_buf();
+let node = resolve_node_with(
+    deps_path.to_str().map(Some).unwrap_or(None),
+    &exe_dir,
+)?;
+```
+
+Both blocks already have `let exe` and `let work_dir` below — merge with the new `exe_dir` (they derive from the same value). The `resolve_server_entry()` call at line 118/159 can also use `exe_dir` directly via `resolve_server_entry_with(&exe_dir)`.
+
+- [ ] **Step 6: Remove the old strict-mode test**
+
+Delete the `resolve_node_strict_fails_when_deps_path_missing` test entirely — it tested the `bail!` behavior we just removed.
+
+- [ ] **Step 7: Update the module-level doc comment**
+
+Replace `launcher/src/spawn.rs:1-11`:
+
+```rust
+// Node child-process spawn for the launcher.
+//
+// Resolves the Node executable using a priority chain:
+//   1. `deps_path` parameter → `<deps_path>/node/node.exe`
+//   2. `<exe_dir>/seed/node/node.exe` (bundled fallback for first-run
+//      before dependencies/ is populated, or when deps node is missing)
+//   3. Error.
+//
+// Server entry is `<exe_dir>/dist/index.js`.
+```
+
+- [ ] **Step 8: Update the supervisor comment**
+
+Replace `launcher/src/supervisor.rs:170-177`:
+
+```rust
+    // deps_path is passed to spawn::spawn_server which both:
+    //   (a) uses it to resolve the Node binary (deps > seed fallback), and
+    //   (b) sets it as DEPS_PATH on the Node child's env for DependencyManager.
+    log::info(&format!("supervisor: deps_path resolved to {:?}", paths.deps_path));
+```
+
+- [ ] **Step 9: Run all tests**
+
+Run: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml" -- --nocapture`
+
+Expected: ALL PASS.
+
+- [ ] **Step 10: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/spawn.rs launcher/src/supervisor.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix: resolve node from deps_path before seed fallback
+
+spawn_server now passes deps_path through to resolve_node_with
+instead of calling resolve_node() which read DEPS_PATH from process
+env (always empty). Relaxes strict mode to fall through to seed when
+deps_path is set but node binary is missing (first-run bootstrap)."
+```
+
+---
+
+### Task 2: Port file contract + port-probing bind (operation_server.rs)
+
+**Files:**
+- Modify: `launcher/src/operation_server.rs` (constants, new functions, tests)
+
+- [ ] **Step 1: Add the port file constant and helper functions**
+
+Add near the top of `operation_server.rs` (after the existing constants around lines 80-98):
+
+```rust
+const PORT_FILE_NAME: &str = "operation-server-port";
+
+/// Write the bound port to `<dataRoot>/control/operation-server-port`.
+/// Node's UpdateService poll-reads this to discover the redirect URL.
+pub fn write_port_file(data_root: &Path, port: u16) -> std::io::Result<PathBuf> {
+    let dir = data_root.join("control");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(PORT_FILE_NAME);
+    std::fs::write(&path, port.to_string())?;
+    Ok(path)
+}
+
+/// Read the operation-server port from the port file. Returns None if
+/// the file doesn't exist or contains invalid data.
+pub fn read_port_file(data_root: &Path) -> Option<u16> {
+    let path = data_root.join("control").join(PORT_FILE_NAME);
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u16>().ok())
+}
+
+/// Delete the port file. Best-effort — called on operation-server exit.
+pub fn delete_port_file(data_root: &Path) {
+    let path = data_root.join("control").join(PORT_FILE_NAME);
+    let _ = std::fs::remove_file(&path);
+}
+```
+
+- [ ] **Step 2: Add a port-probing bind function**
+
+Add after the port file helpers:
+
+```rust
+/// Bind to `0.0.0.0` on `start_port`, probing upward on EADDRINUSE.
+/// Caps at `start_port + max_offset`. Retries transient errors for up to
+/// `retry_timeout`. Returns the listener and the port it bound to.
+pub fn bind_with_probe(
+    start_port: u16,
+    max_offset: u16,
+    retry_timeout: Duration,
+) -> Result<(TcpListener, u16), i32> {
+    for offset in 0..=max_offset {
+        let port = match start_port.checked_add(offset) {
+            Some(p) => p,
+            None => break,
+        };
+        let bind_start = Instant::now();
+        loop {
+            match TcpListener::bind(("0.0.0.0", port)) {
+                Ok(listener) => return Ok((listener, port)),
+                Err(e) => {
+                    let is_in_use = e.kind() == std::io::ErrorKind::AddrInUse;
+                    if is_in_use {
+                        if offset < max_offset {
+                            log::info(&format!(
+                                "operation-server: port {port} in use, trying next"
+                            ));
+                            break; // try next port
+                        }
+                        // Last port in range, keep retrying until timeout
+                    }
+                    if bind_start.elapsed() >= retry_timeout {
+                        if is_in_use {
+                            log::error(&format!(
+                                "operation-server: all ports {start_port}..={} in use after {retry_timeout:?}",
+                                start_port.saturating_add(max_offset)
+                            ));
+                            return Err(3);
+                        }
+                        log::error(&format!(
+                            "operation-server: bind 0.0.0.0:{port} failed after {retry_timeout:?}: {e}"
+                        ));
+                        return Err(3);
+                    }
+                    thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
+                }
+            }
+        }
+    }
+    log::error(&format!(
+        "operation-server: no bindable port in range {start_port}..={}",
+        start_port.saturating_add(max_offset)
+    ));
+    Err(3)
+}
+```
+
+- [ ] **Step 3: Write tests for port file and bind_with_probe**
+
+Add to the `mod tests` block at the bottom of `operation_server.rs`:
+
+```rust
+#[test]
+fn write_and_read_port_file_round_trip() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = super::write_port_file(tmp.path(), 8001).expect("write");
+    assert!(path.exists());
+    assert_eq!(super::read_port_file(tmp.path()), Some(8001));
+}
+
+#[test]
+fn read_port_file_returns_none_when_absent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert_eq!(super::read_port_file(tmp.path()), None);
+}
+
+#[test]
+fn delete_port_file_removes_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    super::write_port_file(tmp.path(), 9999).expect("write");
+    super::delete_port_file(tmp.path());
+    assert_eq!(super::read_port_file(tmp.path()), None);
+}
+
+#[test]
+fn bind_with_probe_skips_occupied_port() {
+    // Occupy the first port
+    let blocker = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind blocker");
+    let blocked_port = blocker.local_addr().expect("addr").port();
+
+    // Probe should skip the blocked port and bind the next one
+    let result = super::bind_with_probe(
+        blocked_port,
+        5,
+        std::time::Duration::from_secs(1),
+    );
+    match result {
+        Ok((_listener, port)) => assert!(port > blocked_port, "should have skipped to a higher port"),
+        Err(_) => panic!("bind_with_probe should have found a free port"),
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify**
+
+Run: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml" -- --nocapture port_file bind_with_probe`
+
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/operation_server.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat: add port file contract and port-probing bind
+
+write_port_file/read_port_file/delete_port_file for the operation-
+server ↔ Node coordination. bind_with_probe tries config_port+1
+upward, skipping occupied ports."
+```
+
+---
+
+### Task 3: Rewrite §40 path in operation_server.rs
+
+**Files:**
+- Modify: `launcher/src/operation_server.rs:240-412` (run function)
+
+This is the core change — rewrite the §40 local-mode path to bind a separate port, write the port file, run the probe after relaunch, and serve `/api/discover`.
+
+- [ ] **Step 1: Update the `run()` function's §40 bind logic**
+
+Replace the bind block at lines 264-302 and the §40 block at lines 304-378 with:
+
+```rust
+    // §40 — local-mode update path. Binds config_port + 1 (probing upward)
+    // to avoid port conflict with Node (which still holds config_port).
+    if variant == OperationVariant::ApplyUpdate {
+        if let Ok(install_root) = std::env::var("WS_SCRCPY_INSTALL_ROOT") {
+            let install_root = PathBuf::from(install_root);
+            let op_port_start = port.saturating_add(1);
+
+            let (listener, bound_port) = match bind_with_probe(
+                op_port_start,
+                PROBE_MAX_OFFSET,
+                Duration::from_secs(BIND_RETRY_TIMEOUT_SECS),
+            ) {
+                Ok(pair) => pair,
+                Err(code) => return code,
+            };
+
+            if let Err(e) = listener.set_nonblocking(true) {
+                log::error(&format!(
+                    "operation-server: set_nonblocking failed (non-fatal): {e}"
+                ));
+            }
+
+            log::info(&format!(
+                "operation-server: §40 bound 0.0.0.0:{bound_port} (app port={port})"
+            ));
+
+            // Write port file so Node can discover our port for the redirect.
+            if let Err(e) = write_port_file(&data_root, bound_port) {
+                log::error(&format!(
+                    "operation-server: failed to write port file: {e}"
+                ));
+            }
+
+            // Stoppable background page-serving thread.
+            let bg_stop = Arc::new(AtomicBool::new(false));
+            let bg_stop2 = bg_stop.clone();
+            let bg_listener = listener.try_clone().expect("clone listener");
+            let bg_redirect: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+            let bg_redirect2 = bg_redirect.clone();
+            let _page_thread = thread::spawn(move || {
+                while !bg_stop2.load(Ordering::SeqCst) {
+                    accept_one(&bg_listener, &bg_redirect2, OperationVariant::ApplyUpdate);
+                }
+            });
+
+            // --- Phase 2: Swap ---
+            log::info("operation-server: §40 killing tray");
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
+                let _ = std::process::Command::new(r"C:\Windows\System32\taskkill.exe")
+                    .args(["/F", "/IM", "ws-scrcpy-web-tray.exe", "/T"])
+                    .creation_flags(CREATE_NO_WINDOW_FLAG)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+            thread::sleep(Duration::from_secs(3));
+
+            let packages_dir = install_root.join("packages");
+            let current_dir = install_root.join("current");
+            match find_and_extract_nupkg(&packages_dir, &current_dir) {
+                Ok(ver) => log::info(&format!("operation-server: extracted {ver} into current/")),
+                Err(e) => {
+                    log::error(&format!("operation-server: nupkg extraction failed: {e}"));
+                    bg_stop.store(true, Ordering::SeqCst);
+                    delete_port_file(&data_root);
+                    return 4;
+                }
+            }
+
+            thread::sleep(Duration::from_secs(1));
+            log::info("operation-server: launching new launcher");
+            #[cfg(windows)]
+            {
+                let launcher = current_dir.join("ws-scrcpy-web-launcher.exe");
+                use std::os::windows::process::CommandExt;
+                const DETACHED_PROCESS: u32 = 0x00000008;
+                const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
+                match std::process::Command::new(&launcher)
+                    .current_dir(&install_root)
+                    .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW_FLAG)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                {
+                    Ok(child) => log::info(&format!(
+                        "operation-server: launched new launcher (pid {})", child.id()
+                    )),
+                    Err(e) => log::error(&format!(
+                        "operation-server: failed to launch new launcher: {e}"
+                    )),
+                }
+            }
+
+            // --- Phase 3: Handoff ---
+            // Probe for the new Node on config_port..+10 and publish redirect.
+            let probe_redirect = bg_redirect.clone();
+            thread::spawn(move || {
+                probe_for_real_node_and_publish(port, probe_redirect);
+            });
+
+            // Serve pages until probe finds Node or 60s lifetime expires.
+            let started_at = Instant::now();
+            while started_at.elapsed() < Duration::from_secs(MAX_LIFETIME_SECS) {
+                accept_one(&listener, &bg_redirect, OperationVariant::ApplyUpdate);
+            }
+
+            log::info("operation-server: §40 max lifetime elapsed, cleaning up");
+            bg_stop.store(true, Ordering::SeqCst);
+            delete_port_file(&data_root);
+            return 0;
+        }
+    }
+
+    // --- Service-mode / uninstall path (unchanged) ---
+    // Bind config_port with retry (service-mode operation-server needs
+    // the same port Node was on).
+    let listener = {
+        let bind_start = Instant::now();
+        let mut first_busy_logged = false;
+        loop {
+            match TcpListener::bind(("0.0.0.0", port)) {
+```
+
+The rest of the `run()` function (from the original bind loop through the main loop + wind_down) stays unchanged — it's only used for service-mode.
+
+- [ ] **Step 2: Update `build_response` to handle `/api/discover` in the §40 context**
+
+The existing `build_response` function at line 616 already handles `/api/discover` (line 629). We need to update it so that when the redirect state has a value, `/api/discover` returns the new JSON shape:
+
+Find the `/api/discover` handler block in `build_response` (lines 629-637) and replace it with:
+
+```rust
+        if path == "/api/discover" {
+            // §40 redesign: /api/discover returns the redirect status.
+            // The updating page polls this to know when the new Node is up.
+            if let Some(url) = redirect {
+                let body = format!(r#"{{"status":"ready","redirect":"{url}"}}"#);
+                return format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Type: application/json\r\n\
+                     Content-Length: {}\r\n\
+                     Cache-Control: no-store\r\n\
+                     X-WsScrcpyWeb-Upgrade-Server: 1\r\n\
+                     Connection: close\r\n\
+                     \r\n\
+                     {}",
+                    body.len(),
+                    body
+                );
+            }
+            let body = r#"{"status":"updating"}"#;
+            return format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Cache-Control: no-store\r\n\
+                 X-WsScrcpyWeb-Upgrade-Server: 1\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {}",
+                body.len(),
+                body
+            );
+        }
+```
+
+- [ ] **Step 3: Run all Rust tests**
+
+Run: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml" -- --nocapture`
+
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/operation_server.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(§40): rewrite local-mode path to bind separate port
+
+Operation-server now binds config_port+1 (probing upward) instead of
+config_port. Writes port file for Node discovery. Runs probe after
+relaunch to find new Node and publishes redirect via /api/discover.
+Eliminates the port conflict that caused IPv4-only binding."
+```
+
+---
+
+### Task 4: Simplify supervisor §40 path
+
+**Files:**
+- Modify: `launcher/src/supervisor.rs:132-157`
+
+- [ ] **Step 1: Gate stop-marker + port-wait to service-mode only**
+
+Replace `launcher/src/supervisor.rs:132-157` with:
+
+```rust
+        // §32 Part 5 — coordinate with any in-flight operation-server.
+        // In service-mode, the operation-server binds the SAME port as
+        // Node (config_port), so we need the stop-marker + port-wait
+        // dance. In §40 local-mode, the operation-server binds a
+        // DIFFERENT port (config_port+1), so no coordination needed.
+        if cfg.is_service_mode() {
+            let port = cfg.web_port.unwrap_or(8000);
+            if let Err(e) = crate::operation_server::write_stop_marker(&paths.data_root) {
+                log::error(&format!(
+                    "supervisor: could not write operation-server stop marker (non-fatal): {e}"
+                ));
+            }
+            crate::operation_server::wait_for_port_free(
+                port,
+                std::time::Duration::from_secs(5),
+            );
+            log::info(&format!(
+                "supervisor: port {port} verified free, proceeding to spawn Node"
+            ));
+        }
+```
+
+- [ ] **Step 2: Run Rust tests**
+
+Run: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml" -- --nocapture`
+
+Expected: ALL PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/supervisor.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(§40): skip wait_for_port_free in local-mode update
+
+Operation-server now uses a separate port in §40, so the supervisor
+no longer needs stop-marker + port-wait coordination for local mode.
+Service-mode path unchanged."
+```
+
+---
+
+### Task 5: Rewrite updating page JS for `/api/discover` polling
+
+**Files:**
+- Modify: `launcher/assets/operation-server-page.html:76-142`
+
+- [ ] **Step 1: Replace the `<script>` block**
+
+Replace `launcher/assets/operation-server-page.html:76-142` (the entire `<script>` block through `</html>`) with:
+
+```html
+<script>
+(function () {
+  var POLL_MS = 2000;
+  var TIMEOUT_MS = 60000;
+  var detail = document.getElementById('detail');
+  var note = document.querySelector('.note');
+  var start = Date.now();
+
+  function poll() {
+    if (Date.now() - start > TIMEOUT_MS) {
+      if (detail) detail.textContent = 'update may have failed';
+      if (note) note.textContent = 'try restarting the app manually';
+      return;
+    }
+
+    fetch('/api/discover', { cache: 'no-store' })
+      .then(function (r) {
+        if (!r.ok) {
+          setTimeout(poll, POLL_MS);
+          return;
+        }
+        return r.json().then(function (body) {
+          if (body && body.status === 'ready' && body.redirect) {
+            if (detail) detail.textContent = 'redirecting';
+            setTimeout(function () { location.href = body.redirect; }, 500);
+            return;
+          }
+          setTimeout(poll, POLL_MS);
+        });
+      })
+      .catch(function () {
+        setTimeout(poll, POLL_MS);
+      });
+  }
+
+  setTimeout(poll, POLL_MS);
+})();
+</script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/assets/operation-server-page.html
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(§40): rewrite updating page to poll /api/discover
+
+Replaces the old /api/config polling (which relied on being on the
+same port as Node) with /api/discover polling on the operation-
+server's own port. 60s timeout shows error message."
+```
+
+---
+
+### Task 6: UpdateService + UpdatesApi redirect flow (Node side)
+
+**Files:**
+- Modify: `src/server/UpdateService.ts:331-390`
+- Modify: `src/server/api/UpdatesApi.ts:117-163`
+- Modify: `src/server/Config.ts` (add `operationServerPortFilePath` getter)
+
+- [ ] **Step 1: Add `operationServerPortFilePath` getter to Config.ts**
+
+Add after the `applyUpdatePendingMarkerPath` getter (line 531 of `src/server/Config.ts`):
+
+```typescript
+    public get operationServerPortFilePath(): string {
+        const base = this._dataRoot !== null
+            ? this._dataRoot
+            : path.dirname(this._dependenciesPath);
+        return path.join(base, 'control', 'operation-server-port');
+    }
+```
+
+- [ ] **Step 2: Add `pollOperationServerPort` method to UpdateService.ts**
+
+Add after `writeApplyUpdatePendingMarker` (around line 417):
+
+```typescript
+    private async pollOperationServerPort(timeoutMs = 5000, intervalMs = 100): Promise<number | null> {
+        const portFilePath = Config.getInstance().operationServerPortFilePath;
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            try {
+                const content = await fs.promises.readFile(portFilePath, 'utf8');
+                const port = parseInt(content.trim(), 10);
+                if (!isNaN(port) && port > 0 && port <= 65535) {
+                    return port;
+                }
+            } catch {
+                // file doesn't exist yet
+            }
+            await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        }
+        return null;
+    }
+```
+
+- [ ] **Step 3: Update `applyUpdate` to spawn operation-server and poll for port**
+
+Replace `src/server/UpdateService.ts:331-390` with:
+
+```typescript
+    public async applyUpdate(): Promise<{ redirectPort: number | null }> {
+        if (!this.mgr || !this.state.pendingUpdate || this.state.status !== 'ready') {
+            throw new Error(`apply not allowed in current state: ${this.state.status}`);
+        }
+        log.info(`applying update v${this.state.availableVersion}`);
+        await this.preApplyHygiene();
+
+        await this.writeApplyUpdatePendingMarker();
+
+        const installMode = Config.getInstance().getAppConfig().installMode;
+        const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
+
+        if (isServiceMode) {
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+            return { redirectPort: null };
+        }
+
+        // Local mode: the supervisor spawns the operation-server on clean
+        // exit. We don't spawn it here — the marker signals the supervisor.
+        // Poll-read the port file to discover the operation-server's port
+        // so we can redirect the browser.
+        //
+        // Note: the operation-server isn't spawned until AFTER Node exits,
+        // so we can't poll here — we return null and let the API handler
+        // use a delayed strategy (exit, let supervisor spawn op-server,
+        // browser reconnects via the existing ServerReachabilityOverlay
+        // or a frontend redirect).
+        return { redirectPort: null };
+    }
+```
+
+Wait — re-reading the spec, the flow is: Node spawns the operation-server BEFORE exiting (via `spawn_detached_helper`). But looking at the current code, the supervisor spawns it AFTER Node exits.
+
+The spec says in Phase 1:
+> 2. `UpdateService.applyUpdate()` spawns the operation-server as a detached process
+
+But the current architecture has the supervisor doing this. Let me re-read the spec...
+
+The spec says Node spawns it, then poll-reads the port file, then redirects. This means we need to move the spawn from the supervisor into UpdateService.
+
+- [ ] **Step 3 (revised): Move operation-server spawn into UpdateService**
+
+Replace `src/server/UpdateService.ts:331-390`:
+
+```typescript
+    public async applyUpdate(): Promise<{ redirectPort: number | null }> {
+        if (!this.mgr || !this.state.pendingUpdate || this.state.status !== 'ready') {
+            throw new Error(`apply not allowed in current state: ${this.state.status}`);
+        }
+        log.info(`applying update v${this.state.availableVersion}`);
+        await this.preApplyHygiene();
+
+        const installMode = Config.getInstance().getAppConfig().installMode;
+        const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
+
+        await this.writeApplyUpdatePendingMarker();
+
+        if (isServiceMode) {
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+            return { redirectPort: null };
+        }
+
+        // Local mode: spawn the operation-server from Node (before exit)
+        // so we can poll-read its port file and redirect the browser.
+        // The operation-server binds config_port+1, writes its port to
+        // <dataRoot>/control/operation-server-port, then waits for us to
+        // exit so it can extract the nupkg.
+        const cfg = Config.getInstance();
+        const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        const helperPath = path.join(
+            dataRoot,
+            'control', 'operation-server', 'ws-scrcpy-web-launcher.exe',
+        );
+        // installRoot is two levels up from __dirname (dist/ inside current/)
+        const installRoot = path.resolve(__dirname, '..', '..');
+
+        try {
+            const child = spawn(helperPath, ['--operation-server'], {
+                cwd: dataRoot,
+                detached: true,
+                stdio: 'ignore',
+                env: {
+                    ...process.env,
+                    WS_SCRCPY_INSTALL_ROOT: installRoot,
+                },
+            });
+            child.unref();
+            log.info(`applyUpdate: spawned operation-server (pid ${child.pid})`);
+        } catch (err) {
+            log.error(`applyUpdate: failed to spawn operation-server: ${(err as Error).message}`);
+            return { redirectPort: null };
+        }
+
+        const port = await this.pollOperationServerPort();
+        if (port !== null) {
+            log.info(`applyUpdate: operation-server ready on port ${port}`);
+        } else {
+            log.warn('applyUpdate: operation-server port file not found within timeout');
+        }
+
+        return { redirectPort: port };
+    }
+```
+
+Update the `child_process` import at line 2 of `UpdateService.ts`:
+
+```typescript
+import { execFile, spawn } from 'child_process';
+```
+
+- [ ] **Step 4: Update `handleApply` in UpdatesApi.ts to serve the redirect**
+
+Replace `src/server/api/UpdatesApi.ts:117-163`:
+
+```typescript
+    private async handleApply(res: ServerResponse): Promise<boolean> {
+        const s = this.svc.getStatus();
+        if (!s.isInstalled) {
+            const body: UpdatesErrorResponse = {
+                ok: false,
+                error: 'dev mode — packaging features disabled',
+            };
+            res.writeHead(503);
+            res.end(JSON.stringify(body));
+            return true;
+        }
+        if (s.status !== 'ready') {
+            const body: UpdatesErrorResponse = {
+                ok: false,
+                error: `apply not allowed in current state: ${s.status}`,
+            };
+            res.writeHead(409);
+            res.end(JSON.stringify(body));
+            return true;
+        }
+
+        let redirectPort: number | null = null;
+        try {
+            const result = await this.svc.applyUpdate();
+            redirectPort = result.redirectPort;
+        } catch (err) {
+            const body: UpdatesErrorResponse = { ok: false, error: (err as Error).message };
+            res.writeHead(500);
+            res.end(JSON.stringify(body));
+            return true;
+        }
+
+        if (redirectPort !== null) {
+            // Serve an HTML page that redirects the browser to the
+            // operation-server's updating page on its own port.
+            const redirectUrl = `http://localhost:${redirectPort}/`;
+            const html = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>updating</title></head>
+<body><p>redirecting to update page...</p>
+<script>window.location.href=${JSON.stringify(redirectUrl)};</script>
+</body></html>`;
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            res.end(html);
+        } else {
+            const body: UpdatesApplyResponse = { ok: true };
+            res.writeHead(200);
+            res.end(JSON.stringify(body));
+        }
+
+        this.schedule(() => {
+            log.info('exiting (process.exit 0) after applyUpdate');
+            this.exit(0);
+        }, APPLY_EXIT_DELAY_MS);
+        return true;
+    }
+```
+
+- [ ] **Step 5: Remove operation-server spawn from supervisor §40 path**
+
+In `launcher/src/supervisor.rs`, replace lines 200-232 (the §40 block inside `match reason { None => { ... }}`):
+
+```rust
+                // §40 — local-mode update: Node already spawned the
+                // operation-server before exiting (it needed the port
+                // file for the browser redirect). The apply-update-
+                // pending marker was consumed by Node writing it; we
+                // just exit cleanly.
+                //
+                // In service mode, Servy's post-stop.bat handles the
+                // operation-server spawn + sc start relaunch.
+                return Ok(code);
+```
+
+Wait — the supervisor currently deletes the marker AND spawns the helper. If we move the spawn to Node, the supervisor still needs to delete the marker (or not — the operation-server cleans it at line 261). Actually, the supervisor deletes `apply-update-pending` at line 222. But the operation-server also checks for it in `detect_operation_variant` at line 117 — it needs it to still exist. However, the supervisor deletes it BEFORE spawning the helper (line 222 before line 230).
+
+In the current code, the supervisor deletes the marker at 222 but `detect_operation_variant` doesn't need it because the operation-server gets `WS_SCRCPY_INSTALL_ROOT` via env var (line 308), not via the marker. The marker is just used by the supervisor to decide whether to spawn.
+
+With the new design, Node spawns the operation-server directly and passes `WS_SCRCPY_INSTALL_ROOT` via env. The supervisor doesn't need to detect the marker at all for the spawn. But the marker still serves as the signal for "this was an update exit, not a user stop" — Node writes it, supervisor reads it... but we don't need the supervisor to act on it anymore since Node already spawned the operation-server.
+
+Simplify: just remove the §40 block from the supervisor entirely. The marker cleanup can happen in the operation-server.
+
+```rust
+                log::info("supervisor: clean exit; not restarting");
+                return Ok(code);
+```
+
+Replace lines 199-234 with just:
+
+```rust
+            None => {
+                log::info("supervisor: clean exit; not restarting");
+                return Ok(code);
+            }
+```
+
+- [ ] **Step 6: Run type-check and vitest**
+
+Run: `npx --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" tsc --noEmit`
+Run: `npm test --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web"`
+
+Expected: tsc clean, vitest passes.
+
+- [ ] **Step 7: Run Rust tests**
+
+Run: `cargo test --manifest-path "C:/Users/jscha/source/repos/ws-scrcpy-web/launcher/Cargo.toml" -- --nocapture`
+
+Expected: ALL PASS.
+
+- [ ] **Step 8: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/UpdateService.ts src/server/api/UpdatesApi.ts src/server/Config.ts launcher/src/supervisor.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(§40): Node spawns operation-server and redirects browser
+
+UpdateService spawns the operation-server, poll-reads the port file,
+and returns the port. UpdatesApi serves an HTML redirect to the
+operation-server's port. Supervisor no longer handles the §40 spawn."
+```
+
+---
+
+### Task 7: CHANGELOG + docs update
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Add under `[Unreleased]` → `### Fixed`:
+
+```markdown
+- **Local-mode update redesign (§40).** Operation-server now binds `config_port + 1` (probing upward) instead of competing with Node for `config_port`. Eliminates the IPv4-dead / dual-stack corruption bug where `127.0.0.1:8000` became unreachable after updates while `[::1]:8000` worked. Three stacked bugs fixed: port conflict (separate port), stale helper binary (neutralized — old code fails gracefully), Node resolution (`spawn_server` now resolves from `dependencies/node/` before falling back to `seed/node/`). Browser redirect flow: Node spawns operation-server → poll-reads port file → serves redirect to browser → operation-server probes for new Node → redirects browser back.
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add CHANGELOG.md
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "docs: CHANGELOG entry for §40 local-mode update redesign"
+```
+
+---
+
+### Task 8: Version bump + manual smoke
+
+- [ ] **Step 1: Bump to v0.1.28-beta.17**
+
+Run: `npm run --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" version:bump 0.1.28-beta.17`
+
+Stage and commit all version files (package.json + root Cargo.toml + Cargo.lock):
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add package.json Cargo.toml Cargo.lock
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "chore: bump to v0.1.28-beta.17"
+```
+
+- [ ] **Step 2: Create PR and merge**
+
+Create a PR encompassing all commits from Tasks 1-7 + the version bump.
+
+- [ ] **Step 3: Manual smoke on VM**
+
+After the release publishes:
+1. Install beta.17 fresh (or update from beta.16 — requires killing + restarting launcher once to pick up the new helper binary)
+2. Let the app detect a subsequent update (or re-trigger from beta.17)
+3. Click "apply update" in browser
+4. **Verify:** browser redirects to `localhost:8001` (or similar) showing updating page
+5. **Verify:** updating page eventually redirects back to `localhost:8000`
+6. **Verify:** `http://127.0.0.1:8000` is reachable (IPv4 works)
+7. **Verify:** `http://[::1]:8000` is reachable (IPv6 works)
+8. **Verify:** tray exit works (POST to `127.0.0.1:8000/api/server/shutdown` returns 200)
+9. **Verify:** `Get-NetTCPConnection -LocalPort 8000 -State Listen` shows only ONE process

--- a/docs/superpowers/specs/2026-05-26-local-mode-update-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-26-local-mode-update-redesign-design.md
@@ -1,0 +1,179 @@
+# Local-Mode Update Redesign — Design Spec
+
+**Date:** 2026-05-26
+**Status:** Draft
+**Scope:** §40 local-mode in-app update relaunch — redesign to eliminate port conflict
+
+## Problem
+
+The local-mode update flow has three stacked bugs that cause the post-update app to be unreachable on IPv4 (`127.0.0.1:8000` dead, `[::1]:8000` works):
+
+1. **Port conflict.** The operation-server binds `0.0.0.0:{config_port}` to serve an "updating" page during the swap. The new Node process tries to bind the same port. If the operation-server hasn't fully released the socket, Node gets only the IPv6 half of a dual-stack bind. The tray's `ureq` POST to `127.0.0.1:{config_port}` times out with WSAETIMEDOUT.
+
+2. **Stale helper binary.** The operation-server runs from a data-root copy (`<dataRoot>/control/operation-server/ws-scrcpy-web-launcher.exe`) refreshed by the previous version's supervisor on startup. Behavior fixes (like PR #167's early-exit) don't take effect until the version after the one that introduced them. The new supervisor's refresh attempt fails with `os error 32` (file in use by the running operation-server).
+
+3. **Node resolution.** `spawn_server()` calls `resolve_node()` which reads `DEPS_PATH` from the launcher's own process env (intentionally empty per SP2b first-run bootstrap design). Resolution always falls through to `seed/node/node.exe` instead of `dependencies/node/node.exe`.
+
+## Design
+
+### Core Principle
+
+The operation-server binds a **different port** from the app's configured web port. No two processes ever compete for the same port. Port conflict, ghost sockets, and dual-stack corruption are structurally impossible.
+
+### Update Flow (4 phases)
+
+**Phase 1 — Trigger**
+
+1. User clicks "apply update" in the browser.
+2. `UpdateService.applyUpdate()` spawns the operation-server as a detached process (existing `spawn_detached_helper` mechanism).
+3. Node poll-reads `<dataRoot>/control/operation-server-port` until the operation-server writes its bound port (timeout: 5 seconds, poll interval: 100ms).
+4. Node responds to the browser with a small HTML page whose JS navigates to `http://localhost:{operation_server_port}/`.
+5. Node writes the `apply-update-pending` marker.
+6. Node exits cleanly (exit code 0, no `waitExitThenApplyUpdate`).
+
+**Phase 2 — Swap**
+
+1. Operation-server binds `config_port + 1`, probing upward on `EADDRINUSE` (cap: `config_port + 10`). Bind-retry loop for transient errors (existing 10-second timeout).
+2. Writes the bound port to `<dataRoot>/control/operation-server-port`.
+3. Serves the "updating, please wait" HTML page to browsers.
+4. Kills the tray process (`taskkill /F /IM ws-scrcpy-web-tray.exe /T`, `CREATE_NO_WINDOW`).
+5. Sleeps 3 seconds (tray cleanup window).
+6. Extracts `*-full.nupkg` from `<installRoot>/packages/` into `<installRoot>/current/` (existing `find_and_extract_nupkg`).
+7. Sleeps 1 second (filesystem settle).
+8. Launches the new launcher from `<installRoot>/current/ws-scrcpy-web-launcher.exe` (detached, `CREATE_NO_WINDOW`, CWD = `install_root`).
+
+**Phase 3 — Handoff**
+
+1. Operation-server runs a background probe thread sweeping `config_port..config_port+10` every 100ms, looking for a 200 response from `/api/config` without the operation-server's sentinel header (existing probe pattern).
+2. The updating page JS polls `GET /api/discover` on the operation-server every 2 seconds.
+   - While updating: `{"status": "updating"}`
+   - When probe finds new Node: `{"status": "ready", "redirect": "http://localhost:{new_node_port}/"}`
+3. On `"ready"`, the browser navigates to the redirect URL.
+
+**Phase 4 — Cleanup**
+
+1. Operation-server deletes `<dataRoot>/control/operation-server-port`.
+2. Operation-server exits with code 0.
+3. Max-lifetime safety cap: 60 seconds. If the probe never finds the new Node, the updating page shows an error message ("Update may have failed — try restarting manually") and the operation-server exits.
+
+### Supervisor Changes
+
+**§40 path (lines 200-232 of `supervisor.rs`):**
+- Structurally unchanged: detect `apply-update-pending` marker on clean Node exit, set `WS_SCRCPY_INSTALL_ROOT`, spawn detached helper.
+- Remove `wait_for_port_free` from the §40 code path. The operation-server is on a different port; nothing to wait for.
+- The existing stop-marker write + port-wait stays for the **service-mode** path only.
+
+**`refresh_helper_binary`:**
+- Unchanged. The stale binary problem is neutralized: old code's `bind("0.0.0.0", config_port)` would fail because Node still holds that port at spawn time (Node hasn't exited yet when the operation-server starts binding). The operation-server exits with error code 3. Graceful degradation, not silent corruption.
+
+### Node Resolution Fix
+
+**`spawn_server` (spawn.rs):**
+
+Change from:
+```rust
+let node = resolve_node()?;
+```
+to:
+```rust
+let exe = std::env::current_exe()?;
+let exe_dir = exe.parent().context("exe has no parent dir")?;
+let node = resolve_node_with(
+    Some(deps_path.to_str().context("deps_path not valid UTF-8")?),
+    exe_dir,
+)?;
+```
+
+**`resolve_node_with` (spawn.rs):**
+
+Relax strict mode — try deps_path first, fall through to seed if the candidate doesn't exist:
+```rust
+pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<PathBuf> {
+    if let Some(deps) = deps_path {
+        let candidate = Path::new(deps).join("node").join("node.exe");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        // deps_path is set but node isn't there yet (first-run before
+        // DependencyManager populates it) — fall through to seed
+    }
+    let seed = exe_dir.join("seed").join("node").join("node.exe");
+    if seed.exists() {
+        return Ok(seed);
+    }
+    bail!("Node not found at deps or seed")
+}
+```
+
+The supervisor comment at lines 170-177 ("do NOT set DEPS_PATH on the launcher's process env") becomes obsolete. The launcher no longer reads `DEPS_PATH` from env for its own resolution — it uses the `deps_path` parameter directly.
+
+### Port File Contract
+
+- **Path:** `<dataRoot>/control/operation-server-port`
+- **Content:** ASCII decimal port number, no newline (e.g., `8001`)
+- **Writer:** Operation-server, immediately after successful bind
+- **Reader:** Node's `UpdateService.applyUpdate()`, poll-read with 100ms interval, 5s timeout
+- **Cleanup:** Operation-server deletes on exit. Stale files from a prior crash are overwritten on next bind.
+
+### `/api/discover` Endpoint
+
+Served by the operation-server on its own port. Two response shapes:
+
+```json
+{"status": "updating"}
+```
+```json
+{"status": "ready", "redirect": "http://localhost:8000/"}
+```
+
+Content-Type: `application/json`. No CORS headers needed (same-origin for `localhost`, different ports are cross-origin but the updating page's JS is served from the operation-server's own origin).
+
+The redirect URL uses the port discovered by the probe, which may differ from `config_port` if the new Node shifted (existing `reconcileWebPort` behavior).
+
+### Updating Page Changes
+
+The HTML page (`launcher/assets/operation-server-page.html`) gains:
+- A `<script>` block that polls `GET /api/discover` every 2 seconds
+- On `"ready"` response, navigates to `redirect` URL
+- On 60-second timeout (no `"ready"` received), replaces the spinner with an error message
+
+The existing `__OPERATION_TITLE__` / `__OPERATION_BODY__` token substitution is unchanged.
+
+### What's Removed
+
+- Operation-server no longer binds `config_port` in the §40 path
+- `wait_for_port_free` call removed from the §40 supervisor path
+- The wind-down + stop-marker coordination is no longer used by §40 (stays for service-mode)
+- The background page-serving thread's infinite `loop { accept_one(...) }` (replaced by a loop gated on an `Arc<AtomicBool>` stop flag, set by the main thread before exit)
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| All ports `config_port+1..+10` busy | Operation-server exits code 3. Node's poll-read times out. Browser stays on Node (which hasn't exited yet). User sees "update failed" in the frontend. |
+| Nupkg extraction fails | Operation-server exits code 4. Updating page times out, shows error. |
+| New launcher fails to start | Probe never finds new Node. 60s timeout, error message on updating page. |
+| Node poll-read for port file times out | Node responds to the browser with an error ("update couldn't start"). Node does not exit. Marker not written. |
+
+### Testing
+
+- **Unit tests for `resolve_node_with`:** Existing tests updated for the relaxed fallback behavior.
+- **Unit test for port-probing bind:** New test confirming the probe skips occupied ports.
+- **Integration test for port file round-trip:** Write port, read it back, verify.
+- **Vitest for UpdateService redirect flow:** Mock the port file, verify the redirect response.
+- **Manual smoke:** Apply an update on the VM, confirm browser redirects to operation-server port, then back to the app. Verify `127.0.0.1:{config_port}` is reachable post-update. Verify tray exit works.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `launcher/src/operation_server.rs` | Bind `config_port+1` with probe; write port file; `/api/discover` endpoint; delete port file on exit; remove wind-down from §40 path |
+| `launcher/src/supervisor.rs` | Remove `wait_for_port_free` from §40 path |
+| `launcher/src/spawn.rs` | `spawn_server` uses `resolve_node_with(deps_path)`; `resolve_node_with` relaxes strict mode |
+| `src/server/UpdateService.ts` | Spawn operation-server, poll-read port file, respond with redirect page |
+| `launcher/assets/operation-server-page.html` | Add `/api/discover` polling JS + timeout error |
+| `common/src/config.rs` or similar | Port file path constant |
+
+### Backwards Compatibility
+
+None required. This is a beta redesign. The first update using the new code must be from a beta that already has it (fresh install or manual restart to pick up the new binary, then subsequent in-app updates work).

--- a/launcher/assets/operation-server-page.html
+++ b/launcher/assets/operation-server-page.html
@@ -75,62 +75,35 @@ h1 {
 </div>
 <script>
 (function () {
-  // Poll the real /api/config endpoint. Three response shapes:
-  //
-  //   1. Real Node is back on this same port:
-  //        200 OK, no X-WsScrcpyWeb-Upgrade-Server header
-  //      → reload to drop the upgrade page and load the real app.
-  //
-  //   2. Upgrade-server's wind-down probe found the real Node on a
-  //      DIFFERENT port (port-shift case — new Node lost the port race
-  //      with upgrade-server and auto-shifted to e.g. config_port+1):
-  //        200 OK, X-WsScrcpyWeb-Upgrade-Server: 1, body has `redirect`
-  //      → navigate to body.redirect (real-Node URL on the new port).
-  //
-  //   3. Still upgrading (probe hasn't found real Node yet):
-  //        503 Service Unavailable, X-WsScrcpyWeb-Upgrade-Server: 1
-  //      → keep polling.
-  //
-  //   4. Connection refused / network error → keep polling (transient
-  //      gap between upgrade-server exit and new Node accept).
-  var POLL_MS = 1000;
-  var attempts = 0;
+  var POLL_MS = 2000;
+  var TIMEOUT_MS = 60000;
   var detail = document.getElementById('detail');
+  var note = document.querySelector('.note');
+  var start = Date.now();
 
   function poll() {
-    attempts += 1;
-    fetch('/api/config', { cache: 'no-store' })
+    if (Date.now() - start > TIMEOUT_MS) {
+      if (detail) detail.textContent = 'update may have failed';
+      if (note) note.textContent = 'try restarting the app manually';
+      return;
+    }
+
+    fetch('/api/discover', { cache: 'no-store' })
       .then(function (r) {
-        var sentinel = r.headers.get('X-WsScrcpyWeb-Upgrade-Server') === '1';
-        if (r.ok && !sentinel) {
-          // Case 1: real app is back on this port. Reload.
-          if (detail) detail.textContent = 'reconnected — reloading';
-          setTimeout(function () { location.reload(); }, 250);
+        if (!r.ok) {
+          setTimeout(poll, POLL_MS);
           return;
         }
-        if (r.ok && sentinel) {
-          // Case 2: upgrade-server has found the real Node on a different
-          // port and is handing us a redirect. Parse body + navigate.
-          r.json()
-            .then(function (body) {
-              if (body && typeof body.redirect === 'string' && body.redirect) {
-                if (detail) detail.textContent = 'redirecting';
-                setTimeout(function () { location.href = body.redirect; }, 250);
-                return;
-              }
-              // 200 + sentinel but no redirect field — unexpected; keep polling.
-              setTimeout(poll, POLL_MS);
-            })
-            .catch(function () {
-              setTimeout(poll, POLL_MS);
-            });
-          return;
-        }
-        // Case 3: still upgrading (503 with sentinel) or unexpected status.
-        setTimeout(poll, POLL_MS);
+        return r.json().then(function (body) {
+          if (body && body.status === 'ready' && body.redirect) {
+            if (detail) detail.textContent = 'redirecting';
+            setTimeout(function () { location.href = body.redirect; }, 500);
+            return;
+          }
+          setTimeout(poll, POLL_MS);
+        });
       })
       .catch(function () {
-        // Case 4: connection refused. Keep polling.
         setTimeout(poll, POLL_MS);
       });
   }

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -153,6 +153,7 @@ pub fn write_port_file(data_root: &Path, port: u16) -> std::io::Result<PathBuf> 
     Ok(path)
 }
 
+#[allow(dead_code)]
 pub fn read_port_file(data_root: &Path) -> Option<u16> {
     let path = data_root.join("control").join(PORT_FILE_NAME);
     std::fs::read_to_string(&path)
@@ -181,13 +182,11 @@ pub fn bind_with_probe(
                 Ok(listener) => return Ok((listener, port)),
                 Err(e) => {
                     let is_in_use = e.kind() == std::io::ErrorKind::AddrInUse;
-                    if is_in_use {
-                        if offset < max_offset {
-                            log::info(&format!(
-                                "operation-server: port {port} in use, trying next"
-                            ));
-                            break; // try next port
-                        }
+                    if is_in_use && offset < max_offset {
+                        log::info(&format!(
+                            "operation-server: port {port} in use, trying next"
+                        ));
+                        break; // try next port
                     }
                     if bind_start.elapsed() >= retry_timeout {
                         if is_in_use {
@@ -684,43 +683,6 @@ fn handle_connection(mut stream: TcpStream, redirect_state: Arc<Mutex<Option<Str
     let _ = stream.shutdown(std::net::Shutdown::Both);
 }
 
-/// Build the HTTP response for GET /api/discover.
-/// Reads config.json from disk, extracts webPort + file mtime.
-/// Returns JSON with null fields on any failure (frontend keeps polling).
-fn build_discover_response(config_path: &Path) -> String {
-    let (web_port, mtime_ms) = match std::fs::metadata(config_path) {
-        Ok(meta) => {
-            let mtime = meta.modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_millis() as u64);
-            let port = std::fs::read_to_string(config_path)
-                .ok()
-                .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
-                .and_then(|v| v.get("webPort")?.as_u64())
-                .map(|p| p as u16);
-            (port, mtime)
-        }
-        Err(_) => (None, None),
-    };
-
-    let port_str = match web_port {
-        Some(p) => format!("{p}"),
-        None => "null".to_string(),
-    };
-    let mtime_str = match mtime_ms {
-        Some(m) => format!("{m}"),
-        None => "null".to_string(),
-    };
-    let body = format!(r#"{{"webPort":{port_str},"configMtime":{mtime_str}}}"#);
-
-    format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n{}",
-        body.len(),
-        body
-    )
-}
-
 fn build_response(path: &str, redirect: Option<&str>, variant: OperationVariant) -> String {
     // Discrimination strategy: the static HTML page (served on root)
     // polls /api/config every 1s. Two response shapes for /api/*:
@@ -895,66 +857,6 @@ pub fn legacy_helper_path_for(data_root: &Path) -> PathBuf {
 /// to local-mode-only at the call site keeps the two architectures from
 /// racing for the bind.
 ///
-/// Best-effort: logs failure and returns. If the spawn fails (helper
-/// missing, permissions denied, etc.), the apply-update degrades to a
-/// brief "can't reach" gap during the upgrade window — the pre-Part-5f
-/// local-mode behavior. Stdio is explicitly null'd so the child doesn't
-/// inherit the launcher's handles (which become invalid after launcher
-/// exits).
-///
-/// Windows-only — on non-Windows the call is a no-op log line.
-pub fn spawn_detached_helper(data_root: &Path) {
-    let helper = helper_path_for(data_root);
-    if !helper.exists() {
-        log::error(&format!(
-            "operation-server: helper not present at {helper:?}, skipping spawn"
-        ));
-        return;
-    }
-
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        use std::process::Stdio;
-        // DETACHED_PROCESS: child does not inherit calling process's console.
-        // CREATE_NO_WINDOW: child runs without console window (windows-subsystem
-        //   binary already has none, but belt-and-braces for parity with the
-        //   post-stop bat's `start "" /b` behavior).
-        const DETACHED_PROCESS: u32 = 0x00000008;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-        match std::process::Command::new(&helper)
-            .arg("--operation-server")
-            .current_dir(data_root)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
-            .spawn()
-        {
-            Ok(child) => log::info(&format!(
-                "operation-server: spawned helper (pid {})",
-                child.id()
-            )),
-            Err(e) => log::error(&format!("operation-server: spawn failed: {e}")),
-        }
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = data_root; // silence unused-variable warning
-        log::info("operation-server: spawn_detached_helper skipped (non-Windows)");
-    }
-}
-
-/// Path of the apply-update-pending marker the launcher's supervisor
-/// reads on clean Node exit to decide whether to spawn the upgrade-
-/// server (local mode) before exiting. Same path the post-stop bat
-/// gates its spawn on (service mode). Written by Node's
-/// `UpdateService.applyUpdate` in both modes via
-/// `Config.applyUpdatePendingMarkerPath`.
-pub fn apply_update_pending_marker(data_root: &Path) -> PathBuf {
-    data_root.join("control").join("apply-update-pending")
-}
-
 /// Wait for the given TCP port to become bindable (i.e., the previous
 /// holder has released it). Polls `set_nonblocking` connects, NOT bind
 /// attempts (bind succeeds even if a previous bind is in TIME_WAIT). A
@@ -1118,43 +1020,6 @@ mod tests {
         let html = super::render_operation_page(super::OperationVariant::Uninstall);
         assert!(html.contains("Uninstalling service, please wait"), "uninstall title present: {html}");
         assert!(!html.contains("__OPERATION_TITLE__"), "template token replaced");
-    }
-
-    #[test]
-    fn build_discover_response_with_valid_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.json");
-        std::fs::write(&config_path, r#"{"webPort":8003,"installMode":"user"}"#).unwrap();
-
-        let response = super::build_discover_response(&config_path);
-        assert!(response.contains("200 OK"));
-        assert!(response.contains(r#""webPort":8003"#));
-        assert!(response.contains(r#""configMtime":"#));
-    }
-
-    #[test]
-    fn build_discover_response_with_missing_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.json");
-
-        let response = super::build_discover_response(&config_path);
-        assert!(response.contains("200 OK"));
-        assert!(response.contains(r#""webPort":null"#));
-        assert!(response.contains(r#""configMtime":null"#));
-    }
-
-    #[test]
-    fn build_discover_response_with_malformed_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.json");
-        std::fs::write(&config_path, "not json at all").unwrap();
-
-        let response = super::build_discover_response(&config_path);
-        assert!(response.contains("200 OK"));
-        assert!(response.contains(r#""webPort":null"#));
-        // configMtime should still be present since the file exists
-        assert!(response.contains(r#""configMtime":"#));
-        assert!(!response.contains(r#""configMtime":null"#));
     }
 
     #[test]

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -332,6 +332,120 @@ fn run() -> i32 {
     let _ = std::fs::remove_file(control_dir.join(STOP_MARKER_FILENAME));
     let _ = std::fs::remove_file(control_dir.join(LEGACY_STOP_MARKER_FILENAME));
 
+    // §40 — local-mode update path. Binds config_port + 1 (probing upward)
+    // to avoid port conflict with Node (which still holds config_port).
+    if variant == OperationVariant::ApplyUpdate {
+        if let Ok(install_root) = std::env::var("WS_SCRCPY_INSTALL_ROOT") {
+            let install_root = PathBuf::from(install_root);
+            let op_port_start = port.saturating_add(1);
+
+            let (listener, bound_port) = match bind_with_probe(
+                op_port_start,
+                PROBE_MAX_OFFSET,
+                Duration::from_secs(BIND_RETRY_TIMEOUT_SECS),
+            ) {
+                Ok(pair) => pair,
+                Err(code) => return code,
+            };
+
+            if let Err(e) = listener.set_nonblocking(true) {
+                log::error(&format!(
+                    "operation-server: set_nonblocking failed (non-fatal): {e}"
+                ));
+            }
+
+            log::info(&format!(
+                "operation-server: §40 bound 0.0.0.0:{bound_port} (app port={port})"
+            ));
+
+            if let Err(e) = write_port_file(&data_root, bound_port) {
+                log::error(&format!(
+                    "operation-server: failed to write port file: {e}"
+                ));
+            }
+
+            let bg_stop = Arc::new(AtomicBool::new(false));
+            let bg_stop2 = bg_stop.clone();
+            let bg_listener = listener.try_clone().expect("clone listener");
+            let bg_redirect: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+            let bg_redirect2 = bg_redirect.clone();
+            let _page_thread = thread::spawn(move || {
+                while !bg_stop2.load(Ordering::SeqCst) {
+                    accept_one(&bg_listener, &bg_redirect2, OperationVariant::ApplyUpdate);
+                }
+            });
+
+            log::info("operation-server: §40 killing tray");
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
+                let _ = std::process::Command::new(r"C:\Windows\System32\taskkill.exe")
+                    .args(["/F", "/IM", "ws-scrcpy-web-tray.exe", "/T"])
+                    .creation_flags(CREATE_NO_WINDOW_FLAG)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+            thread::sleep(Duration::from_secs(3));
+
+            let packages_dir = install_root.join("packages");
+            let current_dir = install_root.join("current");
+            match find_and_extract_nupkg(&packages_dir, &current_dir) {
+                Ok(ver) => log::info(&format!("operation-server: extracted {ver} into current/")),
+                Err(e) => {
+                    log::error(&format!("operation-server: nupkg extraction failed: {e}"));
+                    bg_stop.store(true, Ordering::SeqCst);
+                    delete_port_file(&data_root);
+                    return 4;
+                }
+            }
+
+            thread::sleep(Duration::from_secs(1));
+            log::info("operation-server: launching new launcher");
+            #[cfg(windows)]
+            {
+                let launcher_path = current_dir.join("ws-scrcpy-web-launcher.exe");
+                use std::os::windows::process::CommandExt;
+                const DETACHED_PROCESS: u32 = 0x00000008;
+                const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
+                match std::process::Command::new(&launcher_path)
+                    .current_dir(&install_root)
+                    .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW_FLAG)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                {
+                    Ok(child) => log::info(&format!(
+                        "operation-server: launched new launcher (pid {})", child.id()
+                    )),
+                    Err(e) => log::error(&format!(
+                        "operation-server: failed to launch new launcher: {e}"
+                    )),
+                }
+            }
+
+            // Phase 3: Handoff — probe for the new Node on config_port..+10.
+            let probe_redirect = bg_redirect.clone();
+            thread::spawn(move || {
+                probe_for_real_node_and_publish(port, probe_redirect);
+            });
+
+            let started_at = Instant::now();
+            while started_at.elapsed() < Duration::from_secs(MAX_LIFETIME_SECS) {
+                accept_one(&listener, &bg_redirect, OperationVariant::ApplyUpdate);
+            }
+
+            log::info("operation-server: §40 max lifetime elapsed, cleaning up");
+            bg_stop.store(true, Ordering::SeqCst);
+            delete_port_file(&data_root);
+            return 0;
+        }
+    }
+
+    // --- Service-mode / uninstall path (unchanged from here down) ---
     let listener = {
         let bind_start = Instant::now();
         let mut first_busy_logged = false;
@@ -371,83 +485,6 @@ fn run() -> i32 {
     log::info(&format!(
         "operation-server: bound 0.0.0.0:{port}, serving updating page (max lifetime {MAX_LIFETIME_SECS}s)"
     ));
-
-    // §40 — local-mode update: extract nupkg + relaunch, all from this
-    // process (no Update.exe, no bat). Triggered by WS_SCRCPY_INSTALL_ROOT
-    // env var set by the supervisor for local-mode apply-update only.
-    if variant == OperationVariant::ApplyUpdate {
-        if let Ok(install_root) = std::env::var("WS_SCRCPY_INSTALL_ROOT") {
-            let install_root = PathBuf::from(install_root);
-            // Serve the page on a background thread while we do the apply.
-            let bg_listener = listener.try_clone().expect("clone listener");
-            let bg_redirect: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-            let bg_redirect2 = bg_redirect.clone();
-            let _page_thread = thread::spawn(move || {
-                loop {
-                    accept_one(&bg_listener, &bg_redirect2, OperationVariant::ApplyUpdate);
-                }
-            });
-
-            log::info("operation-server: local-mode apply — killing tray");
-            #[cfg(windows)]
-            {
-                use std::os::windows::process::CommandExt;
-                const CREATE_NO_WINDOW: u32 = 0x08000000;
-                let _ = std::process::Command::new(r"C:\Windows\System32\taskkill.exe")
-                    .args(["/F", "/IM", "ws-scrcpy-web-tray.exe", "/T"])
-                    .creation_flags(CREATE_NO_WINDOW)
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status();
-            }
-            thread::sleep(Duration::from_secs(3));
-
-            let packages_dir = install_root.join("packages");
-            let current_dir = install_root.join("current");
-            match find_and_extract_nupkg(&packages_dir, &current_dir) {
-                Ok(ver) => log::info(&format!("operation-server: extracted {ver} into current/")),
-                Err(e) => {
-                    log::error(&format!("operation-server: nupkg extraction failed: {e}"));
-                    return 4;
-                }
-            }
-
-            thread::sleep(Duration::from_secs(1));
-            log::info("operation-server: launching new launcher");
-            #[cfg(windows)]
-            {
-                let launcher = current_dir.join("ws-scrcpy-web-launcher.exe");
-                use std::os::windows::process::CommandExt;
-                const DETACHED_PROCESS: u32 = 0x00000008;
-                const CREATE_NO_WINDOW: u32 = 0x08000000;
-                match std::process::Command::new(&launcher)
-                    .current_dir(&install_root)
-                    .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn()
-                {
-                    Ok(child) => log::info(&format!(
-                        "operation-server: launched new launcher (pid {})", child.id()
-                    )),
-                    Err(e) => log::error(&format!(
-                        "operation-server: failed to launch new launcher: {e}"
-                    )),
-                }
-            }
-            // Exit immediately so the new launcher gets a clean port
-            // bind. The wind-down + probe redirect loop is for the
-            // service-mode bat case; in §40 the operation-server owns
-            // the whole update and its job is done once the new launcher
-            // is spawned. Holding the port through wind-down causes
-            // Node to bind IPv6-only (dual-stack conflict with our
-            // IPv4 listener), leaving 127.0.0.1 unreachable.
-            log::info("operation-server: local-mode apply complete, exiting");
-            return 0;
-        }
-    }
 
     let stop_flag = Arc::new(AtomicBool::new(false));
     let redirect_state: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
@@ -698,14 +735,34 @@ fn build_response(path: &str, redirect: Option<&str>, variant: OperationVariant)
     // existing "real app is back, reload" path).
     if path.starts_with("/api/") {
         if path == "/api/discover" {
-            let config_path = std::env::var("WS_SCRCPY_DATA_ROOT")
-                .map(|dr| PathBuf::from(dr).join("config.json"))
-                .unwrap_or_else(|_| {
-                    common::config::data_root_from_env()
-                        .unwrap_or_else(|| PathBuf::from("."))
-                        .join("config.json")
-                });
-            return build_discover_response(&config_path);
+            if let Some(url) = redirect {
+                let body = format!(r#"{{"status":"ready","redirect":"{url}"}}"#);
+                return format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Type: application/json\r\n\
+                     Content-Length: {}\r\n\
+                     Cache-Control: no-store\r\n\
+                     X-WsScrcpyWeb-Upgrade-Server: 1\r\n\
+                     Connection: close\r\n\
+                     \r\n\
+                     {}",
+                    body.len(),
+                    body
+                );
+            }
+            let body = r#"{"status":"updating"}"#;
+            return format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Cache-Control: no-store\r\n\
+                 X-WsScrcpyWeb-Upgrade-Server: 1\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {}",
+                body.len(),
+                body
+            );
         }
 
         if let Some(url) = redirect {

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -97,6 +97,8 @@ const PROBE_INTERVAL_MS: u64 = 100;
 const PROBE_CONNECT_TIMEOUT_MS: u64 = 500;
 const PROBE_REQUEST_TIMEOUT_MS: u64 = 2000;
 
+const PORT_FILE_NAME: &str = "operation-server-port";
+
 const OPERATION_PAGE: &str = include_str!("../assets/operation-server-page.html");
 
 /// Which operation triggered this operation-server instance? Drives the
@@ -141,6 +143,75 @@ pub fn render_operation_page(variant: OperationVariant) -> String {
     OPERATION_PAGE
         .replace("__OPERATION_TITLE__", title)
         .replace("__OPERATION_BODY__", body)
+}
+
+pub fn write_port_file(data_root: &Path, port: u16) -> std::io::Result<PathBuf> {
+    let dir = data_root.join("control");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(PORT_FILE_NAME);
+    std::fs::write(&path, port.to_string())?;
+    Ok(path)
+}
+
+pub fn read_port_file(data_root: &Path) -> Option<u16> {
+    let path = data_root.join("control").join(PORT_FILE_NAME);
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u16>().ok())
+}
+
+pub fn delete_port_file(data_root: &Path) {
+    let path = data_root.join("control").join(PORT_FILE_NAME);
+    let _ = std::fs::remove_file(&path);
+}
+
+pub fn bind_with_probe(
+    start_port: u16,
+    max_offset: u16,
+    retry_timeout: Duration,
+) -> Result<(TcpListener, u16), i32> {
+    for offset in 0..=max_offset {
+        let port = match start_port.checked_add(offset) {
+            Some(p) => p,
+            None => break,
+        };
+        let bind_start = Instant::now();
+        loop {
+            match TcpListener::bind(("0.0.0.0", port)) {
+                Ok(listener) => return Ok((listener, port)),
+                Err(e) => {
+                    let is_in_use = e.kind() == std::io::ErrorKind::AddrInUse;
+                    if is_in_use {
+                        if offset < max_offset {
+                            log::info(&format!(
+                                "operation-server: port {port} in use, trying next"
+                            ));
+                            break; // try next port
+                        }
+                    }
+                    if bind_start.elapsed() >= retry_timeout {
+                        if is_in_use {
+                            log::error(&format!(
+                                "operation-server: all ports {start_port}..={} in use after {retry_timeout:?}",
+                                start_port.saturating_add(max_offset)
+                            ));
+                            return Err(3);
+                        }
+                        log::error(&format!(
+                            "operation-server: bind 0.0.0.0:{port} failed after {retry_timeout:?}: {e}"
+                        ));
+                        return Err(3);
+                    }
+                    thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
+                }
+            }
+        }
+    }
+    log::error(&format!(
+        "operation-server: no bindable port in range {start_port}..={}",
+        start_port.saturating_add(max_offset)
+    ));
+    Err(3)
 }
 
 /// Public entry: if argv contains `--operation-server` (or the legacy alias
@@ -1027,5 +1098,44 @@ mod tests {
         // configMtime should still be present since the file exists
         assert!(response.contains(r#""configMtime":"#));
         assert!(!response.contains(r#""configMtime":null"#));
+    }
+
+    #[test]
+    fn write_and_read_port_file_round_trip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = super::write_port_file(tmp.path(), 8001).expect("write");
+        assert!(path.exists());
+        assert_eq!(super::read_port_file(tmp.path()), Some(8001));
+    }
+
+    #[test]
+    fn read_port_file_returns_none_when_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(super::read_port_file(tmp.path()), None);
+    }
+
+    #[test]
+    fn delete_port_file_removes_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        super::write_port_file(tmp.path(), 9999).expect("write");
+        super::delete_port_file(tmp.path());
+        assert_eq!(super::read_port_file(tmp.path()), None);
+    }
+
+    #[test]
+    fn bind_with_probe_skips_occupied_port() {
+        // bind_with_probe uses 0.0.0.0, so the blocker must also use 0.0.0.0
+        // to actually occupy the port on the same address.
+        let blocker = std::net::TcpListener::bind(("0.0.0.0", 0)).expect("bind blocker");
+        let blocked_port = blocker.local_addr().expect("addr").port();
+        let result = super::bind_with_probe(
+            blocked_port,
+            5,
+            std::time::Duration::from_secs(1),
+        );
+        match result {
+            Ok((_listener, port)) => assert!(port > blocked_port, "should have skipped to a higher port"),
+            Err(_) => panic!("bind_with_probe should have found a free port"),
+        }
     }
 }

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -1,11 +1,10 @@
 // Node child-process spawn for the launcher.
 //
-// Resolves the Node executable using a strict priority chain:
-//   1. `DEPS_PATH` env var → `<DEPS_PATH>/node/node.exe` (per SP2b strict
-//      semantics — if DEPS_PATH is set but missing, hard fail; do NOT fall
-//      through to seed/).
-//   2. Otherwise, `<exe_dir>/seed/node/node.exe` (bundled fallback for
-//      first-run before dependencies/ is populated).
+// Resolves the Node executable using a best-effort priority chain:
+//   1. `deps_path` parameter → `<deps_path>/node/node.exe` (preferred;
+//      populated after first-run bootstrap installs Node into dependencies/).
+//   2. `<exe_dir>/seed/node/node.exe` (bundled fallback for first-run
+//      before dependencies/ is populated, or if deps node is missing).
 //   3. Otherwise, error.
 //
 // Server entry is `<exe_dir>/dist/index.js`.
@@ -29,12 +28,8 @@ pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<Path
         if candidate.exists() {
             return Ok(candidate);
         }
-        // Strict mode — DEPS_PATH was set, so we MUST use it. No fallback.
-        bail!(
-            "DEPS_PATH is set to {:?} but Node not found at {:?}",
-            deps,
-            candidate
-        );
+        // deps_path set but node not there yet (first-run bootstrap) — fall
+        // through to seed instead of hard-failing.
     }
 
     let seed = exe_dir.join("seed").join("node").join("node.exe");
@@ -114,10 +109,11 @@ fn open_server_log(data_root: &Path) -> Option<std::fs::File> {
 pub fn spawn_server(deps_path: &Path, data_root: &Path) -> Result<Child> {
     use std::os::windows::process::CommandExt;
 
-    let node = resolve_node()?;
-    let entry = resolve_server_entry()?;
     let exe = std::env::current_exe()?;
     let work_dir = exe.parent().context("exe has no parent dir")?.to_path_buf();
+    let deps_str = deps_path.to_str().context("deps_path is not valid UTF-8")?;
+    let node = resolve_node_with(Some(deps_str), &work_dir)?;
+    let entry = resolve_server_entry_with(&work_dir)?;
 
     let mut cmd = Command::new(&node);
     cmd.arg(&entry)
@@ -155,10 +151,11 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path) -> Result<Child> {
 
 #[cfg(not(windows))]
 pub fn spawn_server(deps_path: &Path, data_root: &Path) -> Result<Child> {
-    let node = resolve_node()?;
-    let entry = resolve_server_entry()?;
     let exe = std::env::current_exe()?;
     let work_dir = exe.parent().context("exe has no parent dir")?.to_path_buf();
+    let deps_str = deps_path.to_str().context("deps_path is not valid UTF-8")?;
+    let node = resolve_node_with(Some(deps_str), &work_dir)?;
+    let entry = resolve_server_entry_with(&work_dir)?;
 
     let mut cmd = Command::new(&node);
     cmd.arg(&entry)
@@ -208,14 +205,29 @@ mod tests {
     }
 
     #[test]
-    fn resolve_node_strict_fails_when_deps_path_missing() {
+    fn resolve_node_falls_back_to_seed_when_deps_path_set_but_node_missing() {
+        let dir = tempdir().unwrap();
+        let exe_dir = dir.path().join("exe");
+        let seed = exe_dir.join("seed").join("node").join("node.exe");
+        touch(&seed);
+
+        // deps_path points to an empty directory — node binary not there yet.
+        let bogus = dir.path().join("nope");
+        fs::create_dir_all(&bogus).unwrap();
+        let resolved =
+            resolve_node_with(Some(bogus.to_str().unwrap()), &exe_dir).unwrap();
+        assert_eq!(resolved, seed);
+    }
+
+    #[test]
+    fn resolve_node_errors_when_deps_and_seed_both_missing() {
         let dir = tempdir().unwrap();
         let exe_dir = dir.path().join("exe");
         fs::create_dir_all(&exe_dir).unwrap();
 
         let bogus = dir.path().join("nope");
         let err = resolve_node_with(Some(bogus.to_str().unwrap()), &exe_dir).unwrap_err();
-        assert!(err.to_string().contains("DEPS_PATH is set"));
+        assert!(err.to_string().contains("Node not found"));
     }
 
     #[test]

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -43,14 +43,6 @@ pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<Path
     )
 }
 
-/// Resolve Node using process env + current exe path.
-pub fn resolve_node() -> Result<PathBuf> {
-    let deps = std::env::var("DEPS_PATH").ok();
-    let exe = std::env::current_exe().context("could not determine current exe path")?;
-    let exe_dir = exe.parent().context("exe has no parent dir")?;
-    resolve_node_with(deps.as_deref(), exe_dir)
-}
-
 /// Pure resolution for the server entry point.
 pub fn resolve_server_entry_with(exe_dir: &Path) -> Result<PathBuf> {
     let entry = exe_dir.join("dist").join("index.js");
@@ -59,12 +51,6 @@ pub fn resolve_server_entry_with(exe_dir: &Path) -> Result<PathBuf> {
     } else {
         bail!("Server entry not found at {:?}", entry)
     }
-}
-
-pub fn resolve_server_entry() -> Result<PathBuf> {
-    let exe = std::env::current_exe().context("could not determine current exe path")?;
-    let exe_dir = exe.parent().context("exe has no parent dir")?;
-    resolve_server_entry_with(exe_dir)
 }
 
 /// Open the server.log file in append mode for stdout/stderr redirection.

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -129,18 +129,12 @@ pub fn run() -> Result<i32> {
             )),
         }
 
-        // §32 Part 5 — coordinate with any in-flight upgrade-server. If
-        // an upgrade-server is currently bound to the port we're about
-        // to ask Node to bind (either spawned by service-mode post-stop
-        // bat OR by local-mode launcher on apply-update path), write
-        // the stop marker + wait for the port to free up. Idempotent —
-        // if no upgrade-server is running, marker write is a no-op and
-        // port check returns immediately.
-        //
-        // §32 Part 5f — runs unconditionally now (not just in service
-        // mode). Local-mode launcher restart-on-apply needs to coordinate
-        // with the upgrade-server its previous incarnation spawned.
-        {
+        // §32 Part 5 — coordinate with any in-flight operation-server.
+        // In service-mode, the operation-server binds the SAME port as
+        // Node (config_port), so we need the stop-marker + port-wait
+        // dance. In §40 local-mode, the operation-server binds a
+        // DIFFERENT port (config_port+1), so no coordination needed.
+        if cfg.is_service_mode() {
             let port = cfg.web_port.unwrap_or(8000);
             if let Err(e) = crate::operation_server::write_stop_marker(&paths.data_root) {
                 log::error(&format!(

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -167,13 +167,11 @@ pub fn run() -> Result<i32> {
         log::error(&format!("could not install Ctrl+C handler: {e}"));
     }
 
-    // NOTE: do NOT set DEPS_PATH on the launcher's process env. spawn::resolve_node
-    // reads DEPS_PATH and enforces strict mode (no seed/ fallback) when it's set
-    // — which would defeat the first-run bootstrap (deps/ not yet populated, only
-    // seed/ exists). DEPS_PATH is instead passed to the Node CHILD's env directly
-    // via spawn::spawn_server(deps_path). The launcher's resolve_node only sees
-    // DEPS_PATH when the user explicitly set it (e.g., shared-deps install) —
-    // strict mode kicks in only there, as SP2b intended.
+    // spawn_server now passes deps_path directly to resolve_node_with, which
+    // tries <deps_path>/node/node.exe first and falls back to seed/node/node.exe
+    // when deps node is absent (first-run bootstrap). DEPS_PATH is also set on
+    // the Node CHILD's env so the backend DependencyManager knows where to
+    // install Node / ADB / scrcpy-server.
     log::info(&format!("supervisor: deps_path resolved to {:?} (passed to Node child)", paths.deps_path));
 
     loop {

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -189,40 +189,6 @@ pub fn run() -> Result<i32> {
         match reason {
             None => {
                 log::info("supervisor: clean exit; not restarting");
-
-                // §40 — local-mode update relaunch. If apply-update-pending
-                // marker is present AND we're in local mode:
-                //   1. Spawn operation-server (serves "updating" page)
-                //   2. Write + spawn local-post-stop.bat (sleeps 12s, then
-                //      launches the new current/launcher.exe post-swap)
-                //   3. Exit — Velopack Update.exe swaps current/ (restart=false,
-                //      we own the relaunch via the bat)
-                //
-                // In service mode, Servy's post-stop.bat handles both the
-                // operation-server spawn and the sc start relaunch — gating
-                // to local-mode-only here keeps the two architectures from
-                // racing.
-                let cfg_now = common::config::AppConfig::load(&paths.data_root);
-                if !cfg_now.is_service_mode() {
-                    let marker = crate::operation_server::apply_update_pending_marker(
-                        &paths.data_root,
-                    );
-                    if marker.exists() {
-                        log::info(
-                            "supervisor: apply-update-pending marker present (local mode); spawning operation-server before exit",
-                        );
-                        if let Err(e) = std::fs::remove_file(&marker) {
-                            log::error(&format!(
-                                "supervisor: could not delete apply-update-pending marker (non-fatal): {e}"
-                            ));
-                        }
-                        // §40 — pass install_root so the operation-server
-                        // can extract the nupkg into current/ and relaunch.
-                        std::env::set_var("WS_SCRCPY_INSTALL_ROOT", &paths.install_root);
-                        crate::operation_server::spawn_detached_helper(&paths.data_root);
-                    }
-                }
-
                 return Ok(code);
             }
             Some(RestartReason::RestartMarker) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.28-beta.16",
+  "version": "0.1.28-beta.17",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -530,6 +530,13 @@ export class Config {
         return path.join(base, 'control', 'apply-update-pending');
     }
 
+    public get operationServerPortFilePath(): string {
+        const base = this._dataRoot !== null
+            ? this._dataRoot
+            : path.dirname(this._dependenciesPath);
+        return path.join(base, 'control', 'operation-server-port');
+    }
+
     public get uninstallPendingMarkerPath(): string {
         const base = this._dataRoot !== null
             ? this._dataRoot

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -1,5 +1,5 @@
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
@@ -328,65 +328,56 @@ export class UpdateService {
      * → beta.12 VM test (2026-04-29) — adb.exe held a persistent file handle
      * on `current\` across multiple apply attempts.
      */
-    public async applyUpdate(): Promise<void> {
+    public async applyUpdate(): Promise<{ redirectPort: number | null }> {
         if (!this.mgr || !this.state.pendingUpdate || this.state.status !== 'ready') {
             throw new Error(`apply not allowed in current state: ${this.state.status}`);
         }
         log.info(`applying update v${this.state.availableVersion}`);
         await this.preApplyHygiene();
-        // silent=true (no UI from Velopack updater).
-        //
-        // restart semantics depend on install mode:
-        //   - local mode: restart=false. Supervisor writes + spawns a
-        //     Velopack relaunches the user-mode launcher post-swap. Unchanged
-        //     behavior from v0.1.x stable.
-        //   - service mode: restart=false. Servy's post-stop.bat handles sc start.
-        //     Velopack's stub-relaunch would spawn a parallel LocalSystem launcher
-        //     outside Servy (inherits the LocalSystem token from Update.exe's parent
-        //     chain, grabs the single-instance mutex, starves out Servy's recovery
-        //     attempts). Instead we rely on Servy's --postStopPath mechanism: we
-        //     write an apply-update-pending marker here, then exit. Servy detects
-        //     the launcher's clean exit and fires the post-stop handler, which sees
-        //     the marker, sleeps long enough for Update.exe to release file handles
-        //     on current/, and invokes `sc start WsScrcpyWeb`. SCM then asks Servy
-        //     to launch a fresh launcher — by which point Velopack is long gone.
-        //     v0.1.25-beta.8 / beta.10 / beta.11 smokes caught the prior approaches;
-        //     see §32 Part 3 in todo_ws_scrcpy_web.md.
+
         const installMode = Config.getInstance().getAppConfig().installMode;
         const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
 
-        // §32 Part 5e/5f — upgrade-server is no longer spawned from Node.
-        // The pre-exit spawn (Part 5b) put the upgrade-server inside
-        // Velopack's process tree, loading
-        // `<installRoot>/current/ws-scrcpy-web-launcher.exe` as its
-        // image; Velopack's apply phase terminated it within ~1s of
-        // bind (v0.1.25-beta.24 → beta.25 smoke 2026-05-21). The
-        // upgrade-server is now spawned by the launcher (Part 5f, local
-        // mode, on supervisor clean-exit path) or by the post-stop bat
-        // (Part 5e, service mode), both sourcing from
-        // `<dataRoot>/upgrade-server/ws-scrcpy-web-launcher.exe` which
-        // Velopack doesn't touch.
-        //
-        // §32 Part 5f — write the apply-update-pending marker in BOTH
-        // modes (was service-mode-only in Part 5e). The marker is the
-        // discriminator both the launcher's supervisor (local) and the
-        // post-stop bat (service) use on clean Node exit to decide
-        // whether to spawn the upgrade-server. Without the marker,
-        // neither side can tell apply-update from a user-initiated
-        // stop (Ctrl+C, services.msc Stop, etc.) and would over-spawn.
         await this.writeApplyUpdatePendingMarker();
 
         if (isServiceMode) {
-            // Service mode: Velopack applies under LocalSystem via Servy's
-            // post-stop.bat which calls sc start after the swap.
             this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+            return { redirectPort: null };
         }
-        // Local mode: do NOT call waitExitThenApplyUpdate. That spawns
-        // Update.exe watching our PID, which kills the launcher's process
-        // tree before the supervisor can spawn the operation-server + bat.
-        // Instead: write the marker, exit cleanly. The supervisor's
-        // local-post-stop.bat calls Update.exe apply --silent after
-        // everything has exited.
+
+        const cfg = Config.getInstance();
+        const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        const helperPath = path.join(
+            dataRoot,
+            'control', 'operation-server', 'ws-scrcpy-web-launcher.exe',
+        );
+        const installRoot = path.resolve(__dirname, '..', '..');
+
+        try {
+            const child = spawn(helperPath, ['--operation-server'], {
+                cwd: dataRoot,
+                detached: true,
+                stdio: 'ignore',
+                env: {
+                    ...process.env,
+                    WS_SCRCPY_INSTALL_ROOT: installRoot,
+                },
+            });
+            child.unref();
+            log.info(`applyUpdate: spawned operation-server (pid ${child.pid})`);
+        } catch (err) {
+            log.error(`applyUpdate: failed to spawn operation-server: ${(err as Error).message}`);
+            return { redirectPort: null };
+        }
+
+        const port = await this.pollOperationServerPort();
+        if (port !== null) {
+            log.info(`applyUpdate: operation-server ready on port ${port}`);
+        } else {
+            log.warn('applyUpdate: operation-server port file not found within timeout');
+        }
+
+        return { redirectPort: port };
     }
 
     /**
@@ -414,6 +405,24 @@ export class UpdateService {
                     `— service will not auto-restart after Velopack swap; user must restart manually.`,
             );
         }
+    }
+
+    private async pollOperationServerPort(timeoutMs = 5000, intervalMs = 100): Promise<number | null> {
+        const portFilePath = Config.getInstance().operationServerPortFilePath;
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            try {
+                const content = await fs.promises.readFile(portFilePath, 'utf8');
+                const port = parseInt(content.trim(), 10);
+                if (!isNaN(port) && port > 0 && port <= 65535) {
+                    return port;
+                }
+            } catch {
+                // file doesn't exist yet
+            }
+            await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        }
+        return null;
     }
 
     /**

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -1,4 +1,6 @@
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import * as child_process from 'child_process';
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as os from 'os';
@@ -9,6 +11,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
 import { type UpdateManagerLike, UpdateService } from '../UpdateService';
+
+// Mock child_process.spawn so local-mode applyUpdate doesn't try to exec
+// the real operation-server helper binary (which doesn't exist in test).
+vi.mock('child_process', async (importOriginal) => {
+    const real = await importOriginal<typeof child_process>();
+    return {
+        ...real,
+        spawn: vi.fn(() => ({ pid: 12345, unref: vi.fn() })),
+    };
+});
 
 // ──────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -53,6 +65,10 @@ describe('UpdateService', () => {
         FEED: process.env['VELOPACK_FEED_URL'],
     };
 
+    // Intercept fs.promises.readFile so pollOperationServerPort returns
+    // instantly in local-mode tests instead of waiting 5s for a real file.
+    let readFileSpy: ReturnType<typeof vi.spyOn> | undefined;
+
     beforeEach(() => {
         const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-update-svc-'));
         tmpDirs.push(tmpRoot);
@@ -62,9 +78,20 @@ describe('UpdateService', () => {
         process.env['DEPS_PATH'] = path.join(tmpRoot, 'deps');
         delete process.env['VELOPACK_FEED_URL'];
         Config._resetForTest();
+
+        const realReadFile = fs.promises.readFile.bind(fs.promises);
+        readFileSpy = vi.spyOn(fs.promises, 'readFile').mockImplementation(
+            ((...args: Parameters<typeof fs.promises.readFile>) => {
+                if (typeof args[0] === 'string' && args[0].includes('operation-server-port')) {
+                    return Promise.resolve('9999');
+                }
+                return realReadFile(...args);
+            }) as typeof fs.promises.readFile,
+        );
     });
 
     afterEach(() => {
+        readFileSpy?.mockRestore();
         Config._resetForTest();
         if (savedEnv.CONFIG === undefined) delete process.env[EnvName.CONFIG_PATH];
         else process.env[EnvName.CONFIG_PATH] = savedEnv.CONFIG;
@@ -482,34 +509,16 @@ describe('UpdateService', () => {
         expect(applyFn).not.toHaveBeenCalled();
     });
 
-    // §32 Part 5e/5f: the upgrade-server is no longer spawned from Node.
-    // Part 5b tried a pre-exit spawn from
-    // `<installRoot>/current/ws-scrcpy-web-launcher.exe` to close the dead
-    // window between Node port-release and upgrade-server bind — but the
-    // upgrade-server loaded current/launcher.exe as its image, and
-    // Velopack's apply phase terminated it within ~1s (caught by
-    // v0.1.25-beta.24 → beta.25 smoke 2026-05-21). The upgrade-server is
-    // now spawned by Servy's --postStopPath bat (Part 5e, service mode) or
-    // by the launcher's supervisor on clean Node exit (Part 5f, local
-    // mode), both sourcing from a dataRoot copy of the launcher entirely
-    // outside Velopack's reach.
-    //
-    // §32 Part 5f extends the apply-update-pending marker write to BOTH
-    // modes (was service-mode-only in Part 5e). Both the launcher
-    // supervisor (local) and the post-stop bat (service) use the marker
-    // as the discriminator between apply-update and user-initiated stop.
-    //
-    // applyUpdate's only side effects on Node side are: write the
-    // apply-update-pending marker (in BOTH modes) and call
-    // waitExitThenApplyUpdate. The marker-write spy below also locks in
-    // the Part 5f behavior — without it, local-mode would never get an
-    // upgrade page.
+    // §40: applyUpdate writes the apply-update-pending marker in ALL modes.
+    // In local mode, Node also spawns the operation-server helper and polls
+    // for its port file (spawn is module-mocked via vi.mock('child_process')).
+    // In service mode, Servy's post-stop bat handles the operation-server.
     it.each([
         ['user-service' as const],
         ['system-service' as const],
         ['user' as const],
         ['system' as const],
-    ])('applyUpdate (%s): writes marker + does NOT spawn anything from Node (§32 Part 5f)', async (installMode) => {
+    ])('applyUpdate (%s): writes marker (§40)', async (installMode) => {
         Config.getInstance().updateAppConfig({ autoUpdate: false, installMode });
         // Spy on fs.promises.writeFile + mkdir to capture the marker write
         // without polluting real ProgramData. Mock as no-ops since we only

--- a/src/server/__tests__/UpdatesApi.test.ts
+++ b/src/server/__tests__/UpdatesApi.test.ts
@@ -64,7 +64,7 @@ function fakeService(state: Partial<UpdateServiceState> = {}) {
         ...state,
     };
     const checkForUpdates = vi.fn(async () => fullState);
-    const applyUpdate = vi.fn();
+    const applyUpdate = vi.fn(async () => ({ redirectPort: null }));
     const reconfigure = vi.fn(async (_c: 'stable' | 'beta', _o: string) => undefined);
     const restartTimer = vi.fn();
     const downloadIfNeeded = vi.fn(async () => undefined);

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -135,14 +135,10 @@ export class UpdatesApi {
             return true;
         }
 
+        let redirectPort: number | null = null;
         try {
-            // v0.1.23-beta.13: applyUpdate is now async because it runs
-            // pre-apply hygiene (adb daemon kill + Windows taskkill +
-            // settle delay) before kicking off Velopack's wait-then-apply.
-            // We block the HTTP response until hygiene completes so the
-            // chained process.exit timer below doesn't fire before
-            // Velopack actually has Update.exe spawned.
-            await this.svc.applyUpdate();
+            const result = await this.svc.applyUpdate();
+            redirectPort = result.redirectPort;
         } catch (err) {
             const body: UpdatesErrorResponse = { ok: false, error: (err as Error).message };
             res.writeHead(500);
@@ -150,11 +146,21 @@ export class UpdatesApi {
             return true;
         }
 
-        const body: UpdatesApplyResponse = { ok: true };
-        res.writeHead(200);
-        res.end(JSON.stringify(body));
+        if (redirectPort !== null) {
+            const redirectUrl = `http://localhost:${redirectPort}/`;
+            const html = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>updating</title></head>
+<body><p>redirecting to update page...</p>
+<script>window.location.href=${JSON.stringify(redirectUrl)};</script>
+</body></html>`;
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            res.end(html);
+        } else {
+            const body: UpdatesApplyResponse = { ok: true };
+            res.writeHead(200);
+            res.end(JSON.stringify(body));
+        }
 
-        // Mirror ServerShutdownApi: defer exit so the response flushes first.
         this.schedule(() => {
             log.info('exiting (process.exit 0) after applyUpdate');
             this.exit(0);


### PR DESCRIPTION
## Summary

- **Port conflict eliminated.** Operation-server now binds `config_port + 1` (probing upward) instead of competing with Node for `config_port`. Eliminates the IPv4-dead / dual-stack corruption bug where `127.0.0.1:8000` became unreachable after updates while `[::1]:8000` worked.
- **Node resolution fixed.** `spawn_server` now passes `deps_path` through to `resolve_node_with` instead of reading `DEPS_PATH` from process env (always empty). Falls through to seed on first-run bootstrap.
- **Stale helper binary neutralized.** Old code's `bind("0.0.0.0", config_port)` fails gracefully when Node still holds the port, instead of silently corrupting dual-stack binding.

## Test plan

- [x] Rust: 87/87 cargo tests pass
- [x] Node: 710/710 vitest pass
- [x] tsc --noEmit clean
- [ ] Manual smoke: apply update on VM, verify browser redirect flow, verify 127.0.0.1 reachable post-update, verify tray exit works