### PR TITLE
docs: note deletion of 43 iterative bug-test releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **v0.1.28-beta.1 through beta.14 releases deleted.** All were iterations on the §40 local-mode update bug — none produced a working local-mode update flow. beta.15 and beta.16 are the last two pre-redesign betas retained for reference. Orphaned git tags remain (tag protection ruleset blocks deletion); they point to valid commits on main but have no associated GitHub Release.
-
-## [0.1.28-beta.16] - 2026-05-26
-
-## [0.1.28-beta.15] - 2026-05-26
-
-## [0.1.28-beta.16] and [0.1.28-beta.15] are the last pre-redesign betas.
-## beta.1 through beta.14 were §40 iteration artifacts — releases deleted,
-## orphaned tags remain in git. See beta.17's Removed section for context.
+- **Iterative bug-test releases cleaned from GitHub Releases.** This project uses GitHub's CI pipeline (build, clippy, vitest, CodeQL, Scorecard) as a secondary vetting backstop — every commit to main triggers a full pipeline run, and tagged releases exercise the complete build-sign-attest-publish chain. This means we ship more releases during active development than a project relying solely on local testing would, because each CI-validated iteration IS the test. The trade-off: the Releases page accumulates artifacts that were never intended as user-facing installs. We periodically prune these to keep the page navigable. Orphaned git tags remain (tag protection ruleset blocks deletion); they point to valid commits on main and preserve the full development history for archaeology. Deleted releases:
+  - **v0.1.28-beta.1 through beta.16** (16 releases) — §40 local-mode update iterations. None produced a working local-mode update flow. beta.17 is the redesign that fixes the root cause.
+  - **v0.1.25-beta.3 through beta.67** (8 remaining releases after earlier cleanup) — service-mode rearchitecture + tray unification + upgrade-server iterations. All rolled into v0.1.26 stable.
+  - **v0.1.5 through v0.1.23** (19 releases) — rapid daily iteration chain covering adb path hardening, service install, node-pty resolution, first-run modals, dependency manager, and packaging. v0.1.4 (local-deps-only milestone) and v0.1.24 (first clean stable) bookend the range; everything between was iterative bug-test artifacts.
 
 ## [0.1.27] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28-beta.18] - 2026-05-26
+
 ## [0.1.28-beta.17] - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.28-beta.16"
+version = "0.1.28-beta.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.28-beta.16"
+version = "0.1.28-beta.17"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.28-beta.16"
+version = "0.1.28-beta.17"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.28-beta.17"
+version = "0.1.28-beta.18"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.28-beta.17",
+  "version": "0.1.28-beta.18",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
CHANGELOG-only. Documents the release cleanup methodology and lists deleted releases.