### PR TITLE
docs: add auto-release pipeline CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Velopack upgraded from prerelease 0.0.1589-ga2c5a97 to stable 1.0.1.** Bumped across all four touchpoints: Rust crate (`Cargo.toml`), npm package (`package.json`), and vpk CLI pin (`release.yml`, both build-windows and build-linux jobs). Zero API changes -- all Rust builder patterns, npm exports, and CLI flags are preserved. The `--msi` flag now produces a true Windows Installer MSI (improved per-machine support, proper installer UI) instead of the older Squirrel-style wrapper.
+- **Automated release pipeline.** New `auto-release.yml` workflow automates version bump + tag push on labeled PR merges. Add `release:beta` or `release:stable` label to a PR; on merge, the pipeline computes the next version, creates a bump PR, and after CI passes, pushes the tag to trigger the full build + publish.
 
 ## [0.1.28] - 2026-05-27
 


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry for the auto-release pipeline (PR #177)

## Test plan
- This PR is labeled `release:beta` to exercise the new auto-release pipeline end-to-end
- Expected: after merge, auto-release.yml creates a bump PR for v0.1.29-beta.1, CI runs on it, auto-merge fires, tag pushed, release.yml builds + publishes