### PR TITLE
fix(ci): pass App token to checkout for git push auth

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,15 +25,16 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Summary
- Move `create-github-app-token` step before `checkout` so the token is available
- Pass token to `checkout` via `token:` input — this configures git credentials for the App instead of the default `GITHUB_TOKEN` (which lacks push access)
- Fixes the 403 on `git push` in run 26524261700

## Test plan
- This PR is labeled `release:beta` to re-test the full auto-release pipeline
- Expected: after merge, auto-release.yml creates bump PR for v0.1.29-beta.1, tag pushed, release published