### PR TITLE
fix: polish shell close modal size and warning text

### DIFF
--- a/src/app/googDevice/client/ShellModal.ts
+++ b/src/app/googDevice/client/ShellModal.ts
@@ -84,12 +84,12 @@ export class ShellModal extends Modal {
         overlay.className = 'shell-close-confirm';
         overlay.style.cssText =
             'border: 1px solid var(--modal-border, rgba(255,255,255,0.15)); border-radius: 8px; ' +
-            'padding: 20px; background: var(--modal-bg, #1e1e2e); color: var(--text-primary, #cdd6f4); ' +
-            'max-width: 340px; text-align: center;';
+            'padding: 32px 40px; background: var(--modal-bg, #1e1e2e); color: var(--text-primary, #cdd6f4); ' +
+            'width: clamp(360px, 40vw, 520px); text-align: center;';
 
         const msg = document.createElement('p');
-        msg.style.cssText = 'margin: 0 0 16px;';
-        msg.textContent = 'end the shell session?';
+        msg.style.cssText = 'margin: 0 0 16px; line-height: 1.5;';
+        msg.textContent = 'ending the shell session loses any active work in the shell. close anyway?';
         overlay.appendChild(msg);
 
         const buttons = document.createElement('div');


### PR DESCRIPTION
Wider modal, more padding, descriptive warning text with wrapping.