### PR TITLE
fix: shell greyed out in service mode (node-pty staging guard)

### DIFF
--- a/src/app/googDevice/client/ShellModal.ts
+++ b/src/app/googDevice/client/ShellModal.ts
@@ -84,12 +84,12 @@ export class ShellModal extends Modal {
         overlay.className = 'shell-close-confirm';
         overlay.style.cssText =
             'border: 1px solid var(--modal-border, rgba(255,255,255,0.15)); border-radius: 8px; ' +
-            'padding: 20px; background: var(--modal-bg, #1e1e2e); color: var(--text-primary, #cdd6f4); ' +
-            'max-width: 340px; text-align: center;';
+            'padding: 32px 40px; background: var(--modal-bg, #1e1e2e); color: var(--text-primary, #cdd6f4); ' +
+            'width: clamp(360px, 40vw, 520px); text-align: center;';
 
         const msg = document.createElement('p');
-        msg.style.cssText = 'margin: 0 0 16px;';
-        msg.textContent = 'end the shell session?';
+        msg.style.cssText = 'margin: 0 0 16px; line-height: 1.5;';
+        msg.textContent = 'ending the shell session loses any active work in the shell. close anyway?';
         overlay.appendChild(msg);
 
         const buttons = document.createElement('div');

--- a/src/server/NodePtyResolver.ts
+++ b/src/server/NodePtyResolver.ts
@@ -156,7 +156,9 @@ export function ptyNodePath(packageDir: string): string {
 
 /** True when the dataRoot package looks complete enough to attempt a load. */
 export function packageHasBinary(packageDir: string): boolean {
-    return fs.existsSync(ptyNodePath(packageDir));
+    if (fs.existsSync(ptyNodePath(packageDir))) return true;
+    const prebuildsDir = path.join(packageDir, 'node_modules', 'node-pty', 'prebuilds');
+    return fs.existsSync(prebuildsDir);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `packageHasBinary()` checked `build/Release/pty.node` (node-gyp legacy path)
- node-pty 1.1.0 uses prebuildify: binary is at `prebuilds/win32-x64/`
- Guard always returned false → re-staged on every startup → EPIPE when two instances overlap during local-to-service transition
- Fix: also check for `prebuilds/` directory existence
- Also includes shell close modal size/text polish from the prior commit

## Test plan
- [ ] Service mode: shell button enabled, `curl /api/capabilities` returns `{"shell":true}`
- [ ] Local → service transition: shell works immediately, no seed-stage-failed