### PR TITLE
chore: bump to v0.1.29-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29-beta.9] - 2026-05-27
+
 ## [0.1.29-beta.8] - 2026-05-27
 
 ## [0.1.29-beta.7] - 2026-05-27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.29-beta.8"
+version = "0.1.29-beta.9"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.29-beta.8",
+  "version": "0.1.29-beta.9",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
Automated version bump to v0.1.29-beta.9.

Smoke target: shell button greyed out due to copy failure (node-pty staging guard fix from PR #198).