### PR TITLE
fix: replace inline shell close confirm with proper Modal subclass

### DIFF
--- a/src/app/client/ShellCloseConfirmModal.ts
+++ b/src/app/client/ShellCloseConfirmModal.ts
@@ -1,0 +1,76 @@
+import { Modal } from '../ui/Modal';
+
+export class ShellCloseConfirmModal extends Modal {
+    private resolveFn: ((value: boolean) => void) | null = null;
+    private resolved = false;
+
+    public static confirm(): Promise<boolean> {
+        return new Promise((resolve) => {
+            new ShellCloseConfirmModal(resolve);
+        });
+    }
+
+    private constructor(resolve: (value: boolean) => void) {
+        super({ title: 'End Shell Session' });
+        this.resolveFn = resolve;
+        this.dialog.classList.add('shell-close-confirm-modal');
+        queueMicrotask(() => this.fillBody(this.bodyEl));
+    }
+
+    protected buildBody(_container: HTMLElement): void {
+        // Body content rendered by fillBody() from the constructor via queueMicrotask.
+    }
+
+    private fillBody(container: HTMLElement): void {
+        const message = document.createElement('p');
+        message.style.cssText = 'margin: 0 0 12px;';
+        message.textContent = 'ending the shell session loses any active work in the shell.';
+        container.appendChild(message);
+
+        const question = document.createElement('p');
+        question.style.cssText = 'margin: 0 0 8px;';
+        question.textContent = 'close anyway?';
+        container.appendChild(question);
+    }
+
+    protected override buildFooter(): HTMLElement | null {
+        const footer = document.createElement('div');
+        footer.style.cssText = 'display: flex; gap: 8px; justify-content: flex-end;';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'settings-btn';
+        cancelBtn.textContent = 'cancel';
+        cancelBtn.addEventListener('click', () => this.resolveAndClose(false));
+        footer.appendChild(cancelBtn);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'settings-btn settings-btn-primary';
+        closeBtn.textContent = 'close';
+        closeBtn.addEventListener('click', () => this.resolveAndClose(true));
+        footer.appendChild(closeBtn);
+
+        return footer;
+    }
+
+    protected override onEscapeKey(_event: Event): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onBackdropClick(_event: MouseEvent): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onCloseButtonClick(): void {
+        this.resolveAndClose(false);
+    }
+
+    private resolveAndClose(value: boolean): void {
+        if (this.resolved) return;
+        this.resolved = true;
+        this.resolveFn?.(value);
+        this.resolveFn = null;
+        this.close(value);
+    }
+}

--- a/src/app/client/__tests__/ShellCloseConfirmModal.test.ts
+++ b/src/app/client/__tests__/ShellCloseConfirmModal.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ShellCloseConfirmModal } from '../ShellCloseConfirmModal';
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        if (this.hasAttribute('open')) {
+            throw new DOMException(
+                "Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.",
+                'InvalidStateError',
+            );
+        }
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+});
+
+function getDialog(): HTMLDialogElement {
+    const dialog = document.querySelector('dialog.shell-close-confirm-modal');
+    expect(dialog, 'modal dialog should be in the DOM').toBeTruthy();
+    return dialog as HTMLDialogElement;
+}
+
+function getButton(label: string): HTMLButtonElement {
+    const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+    const btn = btns.find((b) => b.textContent?.trim().toLowerCase() === label.toLowerCase());
+    expect(btn, `button labeled "${label}" should be in the DOM`).toBeTruthy();
+    return btn!;
+}
+
+describe('ShellCloseConfirmModal.confirm', () => {
+    it('resolves true when close is clicked', async () => {
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('close').click();
+        await expect(promise).resolves.toBe(true);
+    });
+
+    it('resolves false when cancel is clicked', async () => {
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('cancel').click();
+        await expect(promise).resolves.toBe(false);
+    });
+
+    it('resolves false when Esc is pressed', async () => {
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        const dialog = getDialog();
+        const cancelEvent = new Event('cancel', { cancelable: true });
+        dialog.dispatchEvent(cancelEvent);
+        await expect(promise).resolves.toBe(false);
+    });
+
+    it('resolves false when backdrop is clicked', async () => {
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        const dialog = getDialog();
+        const clickEvent = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(clickEvent, 'target', { value: dialog });
+        dialog.dispatchEvent(clickEvent);
+        await expect(promise).resolves.toBe(false);
+    });
+
+    it('resolves only once even if multiple close paths fire', async () => {
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('close').click();
+        getButton('cancel').click();
+        await expect(promise).resolves.toBe(true);
+    });
+
+    it('renders warning text in the body', async () => {
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        const body = document.querySelector('.modal-body');
+        expect(body?.textContent?.toLowerCase()).toContain('ending the shell session');
+        expect(body?.textContent?.toLowerCase()).toContain('close anyway?');
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('calls showModal exactly once', async () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        const promise = ShellCloseConfirmModal.confirm();
+        await Promise.resolve();
+        expect(spy).toHaveBeenCalledTimes(1);
+        getButton('close').click();
+        await expect(promise).resolves.toBe(true);
+        spy.mockRestore();
+    });
+});

--- a/src/app/googDevice/client/ShellModal.ts
+++ b/src/app/googDevice/client/ShellModal.ts
@@ -7,6 +7,7 @@ import { ChannelCode } from '../../../common/ChannelCode';
 import type { MessageXtermClient } from '../../../types/MessageXtermClient';
 import { Multiplexer } from '../../../packages/multiplexer/Multiplexer';
 import { ManagerClient } from '../../client/ManagerClient';
+import { ShellCloseConfirmModal } from '../../client/ShellCloseConfirmModal';
 import { Modal } from '../../ui/Modal';
 
 const TAG = '[ShellModal]';
@@ -76,57 +77,9 @@ export class ShellModal extends Modal {
             this.close();
             return;
         }
-        this.showCloseConfirm();
-    }
-
-    private showCloseConfirm(): void {
-        const overlay = document.createElement('dialog');
-        overlay.className = 'shell-close-confirm';
-        overlay.style.cssText =
-            'border: 1px solid var(--modal-border, rgba(255,255,255,0.15)); border-radius: 8px; ' +
-            'padding: 32px 40px; background: var(--modal-bg, #1e1e2e); color: var(--text-primary, #cdd6f4); ' +
-            'width: clamp(360px, 40vw, 520px); text-align: center;';
-
-        const msg = document.createElement('p');
-        msg.style.cssText = 'margin: 0 0 16px; line-height: 1.5;';
-        msg.textContent = 'ending the shell session loses any active work in the shell. close anyway?';
-        overlay.appendChild(msg);
-
-        const buttons = document.createElement('div');
-        buttons.style.cssText = 'display: flex; gap: 8px; justify-content: center;';
-
-        const cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'settings-btn';
-        cancelBtn.textContent = 'cancel';
-        cancelBtn.addEventListener('click', () => {
-            overlay.close();
-            overlay.remove();
+        ShellCloseConfirmModal.confirm().then((confirmed) => {
+            if (confirmed) this.close();
         });
-        buttons.appendChild(cancelBtn);
-
-        const okBtn = document.createElement('button');
-        okBtn.type = 'button';
-        okBtn.className = 'settings-btn settings-btn-primary';
-        okBtn.textContent = 'ok';
-        okBtn.addEventListener('click', () => {
-            overlay.close();
-            overlay.remove();
-            this.close();
-        });
-        buttons.appendChild(okBtn);
-
-        overlay.appendChild(buttons);
-
-        overlay.addEventListener('click', (e) => {
-            if (e.target === overlay) {
-                overlay.close();
-                overlay.remove();
-            }
-        });
-
-        document.body.appendChild(overlay);
-        overlay.showModal();
     }
 
     protected override onBeforeClose(): void {


### PR DESCRIPTION
## Summary
- Replaced raw `<dialog>` with inline styles in ShellModal.showCloseConfirm() with a proper `ShellCloseConfirmModal` extending the Modal base class
- Now matches AdminConfirmModal pattern: title bar, theme toggle, close button, glassmorphism frame, right-aligned footer buttons
- 7 new tests covering confirm/cancel/escape/backdrop/single-resolution/copy/showModal-once

## Test plan
- [ ] Smoke shell close modal visually matches service install/uninstall modal
- [ ] Cancel dismisses without closing the shell session
- [ ] Close button ends the shell session
- [ ] Escape key dismisses without closing
- [ ] Backdrop click dismisses without closing