### PR TITLE
fix: use platform-conditional node binary name in launcher

### DIFF
--- a/launcher/src/paths.rs
+++ b/launcher/src/paths.rs
@@ -68,7 +68,8 @@ impl Paths {
         };
 
         let restart_marker = data_root.join(".restart");
-        let old_node = deps_path.join("node").join("node.exe.old");
+        let node_bin_old = if cfg!(windows) { "node.exe.old" } else { "node.old" };
+        let old_node = deps_path.join("node").join(node_bin_old);
 
         Ok(Self {
             install_root,

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -1,10 +1,12 @@
 // Node child-process spawn for the launcher.
 //
 // Resolves the Node executable using a best-effort priority chain:
-//   1. `deps_path` parameter → `<deps_path>/node/node.exe` (preferred;
+//   1. `deps_path` parameter → `<deps_path>/node/<node-binary>` (preferred;
 //      populated after first-run bootstrap installs Node into dependencies/).
-//   2. `<exe_dir>/seed/node/node.exe` (bundled fallback for first-run
+//   2. `<exe_dir>/seed/node/<node-binary>` (bundled fallback for first-run
 //      before dependencies/ is populated, or if deps node is missing).
+//
+// Binary name is platform-conditional: `node.exe` on Windows, `node` on Linux.
 //   3. Otherwise, error.
 //
 // Server entry is `<exe_dir>/dist/index.js`.
@@ -13,6 +15,11 @@ use anyhow::{Context, Result, bail};
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
+
+#[cfg(windows)]
+const NODE_BIN: &str = "node.exe";
+#[cfg(not(windows))]
+const NODE_BIN: &str = "node";
 
 // CREATE_NO_WINDOW = 0x08000000. Defined here as a literal so we don't need
 // to thread the windows crate through pure-logic functions / tests on
@@ -24,7 +31,7 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 /// return the Node binary path or an error.
 pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<PathBuf> {
     if let Some(deps) = deps_path {
-        let candidate = Path::new(deps).join("node").join("node.exe");
+        let candidate = Path::new(deps).join("node").join(NODE_BIN);
         if candidate.exists() {
             return Ok(candidate);
         }
@@ -32,7 +39,7 @@ pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<Path
         // through to seed instead of hard-failing.
     }
 
-    let seed = exe_dir.join("seed").join("node").join("node.exe");
+    let seed = exe_dir.join("seed").join("node").join(NODE_BIN);
     if seed.exists() {
         return Ok(seed);
     }
@@ -180,7 +187,7 @@ mod tests {
     fn resolve_node_uses_deps_path_when_present() {
         let dir = tempdir().unwrap();
         let deps = dir.path().join("deps");
-        let node = deps.join("node").join("node.exe");
+        let node = deps.join("node").join(NODE_BIN);
         touch(&node);
 
         let exe_dir = dir.path().join("exe");
@@ -194,7 +201,7 @@ mod tests {
     fn resolve_node_falls_back_to_seed_when_deps_path_set_but_node_missing() {
         let dir = tempdir().unwrap();
         let exe_dir = dir.path().join("exe");
-        let seed = exe_dir.join("seed").join("node").join("node.exe");
+        let seed = exe_dir.join("seed").join("node").join(NODE_BIN);
         touch(&seed);
 
         // deps_path points to an empty directory — node binary not there yet.
@@ -220,7 +227,7 @@ mod tests {
     fn resolve_node_falls_back_to_seed_when_deps_path_unset() {
         let dir = tempdir().unwrap();
         let exe_dir = dir.path().join("exe");
-        let seed = exe_dir.join("seed").join("node").join("node.exe");
+        let seed = exe_dir.join("seed").join("node").join(NODE_BIN);
         touch(&seed);
 
         let resolved = resolve_node_with(None, &exe_dir).unwrap();

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -4,7 +4,7 @@
 //   1. Stale marker cleanup (delete `.restart` if left over from prior crash)
 //   2. Install Ctrl+C handler that signals shutdown intent
 //   3. Loop:
-//      a. Clean up `node.exe.old` (Node auto-update artifact)
+//      a. Clean up stale node binary (Node auto-update artifact)
 //      b. Spawn Node child via spawn::spawn_server
 //      c. Wait for child OR Ctrl+C (poll-based, 100ms granularity)
 //      d. Decide restart based on (exit code == 75) || marker present
@@ -162,7 +162,7 @@ pub fn run() -> Result<i32> {
     }
 
     // spawn_server now passes deps_path directly to resolve_node_with, which
-    // tries <deps_path>/node/node.exe first and falls back to seed/node/node.exe
+    // tries <deps_path>/node/<node-binary> first and falls back to seed/node/<node-binary>
     // when deps node is absent (first-run bootstrap). DEPS_PATH is also set on
     // the Node CHILD's env so the backend DependencyManager knows where to
     // install Node / ADB / scrcpy-server.


### PR DESCRIPTION
## Summary
- Launcher hardcoded `node.exe` in `resolve_node_with()` and seed fallback -- on Linux the binary is `node` (no extension), so every AppImage ever published was DOA
- Add `NODE_BIN` constant resolved at compile time via `#[cfg]`: `node.exe` on Windows, `node` on Linux
- Fix `old_node` cleanup path in `paths.rs` (`node.exe.old` -> `node.old` on Linux)

## Test plan
- [ ] Cargo tests pass (130 tests, platform-conditional stubs updated)
- [ ] Download 0.1.30-beta.1 AppImage on Fedora 44, double-click, verify browser opens
- [ ] Windows Velopack install still works (node.exe resolution unchanged on Windows target)