### PR TITLE
feat: redirect Linux data_root to XDG_DATA_HOME

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -25,16 +25,31 @@ pub fn data_root_for_windows(programdata: Option<&str>) -> PathBuf {
     PathBuf::from(pd).join("WsScrcpyWeb")
 }
 
-/// Convenience wrapper around [`data_root_for_windows`] that reads
-/// `PROGRAMDATA` from the process env. Returns `Some` on Windows, `None`
-/// elsewhere — non-Windows callers should fall back to install-root for
-/// data-root semantics until/unless a Linux migration target is defined.
+/// Pure resolver for the writable-state root on Linux. Follows the XDG
+/// Base Directory spec: `$XDG_DATA_HOME/WsScrcpyWeb` if set, otherwise
+/// `~/.local/share/WsScrcpyWeb`. Mirrors `resolveDataRoot` in
+/// `src/server/Config.ts`. Parameters are injectable for testing.
+pub fn data_root_for_linux(xdg_data_home: Option<&str>, home: Option<&str>) -> PathBuf {
+    if let Some(xdg) = xdg_data_home.filter(|s| !s.is_empty()) {
+        return PathBuf::from(xdg).join("WsScrcpyWeb");
+    }
+    match home {
+        Some(h) => PathBuf::from(h).join(".local").join("share").join("WsScrcpyWeb"),
+        None => PathBuf::from("/tmp").join("WsScrcpyWeb"),
+    }
+}
+
+/// Convenience wrapper that reads env vars and delegates to the
+/// platform-specific resolver. Returns `Some` on all platforms now
+/// (Linux gained XDG support; was `None` before this change).
 pub fn data_root_from_env() -> Option<PathBuf> {
     if cfg!(windows) {
         let pd = std::env::var("PROGRAMDATA").ok();
         Some(data_root_for_windows(pd.as_deref()))
     } else {
-        None
+        let xdg = std::env::var("XDG_DATA_HOME").ok();
+        let home = std::env::var("HOME").ok();
+        Some(data_root_for_linux(xdg.as_deref(), home.as_deref()))
     }
 }
 
@@ -230,6 +245,24 @@ mod tests {
     fn data_root_for_windows_falls_back_on_empty_programdata() {
         let result = data_root_for_windows(Some(""));
         assert_eq!(result, PathBuf::from("C:\\ProgramData\\WsScrcpyWeb"));
+    }
+
+    #[test]
+    fn data_root_for_linux_uses_xdg_data_home_when_set() {
+        let result = data_root_for_linux(Some("/custom/data"), Some("/home/user"));
+        assert_eq!(result, PathBuf::from("/custom/data/WsScrcpyWeb"));
+    }
+
+    #[test]
+    fn data_root_for_linux_falls_back_to_home_local_share() {
+        let result = data_root_for_linux(None, Some("/home/user"));
+        assert_eq!(result, PathBuf::from("/home/user/.local/share/WsScrcpyWeb"));
+    }
+
+    #[test]
+    fn data_root_for_linux_ignores_empty_xdg_data_home() {
+        let result = data_root_for_linux(Some(""), Some("/home/user"));
+        assert_eq!(result, PathBuf::from("/home/user/.local/share/WsScrcpyWeb"));
     }
 
     #[test]

--- a/launcher/src/paths.rs
+++ b/launcher/src/paths.rs
@@ -13,12 +13,12 @@
 //     ws-scrcpy-web-launcher.log
 //     dependencies/                       (DEPS_PATH target — was at install_root pre-Phase-1)
 //
-// On Windows, dataRoot defaults to %PROGRAMDATA%\WsScrcpyWeb. On non-Windows
-// (Linux AppImage), dataRoot collapses to install_root for now — there is no
-// migration target until/unless a Linux Program-Files-equivalent flow is
-// designed. The DEPS_PATH env var continues to override deps_path absolutely
-// when set (used by tests, shared-deps installs, and the service-install
-// envVars block in ServiceApi.handleInstall).
+// On Windows, dataRoot defaults to %PROGRAMDATA%\WsScrcpyWeb. On Linux,
+// dataRoot is $XDG_DATA_HOME/WsScrcpyWeb, falling back to
+// $HOME/.local/share/WsScrcpyWeb when XDG_DATA_HOME is unset. The DEPS_PATH
+// env var continues to override deps_path absolutely when set (used by tests,
+// shared-deps installs, and the service-install envVars block in
+// ServiceApi.handleInstall).
 //
 // Dev layout (target/debug or target/release):
 //   target/debug/ws-scrcpy-web-launcher.exe    <-- exe_dir
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 pub struct Paths {
     pub install_root: PathBuf,
     /// Writable state root — `<PROGRAMDATA>\WsScrcpyWeb` on Windows,
-    /// equal to `install_root` on non-Windows (no migration there).
+    /// `$XDG_DATA_HOME/WsScrcpyWeb` (or `~/.local/share/WsScrcpyWeb`) on Linux.
     pub data_root: PathBuf,
     pub deps_path: PathBuf,
     pub restart_marker: PathBuf,
@@ -44,8 +44,8 @@ impl Paths {
     /// Windows ProgramData path without mutating process env.
     ///
     /// On non-Windows hosts the `programdata_override` is ignored and
-    /// `data_root` collapses to `install_root` — Phase 1 doesn't migrate
-    /// Linux paths.
+    /// `data_root` is resolved via XDG: `$XDG_DATA_HOME/WsScrcpyWeb` or
+    /// `$HOME/.local/share/WsScrcpyWeb` when `XDG_DATA_HOME` is unset.
     pub fn compute(
         exe_dir: &Path,
         deps_override: Option<&str>,
@@ -59,7 +59,9 @@ impl Paths {
         let data_root = if cfg!(windows) {
             common::config::data_root_for_windows(programdata_override)
         } else {
-            install_root.clone()
+            let xdg = std::env::var("XDG_DATA_HOME").ok();
+            let home = std::env::var("HOME").ok();
+            common::config::data_root_for_linux(xdg.as_deref(), home.as_deref())
         };
 
         let deps_path = match deps_override {
@@ -130,20 +132,24 @@ mod tests {
 
     #[test]
     #[cfg(not(windows))]
-    fn compute_collapses_data_root_to_install_root_on_non_windows() {
+    fn compute_uses_xdg_data_root_on_non_windows() {
         let dir = tempdir().unwrap();
         let install_root = dir.path();
         let exe_dir = install_root.join("current");
         std::fs::create_dir_all(&exe_dir).unwrap();
 
-        let paths = Paths::compute(&exe_dir, None, None).unwrap();
-        assert_eq!(paths.install_root, install_root);
-        assert_eq!(paths.data_root, install_root);
-        assert_eq!(paths.deps_path, install_root.join("dependencies"));
-        assert_eq!(
-            paths.restart_marker,
-            install_root.join(".restart")
-        );
+        // Set XDG_DATA_HOME to a temp dir so the test is self-contained.
+        let xdg_dir = dir.path().join("xdg-data");
+        std::fs::create_dir_all(&xdg_dir).unwrap();
+        std::env::set_var("XDG_DATA_HOME", &xdg_dir);
+        let paths = Paths::compute(&exe_dir, None, None);
+        std::env::remove_var("XDG_DATA_HOME");
+
+        let paths = paths.unwrap();
+        let expected_data_root = xdg_dir.join("WsScrcpyWeb");
+        assert_eq!(paths.data_root, expected_data_root);
+        assert_eq!(paths.deps_path, expected_data_root.join("dependencies"));
+        assert_eq!(paths.restart_marker, expected_data_root.join(".restart"));
     }
 
     #[test]

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -112,6 +112,7 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path) -> Result<Child> {
     cmd.arg(&entry)
         .current_dir(&work_dir)
         .env("DEPS_PATH", deps_path)
+        .env("DATA_ROOT", data_root)
         .creation_flags(CREATE_NO_WINDOW);
 
     // Plumb the child's stdout AND stderr into <deps>/server.log so a
@@ -153,7 +154,8 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path) -> Result<Child> {
     let mut cmd = Command::new(&node);
     cmd.arg(&entry)
         .current_dir(&work_dir)
-        .env("DEPS_PATH", deps_path);
+        .env("DEPS_PATH", deps_path)
+        .env("DATA_ROOT", data_root);
 
     if let Some(log) = open_server_log(data_root) {
         let log_clone = log.try_clone().ok();

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -130,11 +130,16 @@ export function resolveAdbPath(
 }
 
 /**
- * Pure resolver for the writable-state root (Phase 1 of the Program Files
- * migration plan). On Windows this is `<PROGRAMDATA>\WsScrcpyWeb` — a
- * machine-wide, all-users-writable location distinct from the install root
- * (where Velopack manages binaries). Returns `null` on non-Windows; the
- * AppImage layout is unchanged for now.
+ * Pure resolver for the writable-state root. On Windows this is
+ * `<PROGRAMDATA>\WsScrcpyWeb` — a machine-wide, all-users-writable location
+ * distinct from the install root (where Velopack manages binaries).
+ *
+ * On non-Windows the resolution order is:
+ *   1. `DATA_ROOT` env var — set by the Rust launcher as a bridge so the
+ *      Node child always knows its data root without platform detection.
+ *   2. `XDG_DATA_HOME/WsScrcpyWeb` — respects the XDG Base Directory spec.
+ *   3. `~/.local/share/WsScrcpyWeb` — XDG default fallback.
+ *   4. `null` — only when HOME is also missing (extreme edge case).
  *
  * Defaulting `PROGRAMDATA` to `C:\ProgramData` matches Microsoft's
  * documented value for the system ProgramData folder when the env var is
@@ -145,11 +150,23 @@ export function resolveDataRoot(
     env: NodeJS.ProcessEnv,
     platform: NodeJS.Platform = process.platform,
 ): string | null {
-    if (platform !== 'win32') return null;
-    const programData = env['PROGRAMDATA'] && env['PROGRAMDATA'].length > 0
-        ? env['PROGRAMDATA']
-        : 'C:\\ProgramData';
-    return path.win32.join(programData, 'WsScrcpyWeb');
+    if (platform === 'win32') {
+        const programData = env['PROGRAMDATA'] && env['PROGRAMDATA'].length > 0
+            ? env['PROGRAMDATA']
+            : 'C:\\ProgramData';
+        return path.win32.join(programData, 'WsScrcpyWeb');
+    }
+    // Non-Windows: DATA_ROOT (launcher bridge) > XDG_DATA_HOME > ~/.local/share
+    if (env['DATA_ROOT'] && env['DATA_ROOT'].length > 0) {
+        return env['DATA_ROOT'];
+    }
+    if (env['XDG_DATA_HOME'] && env['XDG_DATA_HOME'].length > 0) {
+        return path.join(env['XDG_DATA_HOME'], 'WsScrcpyWeb');
+    }
+    if (env['HOME'] && env['HOME'].length > 0) {
+        return path.join(env['HOME'], '.local', 'share', 'WsScrcpyWeb');
+    }
+    return null;
 }
 
 /**

--- a/src/server/__tests__/config.dataRoot.test.ts
+++ b/src/server/__tests__/config.dataRoot.test.ts
@@ -25,15 +25,41 @@ describe('resolveDataRoot', () => {
         });
     });
 
-    describe('on non-win32', () => {
-        it('returns null on linux (no migration target on non-Windows)', () => {
-            const result = resolveDataRoot({}, 'linux');
-            expect(result).toBeNull();
+    describe('on linux', () => {
+        it('returns DATA_ROOT when DATA_ROOT env is set', () => {
+            const result = resolveDataRoot({ DATA_ROOT: '/custom/data/WsScrcpyWeb' }, 'linux');
+            expect(result).toBe('/custom/data/WsScrcpyWeb');
         });
 
-        it('returns null on darwin', () => {
-            const result = resolveDataRoot({}, 'darwin');
-            expect(result).toBeNull();
+        it('returns XDG_DATA_HOME/WsScrcpyWeb when XDG_DATA_HOME is set', () => {
+            const result = resolveDataRoot({ XDG_DATA_HOME: '/custom/xdg', HOME: '/home/user' }, 'linux');
+            expect(result).toBe(path.join('/custom/xdg', 'WsScrcpyWeb'));
+        });
+
+        it('falls back to ~/.local/share/WsScrcpyWeb when no XDG var set', () => {
+            const result = resolveDataRoot({ HOME: '/home/user' }, 'linux');
+            expect(result).toBe(path.join('/home/user', '.local', 'share', 'WsScrcpyWeb'));
+        });
+
+        it('DATA_ROOT takes precedence over XDG_DATA_HOME', () => {
+            const result = resolveDataRoot({
+                DATA_ROOT: '/launcher/provided/WsScrcpyWeb',
+                XDG_DATA_HOME: '/should/not/use',
+                HOME: '/home/user',
+            }, 'linux');
+            expect(result).toBe('/launcher/provided/WsScrcpyWeb');
+        });
+
+        it('ignores empty XDG_DATA_HOME and falls back to HOME', () => {
+            const result = resolveDataRoot({ XDG_DATA_HOME: '', HOME: '/home/user' }, 'linux');
+            expect(result).toBe(path.join('/home/user', '.local', 'share', 'WsScrcpyWeb'));
+        });
+    });
+
+    describe('on darwin', () => {
+        it('returns XDG-based path on darwin (same as linux)', () => {
+            const result = resolveDataRoot({ HOME: '/Users/jamie' }, 'darwin');
+            expect(result).toBe(path.join('/Users/jamie', '.local', 'share', 'WsScrcpyWeb'));
         });
     });
 });


### PR DESCRIPTION
## Summary
- Rust common crate: add `data_root_for_linux()` with XDG_DATA_HOME support, update `data_root_from_env()` to return `Some` on Linux
- Rust launcher `paths.rs`: use XDG path instead of collapsing data_root to install_root (which pointed into read-only squashfs mount)
- Rust launcher `spawn.rs`: pass `DATA_ROOT` env var to Node child (belt-and-suspenders bridge)
- Node `Config.ts`: `resolveDataRoot()` gains Linux branch -- DATA_ROOT env > XDG_DATA_HOME > ~/.local/share

Fixes: config saves, dependency downloads, log writes, and service install on Linux AppImage (all were EPERM against read-only squashfs mount).

## Test plan
- [ ] Cargo: 133 tests pass (3 new for data_root_for_linux)
- [ ] Vitest: 721 tests pass (4 new for resolveDataRoot Linux/darwin)
- [ ] tsc --noEmit clean
- [ ] Download beta.2 AppImage on Fedora 44, verify config saves and deps download
- [ ] Windows Velopack install unchanged (regression check)