### PR TITLE
fix: resolve Node from bin/ subdirectory on Linux

### DIFF
--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -31,14 +31,21 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 /// return the Node binary path or an error.
 pub fn resolve_node_with(deps_path: Option<&str>, exe_dir: &Path) -> Result<PathBuf> {
     if let Some(deps) = deps_path {
+        // Linux tarball extracts with bin/ subdirectory; Windows zip is flat.
+        let candidate = Path::new(deps).join("node").join("bin").join(NODE_BIN);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
         let candidate = Path::new(deps).join("node").join(NODE_BIN);
         if candidate.exists() {
             return Ok(candidate);
         }
-        // deps_path set but node not there yet (first-run bootstrap) — fall
-        // through to seed instead of hard-failing.
     }
 
+    let seed = exe_dir.join("seed").join("node").join("bin").join(NODE_BIN);
+    if seed.exists() {
+        return Ok(seed);
+    }
     let seed = exe_dir.join("seed").join("node").join(NODE_BIN);
     if seed.exists() {
         return Ok(seed);
@@ -195,6 +202,22 @@ mod tests {
 
         let resolved = resolve_node_with(Some(deps.to_str().unwrap()), &exe_dir).unwrap();
         assert_eq!(resolved, node);
+    }
+
+    #[test]
+    fn resolve_node_prefers_bin_subdirectory() {
+        let dir = tempdir().unwrap();
+        let deps = dir.path().join("deps");
+        let bin_node = deps.join("node").join("bin").join(NODE_BIN);
+        let flat_node = deps.join("node").join(NODE_BIN);
+        touch(&bin_node);
+        touch(&flat_node);
+
+        let exe_dir = dir.path().join("exe");
+        fs::create_dir_all(&exe_dir).unwrap();
+
+        let resolved = resolve_node_with(Some(deps.to_str().unwrap()), &exe_dir).unwrap();
+        assert_eq!(resolved, bin_node);
     }
 
     #[test]

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -81,7 +81,10 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             requiresLauncher: true,
             checkInstalled: async (depsPath) => {
                 const ext = platform === 'win32' ? '.exe' : '';
-                const exe = path.join(depsPath, 'node', `node${ext}`);
+                // Linux tarball extracts with bin/ subdirectory; Windows zip is flat.
+                const binPath = path.join(depsPath, 'node', 'bin', `node${ext}`);
+                const flatPath = path.join(depsPath, 'node', `node${ext}`);
+                const exe = fs.existsSync(binPath) ? binPath : flatPath;
                 return runVersionCommand(exe, ['--version'], /v([\d.]+)/);
             },
             checkLatest: async () => {


### PR DESCRIPTION
## Summary
- Linux Node tarballs extract with `node/bin/node`; Windows zips are flat `node/node.exe`
- Rust `resolve_node_with` now checks `node/bin/<binary>` first, falls back to flat
- Node `checkInstalled` in DependencyDefinitions.ts does the same bin-then-flat probe
- New Rust test: `resolve_node_prefers_bin_subdirectory`

## Test plan
- [ ] Cargo: 131 tests pass (1 new)
- [ ] Vitest: 717 tests pass
- [ ] Fedora 44: Node dependency shows "Up to date" instead of "Not installed"