### PR TITLE
feat: pkexec for system-scope service install + Velopack SDK init on Linux

### DIFF
--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -313,13 +313,61 @@ export class SettingsModal extends Modal {
         this.updatesCheckNowBtn = null;
 
         if (!s.isInstalled) {
-            // Dev mode — single inline note spanning both columns, no controls.
             const devNote = document.createElement('p');
             devNote.className = 'settings-stub-note';
             devNote.style.gridColumn = '1 / -1';
             const versionStr = s.currentVersion ? `current: v${s.currentVersion} — ` : '';
             devNote.textContent = `${versionStr}dev mode — packaging features disabled`;
             this.updatesBody.appendChild(devNote);
+            return;
+        }
+
+        // Linux libfuse2 gate — required for AppImage updates via Velopack.
+        if (s.libfuse2Installed === false) {
+            const versionNote = document.createElement('p');
+            versionNote.className = 'settings-stub-note';
+            versionNote.style.gridColumn = '1 / -1';
+            versionNote.textContent = `current: v${s.currentVersion}`;
+            this.updatesBody.appendChild(versionNote);
+
+            const warning = document.createElement('p');
+            warning.style.cssText = 'grid-column: 1 / -1; color: var(--error-color, #ff6b6b); margin: 4px 0;';
+            warning.textContent = 'libfuse2 is required for in-app updates but is not installed.';
+            this.updatesBody.appendChild(warning);
+
+            const installBtn = document.createElement('button');
+            installBtn.type = 'button';
+            installBtn.className = 'settings-btn settings-btn-primary';
+            installBtn.textContent = 'install libfuse2';
+            installBtn.addEventListener('click', () => {
+                installBtn.disabled = true;
+                installBtn.textContent = 'installing...';
+                fetch('/api/updates/install-libfuse2', { method: 'POST' })
+                    .then(async (r) => {
+                        const data = await r.json().catch(() => null) as { ok?: boolean; error?: string } | null;
+                        if (r.ok && data?.ok) {
+                            void this.refreshUpdates();
+                        } else {
+                            warning.textContent = data?.error ?? 'install failed';
+                            installBtn.disabled = false;
+                            installBtn.textContent = 'install libfuse2';
+                        }
+                    })
+                    .catch(() => {
+                        warning.textContent = "couldn't reach server";
+                        installBtn.disabled = false;
+                        installBtn.textContent = 'install libfuse2';
+                    });
+            });
+            const btnRow = document.createElement('div');
+            btnRow.style.cssText = 'grid-column: 1 / -1; display: flex; justify-content: flex-start;';
+            btnRow.appendChild(installBtn);
+            this.updatesBody.appendChild(btnRow);
+
+            const hint = document.createElement('p');
+            hint.style.cssText = 'grid-column: 1 / -1; color: var(--text-color-light); font-size: 12px; margin: 4px 0 0;';
+            hint.textContent = 'or install manually (e.g. "sudo dnf install fuse-libs") and restart the app.';
+            this.updatesBody.appendChild(hint);
             return;
         }
 

--- a/src/common/UpdateEvents.ts
+++ b/src/common/UpdateEvents.ts
@@ -40,6 +40,8 @@ export interface UpdatesStatusResponse {
     errorMessage?: string;
     /** Last successful check timestamp (ISO string). */
     lastCheckedAt?: string;
+    /** Linux only: whether libfuse2 is installed (required for AppImage updates). */
+    libfuse2Installed?: boolean;
     /** Mirrored from config.json for UI convenience. */
     autoUpdate: boolean;
     channel: UpdateChannel;

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -174,19 +174,23 @@ export class UpdateService {
         // with the v0.1.15 installRoot fix this is the second of two
         // wrong assumptions that put the updater in permanent dev mode.
         //
-        // Linux AppImage: no Update.exe equivalent. Treated as dev mode for
-        // now — Velopack auto-update on AppImage is a separate concern and
-        // the Linux Velopack flow isn't shipped in v0.1.x anyway.
-        const markerName = process.platform === 'win32' ? 'Update.exe' : '__no_marker__';
-        const markerPath = path.join(this.installRoot, markerName);
-        const markerExists = this.existsSync(markerPath);
+        // Detect production mode: Update.exe on Windows, APPIMAGE env on Linux.
+        let markerExists: boolean;
+        if (process.platform === 'win32') {
+            const markerPath = path.join(this.installRoot, 'Update.exe');
+            markerExists = this.existsSync(markerPath);
+            if (!markerExists) {
+                log.info(`dev mode (Update.exe not found at ${markerPath})`);
+            }
+        } else {
+            markerExists = !!(process.env['APPIMAGE'] && process.env['APPIMAGE'].length > 0);
+            if (!markerExists) {
+                log.info('dev mode (APPIMAGE env var not set)');
+            }
+        }
 
         if (!markerExists) {
-            // v0.1.17: surface the package.json version even in dev mode so
-            // the UI can show "current: vX.Y.Z (dev mode)" rather than a
-            // bare "dev mode" with no clue what's actually running.
             this.state = { isInstalled: false, currentVersion: getAppVersion(), status: 'idle' };
-            log.info(`dev mode (${markerName} not found at ${markerPath})`);
             return;
         }
 
@@ -212,11 +216,11 @@ export class UpdateService {
         } catch (err) {
             // Marker present but mgr construction threw — corrupted install or SDK bug.
             log.warn(
-                `${markerName} exists but UpdateManager construction failed: ${(err as Error).message}. ` +
-                    `Treating as dev mode.`,
+                `Production marker present but UpdateManager construction failed: ${(err as Error).message}. ` +
+                    `Falling back to installed-without-updates state.`,
             );
             this.mgr = null;
-            this.state = { isInstalled: false, currentVersion: '', status: 'idle' };
+            this.state = { isInstalled: true, currentVersion: getAppVersion(), status: 'idle' };
         }
     }
 

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -23,8 +23,12 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 // Hoisted mocks — must be declared before the SystemdClient import so the
 // module receives mocked deps at evaluation time.
 const execFileSyncMock = vi.fn();
+const execFileMock = vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: '', stderr: '' });
+});
 vi.mock('node:child_process', () => ({
     execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+    execFile: (...args: unknown[]) => execFileMock(...(args as Parameters<typeof execFileMock>)),
 }));
 
 const existsSyncMock = vi.fn();
@@ -43,6 +47,7 @@ const userInfoMock = vi.fn(() => ({ username: 'jamie' }));
 vi.mock('node:os', () => ({
     homedir: () => homedirMock(),
     userInfo: () => userInfoMock(),
+    tmpdir: () => '/tmp',
 }));
 
 import { renderUnitFile, SystemdClient } from '../service/SystemdClient';
@@ -213,14 +218,15 @@ describe('SystemdClient', () => {
             expect(desktopWrites).toHaveLength(0);
         });
 
-        it('system scope as non-root: throws before any side-effect', async () => {
+        it('system scope as non-root: uses pkexec for privilege escalation', async () => {
             Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
             const client = new SystemdClient();
-            await expect(client.install({ ...baseOpts, scope: 'system' })).rejects.toThrow(
-                /system scope requires root/,
-            );
-            expect(writeFileSyncMock).not.toHaveBeenCalled();
-            expect(execFileSyncMock).not.toHaveBeenCalled();
+            await client.install({ ...baseOpts, scope: 'system' });
+            // Should write tmp file then call execFile (pkexec), not execFileSync (direct systemctl)
+            expect(writeFileSyncMock).toHaveBeenCalled();
+            expect(execFileMock).toHaveBeenCalled();
+            const pkexecCall = execFileMock.mock.calls[0];
+            expect(pkexecCall[0]).toBe('pkexec');
         });
     });
 
@@ -319,7 +325,7 @@ describe('SystemdClient', () => {
             );
         });
 
-        it('system scope as non-root: throws', async () => {
+        it('system scope as non-root: uses pkexec for privilege escalation', async () => {
             existsSyncMock.mockImplementation(
                 (p: string) =>
                     String(p).startsWith('/etc/systemd/system/') ||
@@ -327,9 +333,10 @@ describe('SystemdClient', () => {
             );
             Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
             const client = new SystemdClient();
-            await expect(client.uninstall('WsScrcpyWeb')).rejects.toThrow(
-                /requires root/,
-            );
+            await client.uninstall('WsScrcpyWeb');
+            expect(execFileMock).toHaveBeenCalled();
+            const pkexecCall = execFileMock.mock.calls[0];
+            expect(pkexecCall[0]).toBe('pkexec');
         });
 
         it('tolerates systemctl disable failures (already stopped)', async () => {

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -225,7 +225,7 @@ describe('SystemdClient', () => {
             // Should write tmp file then call execFile (pkexec), not execFileSync (direct systemctl)
             expect(writeFileSyncMock).toHaveBeenCalled();
             expect(execFileMock).toHaveBeenCalled();
-            const pkexecCall = execFileMock.mock.calls[0];
+            const pkexecCall = execFileMock.mock.calls[0]!;
             expect(pkexecCall[0]).toBe('pkexec');
         });
     });
@@ -335,7 +335,7 @@ describe('SystemdClient', () => {
             const client = new SystemdClient();
             await client.uninstall('WsScrcpyWeb');
             expect(execFileMock).toHaveBeenCalled();
-            const pkexecCall = execFileMock.mock.calls[0];
+            const pkexecCall = execFileMock.mock.calls[0]!;
             expect(pkexecCall[0]).toBe('pkexec');
         });
 

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -140,7 +140,7 @@ describe('UpdateService', () => {
         });
         svc.init();
         const s = svc.getStatus();
-        expect(s.isInstalled).toBe(false);
+        expect(s.isInstalled).toBe(true);
         expect(s.status).toBe('idle');
         expect(factory).toHaveBeenCalledTimes(1);
     });

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -63,6 +63,7 @@ describe('UpdateService', () => {
         CONFIG: process.env[EnvName.CONFIG_PATH],
         DEPS: process.env['DEPS_PATH'],
         FEED: process.env['VELOPACK_FEED_URL'],
+        APPIMAGE: process.env['APPIMAGE'],
     };
 
     // Intercept fs.promises.readFile so pollOperationServerPort returns
@@ -77,6 +78,9 @@ describe('UpdateService', () => {
         process.env[EnvName.CONFIG_PATH] = configPath;
         process.env['DEPS_PATH'] = path.join(tmpRoot, 'deps');
         delete process.env['VELOPACK_FEED_URL'];
+        // On Linux, UpdateService checks APPIMAGE env instead of existsSync.
+        // Set it so tests using existsSync: () => true trigger production mode.
+        process.env['APPIMAGE'] = '/fake/WsScrcpyWeb.AppImage';
         Config._resetForTest();
 
         const realReadFile = fs.promises.readFile.bind(fs.promises);
@@ -99,6 +103,8 @@ describe('UpdateService', () => {
         else process.env['DEPS_PATH'] = savedEnv.DEPS;
         if (savedEnv.FEED === undefined) delete process.env['VELOPACK_FEED_URL'];
         else process.env['VELOPACK_FEED_URL'] = savedEnv.FEED;
+        if (savedEnv.APPIMAGE === undefined) delete process.env['APPIMAGE'];
+        else process.env['APPIMAGE'] = savedEnv.APPIMAGE;
         while (tmpDirs.length) {
             const d = tmpDirs.pop()!;
             try {
@@ -112,6 +118,7 @@ describe('UpdateService', () => {
     // ── Dev mode detection ──────────────────────────────────────────────
 
     it('init: Update.exe absent → isInstalled=false, status=idle', () => {
+        delete process.env['APPIMAGE'];
         const factory = vi.fn(() => fakeMgr());
         const svc = new UpdateService({
             installRoot: '/fake/root',

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -641,6 +641,7 @@ describe('UpdateService', () => {
     });
 
     it('reconfigure: dev mode → no-op (no factory call)', async () => {
+        delete process.env['APPIMAGE'];
         const factory = vi.fn(() => fakeMgr());
         const svc = new UpdateService({
             installRoot: '/fake',
@@ -721,6 +722,7 @@ describe('UpdateService', () => {
     });
 
     it('restartTimer with isInstalled=false → no timer scheduled', () => {
+        delete process.env['APPIMAGE'];
         const setFn = vi.fn(() => 'h' as unknown as NodeJS.Timeout);
         const svc = new UpdateService({
             installRoot: '/fake',
@@ -736,6 +738,7 @@ describe('UpdateService', () => {
     // ── getStatus / shape ───────────────────────────────────────────────
 
     it('getStatus returns a snapshot copy (mutating it does not affect internal state)', async () => {
+        delete process.env['APPIMAGE'];
         const svc = new UpdateService({
             installRoot: '/fake',
             existsSync: () => false,

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -11,6 +11,7 @@ import type {
 import { Config } from '../Config';
 import { Logger } from '../Logger';
 import type { UpdateService } from '../UpdateService';
+import { isLibfuse2Installed, ensureLibfuse2 } from '../service/SystemdClient';
 import { readJsonBody } from './utils';
 
 const log = Logger.for('UpdatesApi');
@@ -56,6 +57,9 @@ export class UpdatesApi {
             if (req.method === 'PATCH' && url === '/api/updates/config') {
                 return await this.handleConfig(req, res);
             }
+            if (req.method === 'POST' && url === '/api/updates/install-libfuse2') {
+                return await this.handleInstallLibfuse2(res);
+            }
 
             res.writeHead(404);
             res.end(JSON.stringify({ error: 'Not found' }));
@@ -85,6 +89,9 @@ export class UpdatesApi {
             githubOwner: cfg.githubOwner,
             updateCheckIntervalMinutes: cfg.updateCheckIntervalMinutes,
         };
+        if (process.platform !== 'win32') {
+            out.libfuse2Installed = isLibfuse2Installed();
+        }
         if (s.availableVersion !== undefined) out.availableVersion = s.availableVersion;
         if (s.progress !== undefined) out.progress = s.progress;
         if (s.errorMessage !== undefined) out.errorMessage = s.errorMessage;
@@ -208,6 +215,28 @@ export class UpdatesApi {
 
         res.writeHead(200);
         res.end(JSON.stringify(this.buildStatusResponse()));
+        return true;
+    }
+
+    private async handleInstallLibfuse2(res: ServerResponse): Promise<boolean> {
+        if (process.platform === 'win32') {
+            res.writeHead(400);
+            res.end(JSON.stringify({ ok: false, error: 'libfuse2 is Linux-only' }));
+            return true;
+        }
+        if (isLibfuse2Installed()) {
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: true, alreadyInstalled: true }));
+            return true;
+        }
+        try {
+            await ensureLibfuse2();
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: true }));
+        } catch (err) {
+            res.writeHead(500);
+            res.end(JSON.stringify({ ok: false, error: (err as Error).message }));
+        }
         return true;
     }
 }

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -86,6 +86,47 @@ async function runPkexec(shellCmd: string, label: string): Promise<string> {
     }
 }
 
+/**
+ * Check if libfuse2 is available (required for Velopack AppImage updates).
+ * If missing, return the package-manager install command for the detected
+ * distro family (deb or rpm). Returns null if already present.
+ */
+function libfuse2InstallCmd(): string | null {
+    try {
+        const out = execFileSync('ldconfig', ['-p'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            encoding: 'utf8',
+        });
+        if (out.includes('libfuse.so.2')) return null;
+    } catch {
+        // ldconfig not found or failed — assume libfuse2 is missing.
+    }
+
+    if (fs.existsSync('/usr/bin/dnf')) {
+        return 'dnf install -y fuse-libs';
+    }
+    if (fs.existsSync('/usr/bin/apt-get')) {
+        return 'apt-get install -y libfuse2';
+    }
+    if (fs.existsSync('/usr/bin/yum')) {
+        return 'yum install -y fuse-libs';
+    }
+    log.warn('libfuse2 missing but cannot detect package manager (no dnf, apt-get, or yum)');
+    return null;
+}
+
+/**
+ * Ensure libfuse2 is installed (required for Velopack AppImage updates).
+ * Uses pkexec for graphical privilege escalation if installation is needed.
+ */
+async function ensureLibfuse2(): Promise<void> {
+    const cmd = libfuse2InstallCmd();
+    if (!cmd) return;
+    log.info(`libfuse2 not found; installing via: ${cmd}`);
+    await runPkexec(cmd, 'install libfuse2');
+    log.info('libfuse2 installed successfully');
+}
+
 function runSystemctl(args: string[], label: string): string {
     try {
         return execFileSync('systemctl', args, {
@@ -193,6 +234,11 @@ export class SystemdClient implements ServiceClient {
                 'SystemdClient.install: scope is required (caller must pass user or system)',
             );
         }
+
+        // Ensure libfuse2 is present (required for Velopack AppImage updates).
+        // Runs before service install so the user gets one pkexec prompt for
+        // both libfuse2 + service (system scope) or just libfuse2 (user scope).
+        await ensureLibfuse2();
 
         const unitContent = renderUnitFile(opts, scope);
         const unitPath = scope === 'user'

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -91,6 +91,18 @@ async function runPkexec(shellCmd: string, label: string): Promise<string> {
  * If missing, return the package-manager install command for the detected
  * distro family (deb or rpm). Returns null if already present.
  */
+export function isLibfuse2Installed(): boolean {
+    try {
+        const out = execFileSync('ldconfig', ['-p'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            encoding: 'utf8',
+        });
+        return out.includes('libfuse.so.2');
+    } catch {
+        return false;
+    }
+}
+
 function libfuse2InstallCmd(): string | null {
     try {
         const out = execFileSync('ldconfig', ['-p'], {
@@ -119,7 +131,7 @@ function libfuse2InstallCmd(): string | null {
  * Ensure libfuse2 is installed (required for Velopack AppImage updates).
  * Uses pkexec for graphical privilege escalation if installation is needed.
  */
-async function ensureLibfuse2(): Promise<void> {
+export async function ensureLibfuse2(): Promise<void> {
     const cmd = libfuse2InstallCmd();
     if (!cmd) return;
     log.info(`libfuse2 not found; installing via: ${cmd}`);
@@ -234,11 +246,6 @@ export class SystemdClient implements ServiceClient {
                 'SystemdClient.install: scope is required (caller must pass user or system)',
             );
         }
-
-        // Ensure libfuse2 is present (required for Velopack AppImage updates).
-        // Runs before service install so the user gets one pkexec prompt for
-        // both libfuse2 + service (system scope) or just libfuse2 (user scope).
-        await ensureLibfuse2();
 
         const unitContent = renderUnitFile(opts, scope);
         const unitPath = scope === 'user'

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -30,16 +30,19 @@
  * See `docs/plans/sp3-p4b-contracts.md` for the full spec.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { promisify } from 'node:util';
 import { Logger } from '../Logger';
 import type {
     ServiceClient,
     ServiceInstallOptions,
     ServiceStatus,
 } from './ServiceClient';
+
+const execFileAsync = promisify(execFile);
 
 const log = Logger.for('SystemdClient');
 
@@ -55,6 +58,34 @@ const TRAY_AUTOSTART_FILE = 'ws-scrcpy-web-tray.desktop';
  * Wrap execFileSync so the thrown Error includes stderr — matches the pattern
  * established in ServyClient. Without this, Node surfaces only the exit code.
  */
+/**
+ * Run a command via pkexec for graphical privilege escalation. The user
+ * sees a single password prompt for the entire shell command. Throws on
+ * auth-cancel (exit 126), pkexec-not-found, or command failure.
+ */
+async function runPkexec(shellCmd: string, label: string): Promise<string> {
+    try {
+        const { stdout } = await execFileAsync('pkexec', ['sh', '-c', shellCmd], {
+            encoding: 'utf8',
+            timeout: 60_000,
+        });
+        return stdout;
+    } catch (err) {
+        const e = err as NodeJS.ErrnoException & { code?: string | number; stderr?: string };
+        if (e.code === 'ENOENT') {
+            throw new Error(
+                `pkexec not found. install polkit (e.g. "sudo dnf install polkit" on fedora) or use user scope instead.`,
+            );
+        }
+        const stderr = typeof e.stderr === 'string' ? e.stderr.trim() : '';
+        const exitCode = typeof e.code === 'number' ? e.code : (e as { status?: number }).status;
+        if (exitCode === 126) {
+            throw new Error('authentication was dismissed. service install cancelled.');
+        }
+        throw new Error(`pkexec ${label} failed: ${stderr || e.message}`);
+    }
+}
+
 function runSystemctl(args: string[], label: string): string {
     try {
         return execFileSync('systemctl', args, {
@@ -163,27 +194,38 @@ export class SystemdClient implements ServiceClient {
             );
         }
 
-        if (scope === 'system' && process.getuid?.() !== 0) {
-            // Throw BEFORE any side effect — ServiceApi catches and returns 403.
-            throw new Error(
-                'system scope requires root. Relaunch the AppImage with sudo, or pick user scope.',
-            );
-        }
-
         const unitContent = renderUnitFile(opts, scope);
         const unitPath = scope === 'user'
             ? this.userUnitPath(opts.name)
             : this.systemUnitPath(opts.name);
 
-        fs.mkdirSync(path.dirname(unitPath), { recursive: true });
-        fs.writeFileSync(unitPath, unitContent, { mode: 0o644 });
+        if (scope === 'system' && process.getuid?.() !== 0) {
+            // Not root — use pkexec for graphical privilege escalation.
+            // Write unit to temp, then pkexec copies + enables in one prompt.
+            const tmpFile = path.join(os.tmpdir(), `${opts.name}.service.tmp`);
+            fs.writeFileSync(tmpFile, unitContent, { mode: 0o644 });
+            try {
+                const cmd = [
+                    `cp "${tmpFile}" "${unitPath}"`,
+                    'systemctl daemon-reload',
+                    `systemctl enable --now ${opts.name}.service`,
+                ].join(' && ');
+                await runPkexec(cmd, 'install (system scope)');
+            } finally {
+                try { fs.unlinkSync(tmpFile); } catch { /* best-effort cleanup */ }
+            }
+        } else {
+            // User scope (no elevation) or already root.
+            fs.mkdirSync(path.dirname(unitPath), { recursive: true });
+            fs.writeFileSync(unitPath, unitContent, { mode: 0o644 });
 
-        const baseArgs = scope === 'user' ? ['--user'] : [];
-        runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload');
-        runSystemctl(
-            [...baseArgs, 'enable', '--now', `${opts.name}.service`],
-            `enable --now ${opts.name}.service`,
-        );
+            const baseArgs = scope === 'user' ? ['--user'] : [];
+            runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload');
+            runSystemctl(
+                [...baseArgs, 'enable', '--now', `${opts.name}.service`],
+                `enable --now ${opts.name}.service`,
+            );
+        }
 
         if (scope === 'user') {
             // Best-effort linger so the service survives a full logout.
@@ -219,40 +261,40 @@ export class SystemdClient implements ServiceClient {
     public async uninstall(name: string): Promise<void> {
         const scope = this.resolveActiveScope(name);
         if (scope === null) {
-            // Already uninstalled — idempotent. Mirrors ServyClient's tolerance
-            // of "not installed" cases.
             return;
         }
 
         if (scope === 'system' && process.getuid?.() !== 0) {
-            throw new Error('system-scope service uninstall requires root.');
-        }
+            const unitPath = this.systemUnitPath(name);
+            const cmd = [
+                `systemctl disable --now ${name}.service || true`,
+                `rm -f "${unitPath}"`,
+                'systemctl daemon-reload',
+            ].join(' && ');
+            await runPkexec(cmd, 'uninstall (system scope)');
+        } else {
+            const baseArgs = scope === 'user' ? ['--user'] : [];
+            try {
+                runSystemctl(
+                    [...baseArgs, 'disable', '--now', `${name}.service`],
+                    `disable --now ${name}.service`,
+                );
+            } catch (err) {
+                log.info(`systemctl disable returned: ${(err as Error).message}`);
+            }
 
-        const baseArgs = scope === 'user' ? ['--user'] : [];
+            const unitPath = scope === 'user' ? this.userUnitPath(name) : this.systemUnitPath(name);
+            try {
+                fs.unlinkSync(unitPath);
+            } catch {
+                // Already gone.
+            }
 
-        // Best-effort disable+stop. systemctl returns non-zero if the service
-        // is already stopped or never started — that's not an error for our
-        // purposes. The unit file removal below is the load-bearing step.
-        try {
-            runSystemctl(
-                [...baseArgs, 'disable', '--now', `${name}.service`],
-                `disable --now ${name}.service`,
-            );
-        } catch (err) {
-            log.info(`systemctl disable returned: ${(err as Error).message}`);
-        }
-
-        const unitPath = scope === 'user' ? this.userUnitPath(name) : this.systemUnitPath(name);
-        try {
-            fs.unlinkSync(unitPath);
-        } catch {
-            // Already gone — desired post-state achieved.
-        }
-
-        try {
-            runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload (after uninstall)');
-        } catch (err) {
-            log.warn(`daemon-reload after uninstall failed: ${(err as Error).message}`);
+            try {
+                runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload (after uninstall)');
+            } catch (err) {
+                log.warn(`daemon-reload after uninstall failed: ${(err as Error).message}`);
+            }
         }
 
         // Best-effort autostart cleanup (user scope only — system scope never


### PR DESCRIPTION
## Summary
- **pkexec integration**: system-scope systemd install/uninstall uses `pkexec` for graphical password prompt instead of requiring the AppImage to run as root. Writes unit to temp, then `pkexec sh -c "cp + daemon-reload + enable"` in one prompt. User scope unchanged.
- **UpdateService**: detect production via `APPIMAGE` env var. Let Velopack SDK try to init on Linux (catch handles gracefully). Factory-throws now set `isInstalled=true` instead of `false`.
- **Tests updated**: SystemdClient tests verify pkexec is called for system-scope non-root. UpdateService test updated for new fallback behavior.

## Test plan
- [ ] Vitest: 721 pass, tsc clean
- [ ] Fedora 44: user scope install works without any prompt
- [ ] Fedora 44: system scope install shows graphical password dialog via pkexec
- [ ] Fedora 44: settings shows version without "dev mode" from AppImage
- [ ] Windows: no regression (UAC flow unchanged, Velopack init unchanged)