### PR TITLE
fix: device card layout regression + bump to v0.1.30-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.5] - 2026-05-27
+
+### Fixed
+
+- Device card layout regression: `table-layout:fixed` from beta.4 collapsed label column to ~3px, causing device info labels to overlay values and "turn off" button text to overflow its border.
+
+### Added
+
+- **Linux pkexec support.** System-scope service install/uninstall now uses pkexec for graphical privilege escalation instead of requiring `sudo` relaunch.
+- **Linux Velopack SDK init.** AppImage detection via `APPIMAGE` env var enables production-mode update checks on Linux (previously hardcoded to dev mode).
+- **libfuse2 gate.** Settings > Updates shows a warning and one-click install button when libfuse2 is missing (required for AppImage self-updates). Detects dnf/apt-get/yum automatically.
+
 ## [0.1.30-beta.4] - 2026-05-28
 
 ## [0.1.30-beta.3] - 2026-05-27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.4"
+version = "0.1.30-beta.5"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.4",
+  "version": "0.1.30-beta.5",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -100,7 +100,6 @@ body.list #device_list_menu {
     border-collapse: collapse;
     font-size: 13px;
     width: 100%;
-    table-layout: fixed;
 }
 
 #devices .device-info td {


### PR DESCRIPTION
## Summary

- **Device card CSS fix:** Remove `table-layout:fixed` from `#devices table.device-info` -- it collapsed the label column to ~3px (`width:1%` under fixed layout is literal), causing device info labels ("Device Name:", "Model:", etc.) to overlay values and "turn off" button text to overflow its border. The card's `overflow:hidden` from PR #210 stays for edge-case bleed containment.
- **Includes PR #211 features:** pkexec for system-scope service install/uninstall, Linux Velopack SDK init via APPIMAGE env, libfuse2 gate in Settings > Updates.
- **Version bump to 0.1.30-beta.5.**

## Test plan

- [x] 721 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Linux AppImage: verify device card labels no longer overlap values
- [ ] Linux AppImage: verify "turn off" button text fits within border
- [ ] Linux AppImage: verify libfuse2 gate appears in Settings > Updates when libfuse2 is missing