### PR TITLE
fix: linux updates reconfigure error + device card clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.7] - 2026-05-27
+
+### Fixed
+
+- **Linux updates error on channel change.** `reconfigure()` now skips UpdateManager reconstruction when `mgr` is null (init couldn't construct it on Linux AppImage where Velopack SDK has no `Update.exe` equivalent). Prevents "reconfigure failed" error in Settings > Updates.
+- **Device card clipping.** Remove `overflow:hidden` from device card container -- it was clipping the pencil edit button and the right edge of the "turn off" button.
+
 ## [0.1.30-beta.6] - 2026-05-27
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.6"
+version = "0.1.30-beta.7"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.6",
+  "version": "0.1.30-beta.7",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -231,7 +231,12 @@ export class UpdateService {
      */
     public async reconfigure(channel: UpdateChannel, githubOwner: string): Promise<void> {
         if (!this.state.isInstalled) {
-            // Dev mode — config persisted by caller, but no UpdateManager to swap.
+            return;
+        }
+        if (!this.mgr) {
+            // init() couldn't construct UpdateManager (e.g. Linux AppImage
+            // where Velopack SDK has no Update.exe equivalent). Config is
+            // persisted by the caller; reconfigure can't help here.
             return;
         }
         const feedUrl = this.buildFeedUrl(githubOwner);

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -77,7 +77,6 @@ body.list #device_list_menu {
     padding: 8px;
     background: var(--device-list-default-color);
     transition: border-color 0.15s, box-shadow 0.15s;
-    overflow: hidden;
 }
 
 #devices .device-list div.device:hover {


### PR DESCRIPTION
## Summary

- **Linux updates reconfigure fix:** `reconfigure()` now returns early when `mgr` is null -- init couldn't construct UpdateManager on Linux AppImage (Velopack SDK has no `Update.exe` equivalent), so reconfigure can't succeed either. Prevents the "reconfigure failed: Update.exe does not exist" error in Settings > Updates.
- **Device card clipping fix:** Remove `overflow:hidden` from device card container -- it was clipping the pencil edit button off the right edge and cutting off the "turn off" button border.
- **Version bump to 0.1.30-beta.7.**

## Test plan

- [x] 721 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Linux AppImage: Settings > Updates should show idle state, not "reconfigure failed" error
- [ ] Linux AppImage: pencil edit button visible on device cards
- [ ] Linux AppImage: "turn off" button fully visible (not clipped)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>