### PR TITLE
fix: move device card actions out of table to avoid Linux clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.9] - 2026-05-28
+
+### Fixed
+
+- **Linux device card overflow.** Disconnect + turn-on/off buttons moved out of the device-info table cell (`<td rowSpan=2>`) into a dedicated `<div class="device-actions">` sibling row, centered horizontally. Linux's wider mono-font rendering used to push the table layout past the card border when actions were a rowSpan cell -- clipping the "turn off" button and the Device Name pencil edit icon. Buttons now sit in their own row below the SDK info, centered, with no clipping on either platform.
+
 ## [0.1.30-beta.8] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.8"
+version = "0.1.30-beta.9"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.8",
+  "version": "0.1.30-beta.9",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -193,12 +193,13 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         const isNetworkDevice = device.udid.includes(':');
         const row = html`<div class="device ${isActive ? 'active' : 'not-active'}">
             <table class="device-info">
-                <tr class="device-name-row"><td class="device-label">Device Name:</td><td colspan="2"></td></tr>
-                <tr><td class="device-label">Model:</td><td colspan="2">${deviceName}</td></tr>
-                <tr><td class="device-label">Device ID:</td><td colspan="2" class="device-serial">${device.udid}</td></tr>
-                <tr class="android-row"><td class="device-label">Android:</td><td>${(device['ro.build.version.release'] || '').split('.')[0]}</td></tr>
+                <tr class="device-name-row"><td class="device-label">Device Name:</td><td></td></tr>
+                <tr><td class="device-label">Model:</td><td>${deviceName}</td></tr>
+                <tr><td class="device-label">Device ID:</td><td class="device-serial">${device.udid}</td></tr>
+                <tr><td class="device-label">Android:</td><td>${(device['ro.build.version.release'] || '').split('.')[0]}</td></tr>
                 <tr><td class="device-label">SDK:</td><td>${device['ro.build.version.sdk']}</td></tr>
             </table>
+            <div class="device-actions"></div>
             <div id="${overlayId}" class="services">
                 <div class="services-label">opens in modal</div>
             </div>
@@ -219,16 +220,14 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
             return;
         }
 
-        // Add action buttons cell (disconnect + sleep/wake) via DOM
-        const androidRow = row.querySelector('.android-row');
-        if (androidRow) {
-            const td = document.createElement('td');
-            td.rowSpan = 2;
-            td.className = 'device-actions-cell';
-            const wrapper = document.createElement('div');
-            wrapper.className = 'device-actions-wrapper';
-
-            // Disconnect button (network devices only) — left side
+        // Action buttons (disconnect + sleep/wake) live in a sibling div
+        // outside the device-info table. Keeps the table free of column-width
+        // pressure from the buttons so the table fits within the card on both
+        // Windows and Linux (Linux's wider mono font rendering used to push
+        // the table past the card border when actions were a rowSpan cell).
+        const actionsRow = row.querySelector('.device-actions');
+        if (actionsRow) {
+            // Disconnect button (network devices only)
             if (isNetworkDevice) {
                 const disconnectBtn = document.createElement('button');
                 disconnectBtn.className = 'disconnect-btn';
@@ -245,10 +244,10 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                         disconnectBtn.disabled = false;
                     }
                 });
-                wrapper.appendChild(disconnectBtn);
+                actionsRow.appendChild(disconnectBtn);
             }
 
-            // Sleep/wake button (all devices) — right side
+            // Sleep/wake button (all devices)
             // State comes from server via WebSocket (descriptor['screen.state'])
             const screenState = device['screen.state'] || 'unknown';
             const sleepBtn = document.createElement('button');
@@ -267,9 +266,6 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
             sleepBtn.addEventListener('click', async () => {
                 const isAwake = sleepBtn.dataset['awake'] === 'true';
                 sleepBtn.disabled = true;
-                // §25b — using-declaration replaces the prior try/finally that
-                // re-enabled the button on every exit path. Captures sleepBtn
-                // lexically; dispose fires on return or throw from the fetch.
                 using _restoreBtn = {
                     [Symbol.dispose](): void {
                         sleepBtn.disabled = false;
@@ -291,10 +287,7 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                     sleepBtn.className = `sleep-wake-btn ${isAwake ? 'state-on' : 'state-off'}`;
                 }
             });
-            wrapper.appendChild(sleepBtn);
-
-            td.appendChild(wrapper);
-            androidRow.appendChild(td);
+            actionsRow.appendChild(sleepBtn);
         }
 
         // Auto-select best interface: prefer wifi/direct IP, fallback to proxy

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -123,20 +123,22 @@ body.list #device_list_menu {
     font-size: 12px;
 }
 
-/* Device action buttons (disconnect + sleep/wake) */
-#devices .device-info td.device-actions-cell {
-    vertical-align: middle;
-    padding-left: 12px;
-    padding-top: 10px;
-}
-
-#devices .device-actions-wrapper {
+/* Device action buttons (disconnect + sleep/wake) — sibling row to the
+   device-info table. Centered horizontally so the buttons sit symmetrically
+   regardless of how many appear (active network device gets disconnect +
+   turn-on/off; active USB device gets just turn-on/off). Kept outside the
+   table so wider-mono-font platforms (Linux) don't squeeze the table layout. */
+#devices .device-list div.device .device-actions {
     display: flex;
     flex-direction: row;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: center;
     gap: 8px;
-    padding-right: 20px;
+    padding: 8px 0;
+}
+
+#devices .device-list div.device .device-actions:empty {
+    display: none;
 }
 
 #devices .device-list .disconnect-btn {


### PR DESCRIPTION
## Summary

Fixes the Linux device-card clipping: the disconnect + turn-on/off buttons used to render as a `<td rowSpan=2>` inside the `device-info` table. With `width:100%` on the table, the cell sits at the cards content right edge. Linuxs wider mono-font rendering pushed both the "turn off" button border AND the absolutely-positioned pencil edit icon (`right: 0` on `.device-name-cell`) past the card boundary.

### Architectural change
Move the buttons into a sibling `<div class="device-actions">` row, **centered horizontally** between the device-info table and the services overlay. Buttons no longer compete with the table for column width, so the table fits cleanly inside the card on both platforms.

Visual change: action buttons drop one row below their previous vertical position (was inline with the Android/SDK rows; now in their own row below SDK).

### CSS
- Removed `.device-info td.device-actions-cell` and `.device-actions-wrapper` (table-cell context, no longer applicable).
- Added `.device-list div.device .device-actions` with `display: flex; justify-content: center; gap: 8px; padding: 8px 0;`.
- Added `:empty` collapse so an empty actions row contributes zero vertical space (safety net for filtered device states).

### Side benefit
The `.android-row` class on the table row was only there to anchor the rowSpan cell -- removed since the rowSpan is gone.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Linux AppImage: "turn off" button no longer clipped on right edge
- [ ] Linux AppImage: pencil edit icon stays inside the card border
- [ ] Windows: layout still looks clean (small vertical reshuffle of action buttons expected)
- [ ] Both platforms: inactive devices (`turn on` only) still center the single button correctly

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>