### PR TITLE
fix: device card polish — separator, label gap, action gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.10] - 2026-05-28
+
+### Changed
+
+- Device card polish: thin border-top separator above the disconnect/turn-on/off action row (matches the "opens in modal" services separator); label-to-value gap widened from 8px to 24px so info reads less cramped; gap between disconnect and turn-on/off buttons widened from 8px to 20px.
+
 ## [0.1.30-beta.9] - 2026-05-28
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.9"
+version = "0.1.30-beta.10"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.9",
+  "version": "0.1.30-beta.10",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -108,7 +108,7 @@ body.list #device_list_menu {
 
 #devices .device-info td.device-label {
     color: var(--text-color-light, #888);
-    padding-right: 8px;
+    padding-right: 24px;
     white-space: nowrap;
     width: 1%;
 }
@@ -133,8 +133,10 @@ body.list #device_list_menu {
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    gap: 8px;
+    gap: 20px;
+    border-top: 1px solid var(--device-border-color);
     padding: 8px 0;
+    margin-top: 8px;
 }
 
 #devices .device-list div.device .device-actions:empty {


### PR DESCRIPTION
## Summary

Three small CSS tweaks on top of beta.9s actions-row refactor:

1. **Border-top above device-actions** — matches the "opens in modal" services separator below it; `border-top: 1px solid var(--device-border-color)` + `margin-top: 8px`.
2. **Label-to-value gap widened** — `.device-label` `padding-right` 8px → 24px. Card width unchanged because `width: 1%` on the label column means it still shrinks-to-fit; only the gap between label and value expands.
3. **Action button gap widened** — `.device-actions` `gap` 8px → 20px.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: card width unchanged on both platforms
- [ ] Visual: thin line visible between SDK row and actions row

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>