### PR TITLE
fix: move actions to bottom of card, remove 'opens in modal' label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.11] - 2026-05-28
+
+### Changed
+
+- Device card layout: action buttons (disconnect + turn on/off) moved to the bottom of the card. Modal-launch buttons (shell, list files, connect, config stream) shift up accordingly.
+- "opens in modal" label removed; the four blue modal-launch buttons are self-explanatory and the label was making cards taller than needed.
+
 ## [0.1.30-beta.10] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.10"
+version = "0.1.30-beta.11"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.10",
+  "version": "0.1.30-beta.11",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -199,10 +199,8 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                 <tr><td class="device-label">Android:</td><td>${(device['ro.build.version.release'] || '').split('.')[0]}</td></tr>
                 <tr><td class="device-label">SDK:</td><td>${device['ro.build.version.sdk']}</td></tr>
             </table>
+            <div id="${overlayId}" class="services"></div>
             <div class="device-actions"></div>
-            <div id="${overlayId}" class="services">
-                <div class="services-label">opens in modal</div>
-            </div>
         </div>`.content;
         const overlaySection = row.getElementById(overlayId);
 

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -136,7 +136,6 @@ body.list #device_list_menu {
     gap: 20px;
     border-top: 1px solid var(--device-border-color);
     padding: 8px 0;
-    margin-top: 8px;
 }
 
 #devices .device-list div.device .device-actions:empty {
@@ -210,7 +209,7 @@ body.list #device_list_menu {
 #devices .device-list div.device .services {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto auto;
     grid-auto-flow: column;
     gap: 6px;
     align-items: center;
@@ -226,15 +225,6 @@ body.list #device_list_menu {
 
 #devices .device-list div.device .services:first-of-type {
     margin-top: 8px;
-}
-
-#devices .services-label {
-    grid-column: 1 / -1;
-    grid-row: 1;
-    justify-self: start;
-    font-size: 13px;
-    color: var(--text-color-light, #888);
-    margin-bottom: 2px;
 }
 
 #devices .device-list div.desc-block {


### PR DESCRIPTION
## Summary

Two visual changes to the device card:

1. **Swap order of action buttons and modal-launch buttons.** Modal-launch buttons (shell, list files, connect, config stream) move up directly below the device-info table; disconnect + turn-on/off form the bottom row.
2. **Remove "opens in modal" label.** The four blue button-styled rows are self-explanatory, and the label was eating vertical space.

## CSS housekeeping
- services `grid-template-rows: auto auto auto` → `auto auto` (label row no longer needed; cards get a little shorter)
- `.services-label` rule removed (dead code)
- `.device-actions` `margin-top: 8px` removed (services `padding-bottom: 8px` above it already provides the gap)

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: card is a bit shorter (no label row)
- [ ] Visual: modal-launch buttons sit directly under SDK row with the existing thin separator above them
- [ ] Visual: disconnect + turn-on/off form the bottom row with a thin separator above

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>