### PR TITLE
fix: device card polish — borders + column alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.12] - 2026-05-28
+
+### Changed
+
+- Device card separator spacing equalized: gap above the modal-launch buttons now matches the gap above the action buttons (services `padding-top` 4px → 8px).
+- Action button borders unified with the modal-launch button color (`var(--text-color)`); text colors stay red (disconnect), green (turn on), red (turn off), gray (checking…).
+- Action buttons aligned to the same 2-column grid as the modal-launch buttons: disconnect under the left column (shell / list files), turn-on/off under the right column (connect / config stream).
+
 ## [0.1.30-beta.11] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.11"
+version = "0.1.30-beta.12"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.11",
+  "version": "0.1.30-beta.12",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -124,16 +124,17 @@ body.list #device_list_menu {
 }
 
 /* Device action buttons (disconnect + sleep/wake) — sibling row to the
-   device-info table. Centered horizontally so the buttons sit symmetrically
-   regardless of how many appear (active network device gets disconnect +
-   turn-on/off; active USB device gets just turn-on/off). Kept outside the
-   table so wider-mono-font platforms (Linux) don't squeeze the table layout. */
+   device-info table. 2-column grid mirroring the .services grid above:
+   disconnect aligns under the left modal column (shell/list files);
+   turn-on/off aligns under the right modal column (connect/config stream).
+   Kept outside the device-info table so wider-mono-font platforms (Linux)
+   don't squeeze the table layout. */
 #devices .device-list div.device .device-actions {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
     align-items: center;
-    gap: 20px;
+    justify-items: start;
     border-top: 1px solid var(--device-border-color);
     padding: 8px 0;
 }
@@ -143,7 +144,8 @@ body.list #device_list_menu {
 }
 
 #devices .device-list .disconnect-btn {
-    border: 0.5px solid var(--danger-color);
+    grid-column: 1;
+    border: 0.5px solid var(--text-color);
     border-radius: 6px;
     background: transparent;
     color: var(--danger-color);
@@ -166,6 +168,8 @@ body.list #device_list_menu {
 
 /* Sleep/wake button */
 #devices .device-list .sleep-wake-btn {
+    grid-column: 2;
+    border: 0.5px solid var(--text-color);
     border-radius: 6px;
     background: transparent;
     padding: 4px 10px;
@@ -177,17 +181,14 @@ body.list #device_list_menu {
 }
 
 #devices .device-list .sleep-wake-btn.state-off {
-    border: 0.5px solid var(--success-color);
     color: var(--success-color);
 }
 
 #devices .device-list .sleep-wake-btn.state-on {
-    border: 0.5px solid var(--danger-color);
     color: var(--danger-color);
 }
 
 #devices .device-list .sleep-wake-btn.state-unknown {
-    border: 0.5px solid var(--text-color-light, #888);
     color: var(--text-color-light, #888);
 }
 
@@ -215,7 +216,7 @@ body.list #device_list_menu {
     align-items: center;
     justify-items: start;
     border-top: 1px solid var(--device-border-color);
-    padding-top: 4px;
+    padding-top: 8px;
     padding-bottom: 8px;
 }
 


### PR DESCRIPTION
## Summary

Three CSS-only tweaks on top of beta.11:

1. **Separator spacing equalized.** services `padding-top: 4px` → `8px` so the gap above the modal-launch row matches the gap above the action row (which already uses 8px).
2. **Action button borders unified.** disconnect, turn-on/off all use `var(--text-color)` (~white) — same as the modal buttons. Text colors unchanged: disconnect red, turn on green, turn off red, "checking…" muted gray.
3. **Action buttons column-aligned to the modal-launch grid.** `.device-actions` switches from flex-center to 2-column grid (`1fr 1fr`, `justify-items: start`). disconnect → column 1 (under shell/list files); sleep-wake → column 2 (under connect/config stream). USB-only devices (sleep-wake only) still place under the right column.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: gaps above and below the modal-launch row are equal
- [ ] Visual: disconnect/turn-on/off borders are white-ish
- [ ] Visual: disconnect lines up with shell; turn on/off lines up with connect
- [ ] Visual: USB-only card with just "turn on/off" sits under the right column (not centered)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>