### PR TITLE
fix: device card button borders match text color, asymmetric padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.13] - 2026-05-28
+
+### Changed
+
+- Device card button borders now match their text color: disconnect red, turn on green, turn off red, "checking…" gray, modal-launch buttons (shell/list files/connect/config stream) blue.
+- Card inner padding shifted asymmetric (8px / 8px / 8px / 20px — left bumped 8 → 20). Card outer width unchanged; the inner content shifts right to balance the open whitespace on the right of the value column.
+
 ## [0.1.30-beta.12] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.12"
+version = "0.1.30-beta.13"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.12",
+  "version": "0.1.30-beta.13",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -74,7 +74,10 @@ body.list #device_list_menu {
 #devices .device-list div.device {
     border: 1px solid var(--device-border-color);
     border-radius: 8px;
-    padding: 8px;
+    /* Asymmetric padding: extra left to balance the right-side
+       whitespace from the value column. Card outer width is set by
+       the grid; only the inner content area shifts right. */
+    padding: 8px 8px 8px 20px;
     background: var(--device-list-default-color);
     transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -145,7 +148,7 @@ body.list #device_list_menu {
 
 #devices .device-list .disconnect-btn {
     grid-column: 1;
-    border: 0.5px solid var(--text-color);
+    border: 0.5px solid var(--danger-color);
     border-radius: 6px;
     background: transparent;
     color: var(--danger-color);
@@ -169,7 +172,6 @@ body.list #device_list_menu {
 /* Sleep/wake button */
 #devices .device-list .sleep-wake-btn {
     grid-column: 2;
-    border: 0.5px solid var(--text-color);
     border-radius: 6px;
     background: transparent;
     padding: 4px 10px;
@@ -181,14 +183,17 @@ body.list #device_list_menu {
 }
 
 #devices .device-list .sleep-wake-btn.state-off {
+    border: 0.5px solid var(--success-color);
     color: var(--success-color);
 }
 
 #devices .device-list .sleep-wake-btn.state-on {
+    border: 0.5px solid var(--danger-color);
     color: var(--danger-color);
 }
 
 #devices .device-list .sleep-wake-btn.state-unknown {
+    border: 0.5px solid var(--text-color-light, #888);
     color: var(--text-color-light, #888);
 }
 
@@ -232,7 +237,7 @@ body.list #device_list_menu {
     margin: 0;
     display: inline-flex;
     align-items: center;
-    border: 0.5px solid var(--text-color);
+    border: 0.5px solid #5b9aff;
     border-radius: 6px;
     overflow: hidden;
     white-space: nowrap;


### PR DESCRIPTION
## Summary

Four CSS-only tweaks:

1. **Disconnect border** back to red (`var(--danger-color)`) — matches its red text.
2. **Sleep-wake borders** back to their state-specific colors — green for `state-off` ("turn on"), red for `state-on` ("turn off"), gray for `state-unknown` ("checking…"). Border matches text in all states.
3. **Modal-launch button borders** (`.desc-block`) changed from `var(--text-color)` (white) to `#5b9aff` (the established blue used by their text). All buttons in the card now follow the consistent "border = text color" rule.
4. **Asymmetric card padding** — `padding: 8px` → `padding: 8px 8px 8px 20px`. Card outer width is grid-driven so doesn't grow; the inner content shifts right to balance the open whitespace on the right of the value column.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: all button borders match their text color
- [ ] Visual: card content shifted right ~12px relative to beta.12
- [ ] Visual: card outer width unchanged (still fits same number of cards per row)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>