### PR TITLE
fix: dep-btn border to blue; center card grids + vertical divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.14] - 2026-05-28
+
+### Changed
+
+- `.dep-btn` button border (3 scan-section buttons + "check for updates" button) changed from `var(--text-color)` (white) to `#5b9aff` (matching their blue text). Border-matches-text convention now applies across all page chrome.
+- Device card button grids (services + device-actions) centered: `justify-items: start` → `center`. Modal-launch and action buttons now sit at the center of their grid columns.
+- Added a vertical divider line down the centerline of the services and device-actions grids, mirroring the existing horizontal border-tops between sections.
+
 ## [0.1.30-beta.13] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.13"
+version = "0.1.30-beta.14"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.13",
+  "version": "0.1.30-beta.14",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/dependencies.css
+++ b/src/style/dependencies.css
@@ -55,7 +55,7 @@
 /* Buttons */
 .dep-btn {
     padding: 0.3rem 0.75rem;
-    border: 0.5px solid var(--text-color);
+    border: 0.5px solid #5b9aff;
     border-radius: 6px;
     background: transparent;
     color: #5b9aff;

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -137,9 +137,23 @@ body.list #device_list_menu {
     grid-template-columns: 1fr 1fr;
     gap: 6px;
     align-items: center;
-    justify-items: start;
+    justify-items: center;
+    position: relative;
     border-top: 1px solid var(--device-border-color);
     padding: 8px 0;
+}
+
+/* Vertical divider down the center, mirroring the horizontal border-tops
+   between sections. Spans the full height of the actions row. */
+#devices .device-list div.device .device-actions::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    background: var(--device-border-color);
+    pointer-events: none;
 }
 
 #devices .device-list div.device .device-actions:empty {
@@ -219,10 +233,24 @@ body.list #device_list_menu {
     grid-auto-flow: column;
     gap: 6px;
     align-items: center;
-    justify-items: start;
+    justify-items: center;
+    position: relative;
     border-top: 1px solid var(--device-border-color);
     padding-top: 8px;
     padding-bottom: 8px;
+}
+
+/* Vertical divider down the center, mirroring the horizontal border-tops
+   between sections. Spans the full height of the services grid. */
+#devices .device-list div.device .services::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    background: var(--device-border-color);
+    pointer-events: none;
 }
 
 #devices .device-list div.device .services:last-child {


### PR DESCRIPTION
## Summary

Two changes:

1. **`.dep-btn` border to blue.** The 3 scan-section buttons (quick scan, scan network, manually add) and the "check for updates" button in Dependencies were the last buttons on the page still using `var(--text-color)` (white) for their border. Switched to `#5b9aff` so they match their blue text — border-matches-text convention now applied consistently.

2. **Device card buttons centered within their grid cells, with a vertical divider.**
   - `justify-items: start` → `center` on both `.services` and `.device-actions`. Modal-launch buttons and action buttons now sit at the center of their columns.
   - Added a vertical divider line at the centerline of each grid via `::before` pseudo-element, mirroring the horizontal border-tops between sections. Spans the full height of each grid container, drawn in `var(--device-border-color)`.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: all 4 `.dep-btn` buttons (3 scan + 1 updates) have blue borders matching their text
- [ ] Visual: modal-launch buttons centered within their columns
- [ ] Visual: disconnect/turn-on/off centered within their columns
- [ ] Visual: thin vertical divider line at the centerline of the modal-launch grid + action grid
- [ ] Visual: USB-only single-button card still places the lone "turn on/off" centered in the right column

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>