### PR TITLE
fix: device card table-style grids + dep-btn border color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.15] - 2026-05-28
+
+> Note: v0.1.30-beta.14 was tagged but its squash-merge silently failed, so the beta.14 release artifacts contain beta.13 content. This release combines everything that was meant for beta.14 plus the table-grid additions below.
+
+### Changed
+
+- `.dep-btn` button border (3 scan-section buttons + "check for updates" button) changed from `var(--text-color)` (white) to `#5b9aff` (matching their blue text).
+- Device card modal-launch + action buttons centered within their grid cells (`justify-items: start` → `center`).
+- Device card button grids redrawn as full table-style grids with both outer (left/right/top/bottom) and inner (vertical between columns, horizontal between modal-launch rows) borders. Dividers implemented as real 1px grid tracks (`grid-template-columns: 1fr 1px 1fr`, `grid-template-rows: auto 1px auto`) so they land on integer pixel positions regardless of card width — fixes the sub-pixel anti-aliasing artifact where the vertical divider appeared thicker/lighter on cards whose width didn't divide evenly into 2.
+
 ## [0.1.30-beta.13] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.13"
+version = "0.1.30-beta.15"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.13",
+  "version": "0.1.30-beta.15",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/dependencies.css
+++ b/src/style/dependencies.css
@@ -55,7 +55,7 @@
 /* Buttons */
 .dep-btn {
     padding: 0.3rem 0.75rem;
-    border: 0.5px solid var(--text-color);
+    border: 0.5px solid #5b9aff;
     border-radius: 6px;
     background: transparent;
     color: #5b9aff;

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -127,19 +127,32 @@ body.list #device_list_menu {
 }
 
 /* Device action buttons (disconnect + sleep/wake) — sibling row to the
-   device-info table. 2-column grid mirroring the .services grid above:
-   disconnect aligns under the left modal column (shell/list files);
-   turn-on/off aligns under the right modal column (connect/config stream).
-   Kept outside the device-info table so wider-mono-font platforms (Linux)
-   don't squeeze the table layout. */
+   device-info table. Table-style grid: 2 button columns separated by a
+   real 1px column (vertical divider). Outer border on left/right/bottom;
+   border-top is the row divider shared with the services grid above.
+   All dividers are real 1px grid tracks so they land on integer pixel
+   positions regardless of card width — no sub-pixel anti-aliasing
+   artifacts. */
 #devices .device-list div.device .device-actions {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 6px;
+    grid-template-columns: 1fr 1px 1fr;
+    grid-template-rows: auto;
+    gap: 0;
     align-items: center;
-    justify-items: start;
+    justify-items: center;
     border-top: 1px solid var(--device-border-color);
-    padding: 8px 0;
+    border-left: 1px solid var(--device-border-color);
+    border-right: 1px solid var(--device-border-color);
+    border-bottom: 1px solid var(--device-border-color);
+    padding: 0;
+}
+
+#devices .device-list div.device .device-actions::before {
+    content: '';
+    grid-column: 2;
+    grid-row: 1 / -1;
+    background: var(--device-border-color);
+    pointer-events: none;
 }
 
 #devices .device-list div.device .device-actions:empty {
@@ -148,6 +161,7 @@ body.list #device_list_menu {
 
 #devices .device-list .disconnect-btn {
     grid-column: 1;
+    margin: 8px;
     border: 0.5px solid var(--danger-color);
     border-radius: 6px;
     background: transparent;
@@ -171,7 +185,8 @@ body.list #device_list_menu {
 
 /* Sleep/wake button */
 #devices .device-list .sleep-wake-btn {
-    grid-column: 2;
+    grid-column: 3;
+    margin: 8px;
     border-radius: 6px;
     background: transparent;
     padding: 4px 10px;
@@ -210,19 +225,47 @@ body.list #device_list_menu {
     cursor: not-allowed;
 }
 
-/* Services / action buttons — 2x2 grid filled column-first:
-   left col = [shell][list files], right col = [connect][configure stream] */
+/* Modal-launch buttons — 2x2 grid filled column-first:
+   left col = [shell][list files], right col = [connect][configure stream].
+   Table-style grid: 2 button columns separated by a real 1px column
+   (vertical divider) and 2 button rows separated by a real 1px row
+   (horizontal divider). Outer border on left/right; border-top is the
+   row divider shared with the device-info table above. All dividers
+   are real grid tracks for pixel-exact rendering (no sub-pixel AA). */
 #devices .device-list div.device .services {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto;
+    grid-template-columns: 1fr 1px 1fr;
+    grid-template-rows: auto 1px auto;
     grid-auto-flow: column;
-    gap: 6px;
+    gap: 0;
     align-items: center;
-    justify-items: start;
+    justify-items: center;
     border-top: 1px solid var(--device-border-color);
-    padding-top: 8px;
-    padding-bottom: 8px;
+    border-left: 1px solid var(--device-border-color);
+    border-right: 1px solid var(--device-border-color);
+    padding: 0;
+}
+
+#devices .device-list div.device .services::before {
+    content: '';
+    grid-column: 2;
+    grid-row: 1 / -1;
+    background: var(--device-border-color);
+    pointer-events: none;
+}
+
+#devices .device-list div.device .services::after {
+    content: '';
+    grid-column: 1 / -1;
+    grid-row: 2;
+    background: var(--device-border-color);
+    pointer-events: none;
+}
+
+/* Margin around modal buttons gives them breathing room inside the grid
+   cells (container padding is 0 so dividers can span edge-to-edge). */
+#devices .device-list div.device .services > .desc-block {
+    margin: 8px;
 }
 
 #devices .device-list div.device .services:last-child {


### PR DESCRIPTION
## Summary

Combines the centering + dep-btn-color changes from the closed PR #224 (which was tagged into beta.14 but never actually merged) with new table-style grid additions. This is the proper beta.15 release.

### Changes

1. **`.dep-btn` border color:** `var(--text-color)` → `#5b9aff` (matches blue text). Applies to the 3 scan-section buttons + "check for updates" in Dependencies.

2. **Modal-launch + action buttons centered:** `justify-items: start` → `center` on both `.services` and `.device-actions`.

3. **Full table-style grid lines around device card buttons:**
   - Outer borders on `.services` (left, right, top) and `.device-actions` (left, right, top, bottom). The shared row divider between the two grids is `.device-actions border-top` (single line).
   - Inner vertical divider between columns (both grids).
   - Inner horizontal divider between modal-launch rows (services only — actions has 1 row).
   - Dividers are **real 1px grid tracks** (`grid-template-columns: 1fr 1px 1fr`, `grid-template-rows: auto 1px auto` for services), not absolutely-positioned pseudo-elements. Fixes the sub-pixel anti-aliasing artifact where a `left: 50%` line appeared thicker/lighter on cards whose width didnt divide evenly into 2.

### Note on beta.14

`gh pr merge 224 --squash --delete-branch` returned no output earlier but did not actually merge. The beta.14 tag was created pointing to origin/mains then-HEAD (which still had beta.13 content). So the beta.14 release artifacts visually equal beta.13. PR #224 has been closed as superseded; this PR carries forward its intended changes plus the new table-grid work.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: all 4 button cells in services have visible borders (top, left, right + internal dividers); bottom is shared with device-actions top
- [ ] Visual: action buttons have full perimeter borders + vertical divider
- [ ] Visual: vertical divider is consistently 1px thick / matching color across all cards (no sub-pixel AA variance)
- [ ] Visual: dep-btn (scan + updates) borders are blue
- [ ] Visual: USB-only single-button card still places lone "turn on/off" centered in the right column
- [ ] Visual: inactive device (3 modal buttons, no connect) still places shell + list files in left col, config stream top of right col

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>