### PR TITLE
fix: check-for-updates green, scan buttons orange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.16] - 2026-05-28
+
+### Changed
+
+- "check for updates" button (Dependencies section) now uses green border + text (`var(--success-color)`), matching the "turn on" sleep-wake button.
+- Network-discovery scan buttons (quick scan, scan network, manually add) now use orange border + text (`var(--warning-color)`).
+- `--warning-color` (dark theme) changed from amber `#fbbf24` to orange `#fb923c` for a clearer "not yellow" orange. Light theme `#b45309` (already orange-700) unchanged. `.dep-warn` status badge follows the new orange.
+
 ## [0.1.30-beta.15] - 2026-05-28
 
 > Note: v0.1.30-beta.14 was tagged but its squash-merge silently failed, so the beta.14 release artifacts contain beta.13 content. This release combines everything that was meant for beta.14 plus the table-grid additions below.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.15"
+version = "0.1.30-beta.16"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.15",
+  "version": "0.1.30-beta.16",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -21,7 +21,7 @@
     --success-hover-bg: rgba(74, 222, 128, 0.1);
     --danger-color: #f06c75;
     --danger-hover-bg: rgba(240, 108, 117, 0.1);
-    --warning-color: #fbbf24;
+    --warning-color: #fb923c;
     --info-color: #60a5fa;
     --link-color: hsl(218, 63%, 70%);
     --link-color-light: hsl(218, 63%, 50%);

--- a/src/style/dependencies.css
+++ b/src/style/dependencies.css
@@ -75,6 +75,23 @@
     cursor: not-allowed;
 }
 
+/* "Check for updates" — semantic match with the "turn on" / success
+   sleep-wake button. Border + text in success-green. */
+.dep-btn.dep-check-all {
+    border-color: var(--success-color);
+    color: var(--success-color);
+}
+
+/* Network-discovery scan buttons — semantic match with caution / start-
+   an-action. Border + text in warning-orange (--warning-color is solidly
+   orange now: dark #fb923c, light #b45309). */
+.dep-btn.discovery-quick-scan-btn,
+.dep-btn.discovery-scan-btn,
+.dep-btn.discovery-manual-btn {
+    border-color: var(--warning-color);
+    color: var(--warning-color);
+}
+
 .dep-update {
     border-color: #2a6a2a;
     color: #4ade80;


### PR DESCRIPTION
## Summary

Three color tweaks to give Dependencies + Network Discovery action buttons semantic colors:

1. **"check for updates"** (Dependencies header) → green border + text (`var(--success-color)`), matching the "turn on" sleep-wake button.
2. **Network-discovery scan buttons** (quick scan, scan network, manually add) → orange border + text (`var(--warning-color)`). Semantic: scan-initiating actions.
3. **`--warning-color` (dark theme)** changed from `#fbbf24` (amber/yellow) to `#fb923c` (orange-400) for a clearly-orange tone. Light theme already used `#b45309` (orange-700) so unchanged. The existing `.dep-warn` status badge in the dependencies table follows the new orange — appropriate for "needs attention."

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: "check for updates" button is green border + green text
- [ ] Visual: 3 scan buttons (quick scan, scan network, manually add) are orange border + orange text
- [ ] Visual: dep-warn status badges (if any are showing) now appear orange rather than yellow

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>