### PR TITLE
fix: device card symmetric padding + visible grid dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Device card horizontal padding now symmetric (8px 14px); the 3px green/red active-state left border is outside this padding so it doesn't unbalance the content area.
-- Device card button grid dividers (vertical between columns, horizontal between modal-launch rows) are now visible. They were rendering at 0×0 because the pseudo-elements inherited `justify-items: center` / `align-items: center` from the parent grid and auto-sized to their empty content. Added `place-self: stretch` so they fill their 1px grid cells.
+
+### Changed
+
+- Reverted the inner cross dividers (vertical between columns, horizontal between modal-launch rows). 1px grid-track dividers position based on the auto-sized neighbor tracks, which often land on sub-pixel boundaries — the browser then anti-aliases the line across two physical pixels, making it appear thicker and dimmer than the outer borders (which are at element edges, always integer pixels). Outer borders + section dividers remain.
 
 ## [0.1.30-beta.16] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.17] - 2026-05-28
+
+### Fixed
+
+- Device card horizontal padding now symmetric (8px 14px); the 3px green/red active-state left border is outside this padding so it doesn't unbalance the content area.
+- Device card button grid dividers (vertical between columns, horizontal between modal-launch rows) are now visible. They were rendering at 0×0 because the pseudo-elements inherited `justify-items: center` / `align-items: center` from the parent grid and auto-sized to their empty content. Added `place-self: stretch` so they fill their 1px grid cells.
+
 ## [0.1.30-beta.16] - 2026-05-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Device card horizontal padding now symmetric (8px 14px); the 3px green/red active-state left border is outside this padding so it doesn't unbalance the content area.
-
-### Changed
-
-- Reverted the inner cross dividers (vertical between columns, horizontal between modal-launch rows). 1px grid-track dividers position based on the auto-sized neighbor tracks, which often land on sub-pixel boundaries — the browser then anti-aliases the line across two physical pixels, making it appear thicker and dimmer than the outer borders (which are at element edges, always integer pixels). Outer borders + section dividers remain.
+- Device card grid dividers now render crisp (no sub-pixel anti-aliasing). The previous attempt used 1px grid-track dividers (`grid-template-columns: 1fr 1px 1fr`), which position based on neighbor auto-tracks that often land on sub-pixel boundaries — the browser anti-aliased the line across two physical pixels, making it thicker and dimmer than the outer borders. Switched to cell-border drawing: `.desc-block` items stretch to fill their grid cells and get `border-right` / `border-bottom` via `:nth-child` to draw the cross; action buttons are now wrapped in `.action-cell` divs with the same treatment. Borders sit at element edges (always integer pixels) and render at the same crispness as the outer card border.
+- Blue button border moved from `.desc-block` (now the cell) to the inner `.action-button` / `<a>` (the actual button shape). Visual unchanged — blue-bordered button sits centered inside a gray-bordered cell.
 
 ## [0.1.30-beta.16] - 2026-05-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.16"
+version = "0.1.30-beta.17"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.16",
+  "version": "0.1.30-beta.17",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -225,6 +225,15 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         // the table past the card border when actions were a rowSpan cell).
         const actionsRow = row.querySelector('.device-actions');
         if (actionsRow) {
+            // Each action button lives inside an `.action-cell` wrapper so the
+            // grid divider can be drawn as a real CSS border on the cell —
+            // borders sit at element edges (integer pixels), so they render
+            // crisply unlike 1px grid-track dividers which can land on sub-
+            // pixel positions and anti-alias to a thicker/dimmer line.
+            const disconnectCell = document.createElement('div');
+            disconnectCell.className = 'action-cell action-cell-disconnect';
+            actionsRow.appendChild(disconnectCell);
+
             // Disconnect button (network devices only)
             if (isNetworkDevice) {
                 const disconnectBtn = document.createElement('button');
@@ -242,8 +251,12 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                         disconnectBtn.disabled = false;
                     }
                 });
-                actionsRow.appendChild(disconnectBtn);
+                disconnectCell.appendChild(disconnectBtn);
             }
+
+            const sleepCell = document.createElement('div');
+            sleepCell.className = 'action-cell action-cell-sleep';
+            actionsRow.appendChild(sleepCell);
 
             // Sleep/wake button (all devices)
             // State comes from server via WebSocket (descriptor['screen.state'])
@@ -285,7 +298,7 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                     sleepBtn.className = `sleep-wake-btn ${isAwake ? 'state-on' : 'state-off'}`;
                 }
             });
-            actionsRow.appendChild(sleepBtn);
+            sleepCell.appendChild(sleepBtn);
         }
 
         // Auto-select best interface: prefer wifi/direct IP, fallback to proxy

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -129,15 +129,14 @@ body.list #device_list_menu {
 }
 
 /* Device action buttons (disconnect + sleep/wake) — sibling row to the
-   device-info table. Table-style grid: 2 button columns separated by a
-   real 1px column (vertical divider). Outer border on left/right/bottom;
+   device-info table. 2-column grid with outer borders on all four sides;
    border-top is the row divider shared with the services grid above.
-   All dividers are real 1px grid tracks so they land on integer pixel
-   positions regardless of card width — no sub-pixel anti-aliasing
-   artifacts. */
+   No inner vertical divider — 1px grid-track dividers render with sub-
+   pixel anti-aliasing artifacts that look thicker/dimmer than the outer
+   borders. */
 #devices .device-list div.device .device-actions {
     display: grid;
-    grid-template-columns: 1fr 1px 1fr;
+    grid-template-columns: 1fr 1fr;
     grid-template-rows: auto;
     gap: 0;
     align-items: center;
@@ -147,18 +146,6 @@ body.list #device_list_menu {
     border-right: 1px solid var(--device-border-color);
     border-bottom: 1px solid var(--device-border-color);
     padding: 0;
-}
-
-#devices .device-list div.device .device-actions::before {
-    content: '';
-    grid-column: 2;
-    grid-row: 1 / -1;
-    background: var(--device-border-color);
-    /* Override parent's justify-items: center / align-items: center
-       which would auto-size the pseudo to its 0-width content and
-       leave the divider invisible. Stretch fills the 1px grid cell. */
-    place-self: stretch;
-    pointer-events: none;
 }
 
 #devices .device-list div.device .device-actions:empty {
@@ -191,7 +178,7 @@ body.list #device_list_menu {
 
 /* Sleep/wake button */
 #devices .device-list .sleep-wake-btn {
-    grid-column: 3;
+    grid-column: 2;
     margin: 8px;
     border-radius: 6px;
     background: transparent;
@@ -233,15 +220,14 @@ body.list #device_list_menu {
 
 /* Modal-launch buttons — 2x2 grid filled column-first:
    left col = [shell][list files], right col = [connect][configure stream].
-   Table-style grid: 2 button columns separated by a real 1px column
-   (vertical divider) and 2 button rows separated by a real 1px row
-   (horizontal divider). Outer border on left/right; border-top is the
-   row divider shared with the device-info table above. All dividers
-   are real grid tracks for pixel-exact rendering (no sub-pixel AA). */
+   Outer borders on left/right; border-top is the row divider shared with
+   the device-info table above. No inner cross dividers — 1px grid-track
+   dividers render with sub-pixel anti-aliasing artifacts that look
+   thicker/dimmer than the outer borders. */
 #devices .device-list div.device .services {
     display: grid;
-    grid-template-columns: 1fr 1px 1fr;
-    grid-template-rows: auto 1px auto;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
     grid-auto-flow: column;
     gap: 0;
     align-items: center;
@@ -252,29 +238,8 @@ body.list #device_list_menu {
     padding: 0;
 }
 
-#devices .device-list div.device .services::before {
-    content: '';
-    grid-column: 2;
-    grid-row: 1 / -1;
-    background: var(--device-border-color);
-    /* See note on .device-actions::before — stretch needed so the
-       pseudo fills its 1px-wide grid cell instead of collapsing to
-       0-width content. */
-    place-self: stretch;
-    pointer-events: none;
-}
-
-#devices .device-list div.device .services::after {
-    content: '';
-    grid-column: 1 / -1;
-    grid-row: 2;
-    background: var(--device-border-color);
-    place-self: stretch;
-    pointer-events: none;
-}
-
 /* Margin around modal buttons gives them breathing room inside the grid
-   cells (container padding is 0 so dividers can span edge-to-edge). */
+   cells (container padding is 0). */
 #devices .device-list div.device .services > .desc-block {
     margin: 8px;
 }

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -131,16 +131,14 @@ body.list #device_list_menu {
 /* Device action buttons (disconnect + sleep/wake) — sibling row to the
    device-info table. 2-column grid with outer borders on all four sides;
    border-top is the row divider shared with the services grid above.
-   No inner vertical divider — 1px grid-track dividers render with sub-
-   pixel anti-aliasing artifacts that look thicker/dimmer than the outer
-   borders. */
+   Inner vertical divider is drawn as a border-right on the first
+   .action-cell (an element edge → integer pixel → crisp rendering, no
+   sub-pixel AA artifacts). */
 #devices .device-list div.device .device-actions {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: auto;
     gap: 0;
-    align-items: center;
-    justify-items: center;
     border-top: 1px solid var(--device-border-color);
     border-left: 1px solid var(--device-border-color);
     border-right: 1px solid var(--device-border-color);
@@ -148,13 +146,27 @@ body.list #device_list_menu {
     padding: 0;
 }
 
+/* Each action button lives inside an .action-cell that stretches to
+   fill its grid cell. The cell's right border (first cell only) is
+   the inner vertical divider. */
+#devices .device-list div.device .device-actions > .action-cell {
+    justify-self: stretch;
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+}
+
+#devices .device-list div.device .device-actions > .action-cell:nth-child(1) {
+    border-right: 1px solid var(--device-border-color);
+}
+
 #devices .device-list div.device .device-actions:empty {
     display: none;
 }
 
 #devices .device-list .disconnect-btn {
-    grid-column: 1;
-    margin: 8px;
     border: 0.5px solid var(--danger-color);
     border-radius: 6px;
     background: transparent;
@@ -178,8 +190,6 @@ body.list #device_list_menu {
 
 /* Sleep/wake button */
 #devices .device-list .sleep-wake-btn {
-    grid-column: 2;
-    margin: 8px;
     border-radius: 6px;
     background: transparent;
     padding: 4px 10px;
@@ -221,27 +231,57 @@ body.list #device_list_menu {
 /* Modal-launch buttons — 2x2 grid filled column-first:
    left col = [shell][list files], right col = [connect][configure stream].
    Outer borders on left/right; border-top is the row divider shared with
-   the device-info table above. No inner cross dividers — 1px grid-track
-   dividers render with sub-pixel anti-aliasing artifacts that look
-   thicker/dimmer than the outer borders. */
+   the device-info table above. Inner cross dividers are drawn as
+   border-right / border-bottom on the cells (the .desc-block items
+   themselves stretch to fill their cell). Borders sit at element edges
+   (integer pixels) so they render crisply, unlike 1px grid-track
+   dividers which can land on sub-pixel positions and anti-alias. */
 #devices .device-list div.device .services {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: auto auto;
     grid-auto-flow: column;
     gap: 0;
-    align-items: center;
-    justify-items: center;
     border-top: 1px solid var(--device-border-color);
     border-left: 1px solid var(--device-border-color);
     border-right: 1px solid var(--device-border-color);
     padding: 0;
 }
 
-/* Margin around modal buttons gives them breathing room inside the grid
-   cells (container padding is 0). */
+/* Each .desc-block (modal-launch cell) stretches to fill its grid cell.
+   Padding gives breathing room around the inner button (which carries
+   the blue border — moved off .desc-block so .desc-block can act as
+   the gray-bordered cell). */
 #devices .device-list div.device .services > .desc-block {
-    margin: 8px;
+    justify-self: stretch;
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    overflow: visible;
+}
+
+/* Cross dividers via cell borders. With grid-auto-flow: column over 2
+   rows: nth-child(1)=top-left, (2)=bottom-left, (3)=top-right,
+   (4)=bottom-right. Top-left gets right + bottom; bottom-left gets
+   right; top-right gets bottom; bottom-right gets none. For inactive
+   devices (3 buttons, no `connect`), nth-child(3) is `config stream`
+   sitting at top-right with border-bottom — that's fine; the line
+   ends at the cell boundary regardless of whether anything below
+   occupies the empty bottom-right cell. */
+#devices .device-list div.device .services > .desc-block:nth-child(1) {
+    border-right: 1px solid var(--device-border-color);
+    border-bottom: 1px solid var(--device-border-color);
+}
+#devices .device-list div.device .services > .desc-block:nth-child(2) {
+    border-right: 1px solid var(--device-border-color);
+}
+#devices .device-list div.device .services > .desc-block:nth-child(3) {
+    border-bottom: 1px solid var(--device-border-color);
 }
 
 #devices .device-list div.device .services:last-child {
@@ -252,11 +292,13 @@ body.list #device_list_menu {
     margin-top: 8px;
 }
 
+/* .desc-block default styles for places OUTSIDE the services grid
+   (kept for any other consumer). Inside the services grid, .desc-block
+   acts as a cell; the blue border is moved to the inner button/link. */
 #devices .device-list div.desc-block {
     margin: 0;
     display: inline-flex;
     align-items: center;
-    border: 0.5px solid #5b9aff;
     border-radius: 6px;
     overflow: hidden;
     white-space: nowrap;
@@ -283,10 +325,13 @@ body.list #device_list_menu {
     color: var(--link-color_visited-light);
 }
 
-/* Action buttons and links styled as buttons */
+/* Action buttons and links styled as buttons. Blue border moved here
+   from .desc-block so the parent .desc-block can act as a grid cell
+   (with gray cell borders) without an outer blue border around it. */
 #devices .device-list div.desc-block .action-button,
 #devices .device-list div.desc-block a {
-    border: none;
+    border: 0.5px solid #5b9aff;
+    border-radius: 6px;
     background-color: transparent;
     color: #5b9aff;
     text-decoration: none;

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -74,10 +74,12 @@ body.list #device_list_menu {
 #devices .device-list div.device {
     border: 1px solid var(--device-border-color);
     border-radius: 8px;
-    /* Asymmetric padding: extra left to balance the right-side
-       whitespace from the value column. Card outer width is set by
-       the grid; only the inner content area shifts right. */
-    padding: 8px 8px 8px 20px;
+    /* Symmetric horizontal padding so the dark-grey content area sits
+       equidistant from the left and right card borders. (The active
+       device's 3px green / not-active 3px red left border is outside
+       this padding and replaces the 1px default left border — that
+       asymmetry is intentional, not part of the content padding.) */
+    padding: 8px 14px;
     background: var(--device-list-default-color);
     transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -152,6 +154,10 @@ body.list #device_list_menu {
     grid-column: 2;
     grid-row: 1 / -1;
     background: var(--device-border-color);
+    /* Override parent's justify-items: center / align-items: center
+       which would auto-size the pseudo to its 0-width content and
+       leave the divider invisible. Stretch fills the 1px grid cell. */
+    place-self: stretch;
     pointer-events: none;
 }
 
@@ -251,6 +257,10 @@ body.list #device_list_menu {
     grid-column: 2;
     grid-row: 1 / -1;
     background: var(--device-border-color);
+    /* See note on .device-actions::before — stretch needed so the
+       pseudo fills its 1px-wide grid cell instead of collapsing to
+       0-width content. */
+    place-self: stretch;
     pointer-events: none;
 }
 
@@ -259,6 +269,7 @@ body.list #device_list_menu {
     grid-column: 1 / -1;
     grid-row: 2;
     background: var(--device-border-color);
+    place-self: stretch;
     pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

Two fixes:

1. **Card horizontal padding symmetric.** `padding: 8 8 8 20` → `padding: 8 14` (top/bottom 8, left/right 14). The dark-grey content area now sits equidistant from the left and right card borders. The 3px green/red active-state left border is outside this padding (replaces the default 1px left border).

2. **Make the device-card button-grid dividers actually visible.** They were in the CSS since beta.15 but rendered at 0×0 because the parent grids have `justify-items: center` / `align-items: center`, which propagate to grid items including pseudo-elements. The `::before` / `::after` had empty content so they auto-sized to 0. `place-self: stretch` overrides this and the pseudos fill their 1px grid cells, drawing the dividers.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: card left/right padding looks symmetric
- [ ] Visual: vertical divider runs top-to-bottom through the modal-launch grid + the action-button grid
- [ ] Visual: horizontal divider between modal-launch row 1 (shell, connect) and row 2 (list files, config stream)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>