### PR TITLE
fix: device card cells uniform height + reduced button padding + left-align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.18] - 2026-05-28
+
+### Changed
+
+- Device card button internal padding reduced: modal-launch buttons `0.3rem 0.75rem` → `0.15rem 0.5rem`; disconnect + sleep-wake `4px 10px` → `2px 8px`. Text size unchanged.
+- All device card buttons left-aligned within their grid cells (modal-launch + action). Cell padding (8px) provides offset from the gray cell border.
+
 ## [0.1.30-beta.17] - 2026-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Device card button internal padding reduced: modal-launch buttons `0.3rem 0.75rem` → `0.15rem 0.5rem`; disconnect + sleep-wake `4px 10px` → `2px 8px`. Text size unchanged.
-- All device card buttons left-aligned within their grid cells (modal-launch + action). Cell padding (8px) provides offset from the gray cell border.
+- All device card buttons left-aligned within their grid cells (modal-launch + action). Cell padding (`0 8px`) provides offset from the gray cell border.
+- Device card grid cells uniform height (`36px` with `box-sizing: border-box`) across both the services grid and the device-actions row, so all three rows are the same height. Previously the modal-launch row 2 was shortest (button content without icon), and the action row was tallest (heavier button styling); now all three render identical.
 
 ## [0.1.30-beta.17] - 2026-05-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.17"
+version = "0.1.30-beta.18"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.17",
+  "version": "0.1.30-beta.18",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -155,7 +155,9 @@ body.list #device_list_menu {
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    padding: 8px;
+    padding: 0 8px;
+    height: 36px;
+    box-sizing: border-box;
 }
 
 #devices .device-list div.device .device-actions > .action-cell:nth-child(1) {
@@ -258,11 +260,13 @@ body.list #device_list_menu {
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    padding: 8px;
+    padding: 0 8px;
     margin: 0;
     border: none;
     border-radius: 0;
     overflow: visible;
+    height: 36px;
+    box-sizing: border-box;
 }
 
 /* Cross dividers via cell borders. With grid-auto-flow: column over 2

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -154,7 +154,7 @@ body.list #device_list_menu {
     align-self: stretch;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     padding: 8px;
 }
 
@@ -171,7 +171,7 @@ body.list #device_list_menu {
     border-radius: 6px;
     background: transparent;
     color: var(--danger-color);
-    padding: 4px 10px;
+    padding: 2px 8px;
     font-size: var(--font-size);
     cursor: pointer;
     white-space: nowrap;
@@ -192,7 +192,7 @@ body.list #device_list_menu {
 #devices .device-list .sleep-wake-btn {
     border-radius: 6px;
     background: transparent;
-    padding: 4px 10px;
+    padding: 2px 8px;
     font-size: var(--font-size);
     cursor: pointer;
     white-space: nowrap;
@@ -257,7 +257,7 @@ body.list #device_list_menu {
     align-self: stretch;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     padding: 8px;
     margin: 0;
     border: none;
@@ -335,7 +335,7 @@ body.list #device_list_menu {
     background-color: transparent;
     color: #5b9aff;
     text-decoration: none;
-    padding: 0.3rem 0.75rem;
+    padding: 0.15rem 0.5rem;
     font-family: var(--font-mono);
     font-size: var(--font-size);
     cursor: pointer;


### PR DESCRIPTION
## Summary

Final aesthetic-pass on the device card buttons (text size unchanged):

1. **Reduced internal button padding** — modal-launch `0.3rem 0.75rem` → `0.15rem 0.5rem`; disconnect + sleep-wake `4px 10px` → `2px 8px`.
2. **All device card buttons left-aligned** within their grid cells (modal-launch and action).
3. **Uniform 36px cell height** across all three rows (modal-launch row 1, row 2, and action row). Previously the action row was tallest and the modal-launch row 2 was shortest; now all three render identical. Implemented with `height: 36px; box-sizing: border-box; padding: 0 8px;` on both `.desc-block` and `.action-cell`.

## Test plan

- [x] 720 vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual: all three button rows are the same height
- [ ] Visual: buttons left-aligned within cells
- [ ] Visual: button padding visibly tighter

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>