### PR TITLE
fix: linux Velopack UpdateNix locator + make_latest=true for release discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,13 +272,15 @@ jobs:
           # only stable assets. See feedback_velopack_permachine_lessons.md
           # Gotcha 5 for the full diagnosis.
           #
-          # make_latest: 'legacy' lets GitHub determine Latest via its
-          # own SemVer + creation-date algorithm instead of every new
-          # release forcibly stealing the badge. Fixes the releases page
-          # sort order (betas were appearing in the middle instead of at
-          # the top because each publish force-set Latest and GitHub
-          # sorted non-Latest entries by commit date not publish date).
-          make_latest: 'legacy'
+          # make_latest: true — every published release explicitly claims the
+          # Latest badge. Velopack's GithubSource queries /releases/latest to
+          # discover the newest release in the configured channel, so the
+          # Latest badge MUST track the most recent tag or in-app updates
+          # silently no-op. The earlier 'legacy' value (intended to fix
+          # releases-page sort drift) caused the Latest badge to stick at
+          # v0.1.30-beta.9 across the entire beta.10-18 push on 2026-05-28,
+          # making 9 newer betas invisible to auto-update.
+          make_latest: true
           body_path: release-notes.md
           files: |
             artifacts/windows-final/*.msi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux in-app updates now work.** `UpdateService` built `VelopackLocatorConfig` with Windows-shape paths (`UpdateExePath: <root>/Update.exe`, `CurrentBinaryDir: <root>/current`, etc.) on every platform. Velopack 1.0.1's lib-rust `auto_locate_app_manifest` validates `UpdateNix` existence at the configured path before returning, so `UpdateManager` construction threw on every Linux AppImage launch. Beta.7's PR #216 added an `mgr === null` guard in `reconfigure()` to mask the throw at the cost of silent no-op updates. Now platform-branched: Windows keeps the Squirrel-style `<installRoot>/current/` layout; Linux mirrors the Velopack Linux locator exactly — `RootAppDir = $APPIMAGE`, `UpdateExePath = <mount>/usr/bin/UpdateNix`, `PackagesDir = /var/tmp/velopack/WsScrcpyWeb/packages`, `ManifestPath = <mount>/usr/bin/sq.version`, `CurrentBinaryDir = <mount>/usr/bin`, `IsPortable = true`. The `mgr === null` guard is retained as defensive belt-and-suspenders only.
+
+### Changed
+
+- `release.yml` Publish step: `make_latest: 'legacy'` → `make_latest: true`. The legacy value was intended to fix releases-page sort drift but caused GitHub's Latest badge to stick at `v0.1.30-beta.9` across the entire beta.10–18 push on 2026-05-28, making 9 newer betas invisible to Velopack's `GithubSource` (which queries `/releases/latest` to discover the newest release in the configured channel). Forcing every release to claim Latest restores discovery; sort order will be addressed separately if it regresses.
+
+### Removed
+
+- v0.1.30-beta.3 through v0.1.30-beta.17 GitHub releases. They were iterative UI-polish + Linux-debug intermediates that have no value to anyone outside testing. v0.1.30-beta.18 absorbs all their content and remains the discoverable beta. Tags are preserved in git history; only the GitHub releases (and their attached assets) were deleted.
+
 ## [0.1.30-beta.18] - 2026-05-28
 
 ### Changed

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -111,26 +111,57 @@ export class UpdateService {
         this.installRoot = opts.installRoot ?? path.resolve(__dirname, '..', '..');
         // Phase 2 of Program Files migration: explicitly hand Velopack the
         // install paths via VelopackLocatorConfig instead of relying on its
-        // env-var-driven auto-locate. Removes the v0.1.20 service-mode
-        // failure mode ("Could not auto-locate app manifest" when running
-        // as Local System with %LocalAppData% pointing at the system
-        // profile) and stays correct for the Phase 4 Program Files install
-        // root where Velopack should auto-locate fine anyway. Computed
-        // once — installRoot is immutable for the lifetime of the service.
-        this.locator = {
-            RootAppDir: this.installRoot,
-            UpdateExePath: path.join(this.installRoot, 'Update.exe'),
-            PackagesDir: path.join(this.installRoot, 'packages'),
-            // sq.version is Velopack's per-version manifest file, written
-            // inside the swappable `current/` dir. v0.1.17's marker check
-            // moved to `<installRoot>/Update.exe` (which Velopack actually
-            // creates on Windows install); the in-current sq.version
-            // continues to be the manifest file Velopack expects to find
-            // for runtime version reporting.
-            ManifestPath: path.join(this.installRoot, 'current', 'sq.version'),
-            CurrentBinaryDir: path.join(this.installRoot, 'current'),
-            IsPortable: false,
-        };
+        // env-var-driven auto-locate. Computed once — installRoot is
+        // immutable for the lifetime of the service.
+        //
+        // v0.1.30: branch by platform. Windows uses the Squirrel-style
+        // `<installRoot>/current/` swap layout. Linux AppImage mirrors
+        // Velopack 1.0.1's lib-rust `auto_locate_app_manifest` (Linux
+        // branch in src/lib-rust/src/locator.rs):
+        //   RootAppDir       = $APPIMAGE (the .AppImage file path)
+        //   UpdateExePath    = <mount>/usr/bin/UpdateNix
+        //   PackagesDir      = /var/tmp/velopack/<packId>/packages
+        //   ManifestPath     = <mount>/usr/bin/sq.version
+        //   CurrentBinaryDir = <mount>/usr/bin
+        //   IsPortable       = true
+        // installRoot resolves to the AppImage mount root inside the bundle
+        // (webpack outputs to <mount>/usr/bin/dist/index.js; ../.. = <mount>).
+        // Pre-v0.1.30 the single Windows-shape config threw on Linux because
+        // Velopack's Linux locator validates UpdateNix existence at the
+        // configured path; PR #216's `mgr === null` reconfigure guard masked
+        // the throw. Both halves of the fix land together here.
+        if (process.platform === 'win32') {
+            this.locator = {
+                RootAppDir: this.installRoot,
+                UpdateExePath: path.join(this.installRoot, 'Update.exe'),
+                PackagesDir: path.join(this.installRoot, 'packages'),
+                // sq.version is Velopack's per-version manifest file, written
+                // inside the swappable `current/` dir. v0.1.17's marker check
+                // moved to `<installRoot>/Update.exe` (which Velopack actually
+                // creates on Windows install); the in-current sq.version
+                // continues to be the manifest file Velopack expects to find
+                // for runtime version reporting.
+                ManifestPath: path.join(this.installRoot, 'current', 'sq.version'),
+                CurrentBinaryDir: path.join(this.installRoot, 'current'),
+                IsPortable: false,
+            };
+        } else {
+            // Linux AppImage. APPIMAGE may be empty/unset in dev mode — the
+            // locator is only handed to Velopack inside init() when the
+            // production-marker check (APPIMAGE non-empty) passes, so an
+            // invalid locator here is safely unused. packId is fixed by the
+            // `vpk pack --packId WsScrcpyWeb` invocation in release.yml.
+            const appImagePath = process.env['APPIMAGE'] ?? '';
+            const contentsDir = path.join(this.installRoot, 'usr', 'bin');
+            this.locator = {
+                RootAppDir: appImagePath,
+                UpdateExePath: path.join(contentsDir, 'UpdateNix'),
+                PackagesDir: '/var/tmp/velopack/WsScrcpyWeb/packages',
+                ManifestPath: path.join(contentsDir, 'sq.version'),
+                CurrentBinaryDir: contentsDir,
+                IsPortable: true,
+            };
+        }
         this.factory = opts.updateManagerFactory ?? defaultUpdateManagerFactory;
         this.feedUrlOverride = opts.feedUrlOverride;
         this.existsSync = opts.existsSync ?? fs.existsSync;
@@ -234,9 +265,13 @@ export class UpdateService {
             return;
         }
         if (!this.mgr) {
-            // init() couldn't construct UpdateManager (e.g. Linux AppImage
-            // where Velopack SDK has no Update.exe equivalent). Config is
-            // persisted by the caller; reconfigure can't help here.
+            // init() couldn't construct UpdateManager — corrupted install,
+            // SDK init failure, etc. Config is persisted by the caller;
+            // reconfigure can't help here. Pre-v0.1.30 this also masked a
+            // deterministic Linux throw caused by handing Velopack the
+            // Windows-shape locator; the platform-branched locator
+            // constructed above removes that failure mode, so this guard
+            // is now defensive only.
             return;
         }
         const feedUrl = this.buildFeedUrl(githubOwner);

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -192,7 +192,7 @@ describe('UpdateService', () => {
 
     // ── VelopackLocator override (Phase 2 of Program Files migration) ──
 
-    it('init: passes a VelopackLocatorConfig to the factory anchored at installRoot', () => {
+    it('init: passes a VelopackLocatorConfig to the factory shaped for the host platform', () => {
         const installRoot = path.join('/fake', 'install', 'root');
         let receivedLocator: unknown;
         const factory = vi.fn((_feed: string, _opts: UpdateOptions, locator?: unknown) => {
@@ -210,12 +210,25 @@ describe('UpdateService', () => {
 
         expect(receivedLocator).toBeDefined();
         const loc = receivedLocator as Record<string, unknown>;
-        expect(loc['RootAppDir']).toBe(installRoot);
-        expect(loc['UpdateExePath']).toBe(path.join(installRoot, 'Update.exe'));
-        expect(loc['PackagesDir']).toBe(path.join(installRoot, 'packages'));
-        expect(loc['ManifestPath']).toBe(path.join(installRoot, 'current', 'sq.version'));
-        expect(loc['CurrentBinaryDir']).toBe(path.join(installRoot, 'current'));
-        expect(loc['IsPortable']).toBe(false);
+        if (process.platform === 'win32') {
+            expect(loc['RootAppDir']).toBe(installRoot);
+            expect(loc['UpdateExePath']).toBe(path.join(installRoot, 'Update.exe'));
+            expect(loc['PackagesDir']).toBe(path.join(installRoot, 'packages'));
+            expect(loc['ManifestPath']).toBe(path.join(installRoot, 'current', 'sq.version'));
+            expect(loc['CurrentBinaryDir']).toBe(path.join(installRoot, 'current'));
+            expect(loc['IsPortable']).toBe(false);
+        } else {
+            // Linux AppImage shape — mirrors Velopack 1.0.1's lib-rust
+            // auto_locate_app_manifest. beforeEach() sets APPIMAGE so the
+            // marker check passes and the factory actually runs.
+            const contentsDir = path.join(installRoot, 'usr', 'bin');
+            expect(loc['RootAppDir']).toBe('/fake/WsScrcpyWeb.AppImage');
+            expect(loc['UpdateExePath']).toBe(path.join(contentsDir, 'UpdateNix'));
+            expect(loc['PackagesDir']).toBe('/var/tmp/velopack/WsScrcpyWeb/packages');
+            expect(loc['ManifestPath']).toBe(path.join(contentsDir, 'sq.version'));
+            expect(loc['CurrentBinaryDir']).toBe(contentsDir);
+            expect(loc['IsPortable']).toBe(true);
+        }
     });
 
     it('reconfigure: passes the same locator to the new factory invocation', async () => {
@@ -239,8 +252,10 @@ describe('UpdateService', () => {
         expect(captured.length).toBeGreaterThanOrEqual(2);
         const initLocator = captured[0] as Record<string, unknown>;
         const reconfigLocator = captured[captured.length - 1] as Record<string, unknown>;
-        expect(initLocator['RootAppDir']).toBe(installRoot);
-        expect(reconfigLocator['RootAppDir']).toBe(installRoot);
+        const expectedRootAppDir =
+            process.platform === 'win32' ? installRoot : '/fake/WsScrcpyWeb.AppImage';
+        expect(initLocator['RootAppDir']).toBe(expectedRootAppDir);
+        expect(reconfigLocator['RootAppDir']).toBe(expectedRootAppDir);
         expect(reconfigLocator).toEqual(initLocator);
     });
 


### PR DESCRIPTION
## Summary

Two coupled fixes for v0.1.30 release-pipeline shipping bugs surfaced after the beta.10–18 Linux push on 2026-05-28.

- **`UpdateService` platform-branched `VelopackLocatorConfig`** — Windows kept its existing Squirrel-style `<installRoot>/current/` layout; Linux now mirrors Velopack 1.0.1's lib-rust `auto_locate_app_manifest` Linux branch exactly (`RootAppDir = $APPIMAGE`, `UpdateExePath = <mount>/usr/bin/UpdateNix`, `PackagesDir = /var/tmp/velopack/WsScrcpyWeb/packages`, `ManifestPath = <mount>/usr/bin/sq.version`, `CurrentBinaryDir = <mount>/usr/bin`, `IsPortable = true`). Closes the todo item #26 — the pre-fix single Windows-shape config threw on every Linux AppImage launch because Velopack's locator validates `UpdateNix` existence at the configured path, which masked behind beta.7's PR #216 `mgr === null` guard turned into silent no-op in-app updates for every Linux user.
- **`release.yml` `make_latest: 'legacy'` → `make_latest: true`** — the legacy value caused GitHub's Latest badge to stick at v0.1.30-beta.9 across the entire beta.10–18 push, even though all 9 subsequent releases were `isPrerelease: false` with full 6-asset payloads. Velopack's `GithubSource` queries `/releases/latest` for channel discovery (per the existing comment block above the changed line), so beta.10–18 were invisible to in-app updates. Forcing every publish to claim Latest restores discovery.

## Out-of-band cleanup (not in this PR)

- v0.1.30-beta.3 through v0.1.30-beta.17 GitHub releases deleted (iterative noise that beta.18 absorbs). Tags preserved in git history.
- v0.1.30-beta.18 manually promoted to Latest via `gh release edit ... --latest` to fix discovery immediately while this PR makes the change permanent.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 720/720 pass
- [x] `npm run build` clean
- [ ] **Manual VM smoke (Linux):** install AppImage, click "check for updates" in Settings, observe a feed query against `releases.beta.json` (not a silent no-op). Pre-fix this would hit the `mgr === null` branch and return idle without querying.
- [ ] **Manual smoke (Windows):** install Setup.exe, confirm in-app updates still work (regression check on the unchanged Windows branch).
- [ ] **Next beta release:** confirm GitHub Latest badge moves to the new tag automatically (was the stuck-badge symptom of `make_latest: 'legacy'`).