### PR TITLE
fix(settings): linux scope chooser as standard grid row, not column-spanning fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Settings modal Linux scope chooser now lives in a standard 2-column grid row** matching the update channel row. Description on the left ("service scope"), radios on the right ("user" / "system (req. sudo)"). The pre-v0.1.30 implementation rendered the chooser as a `<fieldset>` spanning both columns, which (a) didn't match any other settings row and (b) starved the install-button row below it of horizontal space on narrower modal widths, causing the button text "not installed — install?" to wrap to two lines. Removed the orphaned `.settings-scope-fieldset` CSS as part of the cleanup.
+
 ### Fixed
 
 - **Linux system-scope service install now triggers the pkexec password prompt as designed.** A stale guard in `ServiceApi.handleInstall` (predating PR #211) returned 403 with the message *"system scope requires root. Relaunch the AppImage with sudo, or pick user scope."* whenever the API received a `scope: 'system'` request from a non-root process — short-circuiting before `SystemdClient.install()` (which was rewritten in PR #211 to elevate via pkexec) was ever reached. The guard was a holdover from when `SystemdClient` also threw on non-root system-scope, "doing it at the API boundary lets us return a clean HTTP error code." `SystemdClient` no longer throws there. Removed the guard so the request falls through to the pkexec path. Paired updates: `AdminConfirmModal.ts` Linux confirmation text rewritten from *"the appimage must be launched with sudo"* to *"polkit will show a password prompt next."* The 403-asserting test in `ServiceApi.test.ts` was inverted to confirm `installFn` IS called with `scope: 'system'` and the API returns 200; pkexec mechanics remain `SystemdClient`'s responsibility.

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -812,14 +812,14 @@ export class SettingsModal extends Modal {
 
         const status = resp.status ?? 'not-installed';
 
-        // Linux scope chooser only when not-installed; spans both columns.
+        // Linux scope chooser only when not-installed. Rendered as a standard
+        // settings row (description left, radios right) matching the update
+        // channel row's pattern. Pre-v0.1.30 this used a fieldset spanning
+        // both columns, which broke the grid alignment of the install button
+        // row below it (button wrapped to two lines on narrower modal widths).
         this.serviceScopeSystemRadio = null;
         if (status === 'not-installed' && resp.platform === 'linux') {
-            const fieldset = document.createElement('fieldset');
-            fieldset.className = 'settings-scope-fieldset';
-            const legend = document.createElement('legend');
-            legend.textContent = 'scope';
-            fieldset.appendChild(legend);
+            const scopeFrag = document.createDocumentFragment();
 
             const userLabel = document.createElement('label');
             userLabel.className = 'settings-radio-label';
@@ -829,8 +829,8 @@ export class SettingsModal extends Modal {
             userRadio.value = 'user';
             userRadio.checked = true;
             userLabel.appendChild(userRadio);
-            userLabel.appendChild(document.createTextNode('just for me (no sudo)'));
-            fieldset.appendChild(userLabel);
+            userLabel.appendChild(document.createTextNode('user'));
+            scopeFrag.appendChild(userLabel);
 
             const sysLabel = document.createElement('label');
             sysLabel.className = 'settings-radio-label';
@@ -839,10 +839,10 @@ export class SettingsModal extends Modal {
             sysRadio.name = 'settings-scope';
             sysRadio.value = 'system';
             sysLabel.appendChild(sysRadio);
-            sysLabel.appendChild(document.createTextNode('all users (requires sudo)'));
-            fieldset.appendChild(sysLabel);
+            sysLabel.appendChild(document.createTextNode('system (req. sudo)'));
+            scopeFrag.appendChild(sysLabel);
 
-            this.serviceSection.appendChild(fieldset);
+            this.serviceSection.appendChild(this.buildRow('service scope', scopeFrag));
             this.serviceScopeSystemRadio = sysRadio;
         }
 

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -725,25 +725,6 @@ dialog.settings-modal .settings-confirm-panel .settings-confirm-buttons {
     justify-content: flex-end;
 }
 
-/* Service section: scope chooser fieldset for Linux installs. */
-dialog.settings-modal .settings-scope-fieldset {
-    grid-column: 1 / -1;
-    margin: 0.25rem 0;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 6px;
-}
-
-[data-theme="light"] dialog.settings-modal .settings-scope-fieldset {
-    border-color: rgba(0, 0, 0, 0.12);
-}
-
-dialog.settings-modal .settings-scope-fieldset legend {
-    padding: 0 0.4rem;
-    font-size: 13px;
-    color: var(--text-color-light, #888);
-}
-
 /* --- Service operation modal (Phase 3) --- */
 
 dialog.service-operation-modal .modal-header-controls {


### PR DESCRIPTION
## Summary

The Settings modal's Linux scope picker rendered as a `<fieldset>` with `grid-column: 1 / -1`, sitting outside the 2-column description/control pattern every other settings row uses. It also visually squeezed the install-button row below it: on narrower modal widths the "not installed — install?" button text wrapped to two lines (visible in the Linux screenshot below).

## Before vs after

**Before** (Linux): scope chooser is a bordered fieldset spanning the full modal width, with two long labels ("just for me (no sudo)" / "all users (requires sudo)"). Install button below wraps to two lines.

**After** (Linux): scope row matches the existing `update channel` row exactly — description "service scope" on the left, two radios "user" / "system (req. sudo)" on the right. Install button row gets full horizontal space back.

**Windows** is unaffected (the scope chooser only renders for Linux installs).

## Changes

- `src/app/client/SettingsModal.ts` — replaced the fieldset block with a `DocumentFragment` containing the two radios, handed to `buildRow('service scope', scopeFrag)`. Labels reuse the existing `.settings-radio-label` class; the `.settings-control` flex layout handles side-by-side positioning (same as update channel's stable/beta radios).
- `src/style/modal.css` — removed the orphaned `.settings-scope-fieldset` rules (dark + light theme + legend selector). No other consumer.
- `CHANGELOG.md` — Unreleased Changed entry.

## Scope notes

- WelcomeModal's Linux scope chooser still uses its own inline-styled fieldset. Out of scope here and visually contained inside its own modal body (no neighbor rows being squeezed). Left alone.
- No new tests — DOM client code has no test harness (tracked under the long-running DOM-client-test-gap memo).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 720/720 pass
- [x] `npm run build` clean
- [ ] **Manual smoke (Linux):** open Settings, scroll to Service. Confirm the scope row matches the update channel row aesthetically. Confirm the install button on the next row no longer wraps to two lines.
- [ ] **Manual smoke (Windows):** open Settings, confirm Service section unchanged (no scope row visible; single install/uninstall button row).