### PR TITLE
feat(settings): always render Linux scope row, show current scope when installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings modal Linux scope chooser now always renders, even when the service is installed.** When the service is installed, the radios are pre-selected from the active install mode (`user-service` → user, `system-service` → system) and disabled — switching scope is still a deliberate uninstall→reinstall operation (systemd user-scope and system-scope unit files can't coexist for the same service name), but now the user can see at a glance which scope they picked. Pre-fix the row was hidden entirely once installed and there was no in-UI way to tell the active scope. Disabled-radio labels render with `opacity: 0.5` + `cursor: not-allowed` via a `:has(input:disabled)` rule. `ServiceStatusResponse` now carries `installMode` so the frontend doesn't need a second endpoint to populate the row.
 - **Settings modal Linux scope chooser now lives in a standard 2-column grid row** matching the update channel row. Description on the left ("service scope"), radios on the right ("user" / "system (req. sudo)"). The pre-v0.1.30 implementation rendered the chooser as a `<fieldset>` spanning both columns, which (a) didn't match any other settings row and (b) starved the install-button row below it of horizontal space on narrower modal widths, causing the button text "not installed — install?" to wrap to two lines. Removed the orphaned `.settings-scope-fieldset` CSS as part of the cleanup.
 
 ### Fixed

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -812,13 +812,24 @@ export class SettingsModal extends Modal {
 
         const status = resp.status ?? 'not-installed';
 
-        // Linux scope chooser only when not-installed. Rendered as a standard
-        // settings row (description left, radios right) matching the update
-        // channel row's pattern. Pre-v0.1.30 this used a fieldset spanning
-        // both columns, which broke the grid alignment of the install button
-        // row below it (button wrapped to two lines on narrower modal widths).
+        // Linux scope chooser: standard settings row matching the update
+        // channel row's pattern. Always rendered on Linux. When the service
+        // is installed, the radios are pre-selected from resp.installMode
+        // and disabled — switching scope requires a deliberate
+        // uninstall→reinstall (systemd user-scope and system-scope unit
+        // files live in different paths and can't coexist for the same
+        // service name). Pre-v0.1.30 the row was only rendered when not
+        // installed, leaving no in-UI way to tell which scope was active.
         this.serviceScopeSystemRadio = null;
-        if (status === 'not-installed' && resp.platform === 'linux') {
+        if (resp.platform === 'linux') {
+            const isInstalled = status !== 'not-installed';
+            const installedScope: 'user' | 'system' | null =
+                resp.installMode === 'system-service'
+                    ? 'system'
+                    : resp.installMode === 'user-service'
+                        ? 'user'
+                        : null;
+
             const scopeFrag = document.createDocumentFragment();
 
             const userLabel = document.createElement('label');
@@ -827,7 +838,8 @@ export class SettingsModal extends Modal {
             userRadio.type = 'radio';
             userRadio.name = 'settings-scope';
             userRadio.value = 'user';
-            userRadio.checked = true;
+            userRadio.checked = isInstalled ? installedScope === 'user' : true;
+            userRadio.disabled = isInstalled;
             userLabel.appendChild(userRadio);
             userLabel.appendChild(document.createTextNode('user'));
             scopeFrag.appendChild(userLabel);
@@ -838,12 +850,17 @@ export class SettingsModal extends Modal {
             sysRadio.type = 'radio';
             sysRadio.name = 'settings-scope';
             sysRadio.value = 'system';
+            sysRadio.checked = isInstalled && installedScope === 'system';
+            sysRadio.disabled = isInstalled;
             sysLabel.appendChild(sysRadio);
             sysLabel.appendChild(document.createTextNode('system (req. sudo)'));
             scopeFrag.appendChild(sysLabel);
 
             this.serviceSection.appendChild(this.buildRow('service scope', scopeFrag));
-            this.serviceScopeSystemRadio = sysRadio;
+            // serviceScopeSystemRadio feeds the install request body; null
+            // it out when installed so the install handler (unreachable in
+            // that state anyway) can't accidentally consume a stale value.
+            this.serviceScopeSystemRadio = isInstalled ? null : sysRadio;
         }
 
         // One row: label = informational blurb (left column, wraps),

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -29,6 +29,13 @@ export interface ServiceStatusResponse {
     diskWebPort?: number | undefined;
     /** config.json filesystem mtime in epoch milliseconds. Present when supported=true. */
     configMtime?: number | undefined;
+    /**
+     * Snapshot of `AppConfig.installMode` at status time. Lets the frontend
+     * tell which service scope is active (`user-service` vs `system-service`)
+     * without poking a second endpoint. `null` when never installed. Present
+     * when supported=true.
+     */
+    installMode?: 'user' | 'system' | 'user-service' | 'system-service' | null;
 }
 
 /** Success response shape for /api/service/install and /api/service/uninstall. */
@@ -113,8 +120,9 @@ export type ServiceUninstallResponse = ServiceActionSuccess | ServiceActionFailu
  * - On **Linux**, `scope` selects between user-level (`~/.config/systemd/user/`,
  *   no sudo) and system-level (`/etc/systemd/system/`, requires root) systemd
  *   units. Defaults to `'user'` when omitted. If `scope === 'system'` and the
- *   server isn't running as root, the API returns HTTP 403 with a descriptive
- *   error.
+ *   server isn't running as root, `SystemdClient.install()` elevates via
+ *   pkexec (single graphical password prompt covers cp + daemon-reload +
+ *   enable). The API itself stays unelevated.
  * - On **Windows**, `scope` is IGNORED — the install scope is auto-detected
  *   from `process.execPath` (Per-Machine vs Per-User) at install time.
  */

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -174,6 +174,27 @@ describe('ServiceApi', () => {
         expect(body.configMtime).toBeGreaterThan(0);
     });
 
+    it('GET /status surfaces installMode so the frontend can show the active scope', async () => {
+        // The settings modal uses this to pre-select + disable the scope
+        // radios when a Linux service is already installed. Round-trip the
+        // config value through the status endpoint to confirm it lands in
+        // the response body (not gated by platform).
+        const cfg = Config.getInstance();
+        cfg.updateAppConfig({ installMode: 'system-service' });
+
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'linux',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user');
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.installMode).toBe('system-service');
+    });
+
     it('POST /install returns 501 with unsupportedReason on unsupported platforms', async () => {
         const factoryResult: ServiceClientFactoryResult = {
             client: fakeClient(),

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -113,10 +113,12 @@ export class ServiceApi {
         }
         const status = await result.client.status(WS_SCRCPY_SERVICE_NAME);
         const disk = this.readDiskConfig();
+        const installMode = Config.getInstance().getAppConfig().installMode;
         const body: ServiceStatusResponse = {
             supported: true,
             platform: result.platform,
             status,
+            installMode,
             ...(disk.diskWebPort != null ? { diskWebPort: disk.diskWebPort } : {}),
             ...(disk.configMtime != null ? { configMtime: disk.configMtime } : {}),
         };

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -599,6 +599,17 @@ dialog.settings-modal .settings-control .settings-radio-label {
 }
 
 /*
+ * Disabled radio (e.g. service scope while installed): mute the whole
+ * label, not just the radio circle, so the read-only state reads at a
+ * glance. :has() is supported in the AppImage's bundled webview
+ * (Chrome 105+ / Firefox 121+ / Safari 15.4+).
+ */
+dialog.settings-modal .settings-control .settings-radio-label:has(input:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/*
  * Apply-update button styling — green outline + green text — mirroring
  * the home-page UpdateButton chip's "ready" state. Higher specificity
  * than .settings-btn-primary so it overrides when both classes are


### PR DESCRIPTION
## Summary

Pre-fix the Settings modal's Linux scope chooser was gated on `status === 'not-installed'`, so once a service was installed the user had no in-UI way to tell whether they were running on user-scope or system-scope. The only way to check was reading `config.json` or inspecting the filesystem.

Now the scope row always renders on Linux. When the service IS installed:

- Radios pre-selected from `resp.installMode` (`user-service` → user, `system-service` → system).
- Both radios disabled (`input.disabled = true`).
- Whole label muted via `.settings-radio-label:has(input:disabled)` (opacity 0.5 + cursor not-allowed) so the read-only state reads at a glance.

Switching scope still requires a deliberate uninstall → reinstall — systemd user-scope and system-scope unit files can't coexist for the same service name. The disabled radios communicate *"this is what's installed; uninstall first to change"* without offering a misleading interaction.

## Plumbing

- `ServiceStatusResponse` extended with `installMode?: 'user' | 'system' | 'user-service' | 'system-service' | null`. Lets the frontend pre-select the row without a second endpoint hit.
- `ServiceApi.handleStatus` now populates `installMode` from `Config.getInstance().getAppConfig().installMode`.
- New positive test confirms the round-trip.

## Companion cleanup

- `ServiceInstallRequest`'s jsdoc still said system-scope from non-root returned 403. Updated to point at the pkexec elevation path (PR #211 + PR #231) — caught while editing the same file, cheaper to land here than as its own PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 721/721 pass (+1 new)
- [x] `npm run build` clean
- [ ] **Manual smoke (Linux user scope):** install user-scope service. Reopen Settings. Expect the scope row to show "user" selected, "system (req. sudo)" deselected, both grayed out.
- [ ] **Manual smoke (Linux system scope):** install system-scope service. Reopen Settings. Expect "system (req. sudo)" selected, "user" deselected, both grayed out.
- [ ] **Manual smoke (Linux not-installed):** with no service installed, expect both radios enabled with "user" pre-selected (current behavior).
- [ ] **Manual smoke (Windows):** scope row should not render at all (current behavior, no regression).