### PR TITLE
fix(settings): flex controls column to fill modal width on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Settings modal controls column now flexes to fill remaining width** (`grid-template-columns: [labels] 20rem [controls] 1fr` — was `[labels] 20rem [controls] 16rem [end] 1fr`). The pre-fix fixed 16rem controls column was sized against Windows font rendering ("not installed — install?" ≈ 231px at 13px monospace, fit). On Linux 1920x1080 unscaled the same monospace string renders ~10% wider and wrapped to two lines, along with "system (req. sudo)" radios and other steady-state controls. Flexing controls to `1fr` gives Linux the breathing room without affecting Windows visually (controls hug left via `.settings-control justify-content: flex-start`; extra width on Windows is just empty space to the right of each control).
+- **Server section label tightened** from "save restarts & redirects to new port" to "save restarts & redirects" — the "to new port" suffix is implicit (saving the port field obviously redirects to that port) and was the longest steady-state label string, putting pressure on the 20rem labels column on Linux.
+
 ## [0.1.30-beta.19] - 2026-05-28
 
 ### Changed

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -169,7 +169,7 @@ export class SettingsModal extends Modal {
             void this.onSavePort();
         });
         const { row: saveRow, labelEl: saveLabelEl } = this.buildDynamicLabelRow(
-            'save restarts & redirects to new port',
+            'save restarts & redirects',
             this.serverSaveBtn,
         );
         body.appendChild(saveRow);
@@ -194,7 +194,7 @@ export class SettingsModal extends Modal {
             // Default note: explain the redirect-on-save behavior so the
             // user knows clicking save isn't a static config change but a
             // server restart with auto-redirect to the new URL.
-            this.setServerStatus('save restarts & redirects to new port');
+            this.setServerStatus('save restarts & redirects');
         } catch {
             this.setServerStatus("couldn't reach server", true);
         }

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -537,17 +537,18 @@ dialog.settings-modal .settings-section-heading {
  */
 dialog.settings-modal .settings-section-body {
     display: grid;
-    /* Labels and controls tracks are both fixed-width so the controls
-       column never shifts when dynamic label text changes (status
-       messages, version strings, etc.) or when button text changes
-       (install/uninstall states). 20rem labels fits all steady-state
-       label strings ("save restarts & redirects to new port" ≈ 308px
-       at 13px monospace) with cushion. 16rem controls fits the widest
-       steady-state button text ("not installed — install?" ≈ 231px)
-       without wrap. The trailing 1fr dumps the small remaining width
-       on the right of the controls so the controls column sits a
-       touch left of the modal's right edge. */
-    grid-template-columns: [labels] 20rem [controls] 16rem [end] 1fr;
+    /* Labels fixed at 20rem so the controls boundary doesn't shift when
+       dynamic label text changes (status messages, version strings) or
+       when button text changes (install/uninstall states). Controls
+       take 1fr (was 16rem + [end] 1fr buffer pre-2026-05-28). The fixed
+       16rem controls column was sized against Windows font rendering
+       ("not installed — install?" ≈ 231px at 13px monospace, fit) but
+       wrapped on Linux 1920x1080 unscaled where the same monospace
+       string renders ~10% wider. Flexing controls to 1fr gives Linux
+       the breathing room without affecting Windows (controls hug left
+       via .settings-control justify-content: flex-start, so the extra
+       width on Windows is just empty space to the right of each control). */
+    grid-template-columns: [labels] 20rem [controls] 1fr;
     align-items: center;
     gap: 0.5rem 1rem;
 }


### PR DESCRIPTION
## Summary

Two coupled changes addressing the Linux modal squeeze where steady-state controls ("not installed — install?", "system (req. sudo)", scope radio labels) wrapped to two lines on 1920x1080 unscaled.

**Screenshot comparison from v0.1.30-beta.19 smoke:** Windows renders all controls on one line; Linux wrapped multiple rows because the fixed 16rem controls column was sized against Windows monospace metrics.

## Changes

- **`src/style/modal.css`:** `.settings-section-body` grid columns change from `[labels] 20rem [controls] 16rem [end] 1fr` to `[labels] 20rem [controls] 1fr`. The 16rem controls column was sized against Windows rendering of "not installed — install?" (~231px); Linux renders the same string ~10% wider and tipped over the 16rem limit. Flexing controls to `1fr` (eating the prior `[end] 1fr` buffer) gives Linux the breathing room. Windows is visually unchanged — `.settings-control justify-content: flex-start` keeps controls hugging left, so the extra width on Windows is just empty space to the right of each control. CSS comment rewritten to document the change.
- **`src/app/client/SettingsModal.ts`:** server row label tightened from `"save restarts & redirects to new port"` → `"save restarts & redirects"` (both the `buildDynamicLabelRow` call and the `setServerStatus` message). "to new port" is implicit since the row sits directly below the port input. This was also the longest steady-state label string and was putting pressure on the 20rem labels column on Linux (wrapping to two lines in the same screenshot).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 721/721 pass
- [x] `npm run build` clean
- [ ] **Manual smoke (Linux):** open Settings on a 1920x1080 unscaled Linux box. Confirm controls column controls fit on one line each; confirm "save restarts & redirects" no longer wraps; confirm Windows look unchanged when smoked side-by-side.

## Process note

This is the first PR opened with `--label "release:beta"` at creation via the new `pre-gh-pr-create-release-label-check` PreToolUse hook (registered in `~/.claude/settings.json` 2026-05-28). Hook hard-denies `gh pr create` against release-pipeline repos without a `release:*` label. Auto-release will fire Mode 1 on merge → bump to v0.1.30-beta.20.