### PR TITLE
fix(linux): Velopack auto-locate, systemd ExecStart, and scope reporting

### DIFF
--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -823,12 +823,21 @@ export class SettingsModal extends Modal {
         this.serviceScopeSystemRadio = null;
         if (resp.platform === 'linux') {
             const isInstalled = status !== 'not-installed';
-            const installedScope: 'user' | 'system' | null =
-                resp.installMode === 'system-service'
+            // Prefer the authoritative filesystem scope (which systemd unit
+            // exists) reported by the status endpoint. Fall back to mapping the
+            // installMode config — accepting BOTH the bare ('user'/'system')
+            // and '-service' forms — for older servers that don't report scope.
+            // The pre-fix code only mapped the two '-service' forms and trusted
+            // the mutable installMode, so a drifted/reverted value left both
+            // radios unselected even with a service installed.
+            const scopeFromInstallMode: 'user' | 'system' | null =
+                resp.installMode === 'system-service' || resp.installMode === 'system'
                     ? 'system'
-                    : resp.installMode === 'user-service'
+                    : resp.installMode === 'user-service' || resp.installMode === 'user'
                         ? 'user'
                         : null;
+            const installedScope: 'user' | 'system' | null =
+                resp.scope === 'user' || resp.scope === 'system' ? resp.scope : scopeFromInstallMode;
 
             const scopeFrag = document.createDocumentFragment();
 

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -36,6 +36,16 @@ export interface ServiceStatusResponse {
      * when supported=true.
      */
     installMode?: 'user' | 'system' | 'user-service' | 'system-service' | null;
+    /**
+     * Actual installed scope resolved from the filesystem (which systemd unit
+     * file exists), NOT inferred from the mutable `installMode`. This is the
+     * authoritative source for pre-selecting the Linux scope radio when a
+     * service is installed: `installMode` can drift (reverted on failed
+     * installs / uninstall paths) and leave the UI unable to tell which scope
+     * is active. `null` when not installed or unresolvable. Linux-only —
+     * omitted on Windows, where scope is auto-detected from execPath.
+     */
+    scope?: 'user' | 'system' | null;
 }
 
 /** Success response shape for /api/service/install and /api/service/uninstall. */

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -53,6 +53,13 @@ export interface UpdateServiceOptions {
     setIntervalFn?: (cb: () => void, ms: number) => NodeJS.Timeout;
     /** Override timer cancellation for tests. */
     clearIntervalFn?: (handle: NodeJS.Timeout) => void;
+    /**
+     * Override the host platform for tests. Default: `process.platform`.
+     * Lets the Windows/Linux locator branches be exercised on any host — the
+     * original Linux locator bug (doubled `usr/usr/bin`) slipped through
+     * because tests only ever ran the host-platform branch.
+     */
+    platform?: NodeJS.Platform;
 }
 
 export interface UpdateServiceState {
@@ -89,7 +96,8 @@ export class UpdateService {
     private state: UpdateServiceState;
     private timer: NodeJS.Timeout | null = null;
     private readonly installRoot: string;
-    private readonly locator: VelopackLocatorConfig;
+    private readonly platform: NodeJS.Platform;
+    private readonly locator: VelopackLocatorConfig | undefined;
     private readonly factory: UpdateManagerFactory;
     private readonly feedUrlOverride: string | undefined;
     private readonly existsSync: (p: string) => boolean;
@@ -97,6 +105,7 @@ export class UpdateService {
     private readonly clearIntervalFn: (handle: NodeJS.Timeout) => void;
 
     constructor(opts: UpdateServiceOptions = {}) {
+        this.platform = opts.platform ?? process.platform;
         // v0.1.15: anchor installRoot at the webpack bundle's location, not
         // at process.execPath. Our launcher resolves the Node binary to
         // <base>/current/seed/node/node.exe (first run) or
@@ -109,28 +118,43 @@ export class UpdateService {
         // and dependencies/. Same pattern as the v0.1.10 scrcpy-server seed
         // path fix in DependencyManager.ts.
         this.installRoot = opts.installRoot ?? path.resolve(__dirname, '..', '..');
-        // Phase 2 of Program Files migration: explicitly hand Velopack the
-        // install paths via VelopackLocatorConfig instead of relying on its
-        // env-var-driven auto-locate. Computed once — installRoot is
-        // immutable for the lifetime of the service.
+        // Velopack locator strategy is platform-split:
         //
-        // v0.1.30: branch by platform. Windows uses the Squirrel-style
-        // `<installRoot>/current/` swap layout. Linux AppImage mirrors
-        // Velopack 1.0.1's lib-rust `auto_locate_app_manifest` (Linux
-        // branch in src/lib-rust/src/locator.rs):
-        //   RootAppDir       = $APPIMAGE (the .AppImage file path)
-        //   UpdateExePath    = <mount>/usr/bin/UpdateNix
-        //   PackagesDir      = /var/tmp/velopack/<packId>/packages
-        //   ManifestPath     = <mount>/usr/bin/sq.version
-        //   CurrentBinaryDir = <mount>/usr/bin
-        //   IsPortable       = true
-        // installRoot resolves to the AppImage mount root inside the bundle
-        // (webpack outputs to <mount>/usr/bin/dist/index.js; ../.. = <mount>).
-        // Pre-v0.1.30 the single Windows-shape config threw on Linux because
-        // Velopack's Linux locator validates UpdateNix existence at the
-        // configured path; PR #216's `mgr === null` reconfigure guard masked
-        // the throw. Both halves of the fix land together here.
-        if (process.platform === 'win32') {
+        //   Windows — hand Velopack an explicit VelopackLocatorConfig. Phase 2
+        //   of the Program Files migration: once the PerMachine MSI moved the
+        //   install to C:\Program Files\WsScrcpyWeb\, Velopack's env-var-driven
+        //   auto-locate stopped finding the install root reliably, so we
+        //   compute the Squirrel-style `<installRoot>/current/` swap layout
+        //   ourselves. Computed once — installRoot is immutable for the
+        //   service's lifetime.
+        //
+        //   Linux — DO NOT pass a locator; delegate to Velopack's native
+        //   auto_locate_app_manifest (lib-rust/src/locator.rs). Given $APPIMAGE
+        //   it truncates the exe path at the `/usr/bin/` boundary to find the
+        //   AppImage mount root, then derives everything itself:
+        //     CurrentBinaryDir = <mount>/usr/bin
+        //     UpdateExePath    = <mount>/usr/bin/UpdateNix
+        //     ManifestPath     = <mount>/usr/bin/sq.version
+        //     PackagesDir      = /var/tmp/velopack/<packId>/packages
+        //   The velopack Node binding (node_modules/velopack/lib/index.js)
+        //   forwards `null` to the native FFI whenever the locator arg is
+        //   falsy, which is exactly what enables auto-locate. init() only
+        //   constructs the manager when APPIMAGE is set, so auto-locate always
+        //   has the data it needs.
+        //
+        //   Why not a hand-built Linux locator: beta.7 (PR #216) masked a Linux
+        //   construction throw with a `mgr === null` guard; beta.19 (PR #230)
+        //   then hand-built the config from `path.resolve(__dirname,'..','..')`.
+        //   But that Windows-shaped arithmetic is off by one level on Linux —
+        //   the AppImage payload sits at <mount>/usr/bin/dist (one deeper than
+        //   Windows' <root>/current/dist), so installRoot resolved to
+        //   <mount>/usr and `path.join(installRoot,'usr','bin')` produced a
+        //   DOUBLED <mount>/usr/usr/bin. Velopack couldn't find UpdateNix or
+        //   sq.version there, construction threw, the init() catch nulled mgr,
+        //   and every update check silently no-oped (the "beta.19 still doesn't
+        //   fix Linux updates" report). Letting Velopack locate itself removes
+        //   the entire arithmetic-drift failure mode.
+        if (this.platform === 'win32') {
             this.locator = {
                 RootAppDir: this.installRoot,
                 UpdateExePath: path.join(this.installRoot, 'Update.exe'),
@@ -146,21 +170,8 @@ export class UpdateService {
                 IsPortable: false,
             };
         } else {
-            // Linux AppImage. APPIMAGE may be empty/unset in dev mode — the
-            // locator is only handed to Velopack inside init() when the
-            // production-marker check (APPIMAGE non-empty) passes, so an
-            // invalid locator here is safely unused. packId is fixed by the
-            // `vpk pack --packId WsScrcpyWeb` invocation in release.yml.
-            const appImagePath = process.env['APPIMAGE'] ?? '';
-            const contentsDir = path.join(this.installRoot, 'usr', 'bin');
-            this.locator = {
-                RootAppDir: appImagePath,
-                UpdateExePath: path.join(contentsDir, 'UpdateNix'),
-                PackagesDir: '/var/tmp/velopack/WsScrcpyWeb/packages',
-                ManifestPath: path.join(contentsDir, 'sq.version'),
-                CurrentBinaryDir: contentsDir,
-                IsPortable: true,
-            };
+            // Non-Windows (Linux AppImage): undefined → Velopack auto-locates.
+            this.locator = undefined;
         }
         this.factory = opts.updateManagerFactory ?? defaultUpdateManagerFactory;
         this.feedUrlOverride = opts.feedUrlOverride;
@@ -207,7 +218,7 @@ export class UpdateService {
         //
         // Detect production mode: Update.exe on Windows, APPIMAGE env on Linux.
         let markerExists: boolean;
-        if (process.platform === 'win32') {
+        if (this.platform === 'win32') {
             const markerPath = path.join(this.installRoot, 'Update.exe');
             markerExists = this.existsSync(markerPath);
             if (!markerExists) {

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -195,6 +195,27 @@ describe('ServiceApi', () => {
         expect(body.installMode).toBe('system-service');
     });
 
+    it('GET /status surfaces the filesystem scope from client.getInstalledScope', async () => {
+        // Bug fix: the Linux scope radio must reflect the actual installed unit
+        // (filesystem truth), not the mutable installMode. ServiceApi calls
+        // getInstalledScope when the client implements it (SystemdClient only).
+        const client = fakeClient({
+            status: vi.fn(async () => 'stopped' as const),
+            getInstalledScope: vi.fn(async () => 'user' as const),
+        });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'linux',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user');
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.scope).toBe('user');
+        expect(client.getInstalledScope).toHaveBeenCalledWith('WsScrcpyWeb');
+    });
+
     it('POST /install returns 501 with unsupportedReason on unsupported platforms', async () => {
         const factoryResult: ServiceClientFactoryResult = {
             client: fakeClient(),
@@ -620,6 +641,42 @@ describe('ServiceApi', () => {
             expect((res as any).getStatus()).toBe(200);
             const opts = installFn.mock.calls[0]?.[0];
             expect(opts?.scope).toBe('user');
+        });
+
+        it('POST /install on Linux uses $APPIMAGE as binPath (stable systemd ExecStart)', async () => {
+            // The server runs as a Node child of the launcher, so
+            // process.execPath is the Node binary — using it as ExecStart would
+            // start Node with no script (REPL/immediate-exit under systemd) and
+            // the service would never bind a port. ExecStart must be the stable
+            // .AppImage entry exposed via $APPIMAGE.
+            const savedAppImage = process.env['APPIMAGE'];
+            process.env['APPIMAGE'] = '/home/jamie/Applications/WsScrcpyWeb.AppImage';
+            try {
+                const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
+                const client = fakeClient({
+                    install: installFn,
+                    status: vi.fn(async () => 'running' as const),
+                });
+                const factoryResult: ServiceClientFactoryResult = {
+                    client,
+                    supported: true,
+                    platform: 'linux',
+                };
+                const api = new ServiceApi(() => factoryResult, () => 'user');
+                const { req, res } = makeReqRes(
+                    '/api/service/install',
+                    'POST',
+                    JSON.stringify({ scope: 'user' }),
+                );
+                await api.handle(req, res);
+                expect((res as any).getStatus()).toBe(200);
+                const opts = installFn.mock.calls[0]?.[0];
+                expect(opts?.binPath).toBe('/home/jamie/Applications/WsScrcpyWeb.AppImage');
+                expect(opts?.startupDir).toBe('/home/jamie/Applications');
+            } finally {
+                if (savedAppImage === undefined) delete process.env['APPIMAGE'];
+                else process.env['APPIMAGE'] = savedAppImage;
+            }
         });
     });
 

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -230,6 +230,31 @@ describe('SystemdClient', () => {
         });
     });
 
+    describe('getInstalledScope', () => {
+        // Match against the client's own path methods (not hardcoded strings) so
+        // the mock comparison survives path.join's platform-specific separator
+        // on the Windows dev host.
+        it("returns 'user' when the user-scope unit file exists", async () => {
+            const client = new SystemdClient();
+            const userPath = client.userUnitPath('WsScrcpyWeb');
+            existsSyncMock.mockImplementation((p: string) => p === userPath);
+            expect(await client.getInstalledScope('WsScrcpyWeb')).toBe('user');
+        });
+
+        it("returns 'system' when only the system-scope unit file exists", async () => {
+            const client = new SystemdClient();
+            const systemPath = client.systemUnitPath('WsScrcpyWeb');
+            existsSyncMock.mockImplementation((p: string) => p === systemPath);
+            expect(await client.getInstalledScope('WsScrcpyWeb')).toBe('system');
+        });
+
+        it('returns null when no unit file exists', async () => {
+            existsSyncMock.mockReturnValue(false);
+            const client = new SystemdClient();
+            expect(await client.getInstalledScope('WsScrcpyWeb')).toBeNull();
+        });
+    });
+
     describe('status', () => {
         it("returns 'not-installed' when neither unit file exists", async () => {
             existsSyncMock.mockReturnValue(false);

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -190,9 +190,16 @@ describe('UpdateService', () => {
         expect(captured[0]).toBe('https://internal.example/feed/');
     });
 
-    // ── VelopackLocator override (Phase 2 of Program Files migration) ──
+    // ── VelopackLocator strategy (platform-split) ──────────────────────────
+    //
+    // Windows hands Velopack an explicit locator (Program Files migration).
+    // Linux passes NO locator and delegates to Velopack's native
+    // auto_locate_app_manifest. `platform` is injected so BOTH branches run on
+    // any host — the original doubled-`usr/usr/bin` Linux locator bug (beta.19 /
+    // PR #230) slipped through because tests only ever ran the host-platform
+    // branch with an injected installRoot, never the real __dirname arithmetic.
 
-    it('init: passes a VelopackLocatorConfig to the factory shaped for the host platform', () => {
+    it('init (win32): passes an explicit Windows VelopackLocatorConfig', () => {
         const installRoot = path.join('/fake', 'install', 'root');
         let receivedLocator: unknown;
         const factory = vi.fn((_feed: string, _opts: UpdateOptions, locator?: unknown) => {
@@ -200,6 +207,7 @@ describe('UpdateService', () => {
             return fakeMgr();
         });
         const svc = new UpdateService({
+            platform: 'win32',
             installRoot,
             existsSync: () => true,
             updateManagerFactory: factory,
@@ -210,53 +218,72 @@ describe('UpdateService', () => {
 
         expect(receivedLocator).toBeDefined();
         const loc = receivedLocator as Record<string, unknown>;
-        if (process.platform === 'win32') {
-            expect(loc['RootAppDir']).toBe(installRoot);
-            expect(loc['UpdateExePath']).toBe(path.join(installRoot, 'Update.exe'));
-            expect(loc['PackagesDir']).toBe(path.join(installRoot, 'packages'));
-            expect(loc['ManifestPath']).toBe(path.join(installRoot, 'current', 'sq.version'));
-            expect(loc['CurrentBinaryDir']).toBe(path.join(installRoot, 'current'));
-            expect(loc['IsPortable']).toBe(false);
-        } else {
-            // Linux AppImage shape — mirrors Velopack 1.0.1's lib-rust
-            // auto_locate_app_manifest. beforeEach() sets APPIMAGE so the
-            // marker check passes and the factory actually runs.
-            const contentsDir = path.join(installRoot, 'usr', 'bin');
-            expect(loc['RootAppDir']).toBe('/fake/WsScrcpyWeb.AppImage');
-            expect(loc['UpdateExePath']).toBe(path.join(contentsDir, 'UpdateNix'));
-            expect(loc['PackagesDir']).toBe('/var/tmp/velopack/WsScrcpyWeb/packages');
-            expect(loc['ManifestPath']).toBe(path.join(contentsDir, 'sq.version'));
-            expect(loc['CurrentBinaryDir']).toBe(contentsDir);
-            expect(loc['IsPortable']).toBe(true);
-        }
+        expect(loc['RootAppDir']).toBe(installRoot);
+        expect(loc['UpdateExePath']).toBe(path.join(installRoot, 'Update.exe'));
+        expect(loc['PackagesDir']).toBe(path.join(installRoot, 'packages'));
+        expect(loc['ManifestPath']).toBe(path.join(installRoot, 'current', 'sq.version'));
+        expect(loc['CurrentBinaryDir']).toBe(path.join(installRoot, 'current'));
+        expect(loc['IsPortable']).toBe(false);
     });
 
-    it('reconfigure: passes the same locator to the new factory invocation', async () => {
-        const installRoot = '/fake/install/root';
-        const captured: unknown[] = [];
+    it('init (linux): passes NO locator — delegates to Velopack auto-locate', () => {
+        // beforeEach sets APPIMAGE so the Linux production-marker check passes
+        // and the factory actually runs.
+        let called = false;
+        let receivedLocator: unknown = 'sentinel';
         const factory = vi.fn((_feed: string, _opts: UpdateOptions, locator?: unknown) => {
-            captured.push(locator);
+            called = true;
+            receivedLocator = locator;
             return fakeMgr();
         });
         const svc = new UpdateService({
-            installRoot,
+            platform: 'linux',
+            installRoot: path.join('/fake', 'install', 'root'),
             existsSync: () => true,
             updateManagerFactory: factory,
             setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
             clearIntervalFn: () => undefined,
         });
         svc.init();
-        await svc.reconfigure('beta', 'a-different-owner');
 
-        // init + reconfigure both invoked the factory; both got the locator.
-        expect(captured.length).toBeGreaterThanOrEqual(2);
-        const initLocator = captured[0] as Record<string, unknown>;
-        const reconfigLocator = captured[captured.length - 1] as Record<string, unknown>;
-        const expectedRootAppDir =
-            process.platform === 'win32' ? installRoot : '/fake/WsScrcpyWeb.AppImage';
-        expect(initLocator['RootAppDir']).toBe(expectedRootAppDir);
-        expect(reconfigLocator['RootAppDir']).toBe(expectedRootAppDir);
-        expect(reconfigLocator).toEqual(initLocator);
+        expect(called).toBe(true);
+        // undefined → the velopack binding forwards `null` to the native FFI,
+        // triggering auto_locate_app_manifest. Any hand-built locator here
+        // reintroduces the beta.19 doubled-`usr/usr/bin` failure.
+        expect(receivedLocator).toBeUndefined();
+    });
+
+    it('reconfigure: re-passes the platform-appropriate locator on both platforms', async () => {
+        for (const platform of ['win32', 'linux'] as const) {
+            const installRoot = path.join('/fake', 'install', 'root');
+            const captured: unknown[] = [];
+            const factory = vi.fn((_feed: string, _opts: UpdateOptions, locator?: unknown) => {
+                captured.push(locator);
+                return fakeMgr();
+            });
+            const svc = new UpdateService({
+                platform,
+                installRoot,
+                existsSync: () => true,
+                updateManagerFactory: factory,
+                setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+                clearIntervalFn: () => undefined,
+            });
+            svc.init();
+            await svc.reconfigure('beta', 'a-different-owner');
+
+            // init + reconfigure both invoked the factory.
+            expect(captured.length).toBeGreaterThanOrEqual(2);
+            const initLocator = captured[0];
+            const reconfigLocator = captured[captured.length - 1];
+            if (platform === 'win32') {
+                expect((initLocator as Record<string, unknown>)['RootAppDir']).toBe(installRoot);
+                expect(reconfigLocator).toEqual(initLocator);
+            } else {
+                expect(initLocator).toBeUndefined();
+                expect(reconfigLocator).toBeUndefined();
+            }
+        }
     });
 
     // ── checkForUpdates ─────────────────────────────────────────────────

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -114,11 +114,19 @@ export class ServiceApi {
         const status = await result.client.status(WS_SCRCPY_SERVICE_NAME);
         const disk = this.readDiskConfig();
         const installMode = Config.getInstance().getAppConfig().installMode;
+        // Authoritative installed scope from the filesystem (which systemd unit
+        // exists), independent of the mutable installMode. Only SystemdClient
+        // implements getInstalledScope; Windows omits it (scope auto-detected
+        // from execPath there, and the scope radios are Linux-only in the UI).
+        const scope = result.client.getInstalledScope
+            ? await result.client.getInstalledScope(WS_SCRCPY_SERVICE_NAME)
+            : undefined;
         const body: ServiceStatusResponse = {
             supported: true,
             platform: result.platform,
             status,
             installMode,
+            ...(scope !== undefined ? { scope } : {}),
             ...(disk.diskWebPort != null ? { diskWebPort: disk.diskWebPort } : {}),
             ...(disk.configMtime != null ? { configMtime: disk.configMtime } : {}),
         };
@@ -210,11 +218,28 @@ export class ServiceApi {
             binPath = launcherExe;
             startupDir = installRoot;
         } else {
-            // Linux: SystemdClient takes the launcher binary directly via
-            // process.execPath (the AppImage entrypoint). Working directory
-            // is the launcher's parent dir.
-            binPath = process.execPath;
-            startupDir = path.dirname(process.execPath);
+            // Linux: the systemd unit must point at a STABLE entry that
+            // launches the WHOLE app. The server runs as a Node CHILD of the
+            // launcher (launcher/src/spawn.rs spawns `node dist/index.js`), so
+            // process.execPath here is the Node binary — using it as ExecStart
+            // would start Node with no script (REPL; under systemd's /dev/null
+            // stdin it reads EOF and exits immediately), the exact failure the
+            // win32 branch above warns about. The service would never bind or
+            // auto-shift a web port, the install-flow redirect poll would never
+            // see a config change, and status would read "stopped".
+            //
+            // For an AppImage the stable entry is the .AppImage file itself,
+            // exposed by the runtime as $APPIMAGE (the same env UpdateService
+            // keys production-mode detection off). Running it re-mounts and runs
+            // the launcher, which spawns the server and binds the web port,
+            // auto-shifting +1 on collision (PortPicker / reconcileWebPort) and
+            // persisting the new port to config.json — which is what the
+            // frontend's post-install poll watches. Fall back to
+            // process.execPath for non-AppImage / from-source runs where
+            // $APPIMAGE is unset.
+            const appImagePath = process.env['APPIMAGE'];
+            binPath = appImagePath && appImagePath.length > 0 ? appImagePath : process.execPath;
+            startupDir = path.dirname(binPath);
         }
 
         // v0.1.24-beta.7: service.log moves under <dataRoot>/logs/ to

--- a/src/server/service/ServiceClient.ts
+++ b/src/server/service/ServiceClient.ts
@@ -94,6 +94,13 @@ export interface ServiceClient {
     status(name: string): Promise<ServiceStatus>;
     restart(name: string): Promise<void>;
     stop(name: string): Promise<void>;
+    /**
+     * Resolve the actual installed scope from the filesystem (which unit file
+     * exists), independent of any config value. Optional: only SystemdClient
+     * implements it (Linux user-vs-system scope). Windows is always Local
+     * System, so ServyClient omits it and the API reports no scope.
+     */
+    getInstalledScope?(name: string): Promise<'user' | 'system' | null>;
 }
 
 /**

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -242,6 +242,17 @@ export class SystemdClient implements ServiceClient {
         return null;
     }
 
+    /**
+     * Public accessor for the active scope (which unit file exists on disk).
+     * Surfaced through `/api/service/status` so the frontend can pre-select the
+     * Linux scope radio from filesystem truth rather than the mutable
+     * `installMode` config (which can drift / be reverted). `null` when no unit
+     * file exists for `name`.
+     */
+    public async getInstalledScope(name: string): Promise<SystemdScope | null> {
+        return this.resolveActiveScope(name);
+    }
+
     public async install(opts: ServiceInstallOptions): Promise<void> {
         const scope = opts.scope;
         if (!scope) {


### PR DESCRIPTION
## Summary
Three Linux-only fixes found testing v0.1.30-beta.20. They share a pattern: code that assumed a value would change/resolve one way — true on Windows, false on the Linux AppImage.

### 1. In-app updates silently no-op on Linux (item #26)
`UpdateService` hand-built a `VelopackLocatorConfig` on Linux from `path.resolve(__dirname, '..', '..')`. That arithmetic is Windows-shaped: the Windows bundle is `<root>/current/dist`, but the AppImage nests the payload one level deeper at `<mount>/usr/bin/dist`, so `../..` lands on `<mount>/usr` and `path.join(installRoot,'usr','bin')` produced a **doubled** `<mount>/usr/usr/bin`. Velopack couldn't find `UpdateNix`/`sq.version`, `UpdateManager` threw, `init()`'s catch nulled `mgr`, and every check silently no-oped. beta.19 (#230) introduced this exact arithmetic.

**Fix:** on Linux pass **no** locator and let Velopack's native `auto_locate_app_manifest` derive paths from `$APPIMAGE` (the Node binding forwards a falsy locator as `null` → auto-locate). Windows keeps its explicit locator.

### 2. Service install "couldn't find the new port"; service stays stopped
The Linux systemd unit's `ExecStart` was `process.execPath` = the **Node binary** (the server runs as a Node child of the launcher, `spawn.rs`). Under systemd, `node` with no script reads EOF on `/dev/null` stdin and exits → the service never starts, never binds/auto-shifts a port → the install-flow redirect poll never sees a `config.json` change → "port discovery timed out." Exactly the trap the Windows branch documents and avoids.

**Fix:** use the stable `$APPIMAGE` entry as `ExecStart` (running it re-mounts + runs the launcher → server binds + auto-shifts via PortPicker). Falls back to `process.execPath` for from-source runs. Covers **user and system** scope.

### 3. Service scope radios greyed + neither selected
The settings modal inferred scope only from the mutable `installMode`, recognizing just the two `-service` forms. `/api/service/status` now reports the **authoritative** scope from `SystemdClient.resolveActiveScope()` (which unit file exists on disk) via a new optional `ServiceClient.getInstalledScope()`; the client selects the radio from that, falling back to mapping all four `installMode` forms.

## Tests
- Platform-injection seam on `UpdateService` so both locator branches are unit-tested on any host (the original bug hid because tests only ran the host-platform branch).
- Added the missing Linux `binPath` assertion in `ServiceApi` tests + `getInstalledScope` coverage.
- `tsc --noEmit` clean; **vitest 727 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)