### PR TITLE
ci: narrow dependabot-auto-merge to job-level write permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,14 +7,20 @@
 name: Dependabot auto-merge
 on: pull_request
 
+# Workflow-level default: read-only. The auto-merge job narrows UP to the
+# writes it needs. A top-level write token is what TokenPermissionsID
+# (OpenSSF Scorecard / CodeQL) flags high-severity — closes alert #28.
+# Mirrors release.yml (which closed Scorecard alert #16).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write        # gh pr merge --squash writes the default branch
+      pull-requests: write   # enable auto-merge on the PR
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`dependabot-auto-merge.yml` no longer grants a workflow-level write token.** The top-level `permissions:` block granted `contents: write` + `pull-requests: write` to the entire workflow; the `auto-merge` job now declares those writes itself and the workflow default drops to `contents: read`. Closes the high-severity `TokenPermissionsID` (OpenSSF Scorecard / CodeQL) code-scanning alert. Mirrors the `release.yml` hardening that closed Scorecard alert #16.
+
 ## [0.1.30-beta.22] - 2026-05-28
 
 ### Fixed


### PR DESCRIPTION
## What

`dependabot-auto-merge.yml` declared `contents: write` + `pull-requests: write` at the **top level**, granting those writes to the entire workflow. The OpenSSF Scorecard / CodeQL `TokenPermissionsID` query flags a top-level write token as **high-severity** (broad blast radius — every job inherits it).

This drops the workflow-level default to `contents: read` and moves the two writes onto the `auto-merge` job, the only consumer (`gh pr merge --auto --squash`). Behavior is unchanged.

Mirrors the `release.yml` hardening that previously closed Scorecard alert 16.

## Why

Closes the open high-severity `TokenPermissionsID` code-scanning alert on `dependabot-auto-merge.yml`.

> Note: the tracking TODO described this as a *missing* top-level block — it was actually a top-level *write* block. The end state matches the intended fix either way.

## Verification

- Permissions-only diff; the `fetch-metadata` + `auto-merge` steps are untouched. The job-level block fully covers what the job needs (`gh pr merge` → `contents: write` + `pull-requests: write`; `fetch-metadata` reads PR metadata, covered by `pull-requests: write`).
- The code-scanning alert auto-closes on the next Scorecard/CodeQL scan of `main` after merge.