### PR TITLE
fix(linux): repair in-app updates — locator construction + per-platform feed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,8 @@ jobs:
           path: |
             Releases/*.AppImage
             Releases/*.AppImage.sig
+            Releases/*.nupkg
+            Releases/releases.linux-${{ needs.prepare.outputs.channel }}.json
 
   publish:
     needs: [prepare, build-windows, build-linux]
@@ -289,4 +291,6 @@ jobs:
             artifacts/windows-final/releases.${{ needs.prepare.outputs.channel }}.json
             artifacts/linux-final/*.AppImage
             artifacts/linux-final/*.AppImage.sig
+            artifacts/linux-final/*.nupkg
+            artifacts/linux-final/releases.linux-${{ needs.prepare.outputs.channel }}.json
             SHA256SUMS

--- a/scripts/package-linux.mjs
+++ b/scripts/package-linux.mjs
@@ -36,7 +36,6 @@ const REPO_ROOT = join(__dirname, '..');
 
 const PACK_ID = 'WsScrcpyWeb';                    // Matches Windows packId
 const MAIN_EXE = 'ws-scrcpy-web-launcher';        // Linux binary, no .exe
-const CHANNEL = 'linux';                          // Velopack default for Linux
 const CATEGORIES = 'Utility';                     // FreeDesktop categories spec
 
 const PUBLISH_DIR = join(REPO_ROOT, 'publish');
@@ -111,10 +110,21 @@ function main() {
     }
 
     const version = readVersion();
+    // Linux ships per-platform Velopack channels (linux-beta / linux-stable) so
+    // its releases.<channel>.json feed + nupkg don't collide with the Windows
+    // beta/stable feeds on the same GitHub release. Derive beta/stable from the
+    // version (mirrors release.yml's tag→channel rule; assert-version-sync keeps
+    // package.json === tag). MUST match UpdateService.resolveExplicitChannel so
+    // the installed app queries the feed we actually publish.
+    const channelBase = version.includes('-beta') ? 'beta' : 'stable';
+    const CHANNEL = `linux-${channelBase}`;
     log(`packing AppImage: id=${PACK_ID} version=${version} channel=${CHANNEL}`);
 
     // execFileSync with array-form args — no shell interpolation, no
     // injection surface. Inherit stdio so vpk's progress reaches the user.
+    // -o Releases pins flat output (matching the Windows leg) so the AppImage,
+    // the releases.<channel>.json feed, and the *-full.nupkg all land directly
+    // in Releases/ for the CI upload globs to harvest.
     execFileSync(
         'vpk',
         [
@@ -126,6 +136,7 @@ function main() {
             '--icon', ICON_PATH,
             '--categories', CATEGORIES,
             '--channel', CHANNEL,
+            '-o', 'Releases',
         ],
         { cwd: REPO_ROOT, stdio: 'inherit' },
     );
@@ -134,10 +145,8 @@ function main() {
     // the .AppImage runs on hosts without libfuse2/libfuse3 installed.
     // Velopack ships the older fuse2-linked runtime by default; the
     // swap is what makes the artifact truly portable.
-    const releasesLinuxDir = join(REPO_ROOT, 'Releases', 'linux');
-    const releasesDir = existsSync(releasesLinuxDir)
-        ? releasesLinuxDir
-        : join(REPO_ROOT, 'Releases');
+    // -o Releases (above) pins flat output, so the AppImage is directly in Releases/.
+    const releasesDir = join(REPO_ROOT, 'Releases');
     const appimages = existsSync(releasesDir)
         ? readdirSync(releasesDir).filter((f) => f.endsWith('.AppImage'))
         : [];

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -128,32 +128,33 @@ export class UpdateService {
         //   ourselves. Computed once — installRoot is immutable for the
         //   service's lifetime.
         //
-        //   Linux — DO NOT pass a locator; delegate to Velopack's native
-        //   auto_locate_app_manifest (lib-rust/src/locator.rs). Given $APPIMAGE
-        //   it truncates the exe path at the `/usr/bin/` boundary to find the
-        //   AppImage mount root, then derives everything itself:
-        //     CurrentBinaryDir = <mount>/usr/bin
-        //     UpdateExePath    = <mount>/usr/bin/UpdateNix
-        //     ManifestPath     = <mount>/usr/bin/sq.version
-        //     PackagesDir      = /var/tmp/velopack/<packId>/packages
-        //   The velopack Node binding (node_modules/velopack/lib/index.js)
-        //   forwards `null` to the native FFI whenever the locator arg is
-        //   falsy, which is exactly what enables auto-locate. init() only
-        //   constructs the manager when APPIMAGE is set, so auto-locate always
-        //   has the data it needs.
+        //   Linux (AppImage) — hand-build the locator too, anchored on
+        //   installRoot. We do NOT delegate to Velopack's auto_locate_app_manifest:
+        //   on Linux (lib-rust/src/locator.rs) auto_locate finds the install by
+        //   searching `std::env::current_exe()` for "/usr/bin/" — but our server
+        //   runs inside the Node binary, which (Local-Dependencies-Only) lives at
+        //   <dataRoot>/dependencies/node/node, NOT under the AppImage mount's
+        //   /usr/bin/. So current_exe() has no "/usr/bin/" segment, auto_locate
+        //   returns "Could not locate '/usr/bin/'", UpdateManager construction
+        //   throws, the init() catch nulls mgr, and every check silently no-ops.
+        //   ($APPIMAGE is read by auto_locate only AFTER that search, to set
+        //   RootAppDir — it is NOT used to find the install root, contrary to the
+        //   beta.21 assumption.)
         //
-        //   Why not a hand-built Linux locator: beta.7 (PR #216) masked a Linux
-        //   construction throw with a `mgr === null` guard; beta.19 (PR #230)
-        //   then hand-built the config from `path.resolve(__dirname,'..','..')`.
-        //   But that Windows-shaped arithmetic is off by one level on Linux —
-        //   the AppImage payload sits at <mount>/usr/bin/dist (one deeper than
-        //   Windows' <root>/current/dist), so installRoot resolved to
-        //   <mount>/usr and `path.join(installRoot,'usr','bin')` produced a
-        //   DOUBLED <mount>/usr/usr/bin. Velopack couldn't find UpdateNix or
-        //   sq.version there, construction threw, the init() catch nulled mgr,
-        //   and every update check silently no-oped (the "beta.19 still doesn't
-        //   fix Linux updates" report). Letting Velopack locate itself removes
-        //   the entire arithmetic-drift failure mode.
+        //   installRoot = resolve(__dirname,'..','..'). The bundle is at
+        //   <mount>/usr/bin/dist, so on Linux installRoot = <mount>/usr and the
+        //   Velopack contents dir is installRoot/bin = <mount>/usr/bin — the same
+        //   shape the Windows branch uses (installRoot/current). __dirname is part
+        //   of the read-only AppImage payload, so it is reliably under the mount
+        //   (unlike current_exe()). RootAppDir is the $APPIMAGE file path, matching
+        //   Velopack's own Linux locator output.
+        //
+        //   Lineage: beta.7 (#216) masked the throw with a `mgr===null` guard;
+        //   beta.19 (#230) hand-built from resolve(__dirname,'..','..') but then
+        //   re-appended usr/bin → DOUBLED <mount>/usr/usr/bin; beta.21 (#237)
+        //   delegated to auto_locate (this comment's predecessor) which fails for
+        //   the current_exe() reason above. The contents dir is simply
+        //   installRoot/bin — no re-appended usr, no auto_locate.
         if (this.platform === 'win32') {
             this.locator = {
                 RootAppDir: this.installRoot,
@@ -170,8 +171,25 @@ export class UpdateService {
                 IsPortable: false,
             };
         } else {
-            // Non-Windows (Linux AppImage): undefined → Velopack auto-locates.
-            this.locator = undefined;
+            // Linux AppImage: hand-built locator anchored on installRoot/bin
+            // (= <mount>/usr/bin). See the strategy comment above for why we do
+            // NOT use Velopack's auto_locate here.
+            const contentsDir = path.join(this.installRoot, 'bin');
+            const appImage = process.env['APPIMAGE'];
+            this.locator = {
+                // RootAppDir is the .AppImage FILE path, per Velopack's Linux
+                // auto_locate (locator.rs). Fall back to installRoot only if
+                // APPIMAGE is somehow unset (init() requires it for prod mode).
+                RootAppDir: appImage && appImage.length > 0 ? appImage : this.installRoot,
+                UpdateExePath: path.join(contentsDir, 'UpdateNix'),
+                // Velopack's Linux packages dir: /var/tmp/velopack/<id>/packages
+                // (id = WsScrcpyWeb). Used at download time, not checked at
+                // construction. Hardcoded forward-slash — a Linux-only path.
+                PackagesDir: '/var/tmp/velopack/WsScrcpyWeb/packages',
+                ManifestPath: path.join(contentsDir, 'sq.version'),
+                CurrentBinaryDir: contentsDir,
+                IsPortable: true,
+            };
         }
         this.factory = opts.updateManagerFactory ?? defaultUpdateManagerFactory;
         this.feedUrlOverride = opts.feedUrlOverride;

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -221,6 +221,18 @@ export class UpdateService {
     }
 
     /**
+     * The feed channel the app should query. Linux publishes per-platform
+     * channels (linux-beta / linux-stable) so its releases.<channel>.json feed
+     * doesn't collide with the Windows beta/stable feeds on the same GitHub
+     * release — so a Linux app must query 'linux-<channel>'. Windows queries the
+     * raw channel. (macOS isn't shipped; it would query the raw channel here.)
+     * MUST match the channel package-linux.mjs packs the AppImage with.
+     */
+    private resolveExplicitChannel(channel: UpdateChannel): string {
+        return this.platform === 'linux' ? `linux-${channel}` : channel;
+    }
+
+    /**
      * Initial setup: detect install mode, build mgr if installed, schedule
      * background timer + fire one immediate check. Synchronous-ish; the
      * immediate check is fire-and-forget via void.
@@ -260,7 +272,7 @@ export class UpdateService {
             this.mgr = this.factory(
                 feedUrl,
                 {
-                    ExplicitChannel: cfg.channel,
+                    ExplicitChannel: this.resolveExplicitChannel(cfg.channel),
                     AllowVersionDowngrade: false,
                     MaximumDeltasBeforeFallback: 10,
                 },
@@ -308,7 +320,7 @@ export class UpdateService {
             const newMgr = this.factory(
                 feedUrl,
                 {
-                    ExplicitChannel: channel,
+                    ExplicitChannel: this.resolveExplicitChannel(channel),
                     AllowVersionDowngrade: false,
                     MaximumDeltasBeforeFallback: 10,
                 },

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -192,12 +192,21 @@ describe('UpdateService', () => {
 
     // ── VelopackLocator strategy (platform-split) ──────────────────────────
     //
-    // Windows hands Velopack an explicit locator (Program Files migration).
-    // Linux passes NO locator and delegates to Velopack's native
-    // auto_locate_app_manifest. `platform` is injected so BOTH branches run on
-    // any host — the original doubled-`usr/usr/bin` Linux locator bug (beta.19 /
-    // PR #230) slipped through because tests only ever ran the host-platform
-    // branch with an injected installRoot, never the real __dirname arithmetic.
+    // BOTH platforms hand Velopack an explicit locator. `platform` is injected
+    // so both branches run on any host.
+    //
+    // Linux history: beta.21 (PR #237) passed NO locator, delegating to
+    // Velopack's native auto_locate_app_manifest. That FAILED on real AppImages:
+    // auto_locate (lib-rust locator.rs) finds the install by searching
+    // `std::env::current_exe()` for "/usr/bin/" — but our server runs under the
+    // Node binary in <dataRoot>/dependencies/node/ (Local-Dependencies-Only),
+    // which has no "/usr/bin/" in its path, so auto_locate returns "Could not
+    // locate '/usr/bin/'" → UpdateManager construction throws → mgr=null → every
+    // check silently no-ops. The fix hand-builds the locator anchored on
+    // installRoot (= resolve(__dirname,'..','..') = <mount>/usr at runtime),
+    // whose `bin` subdir is the Velopack contents dir. (beta.19's hand-built
+    // attempt had the right anchor but did ../.. then re-appended usr/bin →
+    // doubled `usr/usr/bin`; the contents dir is just installRoot/bin.)
 
     it('init (win32): passes an explicit Windows VelopackLocatorConfig', () => {
         const installRoot = path.join('/fake', 'install', 'root');
@@ -226,19 +235,19 @@ describe('UpdateService', () => {
         expect(loc['IsPortable']).toBe(false);
     });
 
-    it('init (linux): passes NO locator — delegates to Velopack auto-locate', () => {
-        // beforeEach sets APPIMAGE so the Linux production-marker check passes
-        // and the factory actually runs.
-        let called = false;
-        let receivedLocator: unknown = 'sentinel';
+    it('init (linux): passes an explicit hand-built locator anchored on the AppImage mount', () => {
+        // beforeEach sets APPIMAGE (= /fake/WsScrcpyWeb.AppImage) so the Linux
+        // production-marker check passes and the factory actually runs.
+        // installRoot stands in for resolve(__dirname,'..','..') = <mount>/usr.
+        const installRoot = path.join('/fake', 'mount', 'usr');
+        let receivedLocator: unknown;
         const factory = vi.fn((_feed: string, _opts: UpdateOptions, locator?: unknown) => {
-            called = true;
             receivedLocator = locator;
             return fakeMgr();
         });
         const svc = new UpdateService({
             platform: 'linux',
-            installRoot: path.join('/fake', 'install', 'root'),
+            installRoot,
             existsSync: () => true,
             updateManagerFactory: factory,
             setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
@@ -246,11 +255,17 @@ describe('UpdateService', () => {
         });
         svc.init();
 
-        expect(called).toBe(true);
-        // undefined → the velopack binding forwards `null` to the native FFI,
-        // triggering auto_locate_app_manifest. Any hand-built locator here
-        // reintroduces the beta.19 doubled-`usr/usr/bin` failure.
-        expect(receivedLocator).toBeUndefined();
+        expect(receivedLocator).toBeDefined();
+        const loc = receivedLocator as Record<string, unknown>;
+        const contentsDir = path.join(installRoot, 'bin'); // <mount>/usr/bin
+        // RootAppDir is the AppImage FILE path ($APPIMAGE), mirroring Velopack's
+        // Linux auto_locate (locator.rs:505) — NOT the mount dir.
+        expect(loc['RootAppDir']).toBe('/fake/WsScrcpyWeb.AppImage');
+        expect(loc['UpdateExePath']).toBe(path.join(contentsDir, 'UpdateNix'));
+        expect(loc['ManifestPath']).toBe(path.join(contentsDir, 'sq.version'));
+        expect(loc['CurrentBinaryDir']).toBe(contentsDir);
+        expect(loc['PackagesDir']).toBe('/var/tmp/velopack/WsScrcpyWeb/packages');
+        expect(loc['IsPortable']).toBe(true);
     });
 
     it('reconfigure: re-passes the platform-appropriate locator on both platforms', async () => {
@@ -280,8 +295,13 @@ describe('UpdateService', () => {
                 expect((initLocator as Record<string, unknown>)['RootAppDir']).toBe(installRoot);
                 expect(reconfigLocator).toEqual(initLocator);
             } else {
-                expect(initLocator).toBeUndefined();
-                expect(reconfigLocator).toBeUndefined();
+                // Linux: hand-built locator anchored on the mount, re-passed unchanged.
+                const contentsDir = path.join(installRoot, 'bin');
+                expect((initLocator as Record<string, unknown>)['UpdateExePath']).toBe(
+                    path.join(contentsDir, 'UpdateNix'),
+                );
+                expect((initLocator as Record<string, unknown>)['CurrentBinaryDir']).toBe(contentsDir);
+                expect(reconfigLocator).toEqual(initLocator);
             }
         }
     });

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -306,6 +306,72 @@ describe('UpdateService', () => {
         }
     });
 
+    // ── ExplicitChannel (platform-aware) ───────────────────────────────────
+    //
+    // Linux publishes per-platform channels (linux-beta / linux-stable) so its
+    // releases.<channel>.json feed doesn't collide with the Windows beta/stable
+    // feeds on the same GitHub release. The app must therefore query
+    // 'linux-<channel>' on Linux. Windows queries the raw channel. (Without
+    // this, a Linux app reads releases.beta.json — which lists only the Windows
+    // package — and finds no Linux update even after the locator is fixed.)
+
+    it('init (linux): ExplicitChannel is prefixed linux-<channel>', () => {
+        Config.getInstance().updateAppConfig({ channel: 'beta' });
+        let opts: UpdateOptions | undefined;
+        const factory = vi.fn((_feed: string, o: UpdateOptions) => {
+            opts = o;
+            return fakeMgr();
+        });
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: factory,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+        });
+        svc.init();
+        expect(opts?.ExplicitChannel).toBe('linux-beta');
+    });
+
+    it('init (win32): ExplicitChannel is the raw channel (no prefix)', () => {
+        Config.getInstance().updateAppConfig({ channel: 'beta' });
+        let opts: UpdateOptions | undefined;
+        const factory = vi.fn((_feed: string, o: UpdateOptions) => {
+            opts = o;
+            return fakeMgr();
+        });
+        const svc = new UpdateService({
+            platform: 'win32',
+            installRoot: path.join('/fake', 'root'),
+            existsSync: () => true,
+            updateManagerFactory: factory,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+        });
+        svc.init();
+        expect(opts?.ExplicitChannel).toBe('beta');
+    });
+
+    it('reconfigure (linux): ExplicitChannel is prefixed linux-<channel>', async () => {
+        let lastOpts: UpdateOptions | undefined;
+        const factory = vi.fn((_feed: string, o: UpdateOptions) => {
+            lastOpts = o;
+            return fakeMgr();
+        });
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: factory,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+        });
+        svc.init();
+        await svc.reconfigure('stable', 'bilbospocketses');
+        expect(lastOpts?.ExplicitChannel).toBe('linux-stable');
+    });
+
     // ── checkForUpdates ─────────────────────────────────────────────────
 
     it('checkForUpdates: null result → status=idle, no pendingUpdate', async () => {
@@ -651,6 +717,9 @@ describe('UpdateService', () => {
             .mockReturnValueOnce(newMgr);
 
         const svc = new UpdateService({
+            // Pin platform so ExplicitChannel stays 'beta' (Linux would prefix
+            // it to 'linux-beta' — covered by the platform-aware tests above).
+            platform: 'win32',
             installRoot: '/fake',
             existsSync: () => true,
             updateManagerFactory: factory,


### PR DESCRIPTION
## Problem

A user on **v0.1.30-beta.21** (Linux AppImage) reported the in-app updater sees no updates on either channel. Two independent, confirmed root causes — both Linux-only, both surfaced by the first real-Linux test of the updater.

### 1. `UpdateManager` construction throws (locator)
beta.21 (#237) passed **no locator** on Linux, delegating to Velopack `auto_locate_app_manifest`. That function (velopack 1.0.1 `lib-rust/src/locator.rs`) finds the install by searching **`std::env::current_exe()`** for `/usr/bin/`. But our server runs inside the **Node binary** at `<dataRoot>/dependencies/node/node` (Local-Dependencies-Only) — no `/usr/bin/` segment — so it returns `Could not locate ''/usr/bin/''`, construction throws, `init()` nulls `mgr`, and every check silently no-ops. (`$APPIMAGE` is read only *after* that search, for `RootAppDir`; it does **not** drive install-root discovery, contrary to the beta.21 assumption.)

**Fix:** hand-build the `VelopackLocatorConfig` anchored on `__dirname` (the bundle at `<mount>/usr/bin/dist`, reliably under the mount), mirroring Velopack''s own Linux output. Contents dir = `installRoot/bin` = `<mount>/usr/bin`. (beta.19/#230 had the right anchor but re-appended `usr/bin` -> doubled `usr/usr/bin`.)

### 2. No installable Linux package in the feed (channel/publish)
Even with the locator fixed, the app queries `releases.{beta,stable}.json` — which list only the **Windows** package — while the Linux build packed channel `linux` and CI **never uploaded** its feed/nupkg. So Velopack finds no Linux update.

**Fix:** per-platform channels.
- `UpdateService` queries `linux-<channel>` on Linux (`resolveExplicitChannel`); Windows unchanged.
- `package-linux.mjs` packs `--channel linux-<beta|stable>` (derived from the version) + `-o Releases`.
- `release.yml` uploads the Linux `releases.linux-<channel>.json` feed + `*.nupkg`.

Windows packaging is **untouched** — lowest risk to the working Windows updater.

## Verified
- `tsc --noEmit` clean; **730/730** vitest pass (new locator + channel tests; the two old tests that codified the broken auto-locate behavior were rewritten).
- `node --check scripts/package-linux.mjs` OK.

## NOT yet verified (by design)
- **Real Linux runtime.** beta.21''s updater can''t self-rescue (throws at construction), so existing installs need a **fresh install** of the next beta.
- **The release build** (`package-linux.mjs` / `release.yml`) runs only on a tag push, not PR CI — verified when we cut the next beta.

## Verification plan (post-merge)
1. Cut **beta.23** (both fixes) -> fresh-install on Linux -> confirm Settings -> Updates initializes (no "construction failed" in `~/.local/share/WsScrcpyWeb/logs/ws-scrcpy-web.log`).
2. Cut **beta.24** -> confirm beta.23 auto-updates to beta.24 on Linux (the actual update path).