### PR TITLE
chore: bump to v0.1.30-beta.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.24] - 2026-06-01
+
+### Changed
+
+- **v0.1.30-beta.24 is a no-op companion release to beta.23** — identical code, published solely as the update target for verifying the now-fixed Linux in-app updater (install beta.23, confirm it auto-updates to beta.24). The no-op-companion practice was retired for the stable Windows updater (see `docs/RELEASING.md`), but is re-used here specifically to verify the Linux updater end-to-end.
+
 ## [0.1.30-beta.23] - 2026-06-01
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.23"
+version = "0.1.30-beta.24"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.23",
+  "version": "0.1.30-beta.24",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
No-op companion to beta.23 - the update target for verifying the Linux in-app updater (install beta.23 -> auto-update to beta.24). Identical code to beta.23; version bump only. Velopack stays 1.0.1.