### PR TITLE
fix(linux): in-app update apply + upgrading handoff (Windows untouched)

### DIFF
--- a/docs/plans/2026-06-01-linux-update-apply-handoff.md
+++ b/docs/plans/2026-06-01-linux-update-apply-handoff.md
@@ -1,0 +1,507 @@
+# Linux update apply fix + "upgrading" handoff — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Linux in-app updates apply + relaunch, with a smooth "upgrading…" browser handoff — without changing the Windows update path.
+
+**Architecture:** Server `applyUpdate` gets a Linux local-mode branch that calls Velopack's `waitExitThenApplyUpdate(restart=true)` instead of the Windows `.exe` operation-server helper. The apply response gains a Linux-only `mode:'reconnect'` flag. The client, on that flag, shows a full-viewport overlay and polls the same origin until the new version answers, then reloads (timeout → bookmark fallback). Windows keeps its operation-server redirect + 5s-reload path byte-for-byte.
+
+**Tech Stack:** TypeScript, Node http server, Velopack node binding, vitest. Client is vanilla TS DOM (no framework).
+
+**Spec:** `docs/specs/2026-06-01-linux-update-apply-handoff-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/common/UpdateEvents.ts` | shared API types | add `mode?: 'reconnect'` to `UpdatesApplyResponse` |
+| `src/server/UpdateService.ts` | apply orchestration | Linux local-mode branch in `applyUpdate` |
+| `src/server/api/UpdatesApi.ts` | HTTP transport | Linux apply returns `mode:'reconnect'` |
+| `src/app/client/reconnectAfterApply.ts` (new) | poll the origin until the new version answers | new module (pure logic, testable) |
+| `src/app/client/UpgradingOverlay.ts` (new) | full-viewport overlay UI | new component |
+| `src/app/client/UpdateButton.ts` | home-page apply chip | on `mode:'reconnect'` → overlay + reconnect |
+| `src/app/client/SettingsModal.ts` | settings apply button | on `mode:'reconnect'` → overlay + reconnect |
+
+**Windows-freeze invariant:** the only `applyUpdate`/`handleApply` change behind `win32` is *additive branching*; the Windows code path is unchanged. The two client handlers keep their existing `r.ok` → restart+reload path and ONLY diverge when the JSON body has `mode === 'reconnect'` (Linux). Run the full suite after every server task to confirm Windows tests stay green.
+
+---
+
+## Task 1: Add the `mode` field to the apply response type
+
+**Files:**
+- Modify: `src/common/UpdateEvents.ts:73-76`
+
+- [ ] **Step 1: Edit the type**
+
+Replace:
+```ts
+/** Apply success envelope (returned right before the deferred process.exit). */
+export interface UpdatesApplyResponse {
+    ok: true;
+}
+```
+with:
+```ts
+/** Apply success envelope (returned right before the deferred process.exit). */
+export interface UpdatesApplyResponse {
+    ok: true;
+    /**
+     * Linux only. When 'reconnect', the client shows the upgrading overlay and
+     * polls the same origin until the relaunched app answers on the new
+     * version. Absent on Windows (which uses the operation-server HTML redirect).
+     */
+    mode?: 'reconnect';
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/common/UpdateEvents.ts
+git commit -m "feat(updates): add mode:'reconnect' to UpdatesApplyResponse (Linux)"
+```
+
+---
+
+## Task 2: Linux local-mode branch in `UpdateService.applyUpdate`
+
+The current `applyUpdate` (around lines 420-465) has: service-mode branch (`waitExitThenApplyUpdate(update, true, false)`) then a Windows-shaped local-mode path that spawns `…/operation-server/ws-scrcpy-web-launcher.exe`. Add a Linux local-mode branch BEFORE the helper-spawn so Linux never reaches the `.exe`.
+
+**Files:**
+- Modify: `src/server/UpdateService.ts` (the `applyUpdate` local-mode section)
+- Test: `src/server/__tests__/UpdateService.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `UpdateService.test.ts` (in the applyUpdate describe area). It asserts that on Linux local mode, `waitExitThenApplyUpdate` is called with `restart=true` and the operation-server helper is NOT spawned:
+
+```ts
+it('applyUpdate (linux local mode): waitExitThenApplyUpdate(restart=true), no helper spawn', async () => {
+    Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user' });
+    const info = fakeUpdateInfo('0.2.0');
+    const applyFn = vi.fn();
+    const mgr = fakeMgr({ checkForUpdatesAsync: async () => info, waitExitThenApplyUpdate: applyFn });
+    const spawnMock = vi.mocked(child_process.spawn);
+    spawnMock.mockClear();
+    const svc = new UpdateService({
+        platform: 'linux',
+        installRoot: path.join('/fake', 'mount', 'usr'),
+        existsSync: () => true,
+        updateManagerFactory: () => mgr,
+        setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+        clearIntervalFn: () => undefined,
+    });
+    svc.init();
+    await svc.checkForUpdates();
+    expect(svc.getStatus().status).toBe('ready');
+    const result = await svc.applyUpdate();
+    expect(applyFn).toHaveBeenCalledTimes(1);
+    expect(applyFn.mock.calls[0]![1]).toBe(true);   // silent
+    expect(applyFn.mock.calls[0]![2]).toBe(true);   // restart
+    expect(result.redirectPort).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();        // no operation-server helper
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts -t "linux local mode"`
+Expected: FAIL — current Linux code path falls through to the `.exe` spawn (so `applyFn` not called / spawn called).
+
+- [ ] **Step 3: Add the Linux branch in `applyUpdate`**
+
+In `applyUpdate`, immediately AFTER the existing service-mode block:
+```ts
+        if (isServiceMode) {
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
+            return { redirectPort: null };
+        }
+```
+insert:
+```ts
+        // Linux local mode: Velopack applies on exit and relaunches the AppImage
+        // (which rebinds the freed web port). No Windows operation-server helper
+        // exists on Linux — calling it would ENOENT and the apply would never run.
+        if (this.platform !== 'win32') {
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, true);
+            return { redirectPort: null };
+        }
+```
+Leave the Windows operation-server helper code below it unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts -t "linux local mode"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole UpdateService suite (Windows path unchanged)**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts`
+Expected: all pass (the existing Windows/service apply tests still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/UpdateService.ts src/server/__tests__/UpdateService.test.ts
+git commit -m "fix(linux): apply updates via waitExitThenApplyUpdate(restart=true), not the win32 helper"
+```
+
+---
+
+## Task 3: `handleApply` returns `mode:'reconnect'` on Linux
+
+**Files:**
+- Modify: `src/server/api/UpdatesApi.ts:156-169` (the `redirectPort === null` branch)
+- Test: `src/server/api/__tests__/UpdatesApi.test.ts` (existing apply tests live here; match their pattern)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test asserting that when `applyUpdate` returns `{redirectPort:null}` and platform is non-win32, the JSON body contains `mode:'reconnect'`. Match the existing UpdatesApi test harness (it stubs the `UpdateService` + captures the `ServerResponse`). Minimal shape:
+
+```ts
+it('handleApply (linux): returns { ok:true, mode:"reconnect" } when redirectPort is null', async () => {
+    const svc = makeSvcStub({ isInstalled: true, status: 'ready' }, { redirectPort: null });
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    const api = new UpdatesApi(svc, (cb) => { cb(); return 0; }, () => {});
+    const res = makeResCapture();
+    await api.handle(makeReq('POST', '/api/updates/apply'), res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ ok: true, mode: 'reconnect' });
+    platformSpy.mockRestore();
+});
+```
+(If the existing test file uses different helpers, mirror them — the assertion is the contract: body `{ok:true, mode:'reconnect'}` on non-win32 when redirectPort is null.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/server/api/__tests__/UpdatesApi.test.ts -t "reconnect"`
+Expected: FAIL — body is `{ ok: true }` (no `mode`).
+
+- [ ] **Step 3: Implement**
+
+In `handleApply`, change the `else` branch (currently `const body: UpdatesApplyResponse = { ok: true };`) to:
+```ts
+        } else {
+            const body: UpdatesApplyResponse = { ok: true };
+            if (process.platform !== 'win32') {
+                body.mode = 'reconnect';
+            }
+            res.writeHead(200);
+            res.end(JSON.stringify(body));
+        }
+```
+The Windows `redirectPort !== null` branch (HTML redirect) is unchanged.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/server/api/__tests__/UpdatesApi.test.ts`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/api/UpdatesApi.ts src/server/api/__tests__/UpdatesApi.test.ts
+git commit -m "feat(updates): handleApply signals mode:'reconnect' on Linux"
+```
+
+---
+
+## Task 4: `reconnectAfterApply` — poll the origin until the new version answers
+
+A pure-logic module (no DOM) so it's unit-testable with a stubbed `fetch`.
+
+**Files:**
+- Create: `src/app/client/reconnectAfterApply.ts`
+- Test: `src/app/client/__tests__/reconnectAfterApply.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { reconnectAfterApply } from '../reconnectAfterApply';
+
+function statusResponse(version: string) {
+    return { ok: true, json: async () => ({ currentVersion: version }) } as unknown as Response;
+}
+
+describe('reconnectAfterApply', () => {
+    it('resolves "updated" when status reports a new version', async () => {
+        const fetchMock = vi.fn()
+            .mockRejectedValueOnce(new Error('down'))      // swap window
+            .mockResolvedValueOnce(statusResponse('0.1.0')) // old still
+            .mockResolvedValueOnce(statusResponse('0.2.0')); // new!
+        const result = await reconnectAfterApply({
+            previousVersion: '0.1.0',
+            fetchFn: fetchMock,
+            intervalMs: 0,
+            deadlineMs: 10_000,
+            now: (() => { let t = 0; return () => (t += 1); })(),
+        });
+        expect(result).toBe('updated');
+        expect(fetchMock).toHaveBeenCalledWith('/api/updates/status', { cache: 'no-store' });
+    });
+
+    it('resolves "timeout" when the deadline passes without a new version', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(statusResponse('0.1.0'));
+        const result = await reconnectAfterApply({
+            previousVersion: '0.1.0',
+            fetchFn: fetchMock,
+            intervalMs: 0,
+            deadlineMs: 5,
+            now: (() => { let t = 0; return () => (t += 2); })(),
+        });
+        expect(result).toBe('timeout');
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/app/client/__tests__/reconnectAfterApply.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+export interface ReconnectOptions {
+    previousVersion: string;
+    fetchFn?: typeof fetch;
+    intervalMs?: number;
+    deadlineMs?: number;
+    now?: () => number;
+}
+
+/**
+ * Poll GET /api/updates/status on the same origin until it answers with a
+ * currentVersion different from previousVersion (→ 'updated'), or the deadline
+ * elapses (→ 'timeout'). Fetch errors are expected during the swap and are
+ * swallowed (keep polling). No DOM here — caller handles the UI.
+ */
+export async function reconnectAfterApply(opts: ReconnectOptions): Promise<'updated' | 'timeout'> {
+    const fetchFn = opts.fetchFn ?? fetch;
+    const intervalMs = opts.intervalMs ?? 1000;
+    const deadlineMs = opts.deadlineMs ?? 60_000;
+    const now = opts.now ?? (() => Date.now());
+    const start = now();
+    for (;;) {
+        try {
+            const r = await fetchFn('/api/updates/status', { cache: 'no-store' });
+            if (r.ok) {
+                const s = (await r.json()) as { currentVersion?: string };
+                if (s.currentVersion && s.currentVersion !== opts.previousVersion) {
+                    return 'updated';
+                }
+            }
+        } catch {
+            // server down during the swap — expected; keep polling
+        }
+        if (now() - start >= deadlineMs) return 'timeout';
+        if (intervalMs > 0) await new Promise((res) => setTimeout(res, intervalMs));
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/app/client/__tests__/reconnectAfterApply.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/client/reconnectAfterApply.ts src/app/client/__tests__/reconnectAfterApply.test.ts
+git commit -m "feat(client): reconnectAfterApply poll helper"
+```
+
+---
+
+## Task 5: `UpgradingOverlay` component
+
+A full-viewport overlay with three states. Follow the existing client DOM idiom (plain `document.createElement` + a class with `mount()`/`setState()`/`remove()`; see `PortChangeModal.ts` / `ServiceFirstRunModal.ts` for the style — but this is a non-dismissible takeover, not a dialog). Lowercase copy per the app motif (`feedback` melt: "all UI text lowercase").
+
+**Files:**
+- Create: `src/app/client/UpgradingOverlay.ts`
+- Test: `src/app/client/__tests__/UpgradingOverlay.test.ts` (jsdom — vitest is configured with the happy-dom/jsdom environment used by other client tests; match an existing client test's environment header)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { UpgradingOverlay } from '../UpgradingOverlay';
+
+describe('UpgradingOverlay', () => {
+    it('mounts, shows the applying message, and removes', () => {
+        const o = new UpgradingOverlay();
+        o.mount();
+        const el = document.querySelector('.upgrading-overlay');
+        expect(el).not.toBeNull();
+        expect(el!.textContent).toContain('updating');
+        o.setState('timeout', 'http://localhost:8000/');
+        expect(document.querySelector('.upgrading-overlay')!.textContent).toContain('http://localhost:8000/');
+        o.remove();
+        expect(document.querySelector('.upgrading-overlay')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/app/client/__tests__/UpgradingOverlay.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+type OverlayState = 'applying' | 'reconnecting' | 'timeout';
+
+/**
+ * Full-viewport, non-dismissible overlay shown during a Linux in-app update.
+ * Pure DOM; survives the server exiting (no network needed to render).
+ */
+export class UpgradingOverlay {
+    private root: HTMLDivElement | null = null;
+    private msg: HTMLParagraphElement | null = null;
+
+    mount(): void {
+        if (this.root) return;
+        const root = document.createElement('div');
+        root.className = 'upgrading-overlay';
+        // Inline the few critical styles so the overlay renders even if the
+        // stylesheet is mid-reload. Keep visual polish in the stylesheet.
+        root.style.cssText =
+            'position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;' +
+            'align-items:center;justify-content:center;gap:1rem;background:rgba(0,0,0,0.85);' +
+            'color:#fff;font:14px/1.5 system-ui,sans-serif;text-align:center;padding:2rem;';
+        const spinner = document.createElement('div');
+        spinner.className = 'upgrading-overlay-spinner';
+        const msg = document.createElement('p');
+        msg.className = 'upgrading-overlay-msg';
+        root.append(spinner, msg);
+        document.body.appendChild(root);
+        this.root = root;
+        this.msg = msg;
+        this.setState('applying');
+    }
+
+    setState(state: OverlayState, url?: string): void {
+        if (!this.msg) return;
+        if (state === 'applying') {
+            this.msg.textContent = 'updating — applying the new version…';
+        } else if (state === 'reconnecting') {
+            this.msg.textContent = 'updating — restarting and reconnecting…';
+        } else {
+            this.msg.textContent =
+                `update applied. if this page doesn't return on its own, reopen ${url ?? 'the app url'}.`;
+        }
+    }
+
+    remove(): void {
+        this.root?.remove();
+        this.root = null;
+        this.msg = null;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/app/client/__tests__/UpgradingOverlay.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/client/UpgradingOverlay.ts src/app/client/__tests__/UpgradingOverlay.test.ts
+git commit -m "feat(client): UpgradingOverlay component"
+```
+
+---
+
+## Task 6: Wire both apply handlers to the overlay on `mode:'reconnect'`
+
+Both `UpdateButton.ts` (`onApplyClick`, ~line 203) and `SettingsModal.ts` (`onApplyClick`, ~line 656) currently do: `fetch('/api/updates/apply')` → if `r.ok` → show "restarting…" → `setTimeout(reload, 5000)`. Extend ONLY the `r.ok` success path: parse the JSON body; if `mode === 'reconnect'` (Linux), run the overlay + reconnect instead of the blind 5s reload. Windows responses (HTML, no JSON `mode`) keep the existing reload path.
+
+**Files:**
+- Modify: `src/app/client/UpdateButton.ts` (success branch of `onApplyClick`)
+- Modify: `src/app/client/SettingsModal.ts` (success branch of `onApplyClick`)
+
+- [ ] **Step 1: Add a shared helper call in `UpdateButton.onApplyClick`**
+
+Replace the success branch (`renderRestarting(); window.setTimeout(reload, …)`) with:
+```ts
+            const body = await r.json().catch(() => ({}) as { mode?: string; currentVersion?: string });
+            if (body && (body as { mode?: string }).mode === 'reconnect') {
+                await runUpgradingHandoff(state.currentVersion ?? '');
+                return;
+            }
+            // Windows / fallback: existing blind reload after grace.
+            renderRestarting();
+            window.setTimeout(() => { try { window.location.reload(); } catch { /* down */ } }, APPLY_RELOAD_DELAY_MS);
+```
+where `state.currentVersion` is the version known before apply (the module already tracks status; use the last status's `currentVersion`). Add the helper at module scope:
+```ts
+import { reconnectAfterApply } from './reconnectAfterApply';
+import { UpgradingOverlay } from './UpgradingOverlay';
+
+async function runUpgradingHandoff(previousVersion: string): Promise<void> {
+    const overlay = new UpgradingOverlay();
+    overlay.mount();
+    overlay.setState('reconnecting');
+    const result = await reconnectAfterApply({ previousVersion });
+    if (result === 'updated') {
+        window.location.reload();
+    } else {
+        overlay.setState('timeout', window.location.origin + '/');
+    }
+}
+```
+
+- [ ] **Step 2: Mirror it in `SettingsModal.onApplyClick`**
+
+Same change in the `SettingsModal` success branch (the one that sets `btn.textContent = 'restarting…'` + `setTimeout(reload, 5000)`). Reuse the same `reconnectAfterApply` + `UpgradingOverlay` imports; the previous version is `this.updatesLastStatus?.currentVersion ?? ''`. Define a private `runUpgradingHandoff` method with the identical body (or extract a shared module-level function imported by both — preferred to keep DRY: put `runUpgradingHandoff` in `reconnectAfterApply.ts` and import it in both files).
+
+> DRY note: implement `runUpgradingHandoff(previousVersion)` ONCE in `src/app/client/reconnectAfterApply.ts` (exported) and import it in both `UpdateButton.ts` and `SettingsModal.ts`. Update Task 4's module to export it too.
+
+- [ ] **Step 3: Typecheck + full client/server suite**
+
+Run: `npx tsc --noEmit`
+Run: `npx vitest run`
+Expected: tsc clean; all tests pass (Windows apply tests unchanged + new tests green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/client/UpdateButton.ts src/app/client/SettingsModal.ts src/app/client/reconnectAfterApply.ts
+git commit -m "feat(client): Linux upgrading overlay + reconnect on apply (win path unchanged)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full suite + typecheck**
+
+Run: `npx tsc --noEmit && npx vitest run`
+Expected: tsc clean; **all** tests pass, including the pre-existing Windows operation-server + service-mode apply tests (the Windows-freeze invariant).
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: webpack build succeeds (client bundle includes the new modules).
+
+- [ ] **Step 3: Confirm no Windows behavior change (manual code review)**
+
+Re-read the diffs of `UpdateService.applyUpdate`, `UpdatesApi.handleApply`, and the two client handlers; confirm every Windows branch is byte-identical and the new behavior is reached only on non-win32 / `mode:'reconnect'`.
+
+---
+
+## Out of plan (follow-on, tracked separately)
+
+- Cut **beta.25** (this fix) + **beta.26** (no-op target) via the bump-PR → Auto Release pipeline; user installs beta.25, clicks update, confirms the overlay shows and the app reloads on beta.26 (timeout fallback if Velopack auto-relaunch doesn't fire). This is the real-Linux verification of `waitExitThenApplyUpdate(restart=true)`.

--- a/docs/specs/2026-06-01-linux-update-apply-handoff-design.md
+++ b/docs/specs/2026-06-01-linux-update-apply-handoff-design.md
@@ -1,0 +1,125 @@
+# Linux in-app update — apply fix + "upgrading" handoff
+
+**Date:** 2026-06-01
+**Status:** Approved design
+**Scope:** Linux only. Windows update path is untouched.
+
+## Problem
+
+After the locator + per-platform-feed fixes (PR #242, beta.23), a Linux app
+**discovers** updates correctly, but **applying** one kills the app without
+updating. Root cause (`UpdateService.applyUpdate`, local mode): it spawns the
+Windows operation-server helper —
+
+```js
+path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe')
+```
+
+— a `.exe` at a `dataRoot` location the Linux launcher isn't staged to. On
+Linux that `spawn` throws ENOENT, so the helper never starts **and the actual
+Velopack apply (`waitExitThenApplyUpdate`) never runs** (the helper was meant
+to drive it). The caller then does its deferred `process.exit`, Node exits, the
+launcher follows → **app dies, nothing applied.** Confirmed: re-running the
+beta.23 AppImage comes back on beta.23 (no update applied, nothing corrupted).
+
+## Goal
+
+1. Linux in-app updates **apply and relaunch** on the new version.
+2. A smooth browser **"upgrading…" handoff** (the Linux-native equivalent of
+   the Windows operation-server redirect), so the tab isn't left on a dead
+   connection.
+
+## Hard constraint: Windows is frozen
+
+This is the overriding requirement. The hard-won Windows update path
+(operation-server + redirect) must not change behavior.
+
+- `applyUpdate` is **platform-split**: the `win32` branch keeps its current
+  operation-server-helper code byte-for-byte; only the Linux branch changes.
+- `handleApply` keeps the Windows HTML-redirect path; Linux uses the existing
+  `{ok:true}` branch plus a Linux-only `mode:'reconnect'` flag.
+- The Rust launcher's `--operation-server` mode is **not touched** (the chosen
+  approach avoids the launcher entirely).
+- The client reconnect overlay is gated on the Linux-only `mode:'reconnect'`
+  flag; Windows browsers navigate away (HTML redirect) before reaching it.
+- **Verification:** the full vitest suite — including the Windows
+  operation-server + service-mode apply tests — stays green.
+
+## Design (Approach A: client-side overlay + reconnect-poll)
+
+Chosen over (B) porting the Rust operation-server to Linux — rejected because it
+touches the shared launcher (Windows risk) and is heavier — and (C) apply-only
+with no handoff — rejected as a poor UX (manual reconnect).
+
+### Server — `UpdateService.applyUpdate` (Linux local-mode branch)
+
+```
+if (win32)            → existing operation-server helper (UNCHANGED)
+else if service mode  → waitExitThenApplyUpdate(update, silent=true, restart=false)   (UNCHANGED; supervisor restarts)
+else (Linux local)    → waitExitThenApplyUpdate(update, silent=true, restart=true)     (NEW)
+                        return { redirectPort: null }
+```
+
+`restart=true` asks Velopack to apply on exit and relaunch the AppImage, which
+rebinds the **same** web port (freed when the old process exits).
+
+### Server — `UpdatesApi.handleApply`
+
+Windows unchanged. Linux returns `{ ok: true, mode: 'reconnect' }`
+(`mode` is a new optional field on `UpdatesApplyResponse` in
+`src/common/UpdateEvents.ts`). Then the existing deferred `process.exit(0)`.
+
+### Client — "upgrading" overlay + reconnect-poll
+
+On an apply response with `mode === 'reconnect'`:
+
+1. Render a full-viewport **`UpgradingOverlay`** (states: *applying → reconnecting → done / timed-out*). It hides the now-stale app UI.
+2. Poll `GET /api/updates/status` on the **same origin** every ~1s.
+   - While the server is down, fetches fail — keep polling.
+   - When it answers with `currentVersion !== <version-before-apply>` → state *done* → `window.location.reload()` → user lands on the new version.
+3. **Timeout (~60s):** state *timed-out* → overlay shows
+   "update applied — reopen `<current URL>`" with the URL. The user is never
+   stranded even if Velopack's auto-relaunch doesn't fire.
+
+The overlay is pure client-rendered (already-loaded JS), so it survives the
+server exiting during the swap.
+
+## Components / files
+
+| File | Change |
+|---|---|
+| `src/server/UpdateService.ts` | Linux local-mode branch in `applyUpdate` |
+| `src/common/UpdateEvents.ts` | `mode?: 'reconnect'` on `UpdatesApplyResponse` |
+| `src/server/api/UpdatesApi.ts` | Linux apply returns `mode:'reconnect'` |
+| `src/app/client/UpgradingOverlay.ts` (new) | the overlay + reconnect-poll |
+| `src/app/client/SettingsModal.ts` | wire apply → overlay on `mode:'reconnect'` |
+
+## Error handling / edge cases
+
+- **Apply throws** → existing 500 path (unchanged).
+- **Port shifts** (rare; old port not freed in time) → reconnect-poll never
+  matches → ~60s timeout → bookmark fallback. (Happy path is same-port.)
+- **Velopack auto-relaunch fails on Linux** → app doesn't come back on its own,
+  but the overlay's timeout fallback tells the user to reopen the URL; manual
+  relaunch (known to work) lands them on the new version. Graceful degradation.
+
+## Testing
+
+- `UpdateService.applyUpdate` **Linux local** (TDD): asserts
+  `waitExitThenApplyUpdate(update, true, true)` is called and **no** helper is
+  spawned; `redirectPort` is null. Windows + service-mode branches unchanged
+  (existing tests stay green).
+- `UpdatesApi.handleApply` Linux: response carries `mode:'reconnect'`; Windows
+  redirect path unchanged.
+- `UpgradingOverlay` reconnect logic: given a stubbed `fetch`, transitions
+  applying → reconnecting → done on version change, and → timed-out after the
+  deadline.
+- Full suite green (Windows apply/operation-server tests included).
+
+## Verification (real Linux)
+
+The one piece only a real install confirms is Velopack's Linux apply+relaunch.
+Verify via **beta.25** (this fix) → **beta.26** (no-op target): install
+beta.25, click update, confirm the overlay shows and the app reloads on
+beta.26. If auto-relaunch doesn't fire, the timeout fallback still lands the
+user on the new version after a manual reopen.

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -1,6 +1,7 @@
 import { Modal } from '../ui/Modal';
 import { AdminConfirmModal, type AdminConfirmOptions } from './AdminConfirmModal';
 import { ServiceOperationModal } from './ServiceOperationModal';
+import { runUpgradingHandoff } from './UpgradingOverlay';
 import type { AppConfigEnvelope, AppConfigPatchResponse, UpdateChannel } from '../../common/ConfigEvents';
 import type {
     ServiceStatusResponse,
@@ -676,6 +677,13 @@ export class SettingsModal extends Modal {
                 // Re-poll to learn the current state (probably 409 because state
                 // wasn't 'ready' anymore by the time we got here).
                 void this.refreshUpdates();
+                return;
+            }
+            const applyBody = (await r.json().catch(() => ({}))) as { mode?: string };
+            if (applyBody.mode === 'reconnect') {
+                // Linux: server relaunching the AppImage. Show the upgrading
+                // overlay and poll the same origin until the new version answers.
+                await runUpgradingHandoff(this.updatesLastStatus?.currentVersion ?? '');
                 return;
             }
             // Success: server is exiting within ~100ms. Show "restarting…" and

--- a/src/app/client/UpdateButton.ts
+++ b/src/app/client/UpdateButton.ts
@@ -1,4 +1,5 @@
 import type { UpdatesStatusResponse } from '../../common/UpdateEvents';
+import { runUpgradingHandoff } from './UpgradingOverlay';
 
 /**
  * UpdateButton — small top-right indicator that polls /api/updates/status and
@@ -217,10 +218,18 @@ export function createUpdateButton(): HTMLElement {
                 void poll();
                 return;
             }
-            // Success: server is exiting within ~100ms. Show "restarting…" and
-            // attempt a page reload after a short grace period. The reload will
-            // fail until Velopack finishes the swap and relaunches the server;
-            // that's expected — leave the message visible.
+            const body = (await r.json().catch(() => ({}))) as { mode?: string };
+            if (body.mode === 'reconnect') {
+                // Linux: the server is relaunching the AppImage. Show the
+                // upgrading overlay and poll the same origin until the new
+                // version answers, then reload (timeout → bookmark fallback).
+                await runUpgradingHandoff(lastStatus?.currentVersion ?? '');
+                return;
+            }
+            // Windows / fallback: server is exiting within ~100ms. Show
+            // "restarting…" and attempt a page reload after a short grace
+            // period. The reload fails until Velopack finishes the swap and
+            // relaunches the server; that's expected — leave the message visible.
             renderRestarting();
             window.setTimeout(() => {
                 try {

--- a/src/app/client/UpgradingOverlay.ts
+++ b/src/app/client/UpgradingOverlay.ts
@@ -1,0 +1,69 @@
+import { reconnectAfterApply } from './reconnectAfterApply';
+
+type OverlayState = 'applying' | 'reconnecting' | 'timeout';
+
+/**
+ * Full-viewport, non-dismissible overlay shown during a Linux in-app update.
+ * Pure DOM; it survives the server exiting during the Velopack swap (no network
+ * needed to render). Lowercase copy per the app motif.
+ */
+export class UpgradingOverlay {
+    private root: HTMLDivElement | null = null;
+    private msg: HTMLParagraphElement | null = null;
+
+    mount(): void {
+        if (this.root) return;
+        const root = document.createElement('div');
+        root.className = 'upgrading-overlay';
+        // Inline the few critical styles so the overlay renders even if the
+        // stylesheet is mid-reload. Visual polish belongs in the stylesheet.
+        root.style.cssText =
+            'position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;' +
+            'align-items:center;justify-content:center;gap:1rem;background:rgba(0,0,0,0.85);' +
+            'color:#fff;font:14px/1.5 system-ui,sans-serif;text-align:center;padding:2rem;';
+        const spinner = document.createElement('div');
+        spinner.className = 'upgrading-overlay-spinner';
+        const msg = document.createElement('p');
+        msg.className = 'upgrading-overlay-msg';
+        root.append(spinner, msg);
+        document.body.appendChild(root);
+        this.root = root;
+        this.msg = msg;
+        this.setState('applying');
+    }
+
+    setState(state: OverlayState, url?: string): void {
+        if (!this.msg) return;
+        if (state === 'applying') {
+            this.msg.textContent = 'updating — applying the new version…';
+        } else if (state === 'reconnecting') {
+            this.msg.textContent = 'updating — restarting and reconnecting…';
+        } else {
+            this.msg.textContent =
+                `update applied. if this page doesn't return on its own, reopen ${url ?? 'the app url'}.`;
+        }
+    }
+
+    remove(): void {
+        this.root?.remove();
+        this.root = null;
+        this.msg = null;
+    }
+}
+
+/**
+ * Mount the overlay, poll-reconnect to the relaunched app, then reload on the
+ * new version (or show the bookmark-URL fallback on timeout). DOM-coupled; the
+ * apply handlers call this when the server returns mode:'reconnect' (Linux).
+ */
+export async function runUpgradingHandoff(previousVersion: string): Promise<void> {
+    const overlay = new UpgradingOverlay();
+    overlay.mount();
+    overlay.setState('reconnecting');
+    const result = await reconnectAfterApply({ previousVersion });
+    if (result === 'updated') {
+        window.location.reload();
+    } else {
+        overlay.setState('timeout', `${window.location.origin}/`);
+    }
+}

--- a/src/app/client/__tests__/UpgradingOverlay.test.ts
+++ b/src/app/client/__tests__/UpgradingOverlay.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { UpgradingOverlay } from '../UpgradingOverlay';
+
+describe('UpgradingOverlay', () => {
+    it('mounts, shows the applying message, swaps to timeout copy, and removes', () => {
+        const o = new UpgradingOverlay();
+        o.mount();
+        const el = document.querySelector('.upgrading-overlay');
+        expect(el).not.toBeNull();
+        expect(el!.textContent).toContain('updating');
+
+        o.setState('timeout', 'http://localhost:8000/');
+        expect(document.querySelector('.upgrading-overlay')!.textContent).toContain('http://localhost:8000/');
+
+        o.remove();
+        expect(document.querySelector('.upgrading-overlay')).toBeNull();
+    });
+
+    it('mount() is idempotent (no duplicate overlay)', () => {
+        const o = new UpgradingOverlay();
+        o.mount();
+        o.mount();
+        expect(document.querySelectorAll('.upgrading-overlay')).toHaveLength(1);
+        o.remove();
+    });
+});

--- a/src/app/client/__tests__/reconnectAfterApply.test.ts
+++ b/src/app/client/__tests__/reconnectAfterApply.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reconnectAfterApply } from '../reconnectAfterApply';
+
+function statusResponse(version: string) {
+    return { ok: true, json: async () => ({ currentVersion: version }) } as unknown as Response;
+}
+
+describe('reconnectAfterApply', () => {
+    it('resolves "updated" when status reports a new version (swallows the down window)', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('down')) // swap window
+            .mockResolvedValueOnce(statusResponse('0.1.0')) // old still up
+            .mockResolvedValueOnce(statusResponse('0.2.0')); // new!
+        const result = await reconnectAfterApply({
+            previousVersion: '0.1.0',
+            fetchFn: fetchMock as unknown as typeof fetch,
+            intervalMs: 0,
+            deadlineMs: 10_000,
+            now: (() => { let t = 0; return () => (t += 1); })(),
+        });
+        expect(result).toBe('updated');
+        expect(fetchMock).toHaveBeenCalledWith('/api/updates/status', { cache: 'no-store' });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('resolves "timeout" when the deadline passes without a new version', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(statusResponse('0.1.0'));
+        const result = await reconnectAfterApply({
+            previousVersion: '0.1.0',
+            fetchFn: fetchMock as unknown as typeof fetch,
+            intervalMs: 0,
+            deadlineMs: 5,
+            now: (() => { let t = 0; return () => (t += 2); })(),
+        });
+        expect(result).toBe('timeout');
+    });
+});

--- a/src/app/client/reconnectAfterApply.ts
+++ b/src/app/client/reconnectAfterApply.ts
@@ -1,0 +1,42 @@
+export interface ReconnectOptions {
+    /** The version running before apply; resolve once /status reports a different one. */
+    previousVersion: string;
+    /** Injectable for tests. Defaults to the global fetch. */
+    fetchFn?: typeof fetch;
+    /** Poll interval (ms). Default 1000. */
+    intervalMs?: number;
+    /** Give up after this long (ms). Default 60000. */
+    deadlineMs?: number;
+    /** Injectable clock for tests. Default Date.now. */
+    now?: () => number;
+}
+
+/**
+ * Poll GET /api/updates/status on the same origin until it answers with a
+ * currentVersion different from previousVersion (-> 'updated'), or the deadline
+ * elapses (-> 'timeout'). Fetch errors are expected during the Velopack swap
+ * (the server is down) and are swallowed — keep polling. No DOM here; the
+ * caller owns the UI. Linux in-app update reconnect (see the apply handlers).
+ */
+export async function reconnectAfterApply(opts: ReconnectOptions): Promise<'updated' | 'timeout'> {
+    const fetchFn = opts.fetchFn ?? fetch;
+    const intervalMs = opts.intervalMs ?? 1000;
+    const deadlineMs = opts.deadlineMs ?? 60_000;
+    const now = opts.now ?? (() => Date.now());
+    const start = now();
+    for (;;) {
+        try {
+            const r = await fetchFn('/api/updates/status', { cache: 'no-store' });
+            if (r.ok) {
+                const s = (await r.json()) as { currentVersion?: string };
+                if (s.currentVersion && s.currentVersion !== opts.previousVersion) {
+                    return 'updated';
+                }
+            }
+        } catch {
+            // server down during the swap — expected; keep polling
+        }
+        if (now() - start >= deadlineMs) return 'timeout';
+        if (intervalMs > 0) await new Promise((res) => setTimeout(res, intervalMs));
+    }
+}

--- a/src/common/UpdateEvents.ts
+++ b/src/common/UpdateEvents.ts
@@ -73,4 +73,10 @@ export interface UpdatesErrorResponse {
 /** Apply success envelope (returned right before the deferred process.exit). */
 export interface UpdatesApplyResponse {
     ok: true;
+    /**
+     * Linux only. When 'reconnect', the client shows the upgrading overlay and
+     * polls the same origin until the relaunched app answers on the new
+     * version. Absent on Windows (which uses the operation-server HTML redirect).
+     */
+    mode?: 'reconnect';
 }

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -430,6 +430,15 @@ export class UpdateService {
             return { redirectPort: null };
         }
 
+        // Linux local mode: Velopack applies on exit and relaunches the AppImage
+        // (which rebinds the freed web port). The Windows operation-server helper
+        // below does not exist on Linux — spawning it would ENOENT and the apply
+        // would never run. restart=true so Velopack relaunches the new version.
+        if (this.platform !== 'win32') {
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, true);
+            return { redirectPort: null };
+        }
+
         const cfg = Config.getInstance();
         const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
         const helperPath = path.join(

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -562,6 +562,10 @@ describe('UpdateService', () => {
             waitExitThenApplyUpdate: applyFn,
         });
         const svc = new UpdateService({
+            // Windows local mode (operation-server helper). The Linux local-mode
+            // path (waitExitThenApplyUpdate) has its own test below; pin win32 so
+            // this Windows assertion is deterministic on a Linux CI host too.
+            platform: 'win32',
             installRoot: '/fake',
             existsSync: () => true,
             updateManagerFactory: () => mgr,
@@ -631,6 +635,9 @@ describe('UpdateService', () => {
             waitExitThenApplyUpdate: applyFn,
         });
         const svc = new UpdateService({
+            // Windows local mode; Linux local mode is tested separately. Pin
+            // win32 so this Windows assertion holds on a Linux CI host too.
+            platform: 'win32',
             installRoot: '/fake',
             existsSync: () => true,
             updateManagerFactory: () => mgr,
@@ -673,6 +680,12 @@ describe('UpdateService', () => {
             waitExitThenApplyUpdate: applyFn,
         });
         const svc = new UpdateService({
+            // Pin win32: service variants call waitExitThenApplyUpdate; the
+            // local (user/system) variants use the Windows operation-server
+            // helper (not waitExitThenApplyUpdate). Linux local mode differs and
+            // is covered separately — without this pin the local variants fail
+            // on a Linux CI host (they'd hit the new Linux apply branch).
+            platform: 'win32',
             installRoot: '/fake-install-root',
             existsSync: () => true,
             updateManagerFactory: () => mgr,

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -699,6 +699,34 @@ describe('UpdateService', () => {
         expect(mkdirSpy).toHaveBeenCalled();
     });
 
+    // Linux local-mode apply: no operation-server helper (that's a Windows-only
+    // staged .exe). Velopack applies on exit + relaunches via restart=true.
+    it('applyUpdate (linux local mode): waitExitThenApplyUpdate(restart=true), no helper spawn', async () => {
+        Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user' });
+        const info = fakeUpdateInfo('0.2.0');
+        const applyFn = vi.fn();
+        const mgr = fakeMgr({ checkForUpdatesAsync: async () => info, waitExitThenApplyUpdate: applyFn });
+        const spawnMock = vi.mocked(child_process.spawn);
+        spawnMock.mockClear();
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: () => mgr,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+        });
+        svc.init();
+        await svc.checkForUpdates();
+        expect(svc.getStatus().status).toBe('ready');
+        const result = await svc.applyUpdate();
+        expect(applyFn).toHaveBeenCalledTimes(1);
+        expect(applyFn.mock.calls[0]![1]).toBe(true); // silent
+        expect(applyFn.mock.calls[0]![2]).toBe(true); // restart
+        expect(result.redirectPort).toBeNull();
+        expect(spawnMock).not.toHaveBeenCalled();
+    });
+
     // ── reconfigure ─────────────────────────────────────────────────────
 
     it('reconfigure: swaps internal mgr + triggers immediate check', async () => {

--- a/src/server/__tests__/UpdatesApi.test.ts
+++ b/src/server/__tests__/UpdatesApi.test.ts
@@ -270,6 +270,38 @@ describe('UpdatesApi', () => {
         expect(schedule).not.toHaveBeenCalled();
     });
 
+    it('POST /apply (linux): body carries mode:"reconnect" when redirectPort is null', async () => {
+        const orig = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        try {
+            const svc = fakeService({ isInstalled: true, status: 'ready', availableVersion: '0.2.0' });
+            const api = new UpdatesApi(svc, vi.fn(), vi.fn());
+            const { req, res } = makeReqRes('/api/updates/apply', 'POST');
+            await api.handle(req, res);
+            expect((res as any).getStatus()).toBe(200);
+            expect(JSON.parse((res as any).getBody())).toEqual({ ok: true, mode: 'reconnect' });
+            expect(svc.applyUpdate).toHaveBeenCalledTimes(1);
+        } finally {
+            if (orig) Object.defineProperty(process, 'platform', orig);
+        }
+    });
+
+    it('POST /apply (win32): body is { ok:true } with no mode', async () => {
+        const orig = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+        try {
+            const svc = fakeService({ isInstalled: true, status: 'ready', availableVersion: '0.2.0' });
+            const api = new UpdatesApi(svc, vi.fn(), vi.fn());
+            const { req, res } = makeReqRes('/api/updates/apply', 'POST');
+            await api.handle(req, res);
+            const body = JSON.parse((res as any).getBody());
+            expect(body).toEqual({ ok: true });
+            expect(body.mode).toBeUndefined();
+        } finally {
+            if (orig) Object.defineProperty(process, 'platform', orig);
+        }
+    });
+
     // ── PATCH /config: validation ────────────────────────────────────────
 
     it('PATCH /config: bad channel → 400', async () => {

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -164,6 +164,12 @@ export class UpdatesApi {
             res.end(html);
         } else {
             const body: UpdatesApplyResponse = { ok: true };
+            // Linux: tell the client to show the upgrading overlay and poll-
+            // reconnect to the relaunched app. Windows uses the redirectPort
+            // HTML branch above, so it never reaches here with a real install.
+            if (process.platform !== 'win32') {
+                body.mode = 'reconnect';
+            }
             res.writeHead(200);
             res.end(JSON.stringify(body));
         }


### PR DESCRIPTION
## Summary
Completes the Linux in-app updater. After #242 fixed discovery (locator + per-platform feed), the **apply** phase still failed: local-mode `applyUpdate` spawned the Windows operation-server helper (`ws-scrcpy-web-launcher.exe`) — ENOENT on Linux, so the apply never ran and the app died. This adds the Linux apply path + a smooth browser handoff, with Windows byte-for-byte unchanged.

- **Server:** Linux local-mode `applyUpdate` -> `waitExitThenApplyUpdate(restart=true)` (Velopack applies on exit + relaunches the AppImage). `handleApply` returns `{ok:true, mode:reconnect}` on Linux.
- **Client:** on `mode:reconnect`, both apply handlers (UpdateButton + SettingsModal) mount a full-viewport `UpgradingOverlay` and poll the same origin until the relaunched app answers on the new version -> reload (timeout -> bookmark-URL fallback). `reconnectAfterApply` is pure logic (node-tested); the overlay is jsdom-tested.
- **Windows frozen:** every win32 branch is byte-identical; the operation-server + redirect path is untouched; client reconnect is gated on the Linux-only `mode` flag.

Spec: `docs/specs/2026-06-01-linux-update-apply-handoff-design.md`
Plan: `docs/plans/2026-06-01-linux-update-apply-handoff.md`

## Test Plan
- [x] `tsc --noEmit` clean
- [x] **737/737** vitest (incl. the pre-existing Windows operation-server + service-mode apply tests = Windows-freeze invariant)
- [x] `npm run build` succeeds
- [ ] Real Linux: install beta.25 -> click update -> overlay shows -> app reloads on beta.26 (Velopack Linux apply+relaunch is the one piece only a real install confirms)