### PR TITLE
chore: bump to v0.1.30-beta.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.26] - 2026-06-01
+
+### Changed
+
+- **v0.1.30-beta.26 is a no-op companion release to beta.25** — identical code, published as the update target for verifying the now-fixed Linux in-app update APPLY path (install beta.25, click update, confirm the "updating…" overlay appears and the app reloads on beta.26).
+
 ## [0.1.30-beta.25] - 2026-06-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.25"
+version = "0.1.30-beta.26"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.25",
+  "version": "0.1.30-beta.26",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
No-op companion to beta.25 - the update target for verifying the Linux apply fix (install beta.25 -> click update -> upgrading overlay -> app reloads on beta.26). Identical code to beta.25; version bump only. Velopack stays 1.0.1.