### PR TITLE
fix(linux): real AppImage self-update (download+verify+swap), top-layer overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux in-app updates now actually apply (fourth Linux updater fix — the real one).** beta.25's `waitExitThenApplyUpdate(restart=true)` was inert on Linux: Velopack 1.0.1's `UpdateNix apply`, invoked with only `--root <appimage>`, re-derives its own locator via `FromSpecifiedRootDir` and fails the `UpdateExePath.exists()` check (`locator.rs:114`) — aborting in under a millisecond with "Update.exe does not exist in the expected path", before any file is touched (confirmed on real Fedora via `/tmp/velopack.log`, mode- and restart-independent). Linux local-mode apply no longer uses Velopack's updater: it downloads the published AppImage from the GitHub release, verifies it against the release `SHA256SUMS`, and hands off to an out-of-mount launcher helper (`--linux-apply`) that backs up + swaps `$APPIMAGE` and relaunches it. Velopack 1.1.1 documents no fix for this path, so the dependency is unchanged. Windows + Linux service mode are byte-for-byte unchanged.
+- **Upgrading overlay no longer hides behind the Settings dialog.** The `UpgradingOverlay` was a `z-index:99999` div on `document.body`, but the Settings modal is a native `<dialog>` opened with `showModal()` — the browser top layer, which paints above the normal DOM regardless of z-index, so the overlay (and its "reopen the url" timeout fallback) was invisible when apply failed. The overlay is now itself a top-layer `<dialog>`.
+
+### Changed
+
+- **Linux discovery no longer pre-downloads the unused Velopack nupkg.** With apply fetching the AppImage directly, the ~60 MB nupkg is never used on Linux, so `checkForUpdates` skips it there.
+
 ## [0.1.30-beta.26] - 2026-06-01
 
 ### Changed

--- a/docs/plans/2026-06-01-linux-appimage-self-update.md
+++ b/docs/plans/2026-06-01-linux-appimage-self-update.md
@@ -1,0 +1,914 @@
+# Linux AppImage self-update (local mode) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Linux local-mode in-app updates apply + relaunch deterministically by downloading the published AppImage, verifying its SHA-256 against the release `SHA256SUMS`, and swapping it via the out-of-mount launcher helper — replacing Velopack's broken `UpdateNix` apply — and make the upgrading overlay render in the browser top layer.
+
+**Architecture:** Discovery stays on Velopack (version detection only; the unused nupkg download is skipped on Linux). On apply, the Node server downloads the release AppImage to a `dataRoot` staging dir, verifies it against the release `SHA256SUMS`, and spawns the already-staged launcher helper in a new `--linux-apply` mode; the helper waits for the server to exit, backs up + swaps `$APPIMAGE`, and relaunches it. The client reuses PR #246's reconnect-poll handoff, with the overlay upgraded to a top-layer `<dialog>`. Windows + Linux service mode are untouched.
+
+**Tech Stack:** TypeScript (Node 24 http server, global `fetch`, `node:crypto`), Rust (launcher), vanilla TS DOM client, vitest + cargo test.
+
+**Spec:** `docs/specs/2026-06-01-linux-appimage-self-update-design.md`
+
+---
+
+## Windows-freeze invariant
+
+Every change is reached only on Linux: the Node changes are behind `this.platform !== 'win32'` (and the existing service-mode early-return guarantees the new apply branch is Linux-*local* only), and the Rust helper is `#[cfg(target_os = "linux")]`. `launcher/src/operation_server.rs`, the Windows `applyUpdate` operation-server branch, the Windows `handleApply` redirect, and the service-mode branch are not edited. **Run `npx vitest run` after every Node/client task and confirm the Windows operation-server + service-mode apply tests stay green.**
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/server/linuxUpdateAssets.ts` | Pure helpers: asset name, release URL, `SHA256SUMS` parse | Create |
+| `src/server/verifySha256.ts` | Stream-hash a file + compare | Create |
+| `src/server/downloadToFile.ts` | Download a URL to disk / as text (injectable fetch) | Create |
+| `src/server/UpdateService.ts` | Skip nupkg download on Linux; rewrite Linux-local `applyUpdate` | Modify |
+| `src/app/client/UpgradingOverlay.ts` | Render as a top-layer `<dialog>` (`showModal`) | Modify |
+| `launcher/src/linux_apply.rs` | `--linux-apply` helper: wait-pid, backup, swap, relaunch | Create |
+| `launcher/src/main.rs` | Register + dispatch `linux_apply` (Linux only) | Modify |
+
+---
+
+## Task 1: Skip the unused Velopack nupkg download on Linux
+
+**Files:**
+- Modify: `src/server/UpdateService.ts` (the `checkForUpdates` autoUpdate branch, ~lines 365–372)
+- Test: `src/server/__tests__/UpdateService.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the `describe('UpdateService', …)` block (mirror the existing construction style of the other tests in this file):
+
+```ts
+it('checkForUpdates (linux): autoUpdate=true does NOT download the nupkg; status=ready', async () => {
+    Config.getInstance().updateAppConfig({ autoUpdate: true });
+    const downloadUpdateAsync = vi.fn(async () => undefined);
+    const mgr = fakeMgr({
+        checkForUpdatesAsync: async () => fakeUpdateInfo('0.2.0'),
+        downloadUpdateAsync,
+    });
+    const svc = new UpdateService({
+        platform: 'linux',
+        installRoot: path.join('/fake', 'mount', 'usr'),
+        existsSync: () => true,
+        updateManagerFactory: () => mgr,
+        setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+        clearIntervalFn: () => undefined,
+    });
+    process.env['APPIMAGE'] = '/home/u/Downloads/App.AppImage';
+    svc.init();
+    await svc.checkForUpdates();
+    expect(svc.getStatus().status).toBe('ready');
+    expect(downloadUpdateAsync).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts -t "does NOT download the nupkg"`
+Expected: FAIL — `downloadUpdateAsync` IS called (current code calls `downloadIfNeeded` when `autoUpdate` is true regardless of platform).
+
+- [ ] **Step 3: Implement the Linux skip**
+
+In `checkForUpdates`, replace the autoUpdate branch:
+
+```ts
+            const cfg = Config.getInstance().getAppConfig();
+            if (cfg.autoUpdate) {
+                await this.downloadIfNeeded();
+            } else {
+                // autoUpdate disabled: surface "available" via status='ready' but no download yet.
+                // waitExitThenApplyUpdate handles undownloaded updates internally on Apply.
+                this.state.status = 'ready';
+            }
+```
+
+with:
+
+```ts
+            const cfg = Config.getInstance().getAppConfig();
+            // On Linux our apply downloads the published AppImage directly, so the
+            // Velopack nupkg is never used — never pre-download it (saves ~60 MB per
+            // check). On Windows, keep the autoUpdate pre-download. autoUpdate=false
+            // also lands in the else. Availability is surfaced via status='ready'.
+            if (cfg.autoUpdate && this.platform !== 'linux') {
+                await this.downloadIfNeeded();
+            } else {
+                this.state.status = 'ready';
+            }
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts`
+Expected: PASS (the new test + all existing UpdateService tests; the Windows autoUpdate-download test still passes because its platform is win32).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/UpdateService.ts src/server/__tests__/UpdateService.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): skip unused Velopack nupkg auto-download on Linux"
+```
+
+---
+
+## Task 2: Linux release-asset helpers (URL + SHA256SUMS parse)
+
+Pure functions, no I/O — unit-testable in isolation.
+
+**Files:**
+- Create: `src/server/linuxUpdateAssets.ts`
+- Test: `src/server/__tests__/linuxUpdateAssets.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { linuxAppImageAssetName, releaseAssetUrl, parseSha256Sums } from '../linuxUpdateAssets';
+
+describe('linuxUpdateAssets', () => {
+    it('builds the channel-suffixed AppImage asset name', () => {
+        expect(linuxAppImageAssetName('beta')).toBe('WsScrcpyWeb-linux-beta.AppImage');
+        expect(linuxAppImageAssetName('stable')).toBe('WsScrcpyWeb-linux-stable.AppImage');
+    });
+
+    it('builds the release download URL', () => {
+        expect(releaseAssetUrl('bilbospocketses', '0.1.30-beta.26', 'WsScrcpyWeb-linux-beta.AppImage'))
+            .toBe('https://github.com/bilbospocketses/ws-scrcpy-web/releases/download/v0.1.30-beta.26/WsScrcpyWeb-linux-beta.AppImage');
+    });
+
+    it('parses SHA256SUMS by basename (path-prefixed entries)', () => {
+        const sums =
+            'ec1f3987e95cba5c179b14a1c04aa355a7710d72dc31c8eca9cb39f62ad9c7bc  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n' +
+            '952bebf9fd143145b258348c14d942fe76c9b4018f64f7444c2fdbe22f5aee34  ./linux-final/WsScrcpyWeb-0.1.30-beta.26-linux-beta-full.nupkg\n';
+        expect(parseSha256Sums(sums, 'WsScrcpyWeb-linux-beta.AppImage'))
+            .toBe('ec1f3987e95cba5c179b14a1c04aa355a7710d72dc31c8eca9cb39f62ad9c7bc');
+    });
+
+    it('returns null when the asset is absent', () => {
+        expect(parseSha256Sums('deadbeef  ./x/other.bin\n', 'WsScrcpyWeb-linux-beta.AppImage')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/linuxUpdateAssets.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import type { UpdateChannel } from '../common/ConfigEvents';
+
+/** Published Linux AppImage asset name (channel-suffixed, NOT version-suffixed). */
+export function linuxAppImageAssetName(channel: UpdateChannel): string {
+    return `WsScrcpyWeb-linux-${channel}.AppImage`;
+}
+
+/** GitHub release asset download URL for a given version tag (`v<version>`). */
+export function releaseAssetUrl(githubOwner: string, version: string, assetName: string): string {
+    return `https://github.com/${githubOwner}/ws-scrcpy-web/releases/download/v${version}/${assetName}`;
+}
+
+/**
+ * Parse `sha256sum`-style text and return the lowercase hex digest for `filename`,
+ * matched by BASENAME (our SHA256SUMS lists path-prefixed entries like
+ * `./linux-final/<asset>`). Returns null if not found.
+ */
+export function parseSha256Sums(text: string, filename: string): string | null {
+    for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        // "<64 hex>  <name>"  (two spaces; "*" binary marker tolerated)
+        const m = trimmed.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+        if (!m) continue;
+        const base = m[2].trim().split('/').pop();
+        if (base === filename) return m[1].toLowerCase();
+    }
+    return null;
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/linuxUpdateAssets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/linuxUpdateAssets.ts src/server/__tests__/linuxUpdateAssets.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): release-asset URL + SHA256SUMS parse helpers"
+```
+
+---
+
+## Task 3: SHA-256 file verification
+
+**Files:**
+- Create: `src/server/verifySha256.ts`
+- Test: `src/server/__tests__/verifySha256.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { verifySha256 } from '../verifySha256';
+
+describe('verifySha256', () => {
+    let file: string;
+    let goodHash: string;
+    beforeAll(() => {
+        file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'sha-')), 'blob');
+        const data = Buffer.from('hello appimage');
+        fs.writeFileSync(file, data);
+        goodHash = createHash('sha256').update(data).digest('hex');
+    });
+    afterAll(() => fs.rmSync(path.dirname(file), { recursive: true, force: true }));
+
+    it('returns true for a matching hash (case-insensitive)', async () => {
+        expect(await verifySha256(file, goodHash.toUpperCase())).toBe(true);
+    });
+    it('returns false for a wrong hash', async () => {
+        expect(await verifySha256(file, '0'.repeat(64))).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/verifySha256.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { createHash } from 'crypto';
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { createReadStream } from 'fs';
+
+/** Stream-hash `filePath` (sha256) and return the lowercase hex digest. */
+export function sha256File(filePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const hash = createHash('sha256');
+        const stream = createReadStream(filePath);
+        stream.on('error', reject);
+        stream.on('data', (chunk) => hash.update(chunk));
+        stream.on('end', () => resolve(hash.digest('hex')));
+    });
+}
+
+/** True iff `filePath`'s sha256 equals `expectedHex` (case-insensitive). */
+export async function verifySha256(filePath: string, expectedHex: string): Promise<boolean> {
+    const actual = await sha256File(filePath);
+    return actual.toLowerCase() === expectedHex.toLowerCase();
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/verifySha256.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/verifySha256.ts src/server/__tests__/verifySha256.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat: streaming sha256 file verification helper"
+```
+
+---
+
+## Task 4: Download-to-file + fetch-text helpers
+
+**Files:**
+- Create: `src/server/downloadToFile.ts`
+- Test: `src/server/__tests__/downloadToFile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadToFile, fetchText } from '../downloadToFile';
+
+describe('downloadToFile', () => {
+    const dirs: string[] = [];
+    afterEach(() => { for (const d of dirs) fs.rmSync(d, { recursive: true, force: true }); });
+
+    it('streams a 200 response body to disk', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-')); dirs.push(dir);
+        const dest = path.join(dir, 'out.bin');
+        const fetchFn = (async () => new Response('payload-bytes')) as unknown as typeof fetch;
+        await downloadToFile('https://example/x', dest, fetchFn);
+        expect(fs.readFileSync(dest, 'utf8')).toBe('payload-bytes');
+    });
+
+    it('throws on a non-2xx response', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-')); dirs.push(dir);
+        const fetchFn = (async () => new Response('nope', { status: 404 })) as unknown as typeof fetch;
+        await expect(downloadToFile('https://example/x', path.join(dir, 'o'), fetchFn)).rejects.toThrow(/404/);
+    });
+
+    it('fetchText returns the body text', async () => {
+        const fetchFn = (async () => new Response('line1\nline2')) as unknown as typeof fetch;
+        expect(await fetchText('https://example/s', fetchFn)).toBe('line1\nline2');
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/downloadToFile.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import * as fs from 'fs';
+
+export type FetchFn = typeof fetch;
+
+/**
+ * Download `url` to `destPath`. Buffers the body then writes (artifacts are
+ * ~60 MB — acceptable transient memory; keeps the helper simple and the write
+ * atomic-per-file). Throws on a non-2xx response or network error.
+ */
+export async function downloadToFile(url: string, destPath: string, fetchFn: FetchFn = fetch): Promise<void> {
+    const res = await fetchFn(url);
+    if (!res.ok) {
+        throw new Error(`download failed: ${res.status} ${res.statusText} for ${url}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    await fs.promises.writeFile(destPath, buf);
+}
+
+/** Fetch `url` and return the body as text. Throws on a non-2xx response. */
+export async function fetchText(url: string, fetchFn: FetchFn = fetch): Promise<string> {
+    const res = await fetchFn(url);
+    if (!res.ok) {
+        throw new Error(`fetch failed: ${res.status} ${res.statusText} for ${url}`);
+    }
+    return res.text();
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx vitest run src/server/__tests__/downloadToFile.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/downloadToFile.ts src/server/__tests__/downloadToFile.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat: download-to-file + fetch-text helpers (injectable fetch)"
+```
+
+---
+
+## Task 5: Rewrite the Linux-local `applyUpdate` branch
+
+The existing service-mode block returns first, so the `this.platform !== 'win32'` block is reached only for Linux **local** mode. We replace its body (the old `waitExitThenApplyUpdate(restart=true)`) with download → verify → spawn-helper. We also add a `fetchFn` injection seam.
+
+**Files:**
+- Modify: `src/server/UpdateService.ts` (imports, `UpdateServiceOptions`, constructor, `applyUpdate` Linux branch ~lines 433–440)
+- Test: `src/server/__tests__/UpdateService.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('applyUpdate (linux local): downloads + verifies + spawns helper; mode reconnect', async () => {
+    const { createHash } = await import('crypto');
+    Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user', channel: 'beta', githubOwner: 'bilbospocketses' });
+    const appImageBytes = Buffer.from('NEW-APPIMAGE-CONTENT');
+    const goodHash = createHash('sha256').update(appImageBytes).digest('hex');
+    const sums = `${goodHash}  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n`;
+    const fetchFn = vi.fn(async (url: string) =>
+        url.endsWith('.AppImage') ? new Response(appImageBytes) : new Response(sums),
+    ) as unknown as typeof fetch;
+    const spawnMock = vi.mocked(child_process.spawn);
+    spawnMock.mockClear();
+
+    const mgr = fakeMgr({ checkForUpdatesAsync: async () => fakeUpdateInfo('0.1.30-beta.26') });
+    const svc = new UpdateService({
+        platform: 'linux',
+        installRoot: path.join('/fake', 'mount', 'usr'),
+        existsSync: () => true,
+        updateManagerFactory: () => mgr,
+        setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+        clearIntervalFn: () => undefined,
+        fetchFn,
+    });
+    process.env['APPIMAGE'] = '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage';
+    svc.init();
+    await svc.checkForUpdates();
+    expect(svc.getStatus().status).toBe('ready');
+
+    const result = await svc.applyUpdate();
+    expect(result.redirectPort).toBeNull();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = spawnMock.mock.calls[0]!;
+    expect(String(bin)).toMatch(/control[\\/]operation-server[\\/]ws-scrcpy-web-launcher\.exe$/);
+    expect(argv).toEqual(expect.arrayContaining(['--linux-apply', '--target', '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage']));
+});
+
+it('applyUpdate (linux local): SHA mismatch aborts, no helper spawn', async () => {
+    Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user', channel: 'beta', githubOwner: 'bilbospocketses' });
+    const sums = `${'0'.repeat(64)}  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n`;
+    const fetchFn = vi.fn(async (url: string) =>
+        url.endsWith('.AppImage') ? new Response(Buffer.from('CORRUPT')) : new Response(sums),
+    ) as unknown as typeof fetch;
+    const spawnMock = vi.mocked(child_process.spawn);
+    spawnMock.mockClear();
+
+    const mgr = fakeMgr({ checkForUpdatesAsync: async () => fakeUpdateInfo('0.1.30-beta.26') });
+    const svc = new UpdateService({
+        platform: 'linux', installRoot: path.join('/fake', 'mount', 'usr'), existsSync: () => true,
+        updateManagerFactory: () => mgr, setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+        clearIntervalFn: () => undefined, fetchFn,
+    });
+    process.env['APPIMAGE'] = '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage';
+    svc.init();
+    await svc.checkForUpdates();
+    await expect(svc.applyUpdate()).rejects.toThrow(/mismatch/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts -t "linux local"`
+Expected: FAIL — `fetchFn` is not an accepted option / the branch still calls `waitExitThenApplyUpdate`, so spawn isn't called and `mode` assertions fail.
+
+- [ ] **Step 3: Add the `fetchFn` seam + imports**
+
+The three helper modules live next to `UpdateService.ts` in `src/server/`, so add these server-relative imports alongside the existing ones:
+
+```ts
+import { linuxAppImageAssetName, releaseAssetUrl, parseSha256Sums } from './linuxUpdateAssets';
+import { verifySha256 } from './verifySha256';
+import { downloadToFile, fetchText } from './downloadToFile';
+```
+
+Add to `UpdateServiceOptions`:
+
+```ts
+    /** Override global fetch for tests (download + SHA256SUMS). Default: global fetch. */
+    fetchFn?: typeof fetch;
+```
+
+Add the field + constructor assignment (next to the other `private readonly` fields / assignments):
+
+```ts
+    private readonly fetchFn: typeof fetch;
+```
+```ts
+        this.fetchFn = opts.fetchFn ?? fetch;
+```
+
+- [ ] **Step 4: Replace the Linux-local apply branch**
+
+Replace:
+
+```ts
+        if (this.platform !== 'win32') {
+            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, true);
+            return { redirectPort: null };
+        }
+```
+
+with:
+
+```ts
+        // Linux local mode: Velopack 1.0.1's UpdateNix apply fails on our AppImage
+        // (it re-derives a locator from `--root <appimage>` and fails the
+        // UpdateExePath check — see docs/specs/2026-06-01-linux-appimage-self-update-design.md).
+        // Replace it: download the published AppImage, verify its SHA-256 against the
+        // release SHA256SUMS, then hand off to the out-of-mount helper to swap
+        // $APPIMAGE + relaunch. (Service mode returned above, so this is local-only.)
+        if (this.platform !== 'win32') {
+            const config = Config.getInstance();
+            const appCfg = config.getAppConfig();
+            const version = this.state.availableVersion;
+            if (!version) {
+                throw new Error('apply: no available version resolved');
+            }
+            const assetName = linuxAppImageAssetName(appCfg.channel);
+            const appImageUrl = releaseAssetUrl(appCfg.githubOwner, version, assetName);
+            const sumsUrl = releaseAssetUrl(appCfg.githubOwner, version, 'SHA256SUMS');
+
+            const dataRoot = config.dataRoot ?? path.dirname(config.dependenciesPath);
+            const stagingDir = path.join(dataRoot, 'control', 'update-staging');
+            await fs.promises.mkdir(stagingDir, { recursive: true });
+            const stagedPath = path.join(stagingDir, `${assetName}.new`);
+
+            log.info(`applyUpdate(linux): downloading ${appImageUrl}`);
+            await downloadToFile(appImageUrl, stagedPath, this.fetchFn);
+            const sumsText = await fetchText(sumsUrl, this.fetchFn);
+            const expected = parseSha256Sums(sumsText, assetName);
+            if (!expected) {
+                await fs.promises.rm(stagedPath, { force: true });
+                throw new Error(`apply: SHA256SUMS has no entry for ${assetName}`);
+            }
+            const ok = await verifySha256(stagedPath, expected);
+            if (!ok) {
+                await fs.promises.rm(stagedPath, { force: true });
+                throw new Error(`apply: SHA-256 mismatch for ${assetName} — aborting`);
+            }
+
+            const appImagePath = process.env['APPIMAGE'] ?? '';
+            // The launcher stages this helper copy (named *.exe even on Linux) to
+            // dataRoot on every boot — outside the AppImage mount, so it survives exit.
+            const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            const child = spawn(
+                helperPath,
+                ['--linux-apply', '--staged', stagedPath, '--target', appImagePath, '--wait-pid', String(process.pid)],
+                { detached: true, stdio: 'ignore' },
+            );
+            child.unref();
+            log.info(`applyUpdate(linux): spawned helper pid ${child.pid} to swap ${appImagePath}`);
+            return { redirectPort: null };
+        }
+```
+
+Also clean up the rollback backup on the next Linux launch. In `init()`, immediately after the production-mode check confirms an installed Linux app (just before the `try { … this.factory(…) }` block), best-effort remove a leftover `<$APPIMAGE>.bak` — a successful boot means the previous version's backup is no longer needed:
+
+```ts
+        // Linux: a successful relaunch means the previous version's rollback
+        // backup is safe to drop. Best-effort; ignore failures.
+        if (this.platform !== 'win32') {
+            const appImage = process.env['APPIMAGE'];
+            if (appImage) {
+                void fs.promises.rm(`${appImage}.bak`, { force: true }).catch(() => undefined);
+            }
+        }
+```
+
+- [ ] **Step 5: Run the targeted + full UpdateService suite**
+
+Run: `npx vitest run src/server/__tests__/UpdateService.test.ts`
+Expected: PASS — both new Linux tests + all existing Windows/service apply tests (the service-mode `waitExitThenApplyUpdate(false)` and Windows operation-server tests are unchanged).
+
+- [ ] **Step 6: Typecheck + full suite**
+
+Run: `npx tsc --noEmit`
+Run: `npx vitest run`
+Expected: tsc clean; entire suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/UpdateService.ts src/server/__tests__/UpdateService.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): hand-rolled AppImage apply (download+verify+helper), not Velopack UpdateNix"
+```
+
+---
+
+## Task 6: Render the upgrading overlay in the top layer (Bug A)
+
+The Settings modal is a native `<dialog>` opened with `showModal()` → browser top layer. A `z-index:99999` body div can't sit above it. Re-implement `UpgradingOverlay` as a `<dialog>` opened with `showModal()` (shown last → on top).
+
+**Files:**
+- Modify: `src/app/client/UpgradingOverlay.ts`
+- Test: `src/app/client/__tests__/UpgradingOverlay.test.ts`
+
+- [ ] **Step 1: Update the test (mock showModal like the other dialog tests)**
+
+Replace the existing `UpgradingOverlay.test.ts` body with:
+
+```ts
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { UpgradingOverlay } from '../UpgradingOverlay';
+
+beforeAll(() => {
+    // jsdom doesn't implement the top-layer dialog methods.
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) { this.open = true; });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) { this.open = false; });
+});
+
+describe('UpgradingOverlay', () => {
+    it('mounts a top-layer <dialog> via showModal and removes cleanly', () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        const o = new UpgradingOverlay();
+        o.mount();
+        const el = document.querySelector('dialog.upgrading-overlay');
+        expect(el).not.toBeNull();
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(el!.textContent).toContain('updating');
+        o.setState('timeout', 'http://localhost:8000/');
+        expect(document.querySelector('.upgrading-overlay')!.textContent).toContain('http://localhost:8000/');
+        o.remove();
+        expect(document.querySelector('.upgrading-overlay')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/app/client/__tests__/UpgradingOverlay.test.ts`
+Expected: FAIL — current overlay creates a `div`, not a `dialog`, and never calls `showModal`.
+
+- [ ] **Step 3: Implement the top-layer overlay**
+
+Change the field type and `mount`/`remove` in `UpgradingOverlay.ts`:
+
+```ts
+    private root: HTMLDialogElement | null = null;
+    private msg: HTMLParagraphElement | null = null;
+
+    mount(): void {
+        if (this.root) return;
+        const root = document.createElement('dialog');
+        root.className = 'upgrading-overlay';
+        // Inline critical styles so it renders even if the stylesheet is mid-reload.
+        // It's a <dialog> in the top layer (via showModal), so it sits above the
+        // Settings dialog regardless of z-index. Fill the viewport; kill default
+        // dialog chrome.
+        root.style.cssText =
+            'position:fixed;inset:0;width:100vw;height:100vh;max-width:100vw;max-height:100vh;' +
+            'box-sizing:border-box;border:none;margin:0;padding:2rem;display:flex;' +
+            'flex-direction:column;align-items:center;justify-content:center;gap:1rem;' +
+            'background:rgba(0,0,0,0.85);color:#fff;font:14px/1.5 system-ui,sans-serif;text-align:center;';
+        const spinner = document.createElement('div');
+        spinner.className = 'upgrading-overlay-spinner';
+        const msg = document.createElement('p');
+        msg.className = 'upgrading-overlay-msg';
+        root.append(spinner, msg);
+        document.body.appendChild(root);
+        if (typeof root.showModal === 'function') {
+            root.showModal();
+        }
+        this.root = root;
+        this.msg = msg;
+        this.setState('applying');
+    }
+
+    remove(): void {
+        if (this.root) {
+            if (this.root.open && typeof this.root.close === 'function') {
+                this.root.close();
+            }
+            this.root.remove();
+        }
+        this.root = null;
+        this.msg = null;
+    }
+```
+
+`setState` and `runUpgradingHandoff` are unchanged.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx vitest run src/app/client/__tests__/UpgradingOverlay.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + full suite**
+
+Run: `npx tsc --noEmit && npx vitest run`
+Expected: clean + green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/UpgradingOverlay.ts src/app/client/__tests__/UpgradingOverlay.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): render upgrading overlay as a top-layer <dialog> (above Settings)"
+```
+
+---
+
+## Task 7: Rust `--linux-apply` helper
+
+**Files:**
+- Create: `launcher/src/linux_apply.rs`
+- Modify: `launcher/src/main.rs` (register module + dispatch)
+- Test: inline `#[cfg(test)]` in `linux_apply.rs`
+
+> **Note (host caveat):** this module is `#[cfg(target_os = "linux")]`; it does NOT compile or test on the Windows dev host. It is built + tested by the **Linux** CI leg (`cargo test` on the Linux runner) and confirmed by the real-Linux verification in Task 8. On Windows, `cargo build` simply excludes it.
+
+- [ ] **Step 1: Write `linux_apply.rs` with its failing tests**
+
+```rust
+// §41 — Linux local-mode in-app update apply. Velopack 1.0.1's UpdateNix apply
+// fails on our AppImage (it re-derives a locator from `--root <appimage>` and
+// fails the UpdateExePath check). Instead the Node server downloads + verifies
+// the new AppImage, then spawns THIS helper (the launcher copy staged in
+// dataRoot, outside the mount) to swap $APPIMAGE + relaunch.
+// See docs/specs/2026-06-01-linux-appimage-self-update-design.md.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::log;
+
+/// Dispatch: if argv contains `--linux-apply`, handle it and return Some(exit_code).
+pub fn handle(args: &[String]) -> Option<i32> {
+    if !args.iter().any(|a| a == "--linux-apply") {
+        return None;
+    }
+    Some(run(args))
+}
+
+fn arg_value<'a>(args: &'a [String], key: &str) -> Option<&'a str> {
+    args.iter().position(|a| a == key).and_then(|i| args.get(i + 1)).map(|s| s.as_str())
+}
+
+fn run(args: &[String]) -> i32 {
+    let staged = match arg_value(args, "--staged") {
+        Some(s) => PathBuf::from(s),
+        None => { log::error("linux-apply: missing --staged"); return 2; }
+    };
+    let target = match arg_value(args, "--target") {
+        Some(s) => PathBuf::from(s),
+        None => { log::error("linux-apply: missing --target"); return 2; }
+    };
+    let wait_pid = arg_value(args, "--wait-pid").and_then(|s| s.parse::<u32>().ok());
+    log::info(&format!("linux-apply: staged={staged:?} target={target:?} wait_pid={wait_pid:?}"));
+
+    if let Some(pid) = wait_pid {
+        wait_for_pid_exit(pid, Duration::from_secs(60));
+    }
+
+    match swap_appimage(&staged, &target) {
+        Ok(()) => { log::info("linux-apply: swap ok, relaunching"); relaunch(&target); 0 }
+        Err(e) => { log::error(&format!("linux-apply: swap failed: {e}")); 1 }
+    }
+}
+
+/// `<target>.bak`
+pub fn backup_path(target: &Path) -> PathBuf {
+    let mut s = target.as_os_str().to_os_string();
+    s.push(".bak");
+    PathBuf::from(s)
+}
+
+/// Back up `target` -> `<target>.bak`, move `staged` over `target`, chmod 0755.
+/// On a move failure after backup, restore the backup. Pure file ops — unit-tested.
+pub fn swap_appimage(staged: &Path, target: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if !staged.exists() {
+        return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "staged file missing"));
+    }
+    let backup = backup_path(target);
+    if target.exists() {
+        // rename within-fs; fall back to copy for cross-fs.
+        std::fs::rename(target, &backup)
+            .or_else(|_| std::fs::copy(target, &backup).map(|_| ()))?;
+    }
+    let moved = std::fs::rename(staged, target)
+        .or_else(|_| std::fs::copy(staged, target).and_then(|_| std::fs::remove_file(staged)).map(|_| ()));
+    if let Err(e) = moved {
+        if backup.exists() { let _ = std::fs::rename(&backup, target); }
+        return Err(e);
+    }
+    std::fs::set_permissions(target, std::fs::Permissions::from_mode(0o755))?;
+    Ok(())
+}
+
+/// Poll until `/proc/<pid>` disappears or `timeout` elapses. No libc dependency.
+fn wait_for_pid_exit(pid: u32, timeout: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if !Path::new(&format!("/proc/{pid}")).exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    log::error(&format!("linux-apply: pid {pid} still alive after {timeout:?}; proceeding anyway"));
+}
+
+/// Spawn the new AppImage detached; the helper then exits.
+fn relaunch(target: &Path) {
+    match std::process::Command::new(target)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(child) => log::info(&format!("linux-apply: relaunched {target:?} (pid {})", child.id())),
+        Err(e) => log::error(&format!("linux-apply: relaunch failed: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn swap_replaces_target_and_backs_up_old() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("App.AppImage");
+        let staged = tmp.path().join("App.AppImage.new");
+        std::fs::write(&target, b"OLD").unwrap();
+        std::fs::write(&staged, b"NEW").unwrap();
+
+        swap_appimage(&staged, &target).unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"NEW");
+        assert_eq!(std::fs::read(backup_path(&target)).unwrap(), b"OLD");
+        assert!(!staged.exists(), "staged file consumed");
+    }
+
+    #[test]
+    fn swap_errors_and_preserves_target_when_staged_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("App.AppImage");
+        std::fs::write(&target, b"OLD").unwrap();
+        let staged = tmp.path().join("does-not-exist.new");
+
+        assert!(swap_appimage(&staged, &target).is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), b"OLD", "target untouched on error");
+    }
+
+    #[test]
+    fn arg_value_reads_following_token() {
+        let args = vec!["x".into(), "--target".into(), "/a/b".into()];
+        assert_eq!(arg_value(&args, "--target"), Some("/a/b"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Register + dispatch in `main.rs`**
+
+Add the module declaration near the other `mod` lines (e.g. after `mod operation_server;`):
+
+```rust
+#[cfg(target_os = "linux")]
+mod linux_apply;
+```
+
+In `fn main()`, add the dispatch alongside the other `handle(&args)` early-exits (e.g. right after the `unzip_handler::handle` block):
+
+```rust
+    // Linux in-app update apply helper (spawned by the Node server in dataRoot,
+    // outside the AppImage mount). Swaps $APPIMAGE + relaunches. Linux-only.
+    #[cfg(target_os = "linux")]
+    if let Some(code) = linux_apply::handle(&args) {
+        log::info(&format!("linux-apply exiting with code {code}"));
+        std::process::exit(code);
+    }
+```
+
+- [ ] **Step 3: Verify (Linux toolchain only)**
+
+On a Linux host / CI leg:
+Run: `cargo test -p ws-scrcpy-web-launcher linux_apply`
+Expected: 3 tests pass.
+
+On the Windows dev host (module is cfg'd out):
+Run: `cargo build --workspace`
+Expected: builds (the module + dispatch are excluded on Windows).
+
+> If the launcher crate name differs, use the name from `launcher/Cargo.toml`'s `[package] name`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/linux_apply.rs launcher/src/main.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): --linux-apply launcher helper (swap AppImage + relaunch)"
+```
+
+---
+
+## Task 8: Final verification + Windows-freeze review
+
+- [ ] **Step 1: Full typecheck + suite**
+
+Run: `npx tsc --noEmit && npx vitest run`
+Expected: tsc clean; **all** tests pass, including the pre-existing Windows operation-server + service-mode apply tests.
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: webpack build succeeds (server + client bundles include the new modules).
+
+- [ ] **Step 3: Windows-freeze review (manual)**
+
+Confirm `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" diff main -- launcher/src/operation_server.rs` is empty, and that the `applyUpdate` Windows operation-server branch + `handleApply` redirect + the service-mode `waitExitThenApplyUpdate(...false)` branch are byte-identical to `main`.
+
+- [ ] **Step 4: Real-Linux verification (Fedora, user mode)**
+
+Cut a fix beta via the bump-PR → Auto Release pipeline (e.g. beta.27 then a no-op beta.28 target, or beta.27→whatever-is-next). Install beta.<N> in user mode, click update:
+- The upgrading overlay is **visible** (above any Settings dialog).
+- `$APPIMAGE` is rewritten (size/mtime change; reported version becomes beta.<N+1>); the app relaunches on the new version and the browser reconnects.
+- `<dataRoot>/control/update-staging/` no longer holds the consumed `.new` (the helper renamed it into place); `$APPIMAGE.bak` is created during the swap and removed on the next Linux launch by the `init()` cleanup added in Task 5.
+- `/tmp/velopack.log` shows **no** new `UpdateNix` apply attempt (the updater is no longer invoked for apply).
+
+---
+
+## Out of scope (separate task sets)
+
+- Linux **service-mode** (user-service + system-service) update apply.
+- Items 32 (service uninstall teardown) + 33 (system-scope SELinux AVC).
+- Velopack 1.0.1 → 1.1.1 bump (item 31) — decoupled from this fix.

--- a/docs/specs/2026-06-01-linux-appimage-self-update-design.md
+++ b/docs/specs/2026-06-01-linux-appimage-self-update-design.md
@@ -1,0 +1,159 @@
+# Linux AppImage self-update (local mode) — replace Velopack apply
+
+**Date:** 2026-06-01
+**Status:** Approved design
+**Scope:** Linux, `installMode === 'user'` (local) only. Windows and Linux service mode are untouched.
+
+## Problem
+
+Velopack 1.0.1's `UpdateNix apply` cannot apply updates to our AppImage. Confirmed from
+`/tmp/velopack.log` on real Fedora: the updater spawns, finds the downloaded package, then
+fails in the same millisecond — `Apply error: This application is not properly installed:
+Update.exe does not exist in the expected path` — before touching a single file.
+
+Root cause: `UpdateNix` is launched (`velopack` crate `manager.rs::unsafe_apply_updates`) with
+only `apply --package <nupkg> --waitPid <pid> [--silent] --root <$APPIMAGE>`. It re-derives its
+**own** locator from `--root` via `Context: FromSpecifiedRootDir(<appimage>, None)`; the derived
+`UpdateExePath` does not exist, so `VelopackLocator::new` (`locator.rs:114`) returns
+`NotInstalled`. The explicit `VelopackLocatorConfig` our Node code builds is used only for
+*discovery* (`checkForUpdatesAsync`, which works) and is **not** propagated to the apply binary.
+
+The failure is mode- and restart-independent: reproduced in a clean local install
+(`installMode:"user"`, `Restart:true` — i.e. PR #246's actual Linux branch) and in prior
+service-mode runs (`Restart:false`), always the identical error. The 60 MB nupkg downloads and
+validates; the apply never runs; the install stays on the old version; nothing relaunches.
+
+PR #246's `waitExitThenApplyUpdate(restart=true)` change is therefore inert on Linux — the call
+is made, Velopack simply cannot honor it. Velopack 1.1.1's changelog shows no fix for this path
+(its Linux change is the AppImage type-2 runtime, PR #899).
+
+**Secondary defect (Bug A):** `UpgradingOverlay` (a `position:fixed; z-index:99999` div appended
+to `document.body`) renders *behind* the Settings modal, because the Settings modal is a native
+`<dialog>` opened with `showModal()` → the browser **top layer**, which paints above the entire
+normal-DOM stacking context regardless of z-index. This hides the overlay's timeout fallback
+("reopen the url"), so when apply fails the user is given no guidance.
+
+## Goal
+
+1. Linux local-mode in-app updates **apply and relaunch** on the new version, deterministically,
+   without depending on Velopack's updater.
+2. The upgrading overlay — and especially its fallback message — is **always visible**.
+
+## Hard constraints
+
+- **Windows frozen.** `launcher/src/operation_server.rs`, the Windows `applyUpdate` /
+  `handleApply` branches, and the service-mode branch are byte-for-byte unchanged. The full
+  vitest suite — including the Windows operation-server + service-mode apply tests — stays green.
+- **Linux service mode untouched.** Out of scope; a separate task set (with items 32/33).
+- **Local-Dependencies-Only.** No system-PATH / env-var binary resolution. The apply helper is
+  the app's own launcher binary, already staged inside the app's `dataRoot`.
+
+## Design
+
+### Discovery (unchanged, with one trim)
+
+Velopack `checkForUpdatesAsync` continues to detect the available version from the
+`releases.linux-<channel>.json` feed (works today via the explicit locator). On Linux,
+**skip the Velopack nupkg auto-download** (`downloadIfNeeded`): set status `ready` on
+availability without fetching the now-unused 60 MB nupkg. Our apply downloads the AppImage
+instead.
+
+### Apply — Node (`UpdateService.applyUpdate`, Linux local branch)
+
+Replaces the `waitExitThenApplyUpdate` call for the Linux-local case
+(gated `this.platform !== 'win32' && installMode === 'user'`):
+
+1. Resolve target version (`state.availableVersion`) and channel (`linux-<beta|stable>`).
+2. Stream-download the release AppImage asset to a staging file in `dataRoot` (outside the
+   AppImage mount, so it survives the app exiting):
+   - URL: `https://github.com/<owner>/ws-scrcpy-web/releases/download/v<version>/WsScrcpyWeb-linux-<channel>.AppImage`
+   - Dest: `<dataRoot>/control/update-staging/WsScrcpyWeb-linux-<channel>.AppImage.new`
+3. Download `SHA256SUMS` from the same release; find the line whose filename column equals the
+   AppImage asset name; verify the staged file's SHA-256 against that hash.
+   **On download error or hash mismatch → abort: return an error, do NOT `process.exit`.** The
+   app keeps running on the current version.
+4. Spawn the staged helper, detached:
+   `<dataRoot>/control/operation-server/ws-scrcpy-web-launcher --linux-apply --staged <new> --target <$APPIMAGE> --wait-pid <pid>`
+5. Return `{ redirectPort: null }`; `handleApply` returns `{ ok:true, mode:'reconnect' }` (the
+   existing PR #246 path); the existing deferred `process.exit(0)` runs.
+
+Network + SHA-256 verification live in Node (HTTP + `crypto` already available in the server
+stack). The helper performs only the post-exit file operation.
+
+### Apply — helper (launcher, new `#[cfg(target_os = "linux")]` `--linux-apply` mode)
+
+The helper is the launcher binary already copied to `<dataRoot>/control/operation-server/` by
+`operation_server::refresh_helper_binary` on every boot — outside the mount, so it survives the
+unmount. New subcommand:
+
+1. Parse `--staged`, `--target` (= `$APPIMAGE`), `--wait-pid`.
+2. Wait for the pid to exit (poll, bounded ~60 s).
+3. Back up `--target` → `<target>.bak`.
+4. Move staged → target: `rename` when same filesystem, else copy + `fsync` + `rename`;
+   `chmod 0755` the result.
+5. Relaunch: `exec` (or spawn-detached) `--target`; the helper then exits. The new AppImage
+   re-mounts, runs the launcher, binds the freed web port.
+6. Any failure before relaunch → restore `<target>.bak` and write a
+   `<dataRoot>/control/update-error` marker; do not relaunch.
+
+SELinux (Fedora): the helper runs as the user (`unconfined_u`) and execs a `user_home_t`
+AppImage, which is permitted in user scope — only the `init_t` system-service path (item 33) was
+denied.
+
+### Client (Bug A fix + reuse)
+
+- Reuse `runUpgradingHandoff` / `reconnectAfterApply` (built in PR #246): on `mode:'reconnect'`,
+  show the overlay, poll the same origin, reload on a new version, timeout → "reopen `<url>`".
+- **Fix:** make `UpgradingOverlay` render in the top layer — build it as a `<dialog>` element
+  appended to `document.body` and opened with `showModal()` (shown last → above the Settings
+  `<dialog>`). Keep the inline critical styles (it must render with the stylesheet mid-reload).
+  No z-index reliance.
+
+## Components / files
+
+| File | Change |
+|---|---|
+| `src/server/UpdateService.ts` | Linux-local: skip nupkg download in `checkForUpdates`; in `applyUpdate`, replace `waitExitThenApplyUpdate` with download → verify → spawn-helper. New private helpers: release-asset URL builder, `downloadToFile`, `verifySha256`, `parseSha256Sums`. |
+| `src/server/api/UpdatesApi.ts` | No change expected (`mode:'reconnect'` already returned for non-win32). Re-confirm by test. |
+| `src/app/client/UpgradingOverlay.ts` | Render as a top-layer `<dialog>` via `showModal()` (replaces the body-appended `z-index:99999` div). `remove()` calls `close()` then removes. |
+| `launcher/src/linux_apply.rs` (new) + arg wiring in `launcher/src/main.rs` | `--linux-apply` mode: wait-pid, backup, swap (rename / copy-fallback), relaunch, restore-on-fail. Gated `#[cfg(target_os = "linux")]`. |
+| Tests | Node apply branch + SHA verify; Rust swap/restore; client overlay top-layer. |
+
+## Error handling / edge cases
+
+- Download fail / SHA mismatch → abort before any swap; app unaffected, stays on current version.
+- Helper swap fail → restore backup + error marker; the current version still launches.
+- Relaunch fail → the now-visible overlay timeout fallback tells the user to reopen the URL;
+  the new AppImage is already in place, so a manual reopen lands on the new version.
+- `$APPIMAGE` moved/renamed by the user → `--target` is the actual `process.env.APPIMAGE` path
+  captured at apply time; if it is not writable, abort with an error marker (no partial state).
+- `dataRoot` and `$APPIMAGE` on different filesystems → copy + rename fallback in the helper.
+- `<target>.bak` is cleaned on the next clean launch.
+
+## Testing
+
+- `UpdateService` Linux-local apply (TDD, injected `fetch`/`fs`/`spawn`): downloads → verifies →
+  spawns the helper → returns `mode:'reconnect'`; SHA mismatch → abort, no spawn, error surfaced;
+  Linux `checkForUpdates` does **not** download the nupkg.
+- SHA-256 verify + `SHA256SUMS` parse — unit tests (good hash passes, bad hash fails, correct
+  line selected).
+- Rust helper: backup / swap / restore decision logic in a tempdir (same-fs rename succeeds;
+  induced failure restores the backup). The wait-pid + exec is covered by a thin integration
+  seam; the file-op core is a pure, unit-tested function.
+- Client: `UpgradingOverlay` calls `showModal()` and mounts a `<dialog>` (jsdom).
+- **Full existing suite green** — Windows operation-server + service-mode apply tests unchanged
+  (the freeze guardrail).
+
+## Verification (real Linux)
+
+Cut a beta, install in user mode on Fedora, click update → the overlay is visible → the app
+relaunches on the new version. Confirm: `$APPIMAGE` is rewritten (mtime + reported version
+change), `.bak` is cleaned on the next launch, and `/tmp/velopack.log` no longer shows an
+`UpdateNix` apply attempt (the updater is no longer invoked for apply).
+
+## Out of scope (separate task sets)
+
+- Linux **service-mode** (user-service + system-service) update apply.
+- Item 32 (service uninstall teardown) and item 33 (system-scope SELinux AVC).
+- Velopack 1.0.1 → 1.1.1 bump (item 31) — now decoupled from the apply fix; its remaining value
+  is the type-2 runtime / libfuse2-gate removal only.

--- a/launcher/src/linux_apply.rs
+++ b/launcher/src/linux_apply.rs
@@ -1,0 +1,152 @@
+// §41 — Linux local-mode in-app update apply. Velopack 1.0.1's UpdateNix apply
+// fails on our AppImage (it re-derives a locator from `--root <appimage>` and
+// fails the UpdateExePath check). Instead the Node server downloads + verifies
+// the new AppImage, then spawns THIS helper (the launcher copy staged in
+// dataRoot, outside the mount) to swap $APPIMAGE + relaunch.
+// See docs/specs/2026-06-01-linux-appimage-self-update-design.md.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::log;
+
+/// Dispatch: if argv contains `--linux-apply`, handle it and return Some(exit_code).
+pub fn handle(args: &[String]) -> Option<i32> {
+    if !args.iter().any(|a| a == "--linux-apply") {
+        return None;
+    }
+    Some(run(args))
+}
+
+fn arg_value<'a>(args: &'a [String], key: &str) -> Option<&'a str> {
+    args.iter().position(|a| a == key).and_then(|i| args.get(i + 1)).map(|s| s.as_str())
+}
+
+fn run(args: &[String]) -> i32 {
+    let staged = match arg_value(args, "--staged") {
+        Some(s) => PathBuf::from(s),
+        None => {
+            log::error("linux-apply: missing --staged");
+            return 2;
+        }
+    };
+    let target = match arg_value(args, "--target") {
+        Some(s) => PathBuf::from(s),
+        None => {
+            log::error("linux-apply: missing --target");
+            return 2;
+        }
+    };
+    let wait_pid = arg_value(args, "--wait-pid").and_then(|s| s.parse::<u32>().ok());
+    log::info(&format!("linux-apply: staged={staged:?} target={target:?} wait_pid={wait_pid:?}"));
+
+    if let Some(pid) = wait_pid {
+        wait_for_pid_exit(pid, Duration::from_secs(60));
+    }
+
+    match swap_appimage(&staged, &target) {
+        Ok(()) => {
+            log::info("linux-apply: swap ok, relaunching");
+            relaunch(&target);
+            0
+        }
+        Err(e) => {
+            log::error(&format!("linux-apply: swap failed: {e}"));
+            1
+        }
+    }
+}
+
+/// `<target>.bak`
+pub fn backup_path(target: &Path) -> PathBuf {
+    let mut s = target.as_os_str().to_os_string();
+    s.push(".bak");
+    PathBuf::from(s)
+}
+
+/// Back up `target` -> `<target>.bak`, move `staged` over `target`, chmod 0755.
+/// On a move failure after backup, restore the backup. Pure file ops — unit-tested.
+pub fn swap_appimage(staged: &Path, target: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if !staged.exists() {
+        return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "staged file missing"));
+    }
+    let backup = backup_path(target);
+    if target.exists() {
+        // rename within-fs; fall back to copy for cross-fs.
+        std::fs::rename(target, &backup).or_else(|_| std::fs::copy(target, &backup).map(|_| ()))?;
+    }
+    let moved = std::fs::rename(staged, target)
+        .or_else(|_| std::fs::copy(staged, target).and_then(|_| std::fs::remove_file(staged)).map(|_| ()));
+    if let Err(e) = moved {
+        if backup.exists() {
+            let _ = std::fs::rename(&backup, target);
+        }
+        return Err(e);
+    }
+    std::fs::set_permissions(target, std::fs::Permissions::from_mode(0o755))?;
+    Ok(())
+}
+
+/// Poll until `/proc/<pid>` disappears or `timeout` elapses. No libc dependency.
+fn wait_for_pid_exit(pid: u32, timeout: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if !Path::new(&format!("/proc/{pid}")).exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    log::error(&format!("linux-apply: pid {pid} still alive after {timeout:?}; proceeding anyway"));
+}
+
+/// Spawn the new AppImage detached; the helper then exits.
+fn relaunch(target: &Path) {
+    match std::process::Command::new(target)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(child) => log::info(&format!("linux-apply: relaunched {target:?} (pid {})", child.id())),
+        Err(e) => log::error(&format!("linux-apply: relaunch failed: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn swap_replaces_target_and_backs_up_old() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("App.AppImage");
+        let staged = tmp.path().join("App.AppImage.new");
+        std::fs::write(&target, b"OLD").unwrap();
+        std::fs::write(&staged, b"NEW").unwrap();
+
+        swap_appimage(&staged, &target).unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"NEW");
+        assert_eq!(std::fs::read(backup_path(&target)).unwrap(), b"OLD");
+        assert!(!staged.exists(), "staged file consumed");
+    }
+
+    #[test]
+    fn swap_errors_and_preserves_target_when_staged_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("App.AppImage");
+        std::fs::write(&target, b"OLD").unwrap();
+        let staged = tmp.path().join("does-not-exist.new");
+
+        assert!(swap_appimage(&staged, &target).is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), b"OLD", "target untouched on error");
+    }
+
+    #[test]
+    fn arg_value_reads_following_token() {
+        let args = vec!["x".to_string(), "--target".to_string(), "/a/b".to_string()];
+        assert_eq!(arg_value(&args, "--target"), Some("/a/b"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+}

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -19,6 +19,8 @@ mod tray_supervisor;
 mod uac_requester;
 mod unzip_handler;
 mod operation_server;
+#[cfg(target_os = "linux")]
+mod linux_apply;
 #[cfg(windows)]
 mod user_session_spawn;
 
@@ -81,6 +83,14 @@ fn main() {
     // the SHA-pinned launcher instead of resolving via system PATH.
     if let Some(code) = unzip_handler::handle(&args) {
         log::info(&format!("unzip exiting with code {code}"));
+        std::process::exit(code);
+    }
+
+    // Linux in-app update apply helper (spawned by the Node server in dataRoot,
+    // outside the AppImage mount). Swaps $APPIMAGE + relaunches. Linux-only.
+    #[cfg(target_os = "linux")]
+    if let Some(code) = linux_apply::handle(&args) {
+        log::info(&format!("linux-apply exiting with code {code}"));
         std::process::exit(code);
     }
 

--- a/src/app/client/UpgradingOverlay.ts
+++ b/src/app/client/UpgradingOverlay.ts
@@ -8,25 +8,34 @@ type OverlayState = 'applying' | 'reconnecting' | 'timeout';
  * needed to render). Lowercase copy per the app motif.
  */
 export class UpgradingOverlay {
-    private root: HTMLDivElement | null = null;
+    private root: HTMLDialogElement | null = null;
     private msg: HTMLParagraphElement | null = null;
 
     mount(): void {
         if (this.root) return;
-        const root = document.createElement('div');
+        const root = document.createElement('dialog');
         root.className = 'upgrading-overlay';
-        // Inline the few critical styles so the overlay renders even if the
-        // stylesheet is mid-reload. Visual polish belongs in the stylesheet.
+        // Inline critical styles so it renders even if the stylesheet is mid-reload.
+        // It's a <dialog> in the top layer (via showModal), so it sits above the
+        // Settings <dialog> regardless of z-index. Fill the viewport; kill default
+        // dialog chrome.
         root.style.cssText =
-            'position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;' +
-            'align-items:center;justify-content:center;gap:1rem;background:rgba(0,0,0,0.85);' +
-            'color:#fff;font:14px/1.5 system-ui,sans-serif;text-align:center;padding:2rem;';
+            'position:fixed;inset:0;width:100vw;height:100vh;max-width:100vw;max-height:100vh;' +
+            'box-sizing:border-box;border:none;margin:0;padding:2rem;display:flex;' +
+            'flex-direction:column;align-items:center;justify-content:center;gap:1rem;' +
+            'background:rgba(0,0,0,0.85);color:#fff;font:14px/1.5 system-ui,sans-serif;text-align:center;';
         const spinner = document.createElement('div');
         spinner.className = 'upgrading-overlay-spinner';
         const msg = document.createElement('p');
         msg.className = 'upgrading-overlay-msg';
         root.append(spinner, msg);
         document.body.appendChild(root);
+        // showModal() promotes the dialog to the browser top layer, above any other
+        // open modal (e.g. the Settings <dialog>) regardless of z-index. Guard for
+        // jsdom/older engines where showModal may be absent.
+        if (typeof root.showModal === 'function') {
+            root.showModal();
+        }
         this.root = root;
         this.msg = msg;
         this.setState('applying');
@@ -45,7 +54,12 @@ export class UpgradingOverlay {
     }
 
     remove(): void {
-        this.root?.remove();
+        if (this.root) {
+            if (this.root.open && typeof this.root.close === 'function') {
+                this.root.close();
+            }
+            this.root.remove();
+        }
         this.root = null;
         this.msg = null;
     }

--- a/src/app/client/__tests__/UpgradingOverlay.test.ts
+++ b/src/app/client/__tests__/UpgradingOverlay.test.ts
@@ -1,13 +1,25 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { UpgradingOverlay } from '../UpgradingOverlay';
 
+beforeAll(() => {
+    // jsdom doesn't implement the top-layer dialog methods.
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.open = true;
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.open = false;
+    });
+});
+
 describe('UpgradingOverlay', () => {
-    it('mounts, shows the applying message, swaps to timeout copy, and removes', () => {
+    it('mounts a top-layer <dialog> via showModal, swaps to timeout copy, and removes', () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
         const o = new UpgradingOverlay();
         o.mount();
-        const el = document.querySelector('.upgrading-overlay');
+        const el = document.querySelector('dialog.upgrading-overlay');
         expect(el).not.toBeNull();
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(el!.textContent).toContain('updating');
 
         o.setState('timeout', 'http://localhost:8000/');

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -18,6 +18,9 @@ import type { UpdateState } from '../common/UpdateEvents';
 import { AdbClient } from './AdbClient';
 import { Config } from './Config';
 import { Logger } from './Logger';
+import { linuxAppImageAssetName, releaseAssetUrl, parseSha256Sums } from './linuxUpdateAssets';
+import { verifySha256 } from './verifySha256';
+import { downloadToFile, fetchText } from './downloadToFile';
 
 const execFileAsync = promisify(execFile);
 
@@ -60,6 +63,8 @@ export interface UpdateServiceOptions {
      * because tests only ever ran the host-platform branch.
      */
     platform?: NodeJS.Platform;
+    /** Override global fetch for tests (AppImage download + SHA256SUMS). Default: global fetch. */
+    fetchFn?: typeof fetch;
 }
 
 export interface UpdateServiceState {
@@ -103,6 +108,7 @@ export class UpdateService {
     private readonly existsSync: (p: string) => boolean;
     private readonly setIntervalFn: (cb: () => void, ms: number) => NodeJS.Timeout;
     private readonly clearIntervalFn: (handle: NodeJS.Timeout) => void;
+    private readonly fetchFn: typeof fetch;
 
     constructor(opts: UpdateServiceOptions = {}) {
         this.platform = opts.platform ?? process.platform;
@@ -196,6 +202,7 @@ export class UpdateService {
         this.existsSync = opts.existsSync ?? fs.existsSync;
         this.setIntervalFn = opts.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
         this.clearIntervalFn = opts.clearIntervalFn ?? ((handle) => clearInterval(handle));
+        this.fetchFn = opts.fetchFn ?? fetch;
         this.state = { isInstalled: false, currentVersion: '', status: 'idle' };
     }
 
@@ -264,6 +271,15 @@ export class UpdateService {
         if (!markerExists) {
             this.state = { isInstalled: false, currentVersion: getAppVersion(), status: 'idle' };
             return;
+        }
+
+        // Linux: a successful relaunch means the previous version's rollback
+        // backup is safe to drop. Best-effort; ignore failures.
+        if (this.platform !== 'win32') {
+            const appImage = process.env['APPIMAGE'];
+            if (appImage) {
+                void fs.promises.rm(`${appImage}.bak`, { force: true }).catch(() => undefined);
+            }
         }
 
         try {
@@ -432,12 +448,53 @@ export class UpdateService {
             return { redirectPort: null };
         }
 
-        // Linux local mode: Velopack applies on exit and relaunches the AppImage
-        // (which rebinds the freed web port). The Windows operation-server helper
-        // below does not exist on Linux — spawning it would ENOENT and the apply
-        // would never run. restart=true so Velopack relaunches the new version.
+        // Linux local mode: Velopack 1.0.1's UpdateNix apply fails on our AppImage
+        // (it re-derives a locator from `--root <appimage>` and fails the
+        // UpdateExePath check — see docs/specs/2026-06-01-linux-appimage-self-update-design.md).
+        // Replace it: download the published AppImage, verify its SHA-256 against the
+        // release SHA256SUMS, then hand off to the out-of-mount helper to swap
+        // $APPIMAGE + relaunch. (Service mode returned above, so this is local-only.)
         if (this.platform !== 'win32') {
-            this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, true);
+            const config = Config.getInstance();
+            const appCfg = config.getAppConfig();
+            const version = this.state.availableVersion;
+            if (!version) {
+                throw new Error('apply: no available version resolved');
+            }
+            const assetName = linuxAppImageAssetName(appCfg.channel);
+            const appImageUrl = releaseAssetUrl(appCfg.githubOwner, version, assetName);
+            const sumsUrl = releaseAssetUrl(appCfg.githubOwner, version, 'SHA256SUMS');
+
+            const dataRoot = config.dataRoot ?? path.dirname(config.dependenciesPath);
+            const stagingDir = path.join(dataRoot, 'control', 'update-staging');
+            await fs.promises.mkdir(stagingDir, { recursive: true });
+            const stagedPath = path.join(stagingDir, `${assetName}.new`);
+
+            log.info(`applyUpdate(linux): downloading ${appImageUrl}`);
+            await downloadToFile(appImageUrl, stagedPath, this.fetchFn);
+            const sumsText = await fetchText(sumsUrl, this.fetchFn);
+            const expected = parseSha256Sums(sumsText, assetName);
+            if (!expected) {
+                await fs.promises.rm(stagedPath, { force: true });
+                throw new Error(`apply: SHA256SUMS has no entry for ${assetName}`);
+            }
+            const ok = await verifySha256(stagedPath, expected);
+            if (!ok) {
+                await fs.promises.rm(stagedPath, { force: true });
+                throw new Error(`apply: SHA-256 mismatch for ${assetName} — aborting`);
+            }
+
+            const appImagePath = process.env['APPIMAGE'] ?? '';
+            // The launcher stages this helper copy (named *.exe even on Linux) to
+            // dataRoot on every boot — outside the AppImage mount, so it survives exit.
+            const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            const child = spawn(
+                helperPath,
+                ['--linux-apply', '--staged', stagedPath, '--target', appImagePath, '--wait-pid', String(process.pid)],
+                { detached: true, stdio: 'ignore' },
+            );
+            child.unref();
+            log.info(`applyUpdate(linux): spawned helper pid ${child.pid} to swap ${appImagePath}`);
             return { redirectPort: null };
         }
 

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -363,11 +363,13 @@ export class UpdateService {
             this.state.pendingUpdate = info;
 
             const cfg = Config.getInstance().getAppConfig();
-            if (cfg.autoUpdate) {
+            // On Linux our apply downloads the published AppImage directly, so the
+            // Velopack nupkg is never used — never pre-download it (saves ~60 MB per
+            // check). On Windows, keep the autoUpdate pre-download. autoUpdate=false
+            // also lands in the else. Availability is surfaced via status='ready'.
+            if (cfg.autoUpdate && this.platform !== 'linux') {
                 await this.downloadIfNeeded();
             } else {
-                // autoUpdate disabled: surface "available" via status='ready' but no download yet.
-                // waitExitThenApplyUpdate handles undownloaded updates internally on Apply.
                 this.state.status = 'ready';
             }
         } catch (err) {

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -735,13 +735,20 @@ describe('UpdateService', () => {
         expect(mkdirSpy).toHaveBeenCalled();
     });
 
-    // Linux local-mode apply: no operation-server helper (that's a Windows-only
-    // staged .exe). Velopack applies on exit + relaunches via restart=true.
-    it('applyUpdate (linux local mode): waitExitThenApplyUpdate(restart=true), no helper spawn', async () => {
-        Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user' });
-        const info = fakeUpdateInfo('0.2.0');
+    // Linux local-mode apply: replaces Velopack's broken UpdateNix apply with a
+    // hand-rolled download -> verify-sha256 -> spawn-helper. (Velopack 1.0.1's apply
+    // fails on our AppImage — see docs/specs/2026-06-01-linux-appimage-self-update-design.md.)
+    it('applyUpdate (linux local): downloads + verifies + spawns helper; no waitExitThenApplyUpdate', async () => {
+        const { createHash } = await import('crypto');
+        Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user', channel: 'beta', githubOwner: 'bilbospocketses' });
+        const appImageBytes = Buffer.from('NEW-APPIMAGE-CONTENT');
+        const goodHash = createHash('sha256').update(appImageBytes).digest('hex');
+        const sums = `${goodHash}  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n`;
+        const fetchFn = vi.fn(async (url: string) =>
+            url.endsWith('.AppImage') ? new Response(appImageBytes) : new Response(sums),
+        ) as unknown as typeof fetch;
         const applyFn = vi.fn();
-        const mgr = fakeMgr({ checkForUpdatesAsync: async () => info, waitExitThenApplyUpdate: applyFn });
+        const mgr = fakeMgr({ checkForUpdatesAsync: async () => fakeUpdateInfo('0.1.30-beta.26'), waitExitThenApplyUpdate: applyFn });
         const spawnMock = vi.mocked(child_process.spawn);
         spawnMock.mockClear();
         const svc = new UpdateService({
@@ -751,15 +758,45 @@ describe('UpdateService', () => {
             updateManagerFactory: () => mgr,
             setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
             clearIntervalFn: () => undefined,
+            fetchFn,
         });
+        process.env['APPIMAGE'] = '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage';
         svc.init();
         await svc.checkForUpdates();
         expect(svc.getStatus().status).toBe('ready');
+
         const result = await svc.applyUpdate();
-        expect(applyFn).toHaveBeenCalledTimes(1);
-        expect(applyFn.mock.calls[0]![1]).toBe(true); // silent
-        expect(applyFn.mock.calls[0]![2]).toBe(true); // restart
         expect(result.redirectPort).toBeNull();
+        expect(applyFn).not.toHaveBeenCalled();
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+        const [bin, argv] = spawnMock.mock.calls[0]!;
+        expect(String(bin)).toMatch(/control[\\/]operation-server[\\/]ws-scrcpy-web-launcher\.exe$/);
+        expect(argv).toEqual(
+            expect.arrayContaining(['--linux-apply', '--target', '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage']),
+        );
+    });
+
+    it('applyUpdate (linux local): SHA mismatch aborts, no helper spawn', async () => {
+        Config.getInstance().updateAppConfig({ autoUpdate: false, installMode: 'user', channel: 'beta', githubOwner: 'bilbospocketses' });
+        const sums = `${'0'.repeat(64)}  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n`;
+        const fetchFn = vi.fn(async (url: string) =>
+            url.endsWith('.AppImage') ? new Response(Buffer.from('CORRUPT')) : new Response(sums),
+        ) as unknown as typeof fetch;
+        const spawnMock = vi.mocked(child_process.spawn);
+        spawnMock.mockClear();
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: () => fakeMgr({ checkForUpdatesAsync: async () => fakeUpdateInfo('0.1.30-beta.26') }),
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+            fetchFn,
+        });
+        process.env['APPIMAGE'] = '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage';
+        svc.init();
+        await svc.checkForUpdates();
+        await expect(svc.applyUpdate()).rejects.toThrow(/mismatch/i);
         expect(spawnMock).not.toHaveBeenCalled();
     });
 

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -402,6 +402,7 @@ describe('UpdateService', () => {
         });
         const svc = new UpdateService({
             installRoot: '/fake',
+            platform: 'win32',
             existsSync: () => true,
             updateManagerFactory: () => mgr,
             setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
@@ -414,6 +415,28 @@ describe('UpdateService', () => {
         expect(s.status).toBe('ready');
         expect(s.availableVersion).toBe('0.2.0');
         expect(s.progress).toBe(100);
+    });
+
+    it('checkForUpdates (linux): autoUpdate=true does NOT download the nupkg; status=ready', async () => {
+        Config.getInstance().updateAppConfig({ autoUpdate: true });
+        const downloadUpdateAsync = vi.fn(async () => undefined);
+        const mgr = fakeMgr({
+            checkForUpdatesAsync: async () => fakeUpdateInfo('0.2.0'),
+            downloadUpdateAsync,
+        });
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: () => mgr,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+        });
+        process.env['APPIMAGE'] = '/home/u/Downloads/App.AppImage';
+        svc.init();
+        await svc.checkForUpdates();
+        expect(svc.getStatus().status).toBe('ready');
+        expect(downloadUpdateAsync).not.toHaveBeenCalled();
     });
 
     it('checkForUpdates: UpdateInfo + autoUpdate=false → status=ready without downloading', async () => {

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -509,6 +509,9 @@ describe('UpdateService', () => {
         });
         const svc = new UpdateService({
             installRoot: '/fake',
+            // Pin win32: checkForUpdates only triggers downloadIfNeeded off Linux
+            // (Linux skips the unused nupkg download). This covers the download path.
+            platform: 'win32',
             existsSync: () => true,
             updateManagerFactory: () => mgr,
             setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
@@ -548,6 +551,8 @@ describe('UpdateService', () => {
         });
         const svc = new UpdateService({
             installRoot: '/fake',
+            // Pin win32: checkForUpdates only triggers downloadIfNeeded off Linux.
+            platform: 'win32',
             existsSync: () => true,
             updateManagerFactory: () => mgr,
             setIntervalFn: () => 0 as unknown as NodeJS.Timeout,

--- a/src/server/__tests__/downloadToFile.test.ts
+++ b/src/server/__tests__/downloadToFile.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadToFile, fetchText } from '../downloadToFile';
+
+describe('downloadToFile', () => {
+    const dirs: string[] = [];
+    afterEach(() => {
+        for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+        dirs.length = 0;
+    });
+
+    it('writes a 200 response body to disk', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-'));
+        dirs.push(dir);
+        const dest = path.join(dir, 'out.bin');
+        const fetchFn = (async () => new Response('payload-bytes')) as unknown as typeof fetch;
+        await downloadToFile('https://example/x', dest, fetchFn);
+        expect(fs.readFileSync(dest, 'utf8')).toBe('payload-bytes');
+    });
+
+    it('throws on a non-2xx response', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-'));
+        dirs.push(dir);
+        const fetchFn = (async () => new Response('nope', { status: 404 })) as unknown as typeof fetch;
+        await expect(downloadToFile('https://example/x', path.join(dir, 'o'), fetchFn)).rejects.toThrow(/404/);
+    });
+
+    it('fetchText returns the body text', async () => {
+        const fetchFn = (async () => new Response('line1\nline2')) as unknown as typeof fetch;
+        expect(await fetchText('https://example/s', fetchFn)).toBe('line1\nline2');
+    });
+});

--- a/src/server/__tests__/linuxUpdateAssets.test.ts
+++ b/src/server/__tests__/linuxUpdateAssets.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { linuxAppImageAssetName, releaseAssetUrl, parseSha256Sums } from '../linuxUpdateAssets';
+
+describe('linuxUpdateAssets', () => {
+    it('builds the channel-suffixed AppImage asset name', () => {
+        expect(linuxAppImageAssetName('beta')).toBe('WsScrcpyWeb-linux-beta.AppImage');
+        expect(linuxAppImageAssetName('stable')).toBe('WsScrcpyWeb-linux-stable.AppImage');
+    });
+
+    it('builds the release download URL', () => {
+        expect(releaseAssetUrl('bilbospocketses', '0.1.30-beta.26', 'WsScrcpyWeb-linux-beta.AppImage')).toBe(
+            'https://github.com/bilbospocketses/ws-scrcpy-web/releases/download/v0.1.30-beta.26/WsScrcpyWeb-linux-beta.AppImage',
+        );
+    });
+
+    it('parses SHA256SUMS by basename (path-prefixed entries)', () => {
+        const sums =
+            'ec1f3987e95cba5c179b14a1c04aa355a7710d72dc31c8eca9cb39f62ad9c7bc  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n' +
+            '952bebf9fd143145b258348c14d942fe76c9b4018f64f7444c2fdbe22f5aee34  ./linux-final/WsScrcpyWeb-0.1.30-beta.26-linux-beta-full.nupkg\n';
+        expect(parseSha256Sums(sums, 'WsScrcpyWeb-linux-beta.AppImage')).toBe(
+            'ec1f3987e95cba5c179b14a1c04aa355a7710d72dc31c8eca9cb39f62ad9c7bc',
+        );
+    });
+
+    it('returns null when the asset is absent', () => {
+        expect(parseSha256Sums('deadbeef  ./x/other.bin\n', 'WsScrcpyWeb-linux-beta.AppImage')).toBeNull();
+    });
+});

--- a/src/server/__tests__/verifySha256.test.ts
+++ b/src/server/__tests__/verifySha256.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { verifySha256 } from '../verifySha256';
+
+describe('verifySha256', () => {
+    let dir: string;
+    let file: string;
+    let goodHash: string;
+    beforeAll(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sha-'));
+        file = path.join(dir, 'blob');
+        const data = Buffer.from('hello appimage');
+        fs.writeFileSync(file, data);
+        goodHash = createHash('sha256').update(data).digest('hex');
+    });
+    afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+    it('returns true for a matching hash (case-insensitive)', async () => {
+        expect(await verifySha256(file, goodHash.toUpperCase())).toBe(true);
+    });
+    it('returns false for a wrong hash', async () => {
+        expect(await verifySha256(file, '0'.repeat(64))).toBe(false);
+    });
+});

--- a/src/server/downloadToFile.ts
+++ b/src/server/downloadToFile.ts
@@ -1,0 +1,27 @@
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import * as fs from 'fs';
+
+export type FetchFn = typeof fetch;
+
+/**
+ * Download `url` to `destPath`. Buffers the body then writes (artifacts are
+ * ~60 MB — acceptable transient memory; keeps the write a single file op).
+ * Throws on a non-2xx response or network error.
+ */
+export async function downloadToFile(url: string, destPath: string, fetchFn: FetchFn = fetch): Promise<void> {
+    const res = await fetchFn(url);
+    if (!res.ok) {
+        throw new Error(`download failed: ${res.status} ${res.statusText} for ${url}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    await fs.promises.writeFile(destPath, buf);
+}
+
+/** Fetch `url` and return the body as text. Throws on a non-2xx response. */
+export async function fetchText(url: string, fetchFn: FetchFn = fetch): Promise<string> {
+    const res = await fetchFn(url);
+    if (!res.ok) {
+        throw new Error(`fetch failed: ${res.status} ${res.statusText} for ${url}`);
+    }
+    return res.text();
+}

--- a/src/server/linuxUpdateAssets.ts
+++ b/src/server/linuxUpdateAssets.ts
@@ -1,0 +1,31 @@
+import type { UpdateChannel } from '../common/ConfigEvents';
+
+/** Published Linux AppImage asset name (channel-suffixed, NOT version-suffixed). */
+export function linuxAppImageAssetName(channel: UpdateChannel): string {
+    return `WsScrcpyWeb-linux-${channel}.AppImage`;
+}
+
+/** GitHub release asset download URL for a given version tag (`v<version>`). */
+export function releaseAssetUrl(githubOwner: string, version: string, assetName: string): string {
+    return `https://github.com/${githubOwner}/ws-scrcpy-web/releases/download/v${version}/${assetName}`;
+}
+
+/**
+ * Parse `sha256sum`-style text and return the lowercase hex digest for `filename`,
+ * matched by BASENAME (our SHA256SUMS lists path-prefixed entries like
+ * `./linux-final/<asset>`). Returns null if not found.
+ */
+export function parseSha256Sums(text: string, filename: string): string | null {
+    for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        // "<64 hex>  <name>"  (two spaces; "*" binary marker tolerated)
+        const m = trimmed.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+        const hash = m?.[1];
+        const name = m?.[2];
+        if (!hash || !name) continue;
+        const base = name.trim().split('/').pop();
+        if (base === filename) return hash.toLowerCase();
+    }
+    return null;
+}

--- a/src/server/verifySha256.ts
+++ b/src/server/verifySha256.ts
@@ -1,0 +1,21 @@
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { createHash } from 'crypto';
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { createReadStream } from 'fs';
+
+/** Stream-hash `filePath` (sha256) and return the lowercase hex digest. */
+export function sha256File(filePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const hash = createHash('sha256');
+        const stream = createReadStream(filePath);
+        stream.on('error', reject);
+        stream.on('data', (chunk) => hash.update(chunk));
+        stream.on('end', () => resolve(hash.digest('hex')));
+    });
+}
+
+/** True iff `filePath`'s sha256 equals `expectedHex` (case-insensitive). */
+export async function verifySha256(filePath: string, expectedHex: string): Promise<boolean> {
+    const actual = await sha256File(filePath);
+    return actual.toLowerCase() === expectedHex.toLowerCase();
+}


### PR DESCRIPTION
Replaces Velopack's broken Linux apply with a deterministic AppImage self-update, and fixes the upgrading overlay stacking. Linux local mode only; Windows + Linux service mode untouched.

## Why
Velopack 1.0.1's `UpdateNix apply`, given `--root <appimage>`, re-derives its own locator (`FromSpecifiedRootDir`) and fails the `UpdateExePath.exists()` check (`locator.rs:114`) — aborting instantly with "Update.exe does not exist in the expected path", before touching a file. Confirmed on real Fedora via `/tmp/velopack.log` (clean local mode restart=true AND service mode restart=false). beta.25's `waitExitThenApplyUpdate(restart=true)` was therefore inert. Velopack 1.1.1 documents no fix for this path. Separately, the `UpgradingOverlay` (z-index div) rendered behind the Settings native `<dialog>`+`showModal()` (browser top layer), hiding the apply fallback.

## What
- `applyUpdate` (Linux): download published AppImage -> verify against release `SHA256SUMS` -> spawn out-of-mount launcher helper `--linux-apply` to back up + swap `$APPIMAGE` and relaunch. No Velopack apply.
- New launcher `--linux-apply` (Rust, `#[cfg(target_os="linux")]`): wait-pid -> backup -> swap -> relaunch; restore on failure.
- `checkForUpdates` (Linux): skip the unused ~60 MB nupkg download.
- `UpgradingOverlay`: render as a top-layer `<dialog>`.

## Windows frozen
All changes gated to Linux. `operation_server.rs`, the Windows `applyUpdate`/`handleApply` branches, and service-mode are byte-for-byte unchanged (diff confirms operation_server.rs untouched). vitest 748 + tsc + webpack build green; Windows cargo check green.

Spec: `docs/specs/2026-06-01-linux-appimage-self-update-design.md` · Plan: `docs/plans/2026-06-01-linux-appimage-self-update.md`