### PR TITLE
fix(ui): unify modal buttons - white outline + white text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Consistent modal button styling (all platforms).** The welcome modal's install-service buttons use white text (was blue), and the bookmark (`PortChangeModal`) + service-first-run (`ServiceFirstRunModal`) "got it" buttons now get the same white-outline / white-text / mono treatment — they previously fell back to the browser-default button because their `.modal-button` class had no CSS. All three modals now match the app's outline-button motif.
+
 ## [0.1.30-beta.28] - 2026-06-01
 
 ### Changed

--- a/src/app/client/WelcomeModal.ts
+++ b/src/app/client/WelcomeModal.ts
@@ -208,7 +208,7 @@ export class WelcomeModal extends Modal {
         this.yesBtn.textContent = 'yes, install service';
         this.yesBtn.style.cssText =
             'border: 0.5px solid var(--text-color, #ddd); border-radius: 6px; ' +
-            'background: transparent; color: #5b9aff; padding: 8px 16px; cursor: pointer;';
+            'background: transparent; color: var(--text-color, #ddd); padding: 8px 16px; cursor: pointer;';
         this.yesBtn.addEventListener('click', () => {
             void this.onYes();
         });
@@ -218,7 +218,7 @@ export class WelcomeModal extends Modal {
         this.noBtn.textContent = 'no, run on demand';
         this.noBtn.style.cssText =
             'border: 0.5px solid var(--text-color, #ddd); border-radius: 6px; ' +
-            'background: transparent; color: #5b9aff; padding: 8px 16px; cursor: pointer;';
+            'background: transparent; color: var(--text-color, #ddd); padding: 8px 16px; cursor: pointer;';
         this.noBtn.addEventListener('click', () => {
             void this.onNo();
         });

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -392,6 +392,24 @@ dialog.modal .modal-settings button:hover {
     background: var(--device-list-hover-color, hsl(218, 17%, 18%));
 }
 
+/* Shared "got it" / confirm button for the bookmark (PortChangeModal) +
+   service-first-run (ServiceFirstRunModal) modals. Matches the welcome modal's
+   outline buttons — white outline + white text, transparent, mono font —
+   replacing the browser-default look (the class previously had no CSS). */
+.modal-button {
+    border: 0.5px solid var(--text-color, #ddd);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-color, #ddd);
+    padding: 8px 16px;
+    cursor: pointer;
+    font: inherit;
+}
+
+.modal-button:hover {
+    background: var(--device-list-hover-color, hsl(218, 17%, 18%));
+}
+
 /* ── Status text (footer) ── */
 dialog.modal .status-text {
     font-size: 13px;


### PR DESCRIPTION
Generic all-OS UI consistency fix. Welcome modal yes/no buttons: blue text -> white (var(--text-color)). Bookmark (PortChangeModal) + service-first-run (ServiceFirstRunModal) 'got it' buttons used class modal-button modal-button-primary which had NO CSS anywhere -> browser-default look; added a .modal-button rule (white outline, transparent bg, white text, mono font, radius/padding + hover) matching the welcome buttons. All three modals now match the app outline-button motif. tsc clean, 748/748, webpack build green. Ships as v0.1.30-beta.29.