### PR TITLE
fix(linux): service-mode install/uninstall (items 32+33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux system-scope service install now starts under SELinux (item 33).** The system unit's `ExecStart` was the user-home `$APPIMAGE`, but systemd runs system units under the `init_t` domain and SELinux-enforcing (Fedora) denies `init_t` exec of a `user_home_t` file — so the service failed to start and restart-looped on a repeating AVC. System-scope install now stages the AppImage to a root-owned `/opt/ws-scrcpy-web/`, labels it `bin_t` (persistent `semanage fcontext` + `restorecon`, with a `chcon` fallback for minimal images — all best-effort and isolated so a label failure on a non-SELinux distro doesn't abort the install), and points the unit's `ExecStart` there. User scope is unchanged (runs as the unconfined user from the home AppImage).
+- **Linux service uninstall now tears down cleanly and returns to local mode (item 32).** Uninstall previously ran `systemctl disable --now` from inside the service's own cgroup, killing the calling process mid-operation (leaving stragglers and a non-functional app). It now hands off to an out-of-cgroup helper launched via `systemd-run` (a transient unit that survives stopping the service unit): the helper stops → disables → `reset-failed` → removes the unit (and, for system scope, the `/opt` staging plus the SELinux `fcontext` rule) → reaps the escaped adb daemon → and on user scope relaunches the home AppImage in local mode via its own transient unit. Windows uninstall is byte-for-byte unchanged.
+
+### Changed
+
+- **Linux service-mode OS tools now resolve to absolute paths (Local-Dependencies-Only).** `systemctl`, `pkexec`, `loginctl`, `ldconfig`, `systemd-run`, `cp`, `chmod`, `restorecon`, `chcon`, and `semanage` are invoked by absolute path (resolved across `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`) instead of by bare name, closing the `$PATH`-hijack surface — mirroring the Windows `System32` hardening.
+
 ## [0.1.30-beta.29] - 2026-06-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.28"
+version = "0.1.30-beta.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.28"
+version = "0.1.30-beta.29"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.28"
+version = "0.1.30-beta.29"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/docs/plans/2026-06-01-linux-service-mode-fix.md
+++ b/docs/plans/2026-06-01-linux-service-mode-fix.md
@@ -1,0 +1,1051 @@
+# Linux Service-Mode Fix (items 32 + 33) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Linux service install/uninstall functional in both scopes — system-scope installs and runs under SELinux (item 33), and uninstall (both scopes) tears down cleanly and returns to local mode (item 32).
+
+**Architecture:** System-scope install stages the AppImage to a root-owned, `bin_t`-labelled `/opt/ws-scrcpy-web/` copy so `init_t` can exec it. Uninstall stops doing `systemctl disable --now` from inside its own cgroup; instead it hands off to an out-of-cgroup helper launched via `systemd-run` (a transient unit) that stops → disables → `reset-failed` → removes the unit (+ `/opt` for system) → reaps the escaped adb daemon → relaunches local (user scope) / cleanly tears down (system scope). This is the systemd analogue of the Windows operation-server/post-stop handoff.
+
+**Tech Stack:** TypeScript (Node server, vitest), Rust (the launcher binary, cargo), systemd (`systemctl`/`systemd-run`), SELinux (`semanage`/`restorecon`/`chcon`), pkexec/polkit.
+
+**Scope guard:** Windows and Linux **local** mode are untouched. Phase 2 (service-mode in-app updates) is a **separate plan**, written only after this one is verified on real Fedora. Spec: `docs/specs/2026-06-01-linux-service-mode-fix-and-update-design.md`.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/server/service/systemTools.ts` — pure resolver mapping an OS tool name (`systemctl`, `pkexec`, `loginctl`, `ldconfig`, `systemd-run`) to its first existing absolute path (`/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`), with a documented bare-name fallback. Closes the PATH-hijack surface (Local-Dependencies-Only). One responsibility: tool-path resolution.
+- `src/server/service/systemTools.test.ts` — resolver unit tests.
+- `launcher/src/linux_service.rs` — `#[cfg(target_os = "linux")]` module: the `--linux-service-teardown` helper. Pure command-sequence builders + a thin exec seam. One responsibility: out-of-cgroup service teardown.
+
+**Modified files:**
+- `src/server/service/SystemdClient.ts` — system-scope staging (`/opt` copy + `bin_t` label) inside the pkexec install command; `renderUnitFile`/install render `ExecStart` = staged path for system scope; convert bare-name OS-tool calls to `systemTools`. Add `stagedSystemBinPath()` + `localAppImageMarkerPath()` helpers.
+- `src/server/api/ServiceApi.ts` — Linux install: write the `local-appimage` marker (home `$APPIMAGE`, for the user-scope relaunch). Linux uninstall: revert `installMode → local`, then `systemd-run` the teardown helper instead of calling `client.uninstall()` synchronously.
+- `launcher/src/main.rs` — dispatch `--linux-service-teardown` (Linux only), before the normal-launch path.
+- `src/app/client/SettingsModal.ts` — handle the Linux uninstall response: user scope reconnects to the relaunched local instance; system scope shows a "service removed" message.
+
+**Verification checkpoints (manual, on real Fedora):** after Task 6 (system install runs, no AVC) and after Task 13 (uninstall clean + relaunch).
+
+---
+
+## Task 1: OS-tool absolute-path resolver
+
+**Files:**
+- Create: `src/server/service/systemTools.ts`
+- Test: `src/server/service/systemTools.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/server/service/systemTools.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveSystemTool } from './systemTools';
+
+describe('resolveSystemTool', () => {
+    it('returns the first candidate that exists', () => {
+        const exists = (p: string) => p === '/usr/bin/systemctl';
+        expect(resolveSystemTool('systemctl', exists)).toBe('/usr/bin/systemctl');
+    });
+
+    it('prefers /usr/bin over /bin when both exist', () => {
+        const exists = (p: string) => p === '/usr/bin/pkexec' || p === '/bin/pkexec';
+        expect(resolveSystemTool('pkexec', exists)).toBe('/usr/bin/pkexec');
+    });
+
+    it('checks sbin locations for admin tools (semanage/restorecon)', () => {
+        const exists = (p: string) => p === '/usr/sbin/semanage';
+        expect(resolveSystemTool('semanage', exists)).toBe('/usr/sbin/semanage');
+    });
+
+    it('falls back to the bare name when no absolute path exists', () => {
+        const exists = (_p: string) => false;
+        expect(resolveSystemTool('systemctl', exists)).toBe('systemctl');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/service/systemTools.test.ts`
+Expected: FAIL — `Cannot find module './systemTools'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/server/service/systemTools.ts
+/**
+ * Resolve an OS tool to its absolute path, scanning the canonical bin/sbin
+ * locations in priority order. Closes the PATH-hijack surface required by the
+ * Local-Dependencies-Only rule: we never invoke systemctl/pkexec/etc. by bare
+ * name (which would resolve via $PATH). Falls back to the bare name only when
+ * no absolute candidate exists, so the failure surfaces as a clear ENOENT
+ * rather than a silent miss.
+ */
+import * as fs from 'node:fs';
+
+/** Search order: user bins first (/usr/bin, /bin), then admin bins (/usr/sbin, /sbin). */
+const SEARCH_DIRS = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'] as const;
+
+export function resolveSystemTool(
+    tool: string,
+    exists: (p: string) => boolean = fs.existsSync,
+): string {
+    for (const dir of SEARCH_DIRS) {
+        const candidate = `${dir}/${tool}`;
+        if (exists(candidate)) return candidate;
+    }
+    return tool;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/server/service/systemTools.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/systemTools.ts src/server/service/systemTools.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): absolute-path resolver for OS tools (Local-Deps)"
+```
+
+---
+
+## Task 2: SystemdClient — staged system-scope binary path + helpers
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts`
+- Test: `src/server/service/SystemdClient.test.ts`
+
+- [ ] **Step 1: Write the failing test** (append to the existing describe block)
+
+```typescript
+// src/server/service/SystemdClient.test.ts
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR } from './SystemdClient';
+
+describe('system-scope staging', () => {
+    const baseOpts = {
+        name: 'WsScrcpyWeb',
+        displayName: 'ws-scrcpy-web',
+        description: 'desc',
+        binPath: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage', // source = home AppImage
+        startupDir: '/home/u/Apps',
+        startType: 'Automatic' as const,
+        maxRestartAttempts: 3,
+        envVars: { DEPS_PATH: '/home/u/.local/share/WsScrcpyWeb/dependencies' },
+        logPath: '/home/u/.local/share/WsScrcpyWeb/logs/service.log',
+    };
+
+    it('stagedSystemBinPath is the fixed /opt path', () => {
+        const c = new SystemdClient();
+        expect(c.stagedSystemBinPath()).toBe(`${STAGED_SYSTEM_DIR}/WsScrcpyWeb.AppImage`);
+    });
+
+    it('system unit ExecStart points at the staged /opt path, not the home AppImage', () => {
+        const unit = renderUnitFile(baseOpts, 'system');
+        expect(unit).toContain(`ExecStart=${STAGED_SYSTEM_DIR}/WsScrcpyWeb.AppImage`);
+        expect(unit).not.toContain('/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage');
+    });
+
+    it('user unit ExecStart still points at the home AppImage (unchanged)', () => {
+        const unit = renderUnitFile(baseOpts, 'user');
+        expect(unit).toContain('ExecStart=/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/service/SystemdClient.test.ts -t "system-scope staging"`
+Expected: FAIL — `STAGED_SYSTEM_DIR` / `stagedSystemBinPath` not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the constant near the top of `SystemdClient.ts` (after `TRAY_AUTOSTART_FILE`):
+
+```typescript
+/** Root-owned staging dir for the system-scope AppImage (SELinux bin_t — init_t can exec). */
+export const STAGED_SYSTEM_DIR = '/opt/ws-scrcpy-web';
+/** Stable, channel-agnostic filename for the staged system-scope AppImage. */
+export const STAGED_SYSTEM_APPIMAGE = 'WsScrcpyWeb.AppImage';
+```
+
+Change `renderUnitFile` so system scope uses the staged path for `ExecStart` + `WorkingDirectory` (the source `opts.binPath` is only the copy source; the unit must reference the staged file):
+
+```typescript
+export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope): string {
+    const envLines = Object.entries(opts.envVars)
+        .map(([k, v]) => `Environment=${k}=${v}`)
+        .join('\n');
+    const wantedBy = scope === 'user' ? 'default.target' : 'multi-user.target';
+    // System scope runs under init_t and may NOT exec a user_home_t AppImage,
+    // so the unit references the staged /opt copy (labelled bin_t at install).
+    // User scope runs as the unconfined user and execs the home AppImage directly.
+    const execStart = scope === 'system'
+        ? `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`
+        : opts.binPath;
+    const workingDir = scope === 'system' ? STAGED_SYSTEM_DIR : opts.startupDir;
+    return [
+        '[Unit]',
+        `Description=${opts.description}`,
+        'After=network.target',
+        '',
+        '[Service]',
+        'Type=simple',
+        `ExecStart=${execStart}`,
+        `WorkingDirectory=${workingDir}`,
+        'Restart=on-failure',
+        'RestartSec=5',
+        `StartLimitBurst=${opts.maxRestartAttempts}`,
+        'StartLimitIntervalSec=300',
+        ...(envLines ? [envLines] : []),
+        `StandardOutput=append:${opts.logPath}`,
+        `StandardError=append:${opts.logPath}`,
+        '',
+        '[Install]',
+        `WantedBy=${wantedBy}`,
+        '',
+    ].join('\n');
+}
+```
+
+Add the public accessor inside the `SystemdClient` class (near `userUnitPath`):
+
+```typescript
+    /** Absolute path of the staged system-scope AppImage (system scope ExecStart). */
+    public stagedSystemBinPath(): string {
+        return path.join(STAGED_SYSTEM_DIR, STAGED_SYSTEM_APPIMAGE);
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/server/service/SystemdClient.test.ts -t "system-scope staging"`
+Expected: PASS (3 tests). Re-run the whole file to confirm no regressions: `npx vitest run src/server/service/SystemdClient.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): system-scope unit ExecStart points at staged /opt AppImage (item 33)"
+```
+
+---
+
+## Task 3: SystemdClient — stage + label the AppImage in the system-scope install
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts` (the `install()` system-scope branch + `runPkexec` callers use absolute tool paths)
+- Test: `src/server/service/SystemdClient.test.ts`
+
+The current system-scope branch (no root) writes the unit to a tmp file and runs one pkexec shell command (`cp tmp unit && daemon-reload && enable`). Extend that single shell command to also stage + label the AppImage **before** writing the unit. Build the command via a pure, testable helper so we can assert its shape without running pkexec.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/server/service/SystemdClient.test.ts
+import { buildSystemInstallScript } from './SystemdClient';
+
+describe('buildSystemInstallScript', () => {
+    const args = {
+        sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
+        unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
+        unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
+        name: 'WsScrcpyWeb',
+    };
+
+    it('stages the AppImage to /opt, chmods, labels bin_t, then installs the unit', () => {
+        const script = buildSystemInstallScript(args);
+        // staging
+        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web');
+        expect(script).toContain('cp "/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        // SELinux label: persistent semanage rule + restorecon, chcon fallback
+        expect(script).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv /opt/ws-scrcpy-web');
+        expect(script).toContain('chcon -t bin_t "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        // unit install
+        expect(script).toContain('cp "/tmp/WsScrcpyWeb.service.tmp" "/etc/systemd/system/WsScrcpyWeb.service"');
+        expect(script).toContain('systemctl daemon-reload');
+        expect(script).toContain('systemctl enable --now WsScrcpyWeb.service');
+    });
+
+    it('staging precedes the unit copy (so ExecStart target exists before enable)', () => {
+        const script = buildSystemInstallScript(args);
+        expect(script.indexOf('/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage'))
+            .toBeLessThan(script.indexOf('enable --now'));
+    });
+
+    it('uses absolute tool paths (no bare names)', () => {
+        const script = buildSystemInstallScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        expect(script).toContain('/usr/bin/systemctl daemon-reload');
+        expect(script).toContain('/usr/sbin/restorecon -Rv');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/service/SystemdClient.test.ts -t "buildSystemInstallScript"`
+Expected: FAIL — `buildSystemInstallScript` not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the pure builder (module scope in `SystemdClient.ts`). `semanage`/`restorecon` live in `sbin`; `chcon`/`chmod`/`cp` in `bin`. The `chcon` is a fallback for when `semanage` is absent (`|| chcon …`); `restorecon` is harmless if the semanage rule didn't take. The whole thing is one `&&`-chain so pkexec runs it under a single prompt:
+
+```typescript
+import { resolveSystemTool } from './systemTools';
+
+/**
+ * Build the privileged shell script for a system-scope install. Runs under a
+ * single pkexec prompt. Stages the AppImage into /opt (root-owned), labels it
+ * bin_t so init_t may exec it (item 33), then installs + enables the unit.
+ * `binTool`/`sbinTool` are injectable for testing; production resolves absolute
+ * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
+ */
+export function buildSystemInstallScript(
+    args: { sourceAppImage: string; unitTmpPath: string; unitPath: string; name: string },
+    binTool: (t: string) => string = (t) => resolveSystemTool(t),
+    sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
+): string {
+    const staged = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const cp = binTool('cp');
+    const chmod = binTool('chmod');
+    const chcon = binTool('chcon');
+    const systemctl = binTool('systemctl');
+    const semanage = sbinTool('semanage');
+    const restorecon = sbinTool('restorecon');
+    return [
+        // 1. stage the AppImage into /opt (root-owned)
+        `mkdir -p ${STAGED_SYSTEM_DIR}`,
+        `${cp} "${args.sourceAppImage}" "${staged}"`,
+        `${chmod} 0755 "${staged}"`,
+        // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
+        //    available; restorecon applies it; chcon is the transient fallback
+        //    for minimal images without policycoreutils-python-utils.
+        `( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv ${STAGED_SYSTEM_DIR} ) || ${chcon} -t bin_t "${staged}"`,
+        // 3. install + enable the unit (ExecStart already points at ${staged})
+        `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
+        `${systemctl} daemon-reload`,
+        `${systemctl} enable --now ${args.name}.service`,
+    ].join(' && ');
+}
+```
+
+Rewrite the system-scope branch of `install()` to use it (replacing the inline `cmd` array). The source AppImage is `opts.binPath` (the home `$APPIMAGE` ServiceApi passes):
+
+```typescript
+        if (scope === 'system' && process.getuid?.() !== 0) {
+            const tmpFile = path.join(os.tmpdir(), `${opts.name}.service.tmp`);
+            fs.writeFileSync(tmpFile, unitContent, { mode: 0o644 });
+            try {
+                const cmd = buildSystemInstallScript({
+                    sourceAppImage: opts.binPath,
+                    unitTmpPath: tmpFile,
+                    unitPath,
+                    name: opts.name,
+                });
+                await runPkexec(cmd, 'install (system scope)');
+            } finally {
+                try { fs.unlinkSync(tmpFile); } catch { /* best-effort cleanup */ }
+            }
+        } else {
+```
+
+(The `else` user-scope branch is unchanged in this task.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/service/SystemdClient.test.ts`
+Expected: PASS (all, including the new `buildSystemInstallScript` block).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): stage + bin_t-label AppImage in system-scope install (item 33)"
+```
+
+---
+
+## Task 4: SystemdClient — convert the remaining bare-name OS-tool calls to absolute paths
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts` (the `runSystemctl`, `loginctl`, `is-active`, user-scope `runPkexec` callers)
+- Test: `src/server/service/SystemdClient.test.ts` (assert `runSystemctl` invokes the resolved absolute path)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// SystemdClient.test.ts — verify systemctl is invoked by absolute path.
+import { systemctlArgv } from './SystemdClient';
+
+describe('absolute-path OS tools', () => {
+    it('systemctlArgv resolves systemctl to an absolute path', () => {
+        const argv = systemctlArgv(['--user', 'daemon-reload'], (t) => `/usr/bin/${t}`);
+        expect(argv.bin).toBe('/usr/bin/systemctl');
+        expect(argv.args).toEqual(['--user', 'daemon-reload']);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/service/SystemdClient.test.ts -t "absolute-path OS tools"`
+Expected: FAIL — `systemctlArgv` not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the helper and route `runSystemctl` + the `is-active` call + `loginctl` through it. `execFile`'s first arg becomes the resolved path:
+
+```typescript
+/** Resolve systemctl to an absolute path + return the (bin, args) pair for execFile. */
+export function systemctlArgv(
+    args: string[],
+    resolve: (t: string) => string = (t) => resolveSystemTool(t),
+): { bin: string; args: string[] } {
+    return { bin: resolve('systemctl'), args };
+}
+```
+
+In `runSystemctl`, replace `execFileSync('systemctl', args, …)` with:
+
+```typescript
+    const { bin, args: a } = systemctlArgv(args);
+    try {
+        return execFileSync(bin, a, { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+    } catch (err) {
+        // …unchanged error handling…
+    }
+```
+
+In `status()` replace `execFileSync('systemctl', [...])` similarly. In `install()`'s user-scope linger call, replace `execFileSync('loginctl', …)` with `execFileSync(resolveSystemTool('loginctl'), …)`. In `runPkexec`, replace `execFileAsync('pkexec', …)` with `execFileAsync(resolveSystemTool('pkexec'), …)`. In `isLibfuse2Installed`/`libfuse2InstallCmd`, replace `execFileSync('ldconfig', …)` with `execFileSync(resolveSystemTool('ldconfig'), …)`.
+
+Add `import { resolveSystemTool } from './systemTools';` if not already present from Task 3.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/service/SystemdClient.test.ts`
+Expected: PASS. Then `npx tsc --noEmit` — Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "refactor(linux): resolve systemctl/pkexec/loginctl/ldconfig by absolute path (Local-Deps)"
+```
+
+---
+
+## Task 5: ServiceApi — record the home AppImage at install (for the user-scope uninstall relaunch)
+
+**Files:**
+- Modify: `src/server/api/ServiceApi.ts` (`handleInstall`, Linux branch — after computing `binPath`)
+- Modify: `src/server/service/SystemdClient.ts` (add `localAppImageMarkerPath(dataRoot)` helper + a `writeLocalAppImageMarker` static, or inline in ServiceApi)
+- Test: `src/server/api/ServiceApi.test.ts`
+
+The teardown (Task 9) relaunches the home AppImage in local mode on user-scope uninstall. The service process won't know that path later (system scope runs `/opt`), so capture it at install time as a `dataRoot/control/local-appimage` marker.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/server/api/ServiceApi.test.ts — Linux install records the home AppImage path.
+it('linux install writes the local-appimage marker with $APPIMAGE', async () => {
+    const writes: Record<string, string> = {};
+    // …use the existing ServiceApi test harness (injected factory + fs mock)…
+    process.env.APPIMAGE = '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage';
+    // invoke handleInstall with platform 'linux', scope 'user'
+    // assert the marker file path + contents:
+    expect(writes['<dataRoot>/control/local-appimage'])
+        .toBe('/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage');
+});
+```
+
+(Adapt to the existing `ServiceApi.test.ts` harness — it already injects a fake factory and an `existsCheck`; add an injectable marker-writer or assert via a spy on `fs.writeFileSync`/`fs.promises.writeFile`. Mirror however the existing install tests assert side effects.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/api/ServiceApi.test.ts -t "local-appimage marker"`
+Expected: FAIL — marker not written.
+
+- [ ] **Step 3: Write the implementation**
+
+In `ServiceApi.handleInstall`, Linux branch, after `binPath`/`startupDir` are set and before `result.client.install(...)`, write the marker (best-effort; failure logs but doesn't fail the install):
+
+```typescript
+        // Record the home AppImage path so a later user-scope uninstall can
+        // relaunch the app in local mode. System scope runs the /opt copy and
+        // won't know the user's home AppImage otherwise.
+        if (result.platform === 'linux') {
+            const appImage = process.env['APPIMAGE'];
+            if (appImage && appImage.length > 0) {
+                const markerPath = path.join(
+                    path.dirname(cfg.dependenciesPath), 'control', 'local-appimage',
+                );
+                try {
+                    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+                    fs.writeFileSync(markerPath, appImage, 'utf8');
+                } catch (err) {
+                    log.warn(`could not write local-appimage marker: ${(err as Error).message}`);
+                }
+            }
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/server/api/ServiceApi.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/ServiceApi.ts src/server/api/ServiceApi.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): record home AppImage path at service install (uninstall relaunch)"
+```
+
+---
+
+## Task 6: VERIFY ON FEDORA — system-scope install runs under SELinux (item 33)
+
+**Files:** none (manual verification; the implementation must be built + packaged into a beta first).
+
+- [ ] **Step 1: Build + cut a verification beta** (per the project's release-cycle convention — tag a fix beta, let CI publish).
+
+- [ ] **Step 2: On real Fedora (enforcing SELinux), install system scope** via Settings → install → "system". Enter the pkexec password.
+
+- [ ] **Step 3: Confirm the service is active and SELinux is quiet**
+
+Run on Fedora:
+```bash
+systemctl is-active WsScrcpyWeb.service        # expect: active
+ls -Z /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage  # expect: ...:bin_t:...
+sudo ausearch -m avc -ts recent | grep -i wsscrcpy   # expect: no new denials
+```
+Expected: `active`, label `bin_t`, no AVC. **If denied:** capture `ausearch` output; the label or a transition is wrong — adjust Task 3's labelling (this is the spec's flagged verify-on-Fedora item ①) before proceeding.
+
+- [ ] **Step 4: Confirm the app is reachable** on its web port from a browser; the home page loads.
+
+- [ ] **Step 5: No commit** (verification only). Record the result in the PR / breadcrumb.
+
+---
+
+## Task 7: Rust — `--linux-service-teardown` command builders (pure)
+
+**Files:**
+- Create: `launcher/src/linux_service.rs`
+- Modify: `launcher/src/main.rs` (declare `mod linux_service;` under the existing `#[cfg(target_os = "linux")]`)
+
+Build the teardown as pure, testable command-sequence builders first; wire execution in Task 8.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// launcher/src/linux_service.rs  (#[cfg(test)] mod tests)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_scope_teardown_sequence() {
+        let cmds = teardown_commands(Scope::User, "WsScrcpyWeb", "/usr/bin");
+        // order: stop -> disable -> reset-failed -> rm unit -> daemon-reload
+        let joined: Vec<String> = cmds.iter().map(|c| c.join(" ")).collect();
+        assert!(joined[0].contains("--user stop WsScrcpyWeb.service"));
+        assert!(joined.iter().any(|c| c.contains("--user disable WsScrcpyWeb.service")));
+        assert!(joined.iter().any(|c| c.contains("--user reset-failed WsScrcpyWeb.service")));
+        assert!(joined.iter().any(|c| c.contains("--user daemon-reload")));
+        // user scope does NOT touch /opt
+        assert!(!joined.iter().any(|c| c.contains("/opt/ws-scrcpy-web")));
+    }
+
+    #[test]
+    fn system_scope_teardown_removes_opt_and_fcontext() {
+        let cmds = teardown_commands(Scope::System, "WsScrcpyWeb", "/usr/bin");
+        let joined: Vec<String> = cmds.iter().map(|c| c.join(" ")).collect();
+        assert!(joined.iter().any(|c| c.contains("stop WsScrcpyWeb.service") && !c.contains("--user")));
+        assert!(joined.iter().any(|c| c.contains("rm") && c.contains("/opt/ws-scrcpy-web")));
+        assert!(joined.iter().any(|c| c.contains("semanage fcontext -d")));
+    }
+
+    #[test]
+    fn unit_path_is_scope_correct() {
+        assert_eq!(unit_path(Scope::System, "WsScrcpyWeb"),
+                   std::path::PathBuf::from("/etc/systemd/system/WsScrcpyWeb.service"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p launcher --lib linux_service` (from `C:/Users/jscha/source/repos/ws-scrcpy-web/launcher` — or `cargo test` at repo root if the workspace wires it).
+Expected: FAIL — module/functions don't exist.
+
+> Note: this module is `#[cfg(target_os = "linux")]`; the tests run on the Linux CI leg / a Linux dev box. On Windows the module isn't compiled — that's expected (mirrors `linux_apply.rs`).
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+// launcher/src/linux_service.rs
+// §item32 — out-of-cgroup Linux service teardown. Launched via `systemd-run`
+// from the Node server so it runs in its OWN transient unit, surviving the
+// stop of the service unit it tears down (the service Node lives in that
+// cgroup; calling systemctl stop from there kills itself mid-call — the
+// root of item 32). Mirrors the Windows operation-server/post-stop handoff.
+
+use std::path::{Path, PathBuf};
+use crate::log;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope { User, System }
+
+/// `--user` prefix tokens for user scope, empty for system scope.
+fn scope_prefix(scope: Scope) -> Vec<String> {
+    match scope {
+        Scope::User => vec!["--user".to_string()],
+        Scope::System => vec![],
+    }
+}
+
+pub fn unit_path(scope: Scope, name: &str) -> PathBuf {
+    match scope {
+        Scope::User => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+            PathBuf::from(home).join(".config/systemd/user").join(format!("{name}.service"))
+        }
+        Scope::System => PathBuf::from("/etc/systemd/system").join(format!("{name}.service")),
+    }
+}
+
+/// Ordered command argv-vectors for the teardown. `bindir` is the resolved
+/// absolute bin dir (e.g. "/usr/bin") so we never invoke tools by bare name.
+pub fn teardown_commands(scope: Scope, name: &str, bindir: &str) -> Vec<Vec<String>> {
+    let systemctl = format!("{bindir}/systemctl");
+    let rm = format!("{bindir}/rm");
+    let pre = scope_prefix(scope);
+    let unit = format!("{name}.service");
+    let unit_file = unit_path(scope, name);
+
+    let mut cmds: Vec<Vec<String>> = Vec::new();
+    // stop (synchronous; reaps the in-cgroup launcher+Node+children), disable, reset-failed
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["stop".into(), unit.clone()]].concat());
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["disable".into(), unit.clone()]].concat());
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["reset-failed".into(), unit.clone()]].concat());
+    // remove the unit file
+    cmds.push(vec![rm.clone(), "-f".into(), unit_file.to_string_lossy().into_owned()]);
+    // system scope also removes the /opt staging + the semanage fcontext rule
+    if scope == Scope::System {
+        cmds.push(vec![rm.clone(), "-rf".into(), "/opt/ws-scrcpy-web".into()]);
+        cmds.push(vec![
+            format!("{bindir}/../sbin/semanage").replace("/bin/../sbin", "/sbin"),
+            "fcontext".into(), "-d".into(), "/opt/ws-scrcpy-web(/.*)?".into(),
+        ]);
+    }
+    // reload
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["daemon-reload".into()]].concat());
+    cmds
+}
+
+/// Parse `--scope user|system` + `--unit <name>` from argv.
+pub fn parse_args(args: &[String]) -> Option<(Scope, String)> {
+    let scope = args.iter().position(|a| a == "--scope")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| match s.as_str() {
+            "user" => Some(Scope::User),
+            "system" => Some(Scope::System),
+            _ => None,
+        })?;
+    let unit = args.iter().position(|a| a == "--unit")
+        .and_then(|i| args.get(i + 1))
+        .cloned()?;
+    Some((scope, unit))
+}
+
+let _ = (Path::new("/"), log::info); // keep imports used until Task 8 wires exec
+```
+
+> The trailing `let _ = …` line is a placeholder to keep `Path`/`log` imports referenced before Task 8 adds the exec seam; **remove it in Task 8** (it will be replaced by real usage). It exists only so this task compiles in isolation under `-D warnings`.
+
+Add to `main.rs` near the other linux-only module:
+```rust
+#[cfg(target_os = "linux")]
+mod linux_service;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (Linux): `cargo test -p launcher --lib linux_service`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/linux_service.rs launcher/src/main.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): service-teardown command builders (item 32, pure)"
+```
+
+---
+
+## Task 8: Rust — execute the teardown + relaunch, wire the dispatch
+
+**Files:**
+- Modify: `launcher/src/linux_service.rs` (add `handle()` + `run()` exec seam, reap, relaunch)
+- Modify: `launcher/src/main.rs` (dispatch `--linux-service-teardown`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// linux_service.rs tests — relaunch decision is scope-gated.
+#[test]
+fn relaunch_only_for_user_scope_with_marker() {
+    // user scope + present marker -> Some(path)
+    assert_eq!(
+        relaunch_target(Scope::User, Some("/home/u/Apps/App.AppImage".into())),
+        Some(std::path::PathBuf::from("/home/u/Apps/App.AppImage"))
+    );
+    // system scope -> never relaunch
+    assert_eq!(relaunch_target(Scope::System, Some("/home/u/Apps/App.AppImage".into())), None);
+    // user scope, missing marker -> None
+    assert_eq!(relaunch_target(Scope::User, None), None);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (Linux): `cargo test -p launcher --lib linux_service::tests::relaunch_only_for_user_scope`
+Expected: FAIL — `relaunch_target` not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the `let _ = …` placeholder line from Task 7 with:
+
+```rust
+/// User scope relaunches the home AppImage (from the install-time marker) into
+/// local mode. System scope never auto-relaunches (headless-dominant; the admin
+/// re-launches their own AppImage). Returns the path to spawn, or None.
+pub fn relaunch_target(scope: Scope, marker: Option<String>) -> Option<PathBuf> {
+    match scope {
+        Scope::User => marker.map(PathBuf::from).filter(|p| p.exists() || cfg!(test)),
+        Scope::System => None,
+    }
+}
+
+/// Dispatch: handle `--linux-service-teardown`, return Some(exit_code).
+pub fn handle(args: &[String]) -> Option<i32> {
+    if !args.iter().any(|a| a == "--linux-service-teardown") {
+        return None;
+    }
+    let (scope, unit) = match parse_args(args) {
+        Some(v) => v,
+        None => { log::error("linux-service-teardown: missing/invalid --scope or --unit"); return Some(2); }
+    };
+    Some(run(scope, &unit))
+}
+
+fn bindir() -> String {
+    for d in ["/usr/bin", "/bin"] {
+        if Path::new(&format!("{d}/systemctl")).exists() { return d.to_string(); }
+    }
+    "/usr/bin".to_string()
+}
+
+fn run(scope: Scope, unit: &str) -> i32 {
+    let bd = bindir();
+    log::info(&format!("linux-service-teardown: scope={scope:?} unit={unit}"));
+
+    // 1. run the teardown sequence (best-effort; log non-zero, keep going)
+    for argv in teardown_commands(scope, unit, &bd) {
+        let (cmd, rest) = argv.split_first().expect("non-empty argv");
+        let status = std::process::Command::new(cmd).args(rest).status();
+        match status {
+            Ok(s) if s.success() => log::info(&format!("teardown ok: {}", argv.join(" "))),
+            Ok(s) => log::error(&format!("teardown non-zero ({:?}): {}", s.code(), argv.join(" "))),
+            Err(e) => log::error(&format!("teardown spawn failed: {} ({e})", argv.join(" "))),
+        }
+    }
+
+    // 2. reap the escaped adb daemon (it daemonizes out of the cgroup; the
+    //    cgroup stop above does NOT kill it). Bundled adb, absolute path.
+    if let Some(data_root) = common::config::data_root_from_env() {
+        let adb = data_root.join("dependencies").join("adb").join("adb");
+        if adb.exists() {
+            let _ = std::process::Command::new(&adb).arg("kill-server").status();
+            log::info("teardown: adb kill-server issued");
+        }
+    }
+
+    // 3. relaunch local (user scope only)
+    let marker = read_local_appimage_marker();
+    if let Some(target) = relaunch_target(scope, marker) {
+        match std::process::Command::new(&target)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(c) => log::info(&format!("teardown: relaunched local {target:?} (pid {})", c.id())),
+            Err(e) => log::error(&format!("teardown: relaunch failed: {e}")),
+        }
+    }
+    0
+}
+
+fn read_local_appimage_marker() -> Option<String> {
+    let data_root = common::config::data_root_from_env()?;
+    let p = data_root.join("control").join("local-appimage");
+    std::fs::read_to_string(p).ok().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+```
+
+Add the dispatch in `main.rs` after the `linux_apply::handle` block:
+```rust
+    #[cfg(target_os = "linux")]
+    if let Some(code) = linux_service::handle(&args) {
+        log::info(&format!("linux-service-teardown exiting with code {code}"));
+        std::process::exit(code);
+    }
+```
+
+- [ ] **Step 4: Run tests + clippy**
+
+Run (Linux):
+```bash
+cargo test -p launcher --lib linux_service
+cargo clippy -p launcher -- -D warnings
+```
+Expected: tests PASS; clippy clean (no unused imports — the placeholder line is gone).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/linux_service.rs launcher/src/main.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): execute service teardown + relaunch; wire --linux-service-teardown (item 32)"
+```
+
+---
+
+## Task 9: ServiceApi — Linux uninstall hands off via systemd-run (no in-cgroup self-stop)
+
+**Files:**
+- Modify: `src/server/api/ServiceApi.ts` (`handleUninstall` — add a Linux branch before the generic `client.uninstall()`)
+- Test: `src/server/api/ServiceApi.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// ServiceApi.test.ts — Linux uninstall hands off, never calls client.uninstall().
+it('linux uninstall reverts installMode and spawns the systemd-run teardown (no direct uninstall)', async () => {
+    const spawned: { cmd: string; args: string[] }[] = [];
+    const client = { uninstall: vi.fn(), status: vi.fn().mockResolvedValue('stopped'),
+                     getInstalledScope: vi.fn().mockResolvedValue('user') /* + other ServiceClient methods */ };
+    // inject a spawn spy + a config spy via the test harness; platform 'linux'.
+    // POST /api/service/uninstall …
+    expect(client.uninstall).not.toHaveBeenCalled();
+    expect(spawned[0].cmd).toMatch(/systemd-run$/);
+    expect(spawned[0].args).toContain('--user');
+    expect(spawned[0].args.join(' ')).toContain('--linux-service-teardown --scope user --unit WsScrcpyWeb');
+    // installMode reverted to local
+    // (assert via the config spy: updateAppConfig called with installMode 'user')
+});
+```
+
+(Adapt to the existing harness. `handleUninstall` currently takes no spawn injection; add an injectable spawn function to the `ServiceApi` constructor — default `(cmd, args) => spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref()` — mirroring how `factory`/`scope`/`existsCheck` are injected, so the test can assert the argv without spawning a real process.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/server/api/ServiceApi.test.ts -t "linux uninstall reverts"`
+Expected: FAIL — currently calls `client.uninstall()`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `handleUninstall`, after the resume-token block and BEFORE the generic `try { await result.client.uninstall(...) }`, insert a Linux branch. It reverts `installMode → local`, resolves the scope (filesystem truth), then `systemd-run`s the staged helper out of the cgroup and returns `shutting-down`:
+
+```typescript
+        if (result.platform === 'linux') {
+            const scope = result.client.getInstalledScope
+                ? await result.client.getInstalledScope(WS_SCRCPY_SERVICE_NAME)
+                : null;
+            if (scope === null) {
+                // Not installed — nothing to tear down; report success idempotently.
+                const body: ServiceActionSuccess = { ok: true, status: 'not-installed', installMode: 'user' };
+                res.writeHead(200); res.end(JSON.stringify(body)); return true;
+            }
+
+            // Revert installMode to local BEFORE the teardown so the relaunched
+            // local instance reads local mode (mirrors the Windows revert-first).
+            const newMode: InstallMode = scope === 'system' ? 'system' : 'user';
+            try { cfg.updateAppConfig({ installMode: newMode }); }
+            catch (err) { log.warn(`uninstall: installMode revert failed: ${(err as Error).message}`); }
+
+            // Hand off to an OUT-OF-CGROUP helper. The service Node lives in the
+            // unit's cgroup; running `systemctl stop` here kills us mid-call
+            // (item 32). systemd-run launches the helper in its own transient
+            // unit, which survives stopping our unit. User scope uses the user
+            // manager; system scope is already root so it uses the system manager.
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher');
+            const systemdRun = resolveSystemTool('systemd-run');
+            const sdArgs = [
+                ...(scope === 'user' ? ['--user'] : []),
+                '--collect',
+                `--unit=wsscrcpy-teardown-${Date.now()}`,
+                helper,
+                '--linux-service-teardown', '--scope', scope, '--unit', WS_SCRCPY_SERVICE_NAME,
+            ];
+            this.spawnDetached(systemdRun, sdArgs);
+            log.info(`uninstall(linux): spawned teardown helper via systemd-run (${scope} scope)`);
+
+            const body: ServiceActionSuccess = { ok: true, status: 'shutting-down', installMode: newMode };
+            res.writeHead(200); res.end(JSON.stringify(body)); return true;
+        }
+```
+
+Add `resolveSystemTool` import + an injectable `spawnDetached` on the constructor (default spawns detached + unref). Add `import { resolveSystemTool } from '../service/systemTools';`.
+
+> **Verify-on-Fedora flag (spec item ②/⑤):** the exact `systemd-run` argv — esp. whether `--user` needs `--scope` instead of a transient `--unit` on this cgroup-v2 host, and whether `--collect` is accepted — is confirmed in Task 13. The shape above is the best-known form.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/server/api/ServiceApi.test.ts` then `npx tsc --noEmit`
+Expected: PASS; no type errors. Confirm the Windows uninstall tests are unchanged/green (the Linux branch is gated on `result.platform === 'linux'`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/ServiceApi.ts src/server/api/ServiceApi.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): uninstall hands off to out-of-cgroup systemd-run teardown (item 32)"
+```
+
+---
+
+## Task 10: Client — handle the Linux uninstall response (reconnect / removed)
+
+**Files:**
+- Modify: `src/app/client/SettingsModal.ts` (the uninstall click handler)
+- Test: `src/app/client/SettingsModal.test.ts` (if present; else a focused jsdom test for the response handler)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// A focused test for the uninstall-response handler. status 'shutting-down' +
+// installMode 'user' -> shows reconnect overlay; 'system' -> shows "service removed".
+import { describe, it, expect } from 'vitest';
+import { uninstallFollowupMessage } from './SettingsModal';
+
+describe('uninstallFollowupMessage', () => {
+    it('user scope → reconnect message', () => {
+        expect(uninstallFollowupMessage('user')).toMatch(/relaunch|reconnect|local/i);
+    });
+    it('system scope → service removed message', () => {
+        expect(uninstallFollowupMessage('system')).toMatch(/removed|stopped/i);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/app/client/SettingsModal.test.ts -t "uninstallFollowupMessage"`
+Expected: FAIL — function not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add an exported pure helper + use it in the uninstall handler where the response `status === 'shutting-down'`:
+
+```typescript
+/** Follow-up copy shown after a Linux service uninstall begins, by scope. */
+export function uninstallFollowupMessage(mode: 'user' | 'system'): string {
+    return mode === 'system'
+        ? 'service removed. the system service has been stopped — relaunch the app manually to use local mode.'
+        : 'service removed. relaunching the app in local mode — this page will reconnect shortly.';
+}
+```
+
+In the uninstall handler, when the response is `{ status: 'shutting-down' }` on Linux, render `uninstallFollowupMessage(installMode === 'system-service' || installMode === 'system' ? 'system' : 'user')` and (user scope) begin the existing reconnect/poll used after apply. Keep it lowercase per the app motif.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/app/client/SettingsModal.test.ts` then `npx tsc --noEmit`
+Expected: PASS; no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/SettingsModal.ts src/app/client/SettingsModal.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): uninstall follow-up UX (reconnect / service-removed)"
+```
+
+---
+
+## Task 11: Full suite + build green (regression fence)
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Run the full TS suite**
+
+Run: `npm test`
+Expected: all green — **especially the Windows + Linux-local service/apply tests** (the freeze guardrail; the Linux branches are gated, Windows paths untouched).
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Rust suite + clippy (Linux leg)**
+
+Run: `cargo test` and `cargo clippy -- -D warnings`
+Expected: green (the new `linux_service` tests run on the Linux leg; the module is `#[cfg(target_os = "linux")]`).
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: webpack builds dist/ with no errors.
+
+- [ ] **Step 5: Commit** (only if any fixups were needed)
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -am "test: full suite green for linux service-mode fix"
+```
+
+---
+
+## Task 12: VERIFY ON FEDORA — uninstall tears down cleanly (item 32)
+
+**Files:** none (manual verification; rebuild + cut the verification beta first).
+
+- [ ] **Step 1: User scope** — with a user-scope service installed and the browser on the service port, click uninstall.
+
+- [ ] **Step 2: Confirm clean teardown + relaunch**
+
+Run on Fedora:
+```bash
+systemctl --user status WsScrcpyWeb.service    # expect: not-found / inactive (unit removed)
+ls ~/.config/systemd/user/WsScrcpyWeb.service  # expect: No such file
+pgrep -af 'WsScrcpyWeb|scrcpy-server|adb'       # expect: only the relaunched LOCAL AppImage (+ its adb), no orphans
+```
+Expected: unit gone, no orphaned service process, the page reconnects to the relaunched local instance.
+
+- [ ] **Step 3: System scope** — install system scope, then uninstall.
+
+Run on Fedora:
+```bash
+systemctl status WsScrcpyWeb.service           # expect: not-found
+ls /opt/ws-scrcpy-web                           # expect: No such file (staging removed)
+sudo semanage fcontext -l | grep ws-scrcpy-web  # expect: no rule (fcontext -d ran)
+sudo ausearch -m avc -ts recent | grep -i wsscrcpy   # expect: no restart-loop AVC
+```
+Expected: unit + `/opt` staging + fcontext rule all gone; the restart-loop AVC from item 33 does not recur. Browser shows the "service removed" message.
+
+- [ ] **Step 4:** If the `systemd-run` argv from Task 9 failed (check the launcher log + `journalctl --user -u 'wsscrcpy-teardown-*'`), adjust the flags (cgroup-v2 `--scope` vs transient `--unit`, `--collect` support) and re-verify. This is the spec's verify-on-Fedora item ⑤.
+
+- [ ] **Step 5: No commit** (verification). Record results in the PR / breadcrumb; this gates writing the Phase 2 plan.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** item 33 staging → Tasks 2–3 + Fedora Task 6; item 32 teardown → Tasks 7–9 + Fedora Task 12; Local-Deps absolute paths → Tasks 1, 3, 4, 7–8; user-scope relaunch marker → Tasks 5, 8; client UX → Task 10; regression fence → Task 11. Phase 2 (updates) intentionally excluded — separate plan.
+- **Windows/local freeze:** every Linux change is gated (`platform === 'linux'`, `#[cfg(target_os = "linux")]`, `scope`-branched `renderUnitFile`); Task 11 asserts the Windows + Linux-local suites stay green.
+- **Type consistency:** `Scope::{User,System}` (Rust) ↔ `'user'|'system'` (TS `scope`); `STAGED_SYSTEM_DIR`/`STAGED_SYSTEM_APPIMAGE` reused across Tasks 2/3; `teardown_commands`/`relaunch_target`/`parse_args` defined Task 7 and used Task 8; `resolveSystemTool` defined Task 1 and used Tasks 3/4/9.
+- **Empirical flags:** the SELinux label (Task 6) and the exact `systemd-run` argv (Task 12) are the spec's verify-on-Fedora items; the plan writes the best-known concrete form and gates Phase 2 on confirming them, rather than leaving placeholders.

--- a/docs/plans/2026-06-01-linux-service-mode-fix.md
+++ b/docs/plans/2026-06-01-linux-service-mode-fix.md
@@ -29,6 +29,18 @@
 
 ---
 
+## Rust testing on this Windows host (local, via `cross`)
+
+The launcher's Linux modules (`linux_service`, `linux_apply`) are `#[cfg(target_os = "linux")]`, so they need a Linux toolchain. This host has **`cross` 0.2.5 + the `ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5` Docker image** (machine-tooling inventory, re-confirmed via `docker images`) — so the Rust steps below run **locally**, not just on CI. Wherever a Rust step shows `cargo test … --lib linux_service` or `cargo clippy`, run it as:
+
+- unit tests: `cross test -p launcher --lib linux_service --target x86_64-unknown-linux-gnu`
+- lint: `cross clippy -p launcher --target x86_64-unknown-linux-gnu -- -D warnings`
+- full Rust suite (Linux): `cross test --workspace --target x86_64-unknown-linux-gnu`
+
+Plain `cargo test --target <linux-triple>` FAILS on this host (no Linux linker) — always use `cross` (needs Docker Desktop running). A native-Linux runner / CI can use plain `cargo`. Cross containers compile + run unit tests but do NOT run systemd or SELinux-enforcing, so the runtime behavior in Tasks 6 + 12 still needs the real Fedora box; everything else (including the `linux_service` unit tests) verifies here.
+
+---
+
 ## Task 1: OS-tool absolute-path resolver
 
 **Files:**

--- a/docs/specs/2026-06-01-linux-service-mode-fix-and-update-design.md
+++ b/docs/specs/2026-06-01-linux-service-mode-fix-and-update-design.md
@@ -1,0 +1,139 @@
+# Linux service mode — fix install/uninstall + enable in-app updates (user + system scope)
+
+**Date:** 2026-06-01
+**Status:** Approved design
+**Scope:** Linux **service mode** only (`installMode` = `user-service` / `system-service`). Windows and Linux **local** mode (the beta.27 path) are byte-for-byte untouched.
+
+This is the direct follow-up to `2026-06-01-linux-appimage-self-update-design.md`, which deferred exactly this work in its "Out of scope": Linux service-mode update apply, item 32 (uninstall teardown), item 33 (system-scope SELinux AVC).
+
+## Problem
+
+Three defects, in dependency order. The service modes must be made *functional* (Phase 1) before in-app updates on top of them can be (Phase 2).
+
+### Item 33 — system-scope install can't start (SELinux), confirmed in code
+
+`ServiceApi.handleInstall` sets `binPath = process.env.APPIMAGE` (the **user-home** AppImage) for Linux (`ServiceApi.ts:240-242`), and `SystemdClient.install` renders the system unit with `ExecStart=${opts.binPath}` into `/etc/systemd/system/` (`SystemdClient.ts:178, 266`). A system unit runs under systemd's `init_t` domain; SELinux targeted policy (Fedora enforcing) denies `init_t` exec of a `user_home_t` file → `avc: denied { execute } scontext=…:init_t tcontext=…:user_home_t`. The service can't start; `Restart=on-failure` retries → the AVC repeats endlessly (observed: 7556 alerts in ~11h). User scope is unaffected — it runs as the unconfined user, which may exec home files.
+
+### Item 32 — uninstall leaves the app half-torn-down, confirmed gap in code
+
+Windows uninstall does an elaborate **out-of-process** handoff (operation-server + `post-stop.bat` + scheduled task + spawn a fresh local launcher — `ServiceApi.ts:406-474`, `supervisor.rs:196-307`). The Linux path (`SystemdClient.uninstall`) just runs `systemctl [--user] disable --now` **from the service's own Node process**, which is itself a member of the unit's cgroup. So the service stops the cgroup it is living in, with:
+- no `reset-failed` (a failed/looping unit stays failed),
+- no reap of children that **escaped** the cgroup (the `adb` daemon double-forks/daemonizes and is the prime suspect for "process still running"),
+- no handoff to relaunch the app in local mode ("app non-functional").
+
+The robust fix is correct regardless of the exact straggler; the precise process will be confirmed against the user's Fedora observation during verification.
+
+### Service-mode update gap
+
+`UpdateService.applyUpdate` early-returns **all** service mode into Velopack's `waitExitThenApplyUpdate` (`UpdateService.ts:446-449`) — the `UpdateNix apply` path proven broken on our AppImage (see the sibling spec). So Linux service-mode updates silently no-op. The beta.27 download-based apply that follows is gated local-only by that early-return.
+
+## Goal
+
+1. **System-scope service installs and runs** on SELinux-enforcing distros.
+2. **Uninstall (both scopes) tears down cleanly** — unit removed, stragglers reaped, restart-loop cleared — and returns the user to a working local-mode app where appropriate.
+3. **In-app updates apply + restart the service** in **both** `user-service` and `system-service` modes, without Velopack's apply, reusing the beta.27 download→verify→swap machinery.
+
+## Hard constraints
+
+- **Windows frozen.** All Windows `applyUpdate`/`handleInstall`/`handleUninstall` branches, the operation-server, and the Windows service-mode apply early-return are byte-for-byte unchanged. The full vitest + cargo suites stay green.
+- **Linux local mode frozen.** The beta.27 local apply path (`installMode === 'user'`, `linux_apply.rs` bare-relaunch) is untouched.
+- **Local-Dependencies-Only.** OS tools (`systemctl`, `pkexec`, `loginctl`, `ldconfig`, `systemd-run`, `cp`, `chmod`, `restorecon`, `chcon`, `semanage`) are invoked by **absolute path**, not bare name (closes the same PATH-hijack surface we closed on Windows with absolute `System32` paths). The app binary is the launcher helper already staged in `dataRoot`; `adb` is the bundled `<deps>/adb/adb`. This converts the existing bare-name calls in `SystemdClient` as part of the work.
+
+## Key mechanism — the out-of-cgroup helper
+
+In service mode the launcher → Node → adb/scrcpy-server all live in the **unit's cgroup**. systemd's default `KillMode=control-group` kills the entire cgroup on stop/restart. Therefore **any actor that must stop → swap/teardown → (re)start the unit cannot live in that cgroup**, or it is killed mid-operation. This single fact is the root of item 32 *and* the design of the Phase 2 apply.
+
+The fix, shared by item 32 and Phase 2: perform the lifecycle work from a helper launched **outside** the unit's cgroup via **`systemd-run`** (a transient unit owned by the systemd manager — `--user` for user scope, the system manager for system scope). This is the systemd-idiomatic analogue of the Windows operation-server/post-stop handoff. The helper is the launcher binary already copied to `<dataRoot>/control/operation-server/ws-scrcpy-web-launcher` on every boot by `operation_server::refresh_helper_binary` (cross-platform, `supervisor.rs:123`).
+
+> **Verify on Fedora:** the exact `systemd-run` invocation, including the `--user` cgroup-v2 nuance (systemd#3388), and that a transient unit survives `systemctl stop` of our service unit.
+
+## Design
+
+### Phase 1A — item 33: stage the AppImage to a system path (system scope)
+
+System-scope install stages a root-owned, correctly-labelled copy and points the unit at it. All privileged steps run inside the **single existing pkexec command** in `SystemdClient.install`:
+
+1. `mkdir -p /opt/ws-scrcpy-web`
+2. `cp "<source $APPIMAGE>" /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage` (stable, channel-agnostic name so updates swap a known path)
+3. `chmod 0755` the staged file
+4. **Label `bin_t`** so `init_t` may exec it: prefer persistent `semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'` + `restorecon -Rv /opt/ws-scrcpy-web`; fall back to `chcon -t bin_t` when `semanage` is absent (no `policycoreutils-python-utils`). (`/opt` files otherwise often land `default_t`, which `init_t` can't exec.)
+5. Write the unit with `ExecStart=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage`, `daemon-reload`, `enable --now`.
+
+`SystemdClient` derives the staged target internally for system scope; `ServiceApi` keeps passing the source `$APPIMAGE` as `binPath`. **User scope is unchanged** — `ExecStart=$APPIMAGE` (home), runs as the user, no SELinux issue.
+
+> **Verify on Fedora:** that an `init_t` system service cleanly execs a `bin_t`-labelled `/opt` AppImage (FUSE-mounts as root, binds, no further AVC).
+
+### Phase 1B — item 32: clean uninstall + return to local
+
+Replace the in-cgroup self-uninstall with an out-of-cgroup handoff:
+
+1. **`ServiceApi.handleUninstall` (Linux):** persist `installMode → local` (drop the `-service` suffix) *before* handing off (mirrors the Windows revert-first ordering), then `systemd-run` the staged helper with a new `--linux-service-teardown --scope <user|system> --unit <name>` subcommand and return. The unprivileged user-scope path uses `systemd-run --user`; the system-scope service is already **root**, so it uses the system manager directly (no pkexec).
+2. **Helper (out of cgroup), new launcher mode:**
+   - `systemctl [--user] stop <unit>` — synchronous; reaps everything *in* the cgroup (launcher, Node, in-cgroup children).
+   - `systemctl [--user] disable <unit>`; `systemctl [--user] reset-failed <unit>` (clears the restart-loop state).
+   - Remove the unit file (`~/.config/systemd/user/<name>.service` or `/etc/systemd/system/<name>.service`); for system scope also `rm -rf /opt/ws-scrcpy-web` and `semanage fcontext -d` the rule; `daemon-reload`.
+   - Reap **escaped** stragglers: `adb kill-server` via the bundled `<deps>/adb/adb` (absolute path); best-effort kill of orphaned `scrcpy-server`.
+   - Remove the tray autostart `.desktop` (user scope; already done today — keep).
+   - **Relaunch policy:** *user scope* relaunches the home AppImage into local mode (desktop UX continuity); *system scope* tears down cleanly **without** auto-relaunch (headless-dominant — the admin re-launches their own AppImage), and the browser shows a "service removed" message. The home AppImage path for the user-scope relaunch is captured at install time in a `dataRoot/control/local-appimage` marker (consistent with the other control markers), used only if it still exists, else fall back to the browser-guidance message.
+
+### Phase 2A — user-scope update
+
+1. Narrow the `applyUpdate` service-mode early-return to **Windows only** (`isServiceMode && this.platform === 'win32'`), so Linux service mode falls through to a new service-aware path.
+2. Linux user-service apply: reuse the existing download → `SHA256SUMS` verify → staging-file machinery (identical to the local path). Then `systemd-run --user` the staged helper with `--linux-apply --staged <new> --target <$APPIMAGE> --service-restart user --unit <name>`.
+3. **Extend `linux_apply.rs`:** when `--service-restart <scope> --unit <name>` is present, the post-download sequence becomes `systemctl [--user] stop <unit>` (synchronous) → brief settle/poll until the AppImage file is unlocked (FUSE unmount) → `swap_appimage` (reused) → `systemctl [--user] start <unit>`, instead of the bare relaunch. No `--wait-pid` needed (stop is synchronous).
+4. The service Node does **not** `process.exit`; the helper stops the unit. No privilege needed (user manager, home AppImage, user-owned).
+5. **UI:** the service rebinds the **same** configured web port, so the existing in-browser `reconnectAfterApply` + top-layer `UpgradingOverlay` (`mode:'reconnect'`) bridges the gap. No operation-server needed (unlike Windows, there is no port-shift). Confirm by test + on Fedora.
+
+### Phase 2B — system-scope update
+
+The system service runs as **root**, so the apply handler (hit from the browser → root service Node) can do the privileged work directly — **no pkexec prompt → headless-capable**:
+
+1. Download + verify to a root-writable staging file under `dataRoot`.
+2. `systemd-run` (system manager) the staged helper with `--linux-apply --staged <new> --target /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage --service-restart system --unit <name> --relabel`.
+3. Helper: `systemctl stop <unit>` → swap the `/opt` copy → re-apply the `bin_t` label (`restorecon`, or `chcon -t bin_t`) → `systemctl start <unit>`.
+
+> **Verify on Fedora (the open risk):** whether the `init_t`-domain service / its `systemd-run` transient unit may write `/opt`, relabel, and run `systemctl` under enforcing SELinux. If blocked, ship a **narrow, targeted** policy allowance for this app's path only — **never** broad `audit2allow` (the todo's explicit prohibition).
+
+## Components / files
+
+| File | Change |
+|---|---|
+| `src/server/api/ServiceApi.ts` | Linux install: keep passing source `$APPIMAGE`; persist `localAppImagePath` for the uninstall relaunch. Linux uninstall: replace the direct `client.uninstall()` with revert-to-local + `systemd-run` handoff to the teardown helper. |
+| `src/server/service/SystemdClient.ts` | System-scope: stage to `/opt` + label `bin_t` inside the pkexec command; render unit `ExecStart` = staged path. Uninstall logic moves to the launcher helper (out-of-cgroup); `SystemdClient` retains pure unit/path/command builders. Convert bare-name OS-tool calls to absolute paths. |
+| `src/server/UpdateService.ts` | `applyUpdate`: narrow the service early-return to win32; add the Linux service-apply path (download→verify→`systemd-run` helper with `--service-restart`). |
+| `launcher/src/linux_apply.rs` | Add `--service-restart <user\|system> --unit <name> [--relabel]`: stop → settle → swap → (relabel) → start, instead of bare relaunch. Pure command/sequence builders unit-tested. |
+| `launcher/src/main.rs` | Wire `--linux-service-teardown`; extend `linux_apply` arg parsing. |
+| `launcher/src/linux_service.rs` (new, or extend `linux_apply.rs`) | Teardown sequence (stop/disable/reset-failed/rm/relabel-cleanup/reap/relaunch) as pure, testable builders + a thin exec seam. |
+| OS-tool resolver (new small module) | Absolute-path resolution for `systemctl`/`pkexec`/`systemd-run`/`restorecon`/`chcon`/`semanage`/`cp`/`chmod` (checks known `/usr/bin`,`/usr/sbin`,`/bin`,`/sbin` locations). |
+| Tests | vitest: install (system→staged binPath, user→home), uninstall handoff (marker + `systemd-run`, not direct disable), Linux service-apply branch (download→verify→`systemd-run`; **win32 service early-return preserved**), absolute-path resolver. cargo: `linux_apply` swap/restore (existing) + service-restart + teardown command builders. |
+
+## Error handling / edge cases
+
+- Download fail / SHA-256 mismatch → abort before any stop/swap; the service stays on the current version.
+- `systemd-run` absent (non-systemd host) → error with guidance (systemd-run ships with systemd; service mode already requires systemd).
+- Helper swap fail → restore `<target>.bak`, do **not** `start` into a broken binary; write a `dataRoot/control/update-error` marker; the unit can be re-started on the old version.
+- SELinux denies the 2B privileged ops → error marker + guidance; ship a narrow targeted policy only if Fedora testing requires it.
+- pkexec dismissed at install/uninstall → surfaced as today (`authentication was dismissed`).
+- **Headless system scope:** install/uninstall need a polkit agent (an at-the-machine admin action — a pre-existing constraint from item 28); **updates do not** (root self-update). Documented, not a regression.
+- User-scope relaunch when the home AppImage was moved/renamed → write marker + browser guidance instead of relaunching a missing path.
+
+## Testing
+
+- **vitest (TDD, injected `fetch`/`fs`/`spawn`/exec):** install scope→binPath mapping; uninstall writes the handoff + invokes `systemd-run` (never a direct in-cgroup `disable --now`); `applyUpdate` Linux service path downloads→verifies→`systemd-run`s the helper; **Windows service-mode apply unchanged** (still the `waitExitThenApplyUpdate` early-return — the freeze guardrail); absolute-path OS-tool resolver.
+- **cargo (tempdir/pure):** `linux_apply` backup/swap/restore (existing) + the new `--service-restart` command sequence builder + the teardown sequence builder (stop/disable/reset-failed/rm/reap order).
+- **Full existing suite green** — Windows + Linux-local tests are the regression fence.
+
+## Verification (real Fedora — the oracle)
+
+1. **system install:** service reaches `active` with no AVC; `init_t` execs the `bin_t` `/opt` AppImage.
+2. **uninstall (both scopes):** unit gone, `reset-failed` clears the loop, no straggler (adb daemon reaped); user-scope relaunches local; system-scope clean teardown + browser message.
+3. **user-scope update:** beta.N → N+1, service restarts on the same web port, browser reconnects via the overlay.
+4. **system-scope update:** beta.N → N+1 **headless** (no prompt) — root self-update swaps `/opt` + restarts; confirm `init_t` may write/relabel/`systemctl` (or scope a narrow policy).
+5. **out-of-cgroup helper:** the `systemd-run` transient unit survives `systemctl stop` of our service unit.
+
+## Out of scope (separate work)
+
+- **Phase 3 UX (deferred per user, after Phases 1+2):** restyle the "Administrative Privileges Required" confirm-modal buttons (`cancel`/`continue`, install + uninstall variants) to **white outline + white text**, matching the welcome/bookmark/service-mode modals (beta.29). Platform-agnostic CSS.
+- **Device-name SQLite DB** in `dataRoot` — unrelated deferred item, tracked separately in `todo_ws_scrcpy_web.md`.
+- **Velopack 1.0.1 → 1.1.1 (item 31)** and the libfuse2-gate removal.
+- **System-scope-as-root posture** — a system unit with no `User=` runs the whole app (adb/scrcpy) as root. This is the existing item-28 design; not changed here.

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -4,7 +4,9 @@
 // cgroup; calling systemctl stop from there kills itself mid-call — the
 // root of item 32). Mirrors the Windows operation-server/post-stop handoff.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use crate::log;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scope {
@@ -51,13 +53,14 @@ pub fn teardown_commands(scope: Scope, name: &str, bindir: &str) -> Vec<Vec<Stri
     let unit = format!("{name}.service");
     let unit_file = unit_path(scope, name);
 
-    let mut cmds: Vec<Vec<String>> = Vec::new();
-    // stop (synchronous; reaps the in-cgroup launcher+Node+children), disable, reset-failed
-    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["stop".into(), unit.clone()]].concat());
-    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["disable".into(), unit.clone()]].concat());
-    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["reset-failed".into(), unit.clone()]].concat());
-    // remove the unit file
-    cmds.push(vec![rm.clone(), "-f".into(), unit_file.to_string_lossy().into_owned()]);
+    // stop (synchronous; reaps the in-cgroup launcher+Node+children), disable, reset-failed,
+    // remove unit file, reload — always present.
+    let mut cmds: Vec<Vec<String>> = vec![
+        [vec![systemctl.clone()], pre.clone(), vec!["stop".into(), unit.clone()]].concat(),
+        [vec![systemctl.clone()], pre.clone(), vec!["disable".into(), unit.clone()]].concat(),
+        [vec![systemctl.clone()], pre.clone(), vec!["reset-failed".into(), unit.clone()]].concat(),
+        vec![rm.clone(), "-f".into(), unit_file.to_string_lossy().into_owned()],
+    ];
     // system scope also removes the /opt staging + the semanage fcontext rule
     if scope == Scope::System {
         let semanage = format!("{}/semanage", sbindir_from(bindir));
@@ -91,6 +94,103 @@ pub fn parse_args(args: &[String]) -> Option<(Scope, String)> {
         .and_then(|i| args.get(i + 1))
         .cloned()?;
     Some((scope, unit))
+}
+
+/// User scope relaunches the home AppImage (from the install-time marker) into
+/// local mode. System scope never auto-relaunches (headless-dominant; the admin
+/// re-launches their own AppImage). Returns the path to relaunch, or None.
+pub fn relaunch_target(scope: Scope, marker: Option<String>) -> Option<PathBuf> {
+    match scope {
+        // `|| cfg!(test)` lets the unit test assert Some for a path that doesn't
+        // exist on the test host; in production the marker must point at a real file.
+        Scope::User => marker.map(PathBuf::from).filter(|p| p.exists() || cfg!(test)),
+        Scope::System => None,
+    }
+}
+
+/// Dispatch: handle `--linux-service-teardown`, return Some(exit_code).
+pub fn handle(args: &[String]) -> Option<i32> {
+    if !args.iter().any(|a| a == "--linux-service-teardown") {
+        return None;
+    }
+    let (scope, unit) = match parse_args(args) {
+        Some(v) => v,
+        None => {
+            log::error("linux-service-teardown: missing/invalid --scope or --unit");
+            return Some(2);
+        }
+    };
+    Some(run(scope, &unit))
+}
+
+/// Probe for the absolute dir (/usr/bin then /bin) containing `tool`. Falls back
+/// to /usr/bin. Local-Dependencies-Only: never invoke a tool by bare name.
+fn tool_dir(tool: &str) -> String {
+    for d in ["/usr/bin", "/bin"] {
+        if Path::new(&format!("{d}/{tool}")).exists() {
+            return d.to_string();
+        }
+    }
+    "/usr/bin".to_string()
+}
+
+fn run(scope: Scope, unit: &str) -> i32 {
+    let bd = tool_dir("systemctl");
+    log::info(&format!("linux-service-teardown: scope={scope:?} unit={unit}"));
+
+    // 1. Teardown sequence (best-effort; log non-zero, keep going).
+    for argv in teardown_commands(scope, unit, &bd) {
+        let (cmd, rest) = argv.split_first().expect("non-empty argv");
+        match std::process::Command::new(cmd).args(rest).status() {
+            Ok(s) if s.success() => log::info(&format!("teardown ok: {}", argv.join(" "))),
+            Ok(s) => log::error(&format!("teardown non-zero ({:?}): {}", s.code(), argv.join(" "))),
+            Err(e) => log::error(&format!("teardown spawn failed: {} ({e})", argv.join(" "))),
+        }
+    }
+
+    // 2. Reap the escaped adb daemon (it daemonizes out of the cgroup, so the
+    //    cgroup stop above does NOT kill it). Bundled adb, absolute path.
+    if let Some(data_root) = common::config::data_root_from_env() {
+        let adb = data_root.join("dependencies").join("adb").join("adb");
+        if adb.exists() {
+            let _ = std::process::Command::new(&adb).arg("kill-server").status();
+            log::info("teardown: adb kill-server issued");
+        }
+    }
+
+    // 3. Relaunch local (USER scope only). The relaunched app MUST run in its
+    //    OWN transient unit, NOT as a child of this helper: this helper itself
+    //    runs inside a `systemd-run` transient unit (ServiceApi launches it that
+    //    way), so a plain spawn would be in THIS helper's cgroup and get killed
+    //    when this helper exits and its transient unit deactivates. `systemd-run
+    //    --user --collect` starts the AppImage as an independent transient unit
+    //    that outlives this helper.
+    //    >>> VERIFY ON FEDORA (Phase 1 Task 12): this is the key runtime-survival
+    //    point. Confirm the relaunched local app actually survives this helper's
+    //    exit and the browser reconnects. If the user-manager / XDG_RUNTIME_DIR
+    //    context isn't right when invoked from inside the teardown transient unit,
+    //    adjust this invocation. <<<
+    let marker = read_local_appimage_marker();
+    if let Some(target) = relaunch_target(scope, marker) {
+        let systemd_run = format!("{}/systemd-run", tool_dir("systemd-run"));
+        let target_str = target.to_string_lossy().into_owned();
+        match std::process::Command::new(&systemd_run)
+            .args(["--user", "--collect", &target_str])
+            .status()
+        {
+            Ok(s) => log::info(&format!(
+                "teardown: relaunched local {target_str} via systemd-run (exit {:?})", s.code()
+            )),
+            Err(e) => log::error(&format!("teardown: relaunch via systemd-run failed: {e}")),
+        }
+    }
+    0
+}
+
+fn read_local_appimage_marker() -> Option<String> {
+    let data_root = common::config::data_root_from_env()?;
+    let p = data_root.join("control").join("local-appimage");
+    std::fs::read_to_string(p).ok().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
 }
 
 #[cfg(test)]
@@ -130,5 +230,18 @@ mod tests {
     fn sbindir_derivation() {
         assert_eq!(sbindir_from("/usr/bin"), "/usr/sbin");
         assert_eq!(sbindir_from("/bin"), "/sbin");
+    }
+
+    #[test]
+    fn relaunch_only_for_user_scope_with_marker() {
+        // user scope + marker -> Some(path) (cfg!(test) bypasses the exists() check)
+        assert_eq!(
+            relaunch_target(Scope::User, Some("/home/u/Apps/App.AppImage".into())),
+            Some(PathBuf::from("/home/u/Apps/App.AppImage"))
+        );
+        // system scope -> never relaunch
+        assert_eq!(relaunch_target(Scope::System, Some("/home/u/Apps/App.AppImage".into())), None);
+        // user scope, missing marker -> None
+        assert_eq!(relaunch_target(Scope::User, None), None);
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -1,0 +1,134 @@
+// §item32 — out-of-cgroup Linux service teardown. Launched via `systemd-run`
+// from the Node server so it runs in its OWN transient unit, surviving the
+// stop of the service unit it tears down (the service Node lives in that
+// cgroup; calling systemctl stop from there kills itself mid-call — the
+// root of item 32). Mirrors the Windows operation-server/post-stop handoff.
+
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    User,
+    System,
+}
+
+/// `--user` prefix tokens for user scope, empty for system scope.
+fn scope_prefix(scope: Scope) -> Vec<String> {
+    match scope {
+        Scope::User => vec!["--user".to_string()],
+        Scope::System => vec![],
+    }
+}
+
+pub fn unit_path(scope: Scope, name: &str) -> PathBuf {
+    match scope {
+        Scope::User => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+            PathBuf::from(home)
+                .join(".config/systemd/user")
+                .join(format!("{name}.service"))
+        }
+        Scope::System => PathBuf::from("/etc/systemd/system").join(format!("{name}.service")),
+    }
+}
+
+/// Derive the sbin dir from the bin dir (`/usr/bin` -> `/usr/sbin`, `/bin` -> `/sbin`).
+/// semanage/restorecon live in sbin; everything else in bin.
+fn sbindir_from(bindir: &str) -> String {
+    bindir
+        .strip_suffix("/bin")
+        .map(|p| format!("{p}/sbin"))
+        .unwrap_or_else(|| bindir.to_string())
+}
+
+/// Ordered command argv-vectors for the teardown. `bindir` is the resolved
+/// absolute bin dir (e.g. "/usr/bin") so we never invoke tools by bare name
+/// (Local-Dependencies-Only).
+pub fn teardown_commands(scope: Scope, name: &str, bindir: &str) -> Vec<Vec<String>> {
+    let systemctl = format!("{bindir}/systemctl");
+    let rm = format!("{bindir}/rm");
+    let pre = scope_prefix(scope);
+    let unit = format!("{name}.service");
+    let unit_file = unit_path(scope, name);
+
+    let mut cmds: Vec<Vec<String>> = Vec::new();
+    // stop (synchronous; reaps the in-cgroup launcher+Node+children), disable, reset-failed
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["stop".into(), unit.clone()]].concat());
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["disable".into(), unit.clone()]].concat());
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["reset-failed".into(), unit.clone()]].concat());
+    // remove the unit file
+    cmds.push(vec![rm.clone(), "-f".into(), unit_file.to_string_lossy().into_owned()]);
+    // system scope also removes the /opt staging + the semanage fcontext rule
+    if scope == Scope::System {
+        let semanage = format!("{}/semanage", sbindir_from(bindir));
+        cmds.push(vec![rm.clone(), "-rf".into(), "/opt/ws-scrcpy-web".into()]);
+        cmds.push(vec![
+            semanage,
+            "fcontext".into(),
+            "-d".into(),
+            "/opt/ws-scrcpy-web(/.*)?".into(),
+        ]);
+    }
+    // reload
+    cmds.push([vec![systemctl.clone()], pre.clone(), vec!["daemon-reload".into()]].concat());
+    cmds
+}
+
+/// Parse `--scope user|system` + `--unit <name>` from argv.
+pub fn parse_args(args: &[String]) -> Option<(Scope, String)> {
+    let scope = args
+        .iter()
+        .position(|a| a == "--scope")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| match s.as_str() {
+            "user" => Some(Scope::User),
+            "system" => Some(Scope::System),
+            _ => None,
+        })?;
+    let unit = args
+        .iter()
+        .position(|a| a == "--unit")
+        .and_then(|i| args.get(i + 1))
+        .cloned()?;
+    Some((scope, unit))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_scope_teardown_sequence() {
+        let cmds = teardown_commands(Scope::User, "WsScrcpyWeb", "/usr/bin");
+        let joined: Vec<String> = cmds.iter().map(|c| c.join(" ")).collect();
+        assert!(joined[0].contains("--user stop WsScrcpyWeb.service"));
+        assert!(joined.iter().any(|c| c.contains("--user disable WsScrcpyWeb.service")));
+        assert!(joined.iter().any(|c| c.contains("--user reset-failed WsScrcpyWeb.service")));
+        assert!(joined.iter().any(|c| c.contains("--user daemon-reload")));
+        // user scope does NOT touch /opt
+        assert!(!joined.iter().any(|c| c.contains("/opt/ws-scrcpy-web")));
+    }
+
+    #[test]
+    fn system_scope_teardown_removes_opt_and_fcontext() {
+        let cmds = teardown_commands(Scope::System, "WsScrcpyWeb", "/usr/bin");
+        let joined: Vec<String> = cmds.iter().map(|c| c.join(" ")).collect();
+        assert!(joined.iter().any(|c| c.contains("stop WsScrcpyWeb.service") && !c.contains("--user")));
+        assert!(joined.iter().any(|c| c.contains("rm") && c.contains("/opt/ws-scrcpy-web")));
+        assert!(joined.iter().any(|c| c.contains("semanage fcontext -d")));
+    }
+
+    #[test]
+    fn unit_path_is_scope_correct() {
+        assert_eq!(
+            unit_path(Scope::System, "WsScrcpyWeb"),
+            PathBuf::from("/etc/systemd/system/WsScrcpyWeb.service")
+        );
+    }
+
+    #[test]
+    fn sbindir_derivation() {
+        assert_eq!(sbindir_from("/usr/bin"), "/usr/sbin");
+        assert_eq!(sbindir_from("/bin"), "/sbin");
+    }
+}

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -96,6 +96,12 @@ fn main() {
         std::process::exit(code);
     }
 
+    #[cfg(target_os = "linux")]
+    if let Some(code) = linux_service::handle(&args) {
+        log::info(&format!("linux-service-teardown exiting with code {code}"));
+        std::process::exit(code);
+    }
+
     // Cross-session user-launcher spawn dispatch. Invoked from post-stop.bat
     // after `servy-cli uninstall` completes, to drop a fresh user-session
     // launcher so the user lands on local-mode UI post-uninstall. Wraps

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -21,6 +21,8 @@ mod unzip_handler;
 mod operation_server;
 #[cfg(target_os = "linux")]
 mod linux_apply;
+#[cfg(target_os = "linux")]
+mod linux_service;
 #[cfg(windows)]
 mod user_session_spawn;
 

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -11,6 +11,18 @@ import type {
 import type { UpdatesStatusResponse, UpdatesConfigPatchRequest } from '../../common/UpdateEvents';
 
 /**
+ * Follow-up copy shown after a Linux service uninstall begins, by scope.
+ * User scope: the Rust teardown helper relaunches the home AppImage in local
+ * mode, so the page will reconnect. System scope: no relaunch - user is
+ * informed the service has been stopped.
+ */
+export function uninstallFollowupMessage(mode: 'user' | 'system'): string {
+    return mode === 'system'
+        ? 'service removed. the system service has been stopped. relaunch the app manually to use local mode.'
+        : 'service removed. relaunching the app in local mode. this page will reconnect shortly.';
+}
+
+/**
  * Settings modal — unified two-column grid layout.
  *
  * Every section is built from the same primitive:
@@ -1038,6 +1050,24 @@ export class SettingsModal extends Modal {
                 return;
             }
             if (data.status === 'shutting-down') {
+                // Derive scope from the installMode field so we know whether a
+                // local relaunch is coming (user scope) or not (system scope).
+                const isSystemUninstall =
+                    data.installMode === 'system' || data.installMode === 'system-service';
+                if (isLinux && isSystemUninstall) {
+                    // System scope on Linux: teardown helper stops the unit but
+                    // does NOT relaunch a local instance. Nothing to poll for.
+                    modal.close();
+                    btn.disabled = false;
+                    btn.textContent = prevText;
+                    this.renderServiceError(
+                        uninstallFollowupMessage('system'),
+                        () => void this.refreshService(),
+                    );
+                    return;
+                }
+                // User scope on Linux (or Windows): a fresh local instance is
+                // relaunching. Fall through to the mtime poll / navigate path.
                 // §39: mtime-based discovery via operation-server's /api/discover.
                 // The service-Node is about to die. The operation-server takes over
                 // the port. Poll /api/discover until config.json mtime changes

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { uninstallFollowupMessage } from '../SettingsModal';
+
+describe('uninstallFollowupMessage', () => {
+    it('user scope -> reconnect/relaunch message', () => {
+        expect(uninstallFollowupMessage('user')).toMatch(/relaunch|reconnect|local/i);
+    });
+    it('system scope -> service removed message', () => {
+        expect(uninstallFollowupMessage('system')).toMatch(/removed|stopped/i);
+    });
+});

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -72,6 +72,7 @@ describe('ServiceApi', () => {
     const savedEnv = {
         CONFIG: process.env[EnvName.CONFIG_PATH],
         DEPS: process.env['DEPS_PATH'],
+        PROGRAMDATA: process.env['PROGRAMDATA'],
     };
 
     beforeEach(() => {
@@ -81,6 +82,13 @@ describe('ServiceApi', () => {
         fs.writeFileSync(configPath, JSON.stringify({}));
         process.env[EnvName.CONFIG_PATH] = configPath;
         process.env['DEPS_PATH'] = path.join(tmpRoot, 'deps');
+        // Redirect PROGRAMDATA to tmpRoot so Config.resolveDataRoot (which reads
+        // process.env['PROGRAMDATA'] directly on Windows) resolves cfg.dataRoot
+        // to <tmpRoot>\WsScrcpyWeb. Without this, control-marker writes
+        // (local-appimage, uninstall-pending) land in the REAL C:\ProgramData
+        // on every test run. With it, all such writes land inside tmpRoot, which
+        // afterEach rmSyncs recursively — fully hermetic.
+        process.env['PROGRAMDATA'] = tmpRoot;
         Config._resetForTest();
     });
 
@@ -94,6 +102,8 @@ describe('ServiceApi', () => {
         else process.env[EnvName.CONFIG_PATH] = savedEnv.CONFIG;
         if (savedEnv.DEPS === undefined) delete process.env['DEPS_PATH'];
         else process.env['DEPS_PATH'] = savedEnv.DEPS;
+        if (savedEnv.PROGRAMDATA === undefined) delete process.env['PROGRAMDATA'];
+        else process.env['PROGRAMDATA'] = savedEnv.PROGRAMDATA;
         while (tmpDirs.length) {
             const d = tmpDirs.pop()!;
             try {
@@ -624,12 +634,6 @@ describe('ServiceApi', () => {
             const appImagePath = '/home/jamie/Applications/WsScrcpyWeb.AppImage';
             const savedAppImage = process.env['APPIMAGE'];
             process.env['APPIMAGE'] = appImagePath;
-            // Compute the marker path up-front so we can clean it up in finally.
-            // On Windows cfg.dataRoot = C:\ProgramData\WsScrcpyWeb (a real path),
-            // so the marker lands outside tmpDirs and must be cleaned explicitly.
-            const cfg = Config.getInstance();
-            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
-            const markerPath = path.join(dataRoot, 'control', 'local-appimage');
             try {
                 const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
                 const client = fakeClient({
@@ -651,10 +655,14 @@ describe('ServiceApi', () => {
                 expect((res as any).getStatus()).toBe(200);
 
                 // Verify the marker landed on disk with the correct content.
+                // PROGRAMDATA is redirected to tmpRoot in beforeEach, so
+                // cfg.dataRoot resolves inside tmpRoot (cleaned by afterEach).
+                const cfg = Config.getInstance();
+                const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+                const markerPath = path.join(dataRoot, 'control', 'local-appimage');
                 expect(fs.existsSync(markerPath)).toBe(true);
                 expect(fs.readFileSync(markerPath, 'utf8')).toBe(appImagePath);
             } finally {
-                try { fs.rmSync(markerPath, { force: true }); } catch { /* best-effort */ }
                 if (savedAppImage === undefined) delete process.env['APPIMAGE'];
                 else process.env['APPIMAGE'] = savedAppImage;
             }
@@ -663,11 +671,6 @@ describe('ServiceApi', () => {
         it('POST /install on Linux without $APPIMAGE does NOT write local-appimage marker', async () => {
             const savedAppImage = process.env['APPIMAGE'];
             delete process.env['APPIMAGE'];
-            // Compute the marker path and ensure no stale copy from a prior run.
-            const cfg = Config.getInstance();
-            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
-            const markerPath = path.join(dataRoot, 'control', 'local-appimage');
-            try { fs.rmSync(markerPath, { force: true }); } catch { /* best-effort */ }
             try {
                 const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
                 const client = fakeClient({
@@ -688,7 +691,11 @@ describe('ServiceApi', () => {
                 await api.handle(req, res);
                 expect((res as any).getStatus()).toBe(200);
 
-                // Marker must NOT exist when APPIMAGE is unset.
+                // Marker must NOT exist when APPIMAGE is unset. tmpRoot is fresh
+                // per-test (beforeEach), so no stale marker can leak in.
+                const cfg = Config.getInstance();
+                const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+                const markerPath = path.join(dataRoot, 'control', 'local-appimage');
                 expect(fs.existsSync(markerPath)).toBe(false);
             } finally {
                 if (savedAppImage === undefined) delete process.env['APPIMAGE'];

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -761,6 +761,103 @@ describe('ServiceApi', () => {
                 else process.env['APPIMAGE'] = savedAppImage;
             }
         });
+
+        // ── Linux uninstall — systemd-run teardown handoff (item 32) ───────────
+        //
+        // On Linux, uninstall MUST NOT call client.uninstall() because this Node
+        // process runs inside the service unit's own cgroup — stopping the unit
+        // from within it would kill us mid-call (no clean teardown, no relaunch).
+        // Instead, ServiceApi hands off to an out-of-cgroup helper via systemd-run,
+        // which runs in a transient unit, survives stopping our unit, then tears
+        // down + (user scope) relaunches local. Mirrors the Windows operation-server
+        // handoff on the service-context (LocalSystem) uninstall path.
+
+        it('POST /uninstall on Linux does NOT call client.uninstall(), reverts installMode to user, spawns systemd-run teardown helper', async () => {
+            const uninstallSpy = vi.fn(async () => undefined);
+            const client = fakeClient({
+                uninstall: uninstallSpy,
+                status: vi.fn(async () => 'running' as const),
+                getInstalledScope: vi.fn(async () => 'user' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            let spawnedCmd = '';
+            let spawnedArgs: string[] = [];
+            const spawnDetached = vi.fn((cmd: string, args: string[]) => {
+                spawnedCmd = cmd;
+                spawnedArgs = args;
+            });
+
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+            // Pass spawnDetached as 4th constructor arg (injectable for tests).
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnDetached);
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            // (a) Must NOT call client.uninstall()
+            expect(uninstallSpy).not.toHaveBeenCalled();
+
+            // (b) installMode must be reverted to 'user' (local mode, user scope)
+            expect(Config.getInstance().getAppConfig().installMode).toBe('user');
+
+            // (c) spawnDetached must have been invoked with systemd-run + correct args
+            expect(spawnDetached).toHaveBeenCalledTimes(1);
+            // systemd-run resolved via resolveSystemTool — on a non-Linux host it
+            // falls back to the bare name 'systemd-run' (no /usr/bin/systemd-run on Windows).
+            expect(spawnedCmd).toMatch(/systemd-run/);
+            // user scope → --user flag present
+            expect(spawnedArgs).toContain('--user');
+            expect(spawnedArgs).toContain('--collect');
+            // teardown args forwarded to the helper
+            expect(spawnedArgs).toContain('--linux-service-teardown');
+            expect(spawnedArgs).toContain('--scope');
+            expect(spawnedArgs).toContain('user');
+            expect(spawnedArgs).toContain('--unit');
+            expect(spawnedArgs).toContain('WsScrcpyWeb');
+            // helper path uses the operation-server staged name (same .exe suffix as UpdateService)
+            const helperArg = spawnedArgs.find((a) => a.endsWith('ws-scrcpy-web-launcher.exe'));
+            expect(helperArg).toBeDefined();
+            expect(helperArg).toContain('operation-server');
+
+            // (d) Response: { ok: true, status: 'shutting-down' }
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
+            expect(body.installMode).toBe('user');
+        });
+
+        it('POST /uninstall on Linux with scope=null (not-installed) returns not-installed, no spawn', async () => {
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'not-installed' as const),
+                getInstalledScope: vi.fn(async () => null),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            const spawnDetached = vi.fn();
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnDetached);
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            // Not installed — no spawn, no uninstall call
+            expect(spawnDetached).not.toHaveBeenCalled();
+            expect(client.uninstall).not.toHaveBeenCalled();
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('not-installed');
+        });
     });
 
     it('returns 404 for unrecognized /api/service/* paths', async () => {

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -73,6 +73,8 @@ describe('ServiceApi', () => {
         CONFIG: process.env[EnvName.CONFIG_PATH],
         DEPS: process.env['DEPS_PATH'],
         PROGRAMDATA: process.env['PROGRAMDATA'],
+        XDG_DATA_HOME: process.env['XDG_DATA_HOME'],
+        DATA_ROOT: process.env['DATA_ROOT'],
     };
 
     beforeEach(() => {
@@ -89,6 +91,13 @@ describe('ServiceApi', () => {
         // on every test run. With it, all such writes land inside tmpRoot, which
         // afterEach rmSyncs recursively — fully hermetic.
         process.env['PROGRAMDATA'] = tmpRoot;
+        // On Linux, resolveDataRoot ignores PROGRAMDATA. Redirect via XDG_DATA_HOME
+        // instead (DATA_ROOT has higher priority and must not leak from the runner env,
+        // so clear it first). This makes cfg.dataRoot resolve to <tmpRoot>/WsScrcpyWeb
+        // on Linux too — mirroring the Windows PROGRAMDATA redirect — so marker writes
+        // land inside tmpRoot and are cleaned up by afterEach rmSync.
+        delete process.env['DATA_ROOT'];
+        process.env['XDG_DATA_HOME'] = tmpRoot;
         Config._resetForTest();
     });
 
@@ -104,6 +113,10 @@ describe('ServiceApi', () => {
         else process.env['DEPS_PATH'] = savedEnv.DEPS;
         if (savedEnv.PROGRAMDATA === undefined) delete process.env['PROGRAMDATA'];
         else process.env['PROGRAMDATA'] = savedEnv.PROGRAMDATA;
+        if (savedEnv.XDG_DATA_HOME === undefined) delete process.env['XDG_DATA_HOME'];
+        else process.env['XDG_DATA_HOME'] = savedEnv.XDG_DATA_HOME;
+        if (savedEnv.DATA_ROOT === undefined) delete process.env['DATA_ROOT'];
+        else process.env['DATA_ROOT'] = savedEnv.DATA_ROOT;
         while (tmpDirs.length) {
             const d = tmpDirs.pop()!;
             try {

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -620,6 +620,82 @@ describe('ServiceApi', () => {
             expect(opts?.scope).toBe('system');
         });
 
+        it('POST /install on Linux with $APPIMAGE set writes local-appimage marker to <dataRoot>/control/local-appimage', async () => {
+            const appImagePath = '/home/jamie/Applications/WsScrcpyWeb.AppImage';
+            const savedAppImage = process.env['APPIMAGE'];
+            process.env['APPIMAGE'] = appImagePath;
+            // Compute the marker path up-front so we can clean it up in finally.
+            // On Windows cfg.dataRoot = C:\ProgramData\WsScrcpyWeb (a real path),
+            // so the marker lands outside tmpDirs and must be cleaned explicitly.
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const markerPath = path.join(dataRoot, 'control', 'local-appimage');
+            try {
+                const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
+                const client = fakeClient({
+                    install: installFn,
+                    status: vi.fn(async () => 'running' as const),
+                });
+                const factoryResult: ServiceClientFactoryResult = {
+                    client,
+                    supported: true,
+                    platform: 'linux',
+                };
+                const api = new ServiceApi(() => factoryResult, () => 'user');
+                const { req, res } = makeReqRes(
+                    '/api/service/install',
+                    'POST',
+                    JSON.stringify({ scope: 'user' }),
+                );
+                await api.handle(req, res);
+                expect((res as any).getStatus()).toBe(200);
+
+                // Verify the marker landed on disk with the correct content.
+                expect(fs.existsSync(markerPath)).toBe(true);
+                expect(fs.readFileSync(markerPath, 'utf8')).toBe(appImagePath);
+            } finally {
+                try { fs.rmSync(markerPath, { force: true }); } catch { /* best-effort */ }
+                if (savedAppImage === undefined) delete process.env['APPIMAGE'];
+                else process.env['APPIMAGE'] = savedAppImage;
+            }
+        });
+
+        it('POST /install on Linux without $APPIMAGE does NOT write local-appimage marker', async () => {
+            const savedAppImage = process.env['APPIMAGE'];
+            delete process.env['APPIMAGE'];
+            // Compute the marker path and ensure no stale copy from a prior run.
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const markerPath = path.join(dataRoot, 'control', 'local-appimage');
+            try { fs.rmSync(markerPath, { force: true }); } catch { /* best-effort */ }
+            try {
+                const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
+                const client = fakeClient({
+                    install: installFn,
+                    status: vi.fn(async () => 'running' as const),
+                });
+                const factoryResult: ServiceClientFactoryResult = {
+                    client,
+                    supported: true,
+                    platform: 'linux',
+                };
+                const api = new ServiceApi(() => factoryResult, () => 'user');
+                const { req, res } = makeReqRes(
+                    '/api/service/install',
+                    'POST',
+                    JSON.stringify({ scope: 'user' }),
+                );
+                await api.handle(req, res);
+                expect((res as any).getStatus()).toBe(200);
+
+                // Marker must NOT exist when APPIMAGE is unset.
+                expect(fs.existsSync(markerPath)).toBe(false);
+            } finally {
+                if (savedAppImage === undefined) delete process.env['APPIMAGE'];
+                else process.env['APPIMAGE'] = savedAppImage;
+            }
+        });
+
         it('POST /install on Linux with malformed JSON body falls back to user scope', async () => {
             const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
             const client = fakeClient({

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -242,6 +242,25 @@ export class ServiceApi {
             startupDir = path.dirname(binPath);
         }
 
+        // Record the home AppImage path so a later USER-scope uninstall can
+        // relaunch the app in local mode. System scope runs the /opt copy and
+        // won't know the user's home AppImage otherwise. Best-effort: a failed
+        // marker write logs + continues (it only degrades the post-uninstall
+        // relaunch, not the install).
+        if (result.platform === 'linux') {
+            const appImage = process.env['APPIMAGE'];
+            if (appImage && appImage.length > 0) {
+                const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+                const markerPath = path.join(dataRoot, 'control', 'local-appimage');
+                try {
+                    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+                    fs.writeFileSync(markerPath, appImage, 'utf8');
+                } catch (err) {
+                    log.warn(`could not write local-appimage marker: ${(err as Error).message}`);
+                }
+            }
+        }
+
         // v0.1.24-beta.7: service.log moves under <dataRoot>/logs/ to
         // colocate with launcher.log + server.log + ws-scrcpy-web.log.
         // Pre-beta.7 it lived at <dataRoot>/dependencies/service.log,

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -22,6 +22,7 @@ import {
     getServiceClient,
     type ServiceClientFactoryResult,
 } from '../service';
+import { resolveSystemTool } from '../service/systemTools';
 import { readJsonBody } from './utils';
 
 const log = Logger.for('ServiceApi');
@@ -51,6 +52,11 @@ export class ServiceApi {
         private readonly factory: () => ServiceClientFactoryResult = () => getServiceClient(),
         private readonly scope: () => 'user' | 'system' = () => detectInstallScope(),
         private readonly existsCheck: (p: string) => boolean = (p: string) => fs.existsSync(p),
+        private readonly spawnDetached: (cmd: string, args: string[]) => void = (cmd, args) => {
+            const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+            child.on('error', (err) => log.warn(`spawnDetached ${cmd} error: ${err.message}`));
+            child.unref();
+        },
     ) {}
 
     public async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
@@ -391,6 +397,54 @@ export class ServiceApi {
         }
 
         const cfg = Config.getInstance();
+
+        if (result.platform === 'linux') {
+            // Item 32: do NOT run `systemctl disable --now` from here — this Node
+            // process is inside the service unit's cgroup, so stopping the unit
+            // would kill us mid-call (no clean teardown, no relaunch). Instead
+            // hand off to an OUT-OF-CGROUP helper via systemd-run: it runs in its
+            // own transient unit, survives stopping our unit, then tears down +
+            // (user scope) relaunches local. Mirrors the Windows operation-server
+            // handoff. We do NOT call client.uninstall() on Linux.
+            const scope = result.client.getInstalledScope
+                ? await result.client.getInstalledScope(WS_SCRCPY_SERVICE_NAME)
+                : null;
+            if (scope === null) {
+                const body: ServiceActionSuccess = { ok: true, status: 'not-installed', installMode: 'user' };
+                res.writeHead(200);
+                res.end(JSON.stringify(body));
+                return true;
+            }
+
+            // Revert installMode to local BEFORE the teardown so the relaunched
+            // local instance reads local mode (mirrors the Windows revert-first ordering).
+            const newMode: InstallMode = scope === 'system' ? 'system' : 'user';
+            try {
+                cfg.updateAppConfig({ installMode: newMode });
+            } catch (err) {
+                log.warn(`uninstall(linux): installMode revert failed (continuing): ${(err as Error).message}`);
+            }
+
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            // Same staged out-of-mount helper UpdateService.applyUpdate uses — note the
+            // `.exe` suffix is the fixed staged name even on Linux (refresh_helper_binary).
+            const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            const systemdRun = resolveSystemTool('systemd-run');
+            const sdArgs = [
+                ...(scope === 'user' ? ['--user'] : []),
+                '--collect',
+                `--unit=wsscrcpy-teardown-${Date.now()}`,
+                helper,
+                '--linux-service-teardown', '--scope', scope, '--unit', WS_SCRCPY_SERVICE_NAME,
+            ];
+            this.spawnDetached(systemdRun, sdArgs);
+            log.info(`uninstall(linux): spawned teardown helper via systemd-run (${scope} scope)`);
+
+            const body: ServiceActionSuccess = { ok: true, status: 'shutting-down', installMode: newMode };
+            res.writeHead(200);
+            res.end(JSON.stringify(body));
+            return true;
+        }
 
         // v0.1.8: if a resume token is present in the request headers,
         // validate it before doing anything else. The token comes from

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv } from './SystemdClient';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -70,5 +70,13 @@ describe('buildSystemInstallScript', () => {
         // still proceeds to cp unit + enable.
         expect(script).toContain('|| true');
         expect(script.indexOf('cp "/tmp/WsScrcpyWeb.service.tmp"')).toBeGreaterThan(script.indexOf('chcon'));
+    });
+});
+
+describe('absolute-path OS tools', () => {
+    it('systemctlArgv resolves systemctl to an absolute path', () => {
+        const argv = systemctlArgv(['--user', 'daemon-reload'], (t) => `/usr/bin/${t}`);
+        expect(argv.bin).toBe('/usr/bin/systemctl');
+        expect(argv.args).toEqual(['--user', 'daemon-reload']);
     });
 });

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR } from './SystemdClient';
+
+describe('system-scope staging', () => {
+    const baseOpts = {
+        name: 'WsScrcpyWeb',
+        displayName: 'ws-scrcpy-web',
+        description: 'desc',
+        binPath: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage', // source = home AppImage
+        startupDir: '/home/u/Apps',
+        startType: 'Automatic' as const,
+        maxRestartAttempts: 3,
+        envVars: { DEPS_PATH: '/home/u/.local/share/WsScrcpyWeb/dependencies' },
+        logPath: '/home/u/.local/share/WsScrcpyWeb/logs/service.log',
+    };
+
+    it('stagedSystemBinPath is the fixed /opt path', () => {
+        const c = new SystemdClient();
+        expect(c.stagedSystemBinPath()).toBe(`${STAGED_SYSTEM_DIR}/WsScrcpyWeb.AppImage`);
+    });
+
+    it('system unit ExecStart points at the staged /opt path, not the home AppImage', () => {
+        const unit = renderUnitFile(baseOpts, 'system');
+        expect(unit).toContain(`ExecStart=${STAGED_SYSTEM_DIR}/WsScrcpyWeb.AppImage`);
+        expect(unit).not.toContain('/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage');
+    });
+
+    it('user unit ExecStart still points at the home AppImage (unchanged)', () => {
+        const unit = renderUnitFile(baseOpts, 'user');
+        expect(unit).toContain('ExecStart=/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage');
+    });
+});

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript } from './SystemdClient';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -28,5 +28,39 @@ describe('system-scope staging', () => {
     it('user unit ExecStart still points at the home AppImage (unchanged)', () => {
         const unit = renderUnitFile(baseOpts, 'user');
         expect(unit).toContain('ExecStart=/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage');
+    });
+});
+
+describe('buildSystemInstallScript', () => {
+    const args = {
+        sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
+        unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
+        unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
+        name: 'WsScrcpyWeb',
+    };
+
+    it('stages the AppImage to /opt, chmods, labels bin_t, then installs the unit', () => {
+        const script = buildSystemInstallScript(args);
+        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web');
+        expect(script).toContain('cp "/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(script).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv /opt/ws-scrcpy-web');
+        expect(script).toContain('chcon -t bin_t "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(script).toContain('cp "/tmp/WsScrcpyWeb.service.tmp" "/etc/systemd/system/WsScrcpyWeb.service"');
+        expect(script).toContain('systemctl daemon-reload');
+        expect(script).toContain('systemctl enable --now WsScrcpyWeb.service');
+    });
+
+    it('staging precedes the unit copy (so ExecStart target exists before enable)', () => {
+        const script = buildSystemInstallScript(args);
+        expect(script.indexOf('/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage'))
+            .toBeLessThan(script.indexOf('enable --now'));
+    });
+
+    it('uses absolute tool paths (no bare names)', () => {
+        const script = buildSystemInstallScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        expect(script).toContain('/usr/bin/systemctl daemon-reload');
+        expect(script).toContain('/usr/sbin/restorecon -Rv');
     });
 });

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -45,7 +45,7 @@ describe('buildSystemInstallScript', () => {
         expect(script).toContain('cp "/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
         expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
         expect(script).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
-        expect(script).toContain('restorecon -Rv /opt/ws-scrcpy-web');
+        expect(script).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
         expect(script).toContain('chcon -t bin_t "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
         expect(script).toContain('cp "/tmp/WsScrcpyWeb.service.tmp" "/etc/systemd/system/WsScrcpyWeb.service"');
         expect(script).toContain('systemctl daemon-reload');
@@ -62,5 +62,13 @@ describe('buildSystemInstallScript', () => {
         const script = buildSystemInstallScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
         expect(script).toContain('/usr/bin/systemctl daemon-reload');
         expect(script).toContain('/usr/sbin/restorecon -Rv');
+    });
+
+    it('label step is best-effort — a failed SELinux label does not abort the unit install', () => {
+        const script = buildSystemInstallScript(args);
+        // wrapped in a subshell + `|| true` so a non-SELinux host (semanage absent, chcon errors)
+        // still proceeds to cp unit + enable.
+        expect(script).toContain('|| true');
+        expect(script.indexOf('cp "/tmp/WsScrcpyWeb.service.tmp"')).toBeGreaterThan(script.indexOf('chcon'));
     });
 });

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -44,6 +44,7 @@ import type {
     ServiceInstallOptions,
     ServiceStatus,
 } from './ServiceClient';
+import { resolveSystemTool } from './systemTools';
 
 const execFileAsync = promisify(execFile);
 
@@ -204,6 +205,41 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
 }
 
 /**
+ * Build the privileged shell script for a system-scope install. Runs under a
+ * single pkexec prompt. Stages the AppImage into /opt (root-owned), labels it
+ * bin_t so init_t may exec it (item 33), then installs + enables the unit.
+ * `binTool`/`sbinTool` are injectable for testing; production resolves absolute
+ * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
+ */
+export function buildSystemInstallScript(
+    args: { sourceAppImage: string; unitTmpPath: string; unitPath: string; name: string },
+    binTool: (t: string) => string = (t) => resolveSystemTool(t),
+    sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
+): string {
+    const staged = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const cp = binTool('cp');
+    const chmod = binTool('chmod');
+    const chcon = binTool('chcon');
+    const systemctl = binTool('systemctl');
+    const semanage = sbinTool('semanage');
+    const restorecon = sbinTool('restorecon');
+    return [
+        // 1. stage the AppImage into /opt (root-owned)
+        `mkdir -p ${STAGED_SYSTEM_DIR}`,
+        `${cp} "${args.sourceAppImage}" "${staged}"`,
+        `${chmod} 0755 "${staged}"`,
+        // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
+        //    available; restorecon applies it; chcon is the transient fallback
+        //    for minimal images without policycoreutils-python-utils.
+        `( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv ${STAGED_SYSTEM_DIR} ) || ${chcon} -t bin_t "${staged}"`,
+        // 3. install + enable the unit (ExecStart already points at ${staged})
+        `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
+        `${systemctl} daemon-reload`,
+        `${systemctl} enable --now ${args.name}.service`,
+    ].join(' && ');
+}
+
+/**
  * Resolve the absolute path of the tray helper binary.
  *
  * Mirrors `ServyClient.resolveTrayHelperPath` shape:
@@ -288,15 +324,17 @@ export class SystemdClient implements ServiceClient {
 
         if (scope === 'system' && process.getuid?.() !== 0) {
             // Not root — use pkexec for graphical privilege escalation.
-            // Write unit to temp, then pkexec copies + enables in one prompt.
+            // Write unit to temp, then pkexec stages AppImage + labels bin_t +
+            // copies unit + enables — all under a single graphical prompt.
             const tmpFile = path.join(os.tmpdir(), `${opts.name}.service.tmp`);
             fs.writeFileSync(tmpFile, unitContent, { mode: 0o644 });
             try {
-                const cmd = [
-                    `cp "${tmpFile}" "${unitPath}"`,
-                    'systemctl daemon-reload',
-                    `systemctl enable --now ${opts.name}.service`,
-                ].join(' && ');
+                const cmd = buildSystemInstallScript({
+                    sourceAppImage: opts.binPath,
+                    unitTmpPath: tmpFile,
+                    unitPath,
+                    name: opts.name,
+                });
                 await runPkexec(cmd, 'install (system scope)');
             } finally {
                 try { fs.unlinkSync(tmpFile); } catch { /* best-effort cleanup */ }

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -53,6 +53,14 @@ const log = Logger.for('SystemdClient');
 /** systemd scope: per-user (default.target) or system-wide (multi-user.target). */
 export type SystemdScope = 'user' | 'system';
 
+/** Resolve systemctl to an absolute path + return the (bin, args) pair for execFile. */
+export function systemctlArgv(
+    args: string[],
+    resolve: (t: string) => string = (t) => resolveSystemTool(t),
+): { bin: string; args: string[] } {
+    return { bin: resolve('systemctl'), args };
+}
+
 /** Filename of the tray helper binary on Linux (no extension). */
 const TRAY_HELPER_BIN = 'ws-scrcpy-web-tray';
 /** Autostart .desktop filename written under `~/.config/autostart/`. */
@@ -64,17 +72,13 @@ export const STAGED_SYSTEM_DIR = '/opt/ws-scrcpy-web';
 export const STAGED_SYSTEM_APPIMAGE = 'WsScrcpyWeb.AppImage';
 
 /**
- * Wrap execFileSync so the thrown Error includes stderr — matches the pattern
- * established in ServyClient. Without this, Node surfaces only the exit code.
- */
-/**
  * Run a command via pkexec for graphical privilege escalation. The user
  * sees a single password prompt for the entire shell command. Throws on
  * auth-cancel (exit 126), pkexec-not-found, or command failure.
  */
 async function runPkexec(shellCmd: string, label: string): Promise<string> {
     try {
-        const { stdout } = await execFileAsync('pkexec', ['sh', '-c', shellCmd], {
+        const { stdout } = await execFileAsync(resolveSystemTool('pkexec'), ['sh', '-c', shellCmd], {
             encoding: 'utf8',
             timeout: 60_000,
         });
@@ -102,7 +106,7 @@ async function runPkexec(shellCmd: string, label: string): Promise<string> {
  */
 export function isLibfuse2Installed(): boolean {
     try {
-        const out = execFileSync('ldconfig', ['-p'], {
+        const out = execFileSync(resolveSystemTool('ldconfig'), ['-p'], {
             stdio: ['ignore', 'pipe', 'pipe'],
             encoding: 'utf8',
         });
@@ -114,7 +118,7 @@ export function isLibfuse2Installed(): boolean {
 
 function libfuse2InstallCmd(): string | null {
     try {
-        const out = execFileSync('ldconfig', ['-p'], {
+        const out = execFileSync(resolveSystemTool('ldconfig'), ['-p'], {
             stdio: ['ignore', 'pipe', 'pipe'],
             encoding: 'utf8',
         });
@@ -150,7 +154,8 @@ export async function ensureLibfuse2(): Promise<void> {
 
 function runSystemctl(args: string[], label: string): string {
     try {
-        return execFileSync('systemctl', args, {
+        const { bin, args: a } = systemctlArgv(args);
+        return execFileSync(bin, a, {
             stdio: ['ignore', 'pipe', 'pipe'],
             encoding: 'utf8',
         });
@@ -364,7 +369,7 @@ export class SystemdClient implements ServiceClient {
             // systems), missing privileges on hardened distros. Service is
             // already installed + running — degraded but functional.
             try {
-                execFileSync('loginctl', ['enable-linger', os.userInfo().username], {
+                execFileSync(resolveSystemTool('loginctl'), ['enable-linger', os.userInfo().username], {
                     stdio: ['ignore', 'pipe', 'pipe'],
                 });
             } catch (err) {
@@ -453,9 +458,10 @@ export class SystemdClient implements ServiceClient {
         // error for our purposes (the unit file exists; we just want the
         // running state).
         try {
+            const { bin, args: a } = systemctlArgv([...baseArgs, 'is-active', `${name}.service`]);
             const out = execFileSync(
-                'systemctl',
-                [...baseArgs, 'is-active', `${name}.service`],
+                bin,
+                a,
                 { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
             ).trim();
             return out === 'active' ? 'running' : 'stopped';

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -57,6 +57,11 @@ const TRAY_HELPER_BIN = 'ws-scrcpy-web-tray';
 /** Autostart .desktop filename written under `~/.config/autostart/`. */
 const TRAY_AUTOSTART_FILE = 'ws-scrcpy-web-tray.desktop';
 
+/** Root-owned staging dir for the system-scope AppImage (SELinux bin_t — init_t can exec). */
+export const STAGED_SYSTEM_DIR = '/opt/ws-scrcpy-web';
+/** Stable, channel-agnostic filename for the staged system-scope AppImage. */
+export const STAGED_SYSTEM_APPIMAGE = 'WsScrcpyWeb.AppImage';
+
 /**
  * Wrap execFileSync so the thrown Error includes stderr — matches the pattern
  * established in ServyClient. Without this, Node surfaces only the exit code.
@@ -166,6 +171,13 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
         .map(([k, v]) => `Environment=${k}=${v}`)
         .join('\n');
     const wantedBy = scope === 'user' ? 'default.target' : 'multi-user.target';
+    // System scope runs under init_t and may NOT exec a user_home_t AppImage,
+    // so the unit references the staged /opt copy (labelled bin_t at install).
+    // User scope runs as the unconfined user and execs the home AppImage directly.
+    const execStart = scope === 'system'
+        ? `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`
+        : opts.binPath;
+    const workingDir = scope === 'system' ? STAGED_SYSTEM_DIR : opts.startupDir;
     // StartLimitIntervalSec=300 means: count restart attempts in a rolling
     // 5-minute window; if maxRestartAttempts is exceeded, systemd gives up.
     return [
@@ -175,8 +187,8 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
         '',
         '[Service]',
         'Type=simple',
-        `ExecStart=${opts.binPath}`,
-        `WorkingDirectory=${opts.startupDir}`,
+        `ExecStart=${execStart}`,
+        `WorkingDirectory=${workingDir}`,
         'Restart=on-failure',
         'RestartSec=5',
         `StartLimitBurst=${opts.maxRestartAttempts}`,
@@ -229,6 +241,14 @@ export class SystemdClient implements ServiceClient {
     /** Absolute path to the tray helper autostart .desktop file (user scope). */
     public trayAutostartPath(): string {
         return path.join(os.homedir(), '.config', 'autostart', TRAY_AUTOSTART_FILE);
+    }
+
+    /** Absolute path of the staged system-scope AppImage (system scope ExecStart). */
+    public stagedSystemBinPath(): string {
+        // Forward-slash Linux path on purpose — this is the path written into the
+        // Linux systemd unit. Do NOT use path.join here: on a Windows host it emits
+        // backslashes, which both fails the test and is wrong for a Linux unit file.
+        return `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
     }
 
     /**

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -217,6 +217,7 @@ export function buildSystemInstallScript(
     sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
 ): string {
     const staged = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const mkdir = binTool('mkdir');
     const cp = binTool('cp');
     const chmod = binTool('chmod');
     const chcon = binTool('chcon');
@@ -225,13 +226,18 @@ export function buildSystemInstallScript(
     const restorecon = sbinTool('restorecon');
     return [
         // 1. stage the AppImage into /opt (root-owned)
-        `mkdir -p ${STAGED_SYSTEM_DIR}`,
+        `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
         `${cp} "${args.sourceAppImage}" "${staged}"`,
         `${chmod} 0755 "${staged}"`,
         // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
         //    available; restorecon applies it; chcon is the transient fallback
-        //    for minimal images without policycoreutils-python-utils.
-        `( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv ${STAGED_SYSTEM_DIR} ) || ${chcon} -t bin_t "${staged}"`,
+        //    for minimal images without policycoreutils-python-utils. The whole
+        //    step is a best-effort subshell with a trailing `|| true`: POSIX sh
+        //    gives `&&`/`||` EQUAL precedence (left-assoc), so without isolation
+        //    a label failure on a non-SELinux host (semanage absent + chcon
+        //    erroring on a non-SELinux fs) would break the outer `&&` chain and
+        //    silently skip the unit cp + enable below.
+        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         // 3. install + enable the unit (ExecStart already points at ${staged})
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
         `${systemctl} daemon-reload`,

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -394,6 +394,18 @@ export class SystemdClient implements ServiceClient {
         }
     }
 
+    /**
+     * Disable + remove the systemd unit for `name`, resolving the active scope
+     * from whichever unit file exists on disk. Idempotent — a no-op if neither
+     * unit file is present.
+     *
+     * NOTE (item 32): the Linux `/api/service/uninstall` path no longer calls
+     * this method. ServiceApi.handleUninstall hands off to an out-of-cgroup
+     * `systemd-run` teardown helper instead, because running `systemctl disable
+     * --now` from inside the service unit's own cgroup would kill the calling
+     * process mid-operation. This method is retained as the `ServiceClient`
+     * interface implementation (and for any non-cgroup-bound callers).
+     */
     public async uninstall(name: string): Promise<void> {
         const scope = this.resolveActiveScope(name);
         if (scope === null) {
@@ -402,10 +414,11 @@ export class SystemdClient implements ServiceClient {
 
         if (scope === 'system' && process.getuid?.() !== 0) {
             const unitPath = this.systemUnitPath(name);
+            const systemctl = resolveSystemTool('systemctl');
             const cmd = [
-                `systemctl disable --now ${name}.service || true`,
+                `${systemctl} disable --now ${name}.service || true`,
                 `rm -f "${unitPath}"`,
-                'systemctl daemon-reload',
+                `${systemctl} daemon-reload`,
             ].join(' && ');
             await runPkexec(cmd, 'uninstall (system scope)');
         } else {

--- a/src/server/service/systemTools.test.ts
+++ b/src/server/service/systemTools.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSystemTool } from './systemTools';
+
+describe('resolveSystemTool', () => {
+    it('returns the first candidate that exists', () => {
+        const exists = (p: string) => p === '/usr/bin/systemctl';
+        expect(resolveSystemTool('systemctl', exists)).toBe('/usr/bin/systemctl');
+    });
+
+    it('prefers /usr/bin over /bin when both exist', () => {
+        const exists = (p: string) => p === '/usr/bin/pkexec' || p === '/bin/pkexec';
+        expect(resolveSystemTool('pkexec', exists)).toBe('/usr/bin/pkexec');
+    });
+
+    it('checks sbin locations for admin tools (semanage/restorecon)', () => {
+        const exists = (p: string) => p === '/usr/sbin/semanage';
+        expect(resolveSystemTool('semanage', exists)).toBe('/usr/sbin/semanage');
+    });
+
+    it('falls back to the bare name when no absolute path exists', () => {
+        const exists = (_p: string) => false;
+        expect(resolveSystemTool('systemctl', exists)).toBe('systemctl');
+    });
+});

--- a/src/server/service/systemTools.ts
+++ b/src/server/service/systemTools.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve an OS tool to its absolute path, scanning the canonical bin/sbin
+ * locations in priority order. Closes the PATH-hijack surface required by the
+ * Local-Dependencies-Only rule: we never invoke systemctl/pkexec/etc. by bare
+ * name (which would resolve via $PATH). Falls back to the bare name only when
+ * no absolute candidate exists, so the failure surfaces as a clear ENOENT
+ * rather than a silent miss.
+ */
+import * as fs from 'node:fs';
+
+/** Search order: user bins first (/usr/bin, /bin), then admin bins (/usr/sbin, /sbin). */
+const SEARCH_DIRS = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'] as const;
+
+export function resolveSystemTool(
+    tool: string,
+    exists: (p: string) => boolean = fs.existsSync,
+): string {
+    for (const dir of SEARCH_DIRS) {
+        const candidate = `${dir}/${tool}`;
+        if (exists(candidate)) return candidate;
+    }
+    return tool;
+}


### PR DESCRIPTION
Phase 1 of the Linux service-mode work: make service install + uninstall functional on Linux. Windows + Linux-local mode are byte-for-byte unchanged.

## What
- item 33 (system scope starts under SELinux): system-scope install stages the AppImage to root-owned /opt/ws-scrcpy-web/ and labels it bin_t (semanage+restorecon, chcon fallback, best-effort/isolated so non-SELinux distros do not abort); the unit ExecStart points there. Previously init_t was denied exec of the user-home AppImage -> repeating AVC.
- item 32 (uninstall tears down cleanly): uninstall hands off to an out-of-cgroup systemd-run teardown helper (stop/disable/reset-failed/rm; +/opt+fcontext for system; adb reap; user-scope relaunch local) instead of self-killing via in-cgroup `systemctl disable --now`.
- Local-Deps: OS tools (systemctl/pkexec/loginctl/ldconfig/systemd-run/semanage/restorecon/...) resolve to absolute paths.

## Verification (off-Fedora, all green)
TS 766/766 (incl. untouched Windows service/apply tests); tsc clean; webpack build clean; launcher Rust 82 tests via cross + clippy -D warnings clean; final cross-task TS<->Rust contract review coherent.

## Pending: real-Fedora runtime verification (this beta is the test artifact)
system install (active + bin_t + no AVC); uninstall both scopes (unit gone, no straggler, /opt+fcontext removed, user relaunch+reconnect). Key unknown: the systemd-run teardown/relaunch surviving stop of our own unit.

Spec: docs/specs/2026-06-01-linux-service-mode-fix-and-update-design.md
Plan: docs/plans/2026-06-01-linux-service-mode-fix.md

release:beta -> cuts v0.1.30-beta.30.