### PR TITLE
v0.1.30-beta.31 — Linux service-mode fixes (Fedora smoke follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.31] - 2026-06-02
+
+Fixes for issues found smoke-testing **beta.30**'s Linux service mode on real Fedora 44 (SELinux enforcing), plus a bookmark global-dismiss option. Windows service mode and Linux local mode are byte-for-byte unchanged; there are no launcher/Rust changes.
+
+### Added
+
+- **Global bookmark dismissal.** The bookmark reminder (`PortChangeModal`) gains a second option — "don't show again — ever, even when the port changes" — gated behind a confirmation dialog and persisted as `bookmarkDismissedGlobally` in `config.json`. Checking it supersedes and disables the per-port checkbox. "Reset welcome and bookmark prompts" now clears it as well.
+
+### Fixed
+
+- **Linux system-scope service uninstall now tears down under SELinux.** The teardown handoff exec'd the launcher helper from `~/.local/share/…` (`data_home_t`), which SELinux (Fedora enforcing) denies `init_t` from executing — so a system-scope uninstall silently failed and the service persisted. System install now also stages the helper into `/opt/ws-scrcpy-web/` (labelled `bin_t` by the existing fcontext rule), and uninstall execs that copy via `systemd-run --system`, wrapped in `pkexec` when the triggering process isn't already root. User-scope uninstall is unchanged.
+- **systemd `StartLimit*` keys moved to `[Unit]`.** `StartLimitIntervalSec`/`StartLimitBurst` were emitted in `[Service]`, where systemd ignores them — so the restart cap never applied and a failing unit restarted every 5 s indefinitely. They now live in `[Unit]`.
+- **No more orphaned/concurrent local instances after a Linux service install.** The post-install local-instance exit was gated to Windows; on Linux the originating local app lingered (up to three concurrent instances were observed) and held the web port. It now exits after a successful install on Linux too.
+- **No false "port discovery timed out" after install.** When the service reclaims the same web port — now the common case, since the local instance exits — the install poll detects the local server going away and reconnects to the same URL after a short grace, instead of reporting an error. The port-shift navigate path (used on Windows) is unchanged.
+- **Install-scope radio contrast.** When a service is installed the scope radios are disabled and were muted to `opacity:0.5` with no `accent-color`, hiding the selected dot; they now use `accent-color:#5b9aff` and a lifted `0.65` disabled opacity.
+
+### Docs
+
+- **README:** corrected the systemd unit name to `WsScrcpyWeb.service` and scope-qualified the "do not move the AppImage" caveat — a system-scope service runs the staged `/opt/ws-scrcpy-web/` copy, so only a user-scope service is affected by moving the home AppImage.
+
 ## [0.1.30-beta.30] - 2026-06-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.30-beta.29"
+version = "0.1.30-beta.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.30-beta.29"
+version = "0.1.30-beta.31"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.30-beta.29"
+version = "0.1.30-beta.31"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.30"
+version = "0.1.30-beta.31"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -268,14 +268,14 @@ Linux releases ship as a single self-contained AppImage built with [Velopack](ht
 
 The first-run welcome modal offers to install ws-scrcpy-web as a systemd service. Two scopes are available:
 
-- **just for me (no sudo)** — installs to `~/.config/systemd/user/ws-scrcpy-web.service`. Starts at login. `loginctl enable-linger` is invoked best-effort so the service survives logout.
-- **all users (requires sudo)** — installs to `/etc/systemd/system/ws-scrcpy-web.service`. Starts at boot. The install API triggers a `pkexec` graphical password prompt to acquire root for the single shell command that writes the unit + runs `systemctl daemon-reload` + `systemctl enable --now`. No AppImage relaunch needed. Falls back gracefully if `pkexec` isn't installed: error message tells the user to install polkit (`sudo dnf install polkit` on Fedora) or pick user scope.
+- **just for me (no sudo)** — installs to `~/.config/systemd/user/WsScrcpyWeb.service`. Starts at login. `loginctl enable-linger` is invoked best-effort so the service survives logout.
+- **all users (requires sudo)** — installs to `/etc/systemd/system/WsScrcpyWeb.service`. Starts at boot. The install API triggers a `pkexec` graphical password prompt to acquire root for the single shell command that writes the unit + runs `systemctl daemon-reload` + `systemctl enable --now`. No AppImage relaunch needed. Falls back gracefully if `pkexec` isn't installed: error message tells the user to install polkit (`sudo dnf install polkit` on Fedora) or pick user scope.
 
 You can also install/uninstall the service later from Settings → Service.
 
 #### AppImage placement caveat
 
-The systemd unit's `ExecStart=` is set to the absolute AppImage path at install time. **Do not move or rename the AppImage after installing the service** — the service will fail to start on next boot/login. If you need to relocate the AppImage, uninstall the service first, move the file, then re-install.
+For a **user-scope** service the systemd unit's `ExecStart=` points at the AppImage where it lived at install time, so **do not move or rename the AppImage after installing a user-scope service** — it will fail to start on next login. If you need to relocate it, uninstall the service first, move the file, then re-install. A **system-scope** service is unaffected: the installer stages a copy of the AppImage to `/opt/ws-scrcpy-web/` (labelled `bin_t` for SELinux) and points `ExecStart=` there, so moving your home AppImage does not break it.
 
 #### Verifying the AppImage signature
 

--- a/docs/plans/2026-06-02-linux-service-mode-beta31-fixes.md
+++ b/docs/plans/2026-06-02-linux-service-mode-beta31-fixes.md
@@ -1,0 +1,634 @@
+# Linux Service-Mode beta.31 Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 7 issues found smoke-testing v0.1.30-beta.30's Linux service-mode on real Fedora 44 (SELinux enforcing), plus a bookmark global-dismiss enhancement; ship as v0.1.30-beta.31.
+
+**Architecture:** All changes are TypeScript/CSS/doc — **no Rust, no launcher rebuild**. The system-scope teardown reuses the existing Rust helper, just exec'd from a `bin_t` path in `/opt`. The modal-precedence tree already exists in `src/app/index.ts`; #5 only adds the bookmark global-dismiss.
+
+**Tech Stack:** TypeScript (server + client), Vitest, webpack, CSS. Spec: `docs/specs/2026-06-01-linux-service-mode-beta31-fixes-design.md`.
+
+**PRINCIPLE 0 — Windows stays byte-for-byte identical.** Every fix is Linux-platform-gated or additive. The existing win32 service tests must stay green, unchanged. Branch: `linux-service-mode-beta31-fixes`.
+
+**Commands** (run from repo root `C:/Users/jscha/source/repos/ws-scrcpy-web`, use `git -C`):
+- Single test file: `npx vitest run <path>`
+- Full suite: `npm test`
+- Types: `npm run build:types` · Prod build: `npm run build`
+- Rust (no changes expected; confirm at the fence): `cargo test` + `cargo clippy --` in `launcher/` via `cross` per existing CI.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `src/server/service/SystemdClient.ts` | #1 `renderUnitFile` (StartLimit→[Unit]); #2 `buildSystemInstallScript` (stage helper) + `install()` system branch (pass helper source) |
+| `src/server/api/ServiceApi.ts` | #2 `handleUninstall` system-scope handoff (/opt helper + pkexec); #2 `handleInstall` (resolve+pass helper source); #3 local-exit on Linux |
+| `src/app/client/SettingsModal.ts` | #4 install poll reconnect; #5d reset clears global flag |
+| `src/common/ConfigEvents.ts` | #5a `bookmarkDismissedGlobally` in `AppConfig` + defaults |
+| `src/server/Config.ts` | #5a `FlatConfig` + `validateField` for the new flag |
+| `src/app/index.ts` | #5b `maybeShowPortChangeModal` global gate |
+| `src/app/client/PortChangeModal.ts` | #5c global checkbox + confirmation dialog |
+| `src/style/modal.css` | #6 scope-radio accent-color + disabled opacity |
+| `README.md` | #7 unit name + scope-qualified warning |
+| `package.json` / `Cargo.toml` | Task 12 version bump (via the bump script) |
+
+---
+
+## Task 1: `StartLimit*` keys → `[Unit]` (#1)
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts:189-209` (`renderUnitFile`)
+- Test: `src/server/service/SystemdClient.test.ts`
+
+Current `renderUnitFile` return (lines 189-209) places `StartLimitBurst`/`StartLimitIntervalSec` in `[Service]`:
+```typescript
+    return [
+        '[Unit]',
+        `Description=${opts.description}`,
+        'After=network.target',
+        '',
+        '[Service]',
+        'Type=simple',
+        `ExecStart=${execStart}`,
+        `WorkingDirectory=${workingDir}`,
+        'Restart=on-failure',
+        'RestartSec=5',
+        `StartLimitBurst=${opts.maxRestartAttempts}`,
+        'StartLimitIntervalSec=300',
+        ...(envLines ? [envLines] : []),
+        `StandardOutput=append:${opts.logPath}`,
+        `StandardError=append:${opts.logPath}`,
+        '',
+        '[Install]',
+        `WantedBy=${wantedBy}`,
+        '',
+    ].join('\n');
+```
+
+- [ ] **Step 1: Write the failing test** — add to `SystemdClient.test.ts` in the `renderUnitFile` describe block:
+
+```typescript
+it('places StartLimit keys in [Unit], not [Service] (systemd ignores them in [Service])', () => {
+    const unit = renderUnitFile(baseOpts, 'system');
+    const unitSection = unit.slice(unit.indexOf('[Unit]'), unit.indexOf('[Service]'));
+    const serviceSection = unit.slice(unit.indexOf('[Service]'), unit.indexOf('[Install]'));
+    expect(unitSection).toContain('StartLimitIntervalSec=300');
+    expect(unitSection).toContain('StartLimitBurst=3');
+    expect(serviceSection).not.toContain('StartLimitIntervalSec');
+    expect(serviceSection).not.toContain('StartLimitBurst');
+});
+```
+(Use the existing `baseOpts` fixture in that describe, or construct one with `maxRestartAttempts: 3`, `description`, `logPath`, `binPath`, `startupDir`.)
+
+- [ ] **Step 2: Run — expect FAIL.** `npx vitest run src/server/service/SystemdClient.test.ts` → fails (keys currently in `[Service]`).
+
+- [ ] **Step 3: Implement** — move the two lines into `[Unit]` (after `After=network.target`):
+
+```typescript
+    return [
+        '[Unit]',
+        `Description=${opts.description}`,
+        'After=network.target',
+        // systemd reads StartLimit* from [Unit], NOT [Service] (it silently
+        // ignores them in [Service] → the restart cap never applies).
+        'StartLimitIntervalSec=300',
+        `StartLimitBurst=${opts.maxRestartAttempts}`,
+        '',
+        '[Service]',
+        'Type=simple',
+        `ExecStart=${execStart}`,
+        `WorkingDirectory=${workingDir}`,
+        'Restart=on-failure',
+        'RestartSec=5',
+        ...(envLines ? [envLines] : []),
+        `StandardOutput=append:${opts.logPath}`,
+        `StandardError=append:${opts.logPath}`,
+        '',
+        '[Install]',
+        `WantedBy=${wantedBy}`,
+        '',
+    ].join('\n');
+```
+
+- [ ] **Step 4: Run — expect PASS.** Also re-run any existing `renderUnitFile` tests (they may assert the unit contains the keys — those still pass since the keys are present, just in a different section).
+- [ ] **Step 5: Commit.** `git -C <repo> add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts && git -C <repo> commit -m "fix(linux): move systemd StartLimit* keys to [Unit] (#1)"`
+
+---
+
+## Task 2: Stage the launcher helper into `/opt` at system install (#2 install side)
+
+**Why:** the system-scope teardown must exec a `bin_t` helper; staging it beside the AppImage in `/opt/ws-scrcpy-web/` gets it `bin_t` via the existing fcontext rule.
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts` (`buildSystemInstallScript` + the `install()` system branch)
+- Modify: `src/server/api/ServiceApi.ts` (`handleInstall`: resolve + pass the helper source path)
+- Test: `src/server/service/SystemdClient.test.ts`
+
+- [ ] **Step 1: Failing test** — `buildSystemInstallScript` stages the helper. Add:
+
+```typescript
+it('stages the launcher helper into /opt alongside the AppImage (bin_t via the fcontext rule)', () => {
+    const script = buildSystemInstallScript({
+        sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
+        sourceHelper: '/home/u/.local/share/WsScrcpyWeb/control/operation-server/ws-scrcpy-web-launcher.exe',
+        unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
+        unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
+        name: 'WsScrcpyWeb',
+    });
+    // helper copied to /opt + chmod, BEFORE the relabel so restorecon labels it bin_t
+    expect(script).toContain('cp "/home/u/.local/share/WsScrcpyWeb/control/operation-server/ws-scrcpy-web-launcher.exe" "/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe"');
+    expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe"');
+    const helperCp = script.indexOf('/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe');
+    const relabel = script.indexOf('restorecon -Rv');
+    expect(helperCp).toBeLessThan(relabel);
+});
+
+it('omits the helper cp when no sourceHelper is provided (from-source / unavailable)', () => {
+    const script = buildSystemInstallScript({
+        sourceAppImage: '/a.AppImage', unitTmpPath: '/t', unitPath: '/u', name: 'WsScrcpyWeb',
+    });
+    expect(script).not.toContain('ws-scrcpy-web-launcher.exe');
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (the `sourceHelper` arg + cp don't exist yet).
+
+- [ ] **Step 3: Implement `buildSystemInstallScript`** — add optional `sourceHelper`; insert the helper cp+chmod after the AppImage chmod, before the relabel. Replace the function body (lines 219-251):
+
+```typescript
+export function buildSystemInstallScript(
+    args: { sourceAppImage: string; sourceHelper?: string; unitTmpPath: string; unitPath: string; name: string },
+    binTool: (t: string) => string = (t) => resolveSystemTool(t),
+    sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
+): string {
+    const staged = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const stagedHelper = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_HELPER}`;
+    const mkdir = binTool('mkdir');
+    const cp = binTool('cp');
+    const chmod = binTool('chmod');
+    const chcon = binTool('chcon');
+    const systemctl = binTool('systemctl');
+    const semanage = sbinTool('semanage');
+    const restorecon = sbinTool('restorecon');
+    const steps = [
+        // 1. stage the AppImage into /opt (root-owned)
+        `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
+        `${cp} "${args.sourceAppImage}" "${staged}"`,
+        `${chmod} 0755 "${staged}"`,
+    ];
+    // 1b. stage the out-of-mount teardown helper into /opt too, so the
+    // system-scope uninstall can exec it under init_t (a home-dir copy is
+    // data_home_t → init_t exec is SELinux-denied — the beta.30 AVC).
+    if (args.sourceHelper) {
+        steps.push(`${cp} "${args.sourceHelper}" "${stagedHelper}"`);
+        steps.push(`${chmod} 0755 "${stagedHelper}"`);
+    }
+    steps.push(
+        // 2. label bin_t (the rule covers /opt/ws-scrcpy-web(/.*)?, so the helper
+        //    copied above is relabelled bin_t too). Isolated best-effort subshell.
+        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        // 3. install + enable the unit
+        `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
+        `${systemctl} daemon-reload`,
+        `${systemctl} enable --now ${args.name}.service`,
+    );
+    return steps.join(' && ');
+}
+```
+Add the constant near `STAGED_SYSTEM_APPIMAGE` (line ~70-72):
+```typescript
+export const STAGED_SYSTEM_HELPER = 'ws-scrcpy-web-launcher.exe';
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Plumb the helper source through `install()` + `ServiceApi`.** In `ServiceApi.handleInstall`, the Linux branch already computes `dataRoot`; resolve the home helper path and pass it via a new install opt. After the `binPath`/`startupDir` block (~line 248), add:
+```typescript
+        // Source for the /opt teardown-helper staging (system scope). The
+        // out-of-mount helper is staged at startup under control/operation-server;
+        // pass it so SystemdClient can copy it into /opt (bin_t) for the
+        // SELinux-safe system-scope uninstall.
+        let linuxHelperSource: string | undefined;
+        if (result.platform === 'linux') {
+            const dr = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const cand = path.join(dr, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            if (this.existsCheck(cand)) linuxHelperSource = cand;
+            else log.warn(`linux system install: teardown helper not found at ${cand}; /opt staging skipped (system uninstall may need manual cleanup)`);
+        }
+```
+Add `linuxHelperSource` to the `client.install({...})` call object (after `scope,`). Extend `ServiceInstallOptions` (its type, likely in `src/server/service/types.ts` or `ServiceEvents.ts` — locate) with `linuxHelperSource?: string`. In `SystemdClient.install` system branch (lines 336-365), pass it through:
+```typescript
+        const cmd = buildSystemInstallScript({
+            sourceAppImage: opts.binPath,
+            sourceHelper: opts.linuxHelperSource,
+            unitTmpPath: tmpFile,
+            unitPath,
+            name: opts.name,
+        });
+```
+
+- [ ] **Step 6: Run full server suite** `npx vitest run src/server` — green (existing install tests unaffected; the new opt is optional). Add a `ServiceApi` test asserting `client.install` receives `linuxHelperSource` when the candidate exists (mirror the existing install test, set platform `linux`, create the candidate file in the tmp dataRoot).
+- [ ] **Step 7: Commit.** `git -C <repo> commit -am "fix(linux): stage teardown helper into /opt+bin_t at system install (#2 install)"`
+
+---
+
+## Task 3: System-scope uninstall execs the `/opt` helper, elevated (#2 uninstall side)
+
+**Files:**
+- Modify: `src/server/api/ServiceApi.ts` (`handleUninstall` Linux branch, lines ~428-441)
+- Test: `src/server/__tests__/ServiceApi.test.ts`
+
+Current handoff (lines 428-441):
+```typescript
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            const systemdRun = resolveSystemTool('systemd-run');
+            const sdArgs = [
+                ...(scope === 'user' ? ['--user'] : []),
+                '--collect',
+                `--unit=wsscrcpy-teardown-${Date.now()}`,
+                helper,
+                '--linux-service-teardown', '--scope', scope, '--unit', WS_SCRCPY_SERVICE_NAME,
+            ];
+            this.spawnDetached(systemdRun, sdArgs);
+```
+
+- [ ] **Step 1: Failing tests** — add to `ServiceApi.test.ts` (mirror the existing Linux-uninstall test, which injects `spawnDetached`):
+
+```typescript
+it('system-scope uninstall execs the /opt helper (bin_t) via systemd-run --system, root → no pkexec', async () => {
+    // factoryResult.platform = 'linux', client.getInstalledScope → 'system'
+    // process.getuid stubbed to 0 (root) for this test
+    const getuidSpy = vi.spyOn(process, 'getuid').mockReturnValue(0);
+    // ... construct api with spawnDetached, installMode system-service ...
+    await api.handle(req, res);
+    expect(spawnedCmd).toMatch(/systemd-run$/);
+    expect(spawnedArgs).not.toContain('--user');
+    expect(spawnedArgs).toContain('--system');
+    expect(spawnedArgs.some((a) => a.endsWith('/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe'))).toBe(true);
+    expect(spawnedArgs).toContain('system');
+    getuidSpy.mockRestore();
+});
+
+it('system-scope uninstall wraps in pkexec when the serving process is NOT root', async () => {
+    const getuidSpy = vi.spyOn(process, 'getuid').mockReturnValue(1000);
+    // ... system scope ...
+    await api.handle(req, res);
+    expect(spawnedCmd).toMatch(/pkexec$/);
+    expect(spawnedArgs[0]).toMatch(/systemd-run$/);
+    expect(spawnedArgs).toContain('--system');
+    expect(spawnedArgs.some((a) => a.endsWith('/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe'))).toBe(true);
+    getuidSpy.mockRestore();
+});
+
+it('user-scope uninstall is UNCHANGED (home helper, systemd-run --user, no pkexec)', async () => {
+    // existing behavior — keep the existing assertion: --user + the home helper + --scope user
+    expect(spawnedCmd).toMatch(/systemd-run$/);
+    expect(spawnedArgs).toContain('--user');
+    expect(spawnedArgs.some((a) => a.includes('control/operation-server/ws-scrcpy-web-launcher.exe'))).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (system scope currently uses the home helper, no `--system`/pkexec).
+
+- [ ] **Step 3: Implement** — replace the handoff (lines 428-441) with scope-aware logic. Import `STAGED_SYSTEM_DIR`, `STAGED_SYSTEM_HELPER` from SystemdClient:
+```typescript
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const systemdRun = resolveSystemTool('systemd-run');
+            const teardownUnit = `--unit=wsscrcpy-teardown-${Date.now()}`;
+            let cmd: string;
+            let sdArgs: string[];
+            if (scope === 'system') {
+                // System scope: exec the /opt-staged helper (bin_t — init_t may
+                // exec it, unlike the data_home_t home copy that SELinux blocks),
+                // out-of-cgroup via systemd-run --system, elevated by pkexec when
+                // the serving process isn't already root (the system service is).
+                const optHelper = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_HELPER}`;
+                const runArgs = [
+                    '--system', '--collect', teardownUnit,
+                    optHelper, '--linux-service-teardown', '--scope', 'system', '--unit', WS_SCRCPY_SERVICE_NAME,
+                ];
+                if (process.getuid?.() === 0) {
+                    cmd = systemdRun;
+                    sdArgs = runArgs;
+                } else {
+                    cmd = resolveSystemTool('pkexec');
+                    sdArgs = [systemdRun, ...runArgs];
+                }
+            } else {
+                // User scope: UNCHANGED — home helper, user manager, includes relaunch.
+                const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+                cmd = systemdRun;
+                sdArgs = [
+                    '--user', '--collect', teardownUnit,
+                    helper, '--linux-service-teardown', '--scope', 'user', '--unit', WS_SCRCPY_SERVICE_NAME,
+                ];
+            }
+            this.spawnDetached(cmd, sdArgs);
+```
+
+- [ ] **Step 4: Run — expect PASS** (all three tests, plus the existing Linux-uninstall test still green for user scope).
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "fix(linux): system-scope uninstall execs /opt bin_t helper + pkexec when non-root (#2 uninstall)"`
+
+**Note (no code):** the helper's `rm -rf /opt/ws-scrcpy-web` deletes itself while running — fine on Linux (inode held). The helper's adb-reap may log a benign AVC under init_t; `systemctl stop` already reaps the unit cgroup. Out of scope.
+
+---
+
+## Task 4: Local instance exits after a Linux service install (#3)
+
+**Files:**
+- Modify: `src/server/api/ServiceApi.ts:367-372`
+- Test: `src/server/__tests__/ServiceApi.test.ts`
+
+Current (lines 363-372):
+```typescript
+        // Schedule local-Node exit. ... safety cap ...
+        if (result.platform === 'win32') {
+            setTimeout(() => {
+                log.info('install-flow: local instance exiting (service is running)');
+                process.exit(0);
+            }, 15_000).unref();
+        }
+```
+
+- [ ] **Step 1: Failing test.** The `process.exit` + `setTimeout` make this awkward to assert directly. Inject the exit scheduler for testability — add a 5th constructor param `scheduleExit: (fn: () => void, ms: number) => void = (fn, ms) => { setTimeout(fn, ms).unref(); }` and call `this.scheduleExit(...)`. Then test:
+```typescript
+it('schedules local-instance exit after a successful install on Linux (mirrors win32)', async () => {
+    const scheduled: number[] = [];
+    const scheduleExit = vi.fn((_fn: () => void, ms: number) => { scheduled.push(ms); });
+    // factoryResult.platform = 'linux', client.install resolves, status 'running'
+    const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnDetached, scheduleExit);
+    await api.handle(req, res);
+    expect(scheduleExit).toHaveBeenCalledTimes(1);
+    expect(scheduled[0]).toBe(15_000);
+});
+```
+Also keep/confirm the existing win32 behavior with the same injected scheduler.
+
+- [ ] **Step 2: Run — expect FAIL** (Linux currently doesn't schedule).
+- [ ] **Step 3: Implement** — add the `scheduleExit` ctor param (default preserves current behavior), and widen the platform gate:
+```typescript
+        // Schedule local-Node exit. This instance is useless once the service is
+        // running. Fires on win32 AND linux — the frontend navigates/reconnects
+        // once the service binds; this timer is a safety cap, not the mechanism.
+        if (result.platform === 'win32' || result.platform === 'linux') {
+            this.scheduleExit(() => {
+                log.info('install-flow: local instance exiting (service is running)');
+                process.exit(0);
+            }, 15_000);
+        }
+```
+
+- [ ] **Step 4: Run — expect PASS.** Confirm the existing win32 install test still green (byte-identical behavior — win32 still schedules).
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "fix(linux): exit the local instance after a Linux service install (#3)"`
+
+---
+
+## Task 5: Install discovery reconnects on same-port handoff (#4)
+
+**Files:**
+- Modify: `src/app/client/SettingsModal.ts` install poll (lines ~977-1012)
+- Test: `src/app/client/__tests__/SettingsModal.test.ts` (extract the discovery logic into a testable pure helper)
+
+The poll's `catch` currently errors when the local server drops (lines 1002-1011). Under decision A, the local instance exiting (#3) makes the service take the same port → that drop is now the EXPECTED success path → reconnect-reload instead of error.
+
+- [ ] **Step 1: Extract + test a pure decision helper.** Add an exported helper that classifies a poll tick, so it's unit-testable without timers/DOM:
+```typescript
+export type PollOutcome =
+    | { kind: 'keep-polling' }
+    | { kind: 'navigate'; port: number }
+    | { kind: 'reconnect' }      // local gone → service taking same port → reload current URL
+    | { kind: 'timeout' };
+export function classifyInstallPoll(
+    args: { reachable: boolean; configMtime: number | null; baselineMtime: number; diskWebPort: number | null; iterations: number; maxIterations: number },
+): PollOutcome {
+    if (!args.reachable) return { kind: 'reconnect' };   // local server dropped (instance exiting)
+    if (args.configMtime != null && args.configMtime !== args.baselineMtime && args.diskWebPort != null)
+        return { kind: 'navigate', port: args.diskWebPort };
+    if (args.iterations > args.maxIterations) return { kind: 'timeout' };
+    return { kind: 'keep-polling' };
+}
+```
+Tests:
+```typescript
+describe('classifyInstallPoll', () => {
+    const base = { reachable: true, configMtime: 100, baselineMtime: 100, diskWebPort: null, iterations: 1, maxIterations: 30 };
+    it('navigates when config mtime changed + port known (existing Windows path)', () => {
+        expect(classifyInstallPoll({ ...base, configMtime: 200, diskWebPort: 8002 })).toEqual({ kind: 'navigate', port: 8002 });
+    });
+    it('reconnects (not errors) when the local server becomes unreachable — same-port handoff', () => {
+        expect(classifyInstallPoll({ ...base, reachable: false })).toEqual({ kind: 'reconnect' });
+    });
+    it('keeps polling while reachable + no config change', () => {
+        expect(classifyInstallPoll(base)).toEqual({ kind: 'keep-polling' });
+    });
+    it('times out after maxIterations', () => {
+        expect(classifyInstallPoll({ ...base, iterations: 31 })).toEqual({ kind: 'timeout' });
+    });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`classifyInstallPoll` not defined).
+- [ ] **Step 3: Implement** the helper, then rewire the poll body to use it. Replace the poll's per-tick logic (the `try { fetch status… } catch {…}` block) so:
+  - `navigate` → `clearInterval(poll); window.location.href = http://localhost:${port}/`
+  - `reconnect` → `clearInterval(poll)`, close modal, and after a 2.5s grace reload to the current origin with a small retry budget:
+```typescript
+                case 'reconnect': {
+                    clearInterval(poll);
+                    // The local instance is exiting (#3); the service is taking
+                    // over the same port. Reload current URL after a grace.
+                    modal.setMessage?.('service installed — reconnecting…');
+                    setTimeout(() => { window.location.reload(); }, 2500);
+                    return;
+                }
+```
+  - `timeout` → existing "port discovery timed out" error.
+  - `keep-polling` → return.
+  Reachability: wrap the status `fetch` so a thrown/`!ok` fetch sets `reachable=false` for the classifier (the existing `catch` becomes "reachable=false" feeding `classifyInstallPoll`).
+
+- [ ] **Step 4: Run — expect PASS.** Manually re-read the poll to confirm the **navigate** branch is byte-equivalent to today (Windows relies on it).
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "fix(linux): reconnect on same-port service handoff instead of false timeout (#4)"`
+
+---
+
+## Task 6: `bookmarkDismissedGlobally` config field (#5a)
+
+**Files:**
+- Modify: `src/common/ConfigEvents.ts` (`AppConfig` line ~20-59, `APP_CONFIG_DEFAULTS` ~99-109)
+- Modify: `src/server/Config.ts` (`FlatConfig` ~30-51, `validateField` ~237-243, and the flat↔app mapping)
+- Test: `src/server/__tests__/` Config tests (locate the existing Config test)
+
+- [ ] **Step 1: Failing test** — a PATCH of `bookmarkDismissedGlobally: true` round-trips:
+```typescript
+it('persists bookmarkDismissedGlobally', () => {
+    const cfg = Config.getInstance();
+    cfg.updateAppConfig({ bookmarkDismissedGlobally: true });
+    expect(cfg.getAppConfig().bookmarkDismissedGlobally).toBe(true);
+});
+```
+- [ ] **Step 2: Run — expect FAIL** (field unknown / not persisted).
+- [ ] **Step 3: Implement** — add `bookmarkDismissedGlobally: boolean;` to `AppConfig` (next to `bookmarkDismissedForPort`), `bookmarkDismissedGlobally: false` to `APP_CONFIG_DEFAULTS`, `bookmarkDismissedGlobally?: boolean;` to `FlatConfig`, a `validateField` case mirroring `firstRunComplete`/`serviceFirstRunSeen` (boolean validation), and include it in the flat↔app read/write mapping in `Config.ts` (mirror `serviceFirstRunSeen` everywhere it appears).
+- [ ] **Step 4: Run — expect PASS.** `npx vitest run src/server` green.
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "feat: add bookmarkDismissedGlobally config flag (#5a)"`
+
+---
+
+## Task 7: Bookmark routing honors the global flag (#5b)
+
+**Files:**
+- Modify: `src/app/index.ts` (`maybeShowWelcomeModal` + `maybeShowPortChangeModal`, lines 74-136)
+- Test: extract the gate into a pure helper + test it.
+
+`maybeShowPortChangeModal` currently only checks per-port. Gate it on the global flag.
+
+- [ ] **Step 1: Failing test** — pure helper `shouldShowBookmark`:
+```typescript
+export function shouldShowBookmark(args: { globallyDismissed: boolean; dismissedForPort: number | null; currentPort: number }): boolean {
+    if (args.globallyDismissed) return false;
+    if (args.dismissedForPort === args.currentPort) return false;
+    return true;
+}
+```
+Tests: global set → false; per-port match → false; otherwise → true.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** the helper; pass `config.bookmarkDismissedGlobally` into `maybeShowPortChangeModal` and call `shouldShowBookmark(...)` before importing/showing `PortChangeModal`. Both call sites (service-seen branch + local-firstRunComplete branch) pass the flag.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "feat: bookmark routing honors the global-dismiss flag (#5b)"`
+
+---
+
+## Task 8: PortChangeModal global-dismiss checkbox + confirmation (#5c)
+
+**Files:**
+- Modify: `src/app/client/PortChangeModal.ts`
+- Reference (confirm-dialog pattern): `src/app/client/ShellCloseConfirmModal.ts` (white-outline buttons) — reuse its pattern/styles
+- Test: `src/app/client/__tests__/PortChangeModal.test.ts` (new)
+
+- [ ] **Step 1: Failing tests** (jsdom): construct `PortChangeModal`, then:
+  - both checkboxes render ("for this port" + the new global one);
+  - checking the global box disables the per-port box;
+  - dismissing with global checked + confirmed PATCHes `{ bookmarkDismissedGlobally: true }`;
+  - dismissing with global checked + cancelled does NOT PATCH and leaves the modal open.
+  (Mock `fetch`; for the confirmation, stub the confirm-modal to resolve true/false.)
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement.** Add the second checkbox after the existing one (mirror lines 95-106):
+```typescript
+const globalLabel = document.createElement('label');
+globalLabel.style.cssText = dontShowLabel.style.cssText;
+const globalCheckbox = document.createElement('input');
+globalCheckbox.type = 'checkbox';
+globalLabel.appendChild(globalCheckbox);
+globalLabel.appendChild(document.createTextNode("don't show again — ever, even when the port changes"));
+this.globalCheckbox = globalCheckbox;
+container.appendChild(globalLabel);
+globalCheckbox.addEventListener('change', () => {
+    checkbox.disabled = globalCheckbox.checked;            // grey out per-port when global
+    dontShowLabel.style.opacity = globalCheckbox.checked ? '0.5' : '1';
+});
+```
+Update `dismiss()` (lines 109-121): if `globalCheckbox.checked`, await a confirmation dialog; on confirm PATCH `{ bookmarkDismissedGlobally: true }` and close; on cancel, return without closing (modal stays, global box stays checked). Else keep the existing per-port behavior.
+```typescript
+private async dismiss(): Promise<void> {
+    if (this.globalCheckbox?.checked) {
+        const ok = await ConfirmModal.confirm({
+            title: 'dismiss bookmark reminder',
+            message: "You won't see this bookmark helper again, even when the port changes.",
+            confirmText: 'OK', cancelText: 'Cancel',
+        });
+        if (!ok) return;   // back to the bookmark modal, flag NOT committed
+        void fetch('/api/config', { method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ bookmarkDismissedGlobally: true }) }).catch(() => {});
+        this.opts.onDismissed?.();
+        this.close();
+        return;
+    }
+    if (this.dismissBtn) this.dismissBtn.disabled = true;
+    if (this.dontShowCheckbox?.checked) {
+        void fetch('/api/config', { method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ bookmarkDismissedForPort: this.opts.webPort }) }).catch(() => {});
+    }
+    this.opts.onDismissed?.();
+    this.close();
+}
+```
+If no reusable `ConfirmModal` exists, create a tiny `src/app/client/ConfirmModal.ts` (extends `Modal`, white-outline buttons mirroring `ShellCloseConfirmModal`, static `confirm(opts): Promise<boolean>`). Confirm the button style class matches the beta.29 white-outline buttons.
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "feat: bookmark modal global-dismiss + confirmation (#5c)"`
+
+---
+
+## Task 9: Reset clears the global flag (#5d)
+
+**Files:**
+- Modify: `src/app/client/SettingsModal.ts` reset handler (lines 1190-1202) + the label copy (line ~1168-1172)
+
+- [ ] **Step 1: Failing test** — assert the reset PATCH body includes `bookmarkDismissedGlobally: false`. If the handler isn't unit-testable, extract the reset payload into an exported constant/function `resetPromptsPayload()` and test it:
+```typescript
+export function resetPromptsPayload() {
+    return { firstRunComplete: false, serviceFirstRunSeen: false, bookmarkDismissedForPort: null, bookmarkDismissedGlobally: false };
+}
+it('reset clears all four prompt flags', () => {
+    expect(resetPromptsPayload()).toEqual({ firstRunComplete: false, serviceFirstRunSeen: false, bookmarkDismissedForPort: null, bookmarkDismissedGlobally: false });
+});
+```
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** — use `resetPromptsPayload()` in the reset PATCH (lines 1190-1202) and update the label copy (line ~1168) to mention the global bookmark dismissal too: `'…service-mode modal, per-port bookmark reminder, and the global bookmark dismissal…'`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit.** `git -C <repo> commit -am "fix: reset prompts also clears the global bookmark dismissal (#5d)"`
+
+---
+
+## Task 10: Scope-radio contrast (#6)
+
+**Files:**
+- Modify: `src/style/modal.css` (radio rules ~610-629)
+
+- [ ] **Step 1: Implement** (CSS — manual visual test, no unit test). Add `accent-color` to the scope radios and lift the disabled opacity. After the `.settings-radio-label` rule (line ~610-618), add:
+```css
+dialog.settings-modal .settings-control .settings-radio-label input[type="radio"] {
+    accent-color: #5b9aff;   /* match the app's checkboxes/range; keeps the checked dot visible */
+}
+```
+And change the disabled rule (line 626-629) opacity:
+```css
+dialog.settings-modal .settings-control .settings-radio-label:has(input:disabled) {
+    opacity: 0.65;           /* was 0.5 — 0.5 hid the selected dot when muted */
+    cursor: not-allowed;
+}
+```
+- [ ] **Step 2: Build** `npm run build` to confirm CSS compiles into the bundle.
+- [ ] **Step 3: Commit.** `git -C <repo> commit -am "fix(ui): scope-radio contrast — accent-color + lift disabled opacity (#6)"`
+
+---
+
+## Task 11: README service-name fix (#7)
+
+**Files:**
+- Modify: `README.md` (Service Mode section, ~lines 271-292)
+
+- [ ] **Step 1: Implement.** Change `ws-scrcpy-web.service` → `WsScrcpyWeb.service` (user + system unit paths). Scope-qualify the "do not move/rename the AppImage" warning (~line 278): note it applies to **user scope** (ExecStart = home AppImage); **system scope** runs the `/opt/ws-scrcpy-web/` staged copy, so moving the home AppImage doesn't break a system-scope service. Verify against the actual install behavior.
+- [ ] **Step 2: Commit.** `git -C <repo> commit -am "docs: correct service unit name (WsScrcpyWeb.service) + scope-qualify AppImage-move warning (#7)"`
+
+---
+
+## Task 12: Regression fence + cut beta.31
+
+- [ ] **Step 1: Full TS suite.** `npm test` — all green, **including the existing win32 service tests unchanged** (Principle 0).
+- [ ] **Step 2: Types + build.** `npm run build:types` && `npm run build` — clean.
+- [ ] **Step 3: Rust (confirm no regression — no Rust changed).** Per existing CI: launcher `cargo test` + `cargo clippy -- -D warnings` (via `cross`). Expect unchanged-green.
+- [ ] **Step 4: Self-review the diff** for any accidental Windows-path behavior change (handleInstall win32 branch, the install-poll navigate branch). Confirm byte-identical.
+- [ ] **Step 5: CHANGELOG** — add a `[Unreleased]` section: the 7 fixes + the bookmark global-dismiss.
+- [ ] **Step 6: Version bump** via the bump script (`reference_wsscrcpy_version_bump`) → v0.1.30-beta.31; confirm it syncs `Cargo.lock` (item 40 gap — if it doesn't, sync manually).
+- [ ] **Step 7: PR** (release:beta label) → auto-release pipeline → beta.31. **Then the user resumes the Fedora smoke** (system-scope uninstall: teardown fires, no AVC, /opt+fcontext gone; single instance after install; same-port reconnect; service modal on first install; bookmark global-dismiss; radio contrast).
+
+---
+
+## Self-Review (writing-plans)
+
+**Spec coverage:** #1 Task 1 · #2 Tasks 2+3 · #3 Task 4 · #4 Task 5 · #5 (precedence already in `index.ts`, verified) Tasks 6-9 (the net-new global-dismiss + storage + reset) · #6 Task 10 · #7 Task 11 · regression+cut Task 12. All spec items covered.
+
+**Type consistency:** `STAGED_SYSTEM_HELPER` (Task 2) reused in Task 3. `linuxHelperSource` opt (Task 2) added to `ServiceInstallOptions`. `bookmarkDismissedGlobally` (Task 6) consumed by Tasks 7/8/9. `classifyInstallPoll` / `shouldShowBookmark` / `resetPromptsPayload` are new exported helpers — names consistent across tasks.
+
+**Open detail flagged for implementation:** the `ServiceInstallOptions` type location (Task 2 — add `linuxHelperSource?`); the exact `Config.ts` flat↔app mapping spots for the new flag (Task 6); whether a reusable `ConfirmModal` exists or must be created (Task 8). Each is a "locate during the task" item, not a placeholder for unspecified behavior.

--- a/docs/specs/2026-06-01-linux-service-mode-beta31-fixes-design.md
+++ b/docs/specs/2026-06-01-linux-service-mode-beta31-fixes-design.md
@@ -1,0 +1,99 @@
+# Linux Service-Mode beta.31 Fixes — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorm); implementation plan next.
+**Goal:** Fix the 7 issues found smoke-testing **v0.1.30-beta.30**'s Linux service-mode (items 32/33) on real Fedora 44 (SELinux enforcing), plus a bookmark-modal global-dismiss enhancement. Ship as **v0.1.30-beta.31**.
+
+**Companion:** follows `2026-06-01-linux-service-mode-fix-and-update-design.md` (Phase 1 = items 32/33, shipped beta.30). Phase 2 (service-mode in-app update apply, todo item 39) stays separate and gated on this smoke passing.
+
+## Smoke results that motivate this (real Fedora 44, SELinux enforcing)
+- **Item 33 (system-scope SELinux install): VERIFIED FIXED** — `/opt` staging + `bin_t` + fcontext rule + zero AVC + serves clean.
+- **Item 32 user-scope uninstall: WORKS.**
+- **Item 32 system-scope uninstall: FAILS** — SELinux AVC: `init_t` denied `execute` on the teardown helper `ws-scrcpy-web-launcher.exe` (labelled `data_home_t` in `~/.local/share/...`). Same SELinux class as item 33, hitting the helper instead of the AppImage.
+- **Install handoff** leaves the originating local instance running → multiple concurrent instances (observed THREE) + a false "port discovery timed out".
+- **UX:** a user-scope install shows the bookmark modal instead of the service-installed modal; the disabled scope-radios are unreadable.
+
+## Principle 0 — Windows service mode stays byte-for-byte identical
+Windows service install/uninstall is verified-working and MUST NOT change behavior. Every fix is either **Linux-platform-gated** or an **additive client change** that leaves the existing Windows path untouched. The existing win32 service tests are the regression fence — they must stay green, unchanged.
+
+---
+
+## The fixes
+
+### 1. systemd `StartLimit*` keys belong in `[Unit]`, not `[Service]`
+**Evidence:** journal warns `Unknown key 'StartLimitIntervalSec' in section [Service], ignoring` on every unit load (beta.30 + earlier). systemd requires `StartLimitIntervalSec` + `StartLimitBurst` in `[Unit]` (since v229); ignored in `[Service]` → the restart cap never applies → a failing unit restarts every 5s forever (observed restart-counter 33+).
+**Fix:** `SystemdClient.renderUnitFile` (`src/server/service/SystemdClient.ts`) — emit `StartLimitBurst=${maxRestartAttempts}` + `StartLimitIntervalSec=300` in the `[Unit]` block (after `After=network.target`), not `[Service]`.
+**Test:** rendered unit places both keys under `[Unit]` (user + system scope).
+**Windows:** Linux-only (systemd unit). No Windows impact.
+
+### 2. System-scope uninstall — exec the teardown helper from `/opt` (`bin_t`), elevated
+**Evidence:** the system service runs under `init_t`. Its teardown handoff (`systemd-run --system`) execs the helper at `~/.local/share/WsScrcpyWeb/control/operation-server/ws-scrcpy-web-launcher.exe` (labelled `data_home_t`). SELinux denies `init_t` exec of `data_home_t` (AVC confirmed) → teardown never runs → service persists. User scope works because it runs under the unconfined user context (which may exec `data_home_t`).
+**Fix (decided: consolidate the helper in `/opt` with the AppImage — no `sh -c`):**
+- **Install (system scope):** `buildSystemInstallScript` stages BOTH the AppImage AND a copy of the launcher helper into `/opt/ws-scrcpy-web/`. The existing `/opt/ws-scrcpy-web(/.*)?` → `bin_t` fcontext rule + `restorecon -Rv /opt/ws-scrcpy-web` already labels the helper `bin_t` (no new rule needed — just add the `cp` + `chmod` before the relabel step).
+  - **Helper source at install time:** the running AppImage mount (`$APPDIR`). Exact internal path of the launcher binary inside the AppImage to be confirmed during implementation; fall back to the home staged copy (`<dataRoot>/control/operation-server/ws-scrcpy-web-launcher.exe`) if `$APPDIR` is unset (from-source runs). Sourcing from the mount avoids the "never-updated fresh install lacks the home copy" risk.
+- **Uninstall (system scope):** the teardown handoff execs `/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe` (`bin_t` → `init_t` can exec → no AVC), via `systemd-run --system --collect --unit=wsscrcpy-teardown-<ts>`, run **directly when the serving Node is already root** (`process.getuid?.() === 0` — the system service itself) or **`pkexec`-prefixed when it isn't** (a non-root instance triggering it → polkit prompt, mirroring install). Reuses the existing Rust teardown helper unchanged.
+- **User scope:** UNCHANGED — home helper, `systemd-run --user`, includes the local relaunch (verified-green).
+**Files:** `SystemdClient.buildSystemInstallScript` (+ stage helper) · `SystemdClient.install` / install path (helper-source resolution) · `ServiceApi.handleUninstall` (system-scope handoff: `/opt` helper path + root-vs-`pkexec` branch).
+**Notes:** the teardown's `rm -rf /opt/ws-scrcpy-web` unlinks the running helper — fine on Linux (inode held until process exit). The helper's best-effort adb-reap may log a benign AVC under `init_t` (home `adb` is `data_home_t`); `systemctl stop` already reaps the unit's cgroup adb, so it's moot — optional Rust cleanup, out of scope here.
+**No Rust change** — the helper already performs system-scope teardown; it's just exec'd from a `bin_t` path now.
+**Test:** the install script includes the helper `cp` into `/opt`; the uninstall handoff builds the `/opt` helper path + the root-vs-`pkexec` branch (unit tests on the argv builders).
+**Windows:** Linux-only (system-scope systemd). Windows uninstall path untouched.
+
+### 3. Local instance must exit after a Linux service install (root of bugs 3 + 4)
+**Evidence:** `ServiceApi.handleInstall` (~line 367) schedules the local Node to exit 15s after a successful install ("this instance is useless once the service is running") — but the block is gated `if (result.platform === 'win32')`. On Linux it never fires, so the originating local instance lingers; repeated installs/launches accumulate (observed THREE concurrent), and the lingering instance holds the web port.
+**Fix:** fire the local-exit on Linux as well (widen the platform condition; the win32 branch/behavior is unchanged — Linux is added).
+**Test:** the exit is scheduled after a successful Linux install (mirror the win32 test).
+**Windows:** win32 branch byte-identical; Linux added.
+
+### 4. Install discovery handles a same-port handoff (no false timeout)
+**Evidence:** the client install poll (`SettingsModal` ~line 977) completes only when `config.json` mtime CHANGES (service bound a different port) → navigate. Under decision A, once the local instance exits (#3) the service typically reclaims the SAME port → no config change → the poll runs its full 60s → false "port discovery timed out" (the handoff actually succeeded; reload works).
+**Fix (additive — Windows navigate path untouched):** keep the existing "config mtime changed + `diskWebPort` → navigate to new port" path. ADD: when the local `/api/service/status` becomes unreachable mid-handoff (the local instance exited per #3), the service is taking over the same port — after a short grace, reload the current URL (with a couple of reachability retries) instead of throwing "lost connection." Outcomes: port shifted → navigate (existing); same port → reconnect-reload (new). The reloaded landing page runs the modal tree (#5).
+**Decision A:** "service grabs whatever port, client follows" (mirrors Windows; an occasional `+1` only if the local hadn't released the port yet).
+**Files:** `SettingsModal` install poll (the catch/timeout branches).
+**Test:** the local-unreachable branch triggers a reconnect-reload, not the error.
+**Windows:** additive; the win32 navigate-on-mtime path is unchanged.
+
+### 5. Post-install / landing modal routing + bookmark global-dismiss
+**Evidence:** a first user-scope install showed the bookmark modal instead of the service-installed (service-mode first-run) modal — the precedence wasn't honored.
+**Fix — modal precedence (post-install landing + every page load):** pick at most one modal:
+1. **SERVICE mode** (installMode `user-service` or `system-service`) + service-mode modal not dismissed → **SERVICE-MODE modal** (the "service installed" first-run modal; Linux fires it for BOTH user and system scope; persists until dismissed).
+2. **LOCAL mode** + welcome modal not dismissed → **WELCOME modal**.
+3. Otherwise → **BOOKMARK check**.
+
+The first-run modal (welcome/service) always takes precedence; the bookmark modal is the fallback once the relevant first-run modal is dismissed.
+
+**Fix — bookmark global-dismiss (new):**
+- **Bookmark check:** global-dismiss flag set → never show; else this port already dismissed-for-bookmark → skip; else → show the bookmark modal.
+- **Bookmark modal UI** gains a second checkbox: existing **"don't show again for this port"** + NEW **"don't show again — ever, even when the port changes"** (global). Checking global **disables/greys out** the per-port checkbox.
+- **OK with global checked** → a confirmation dialog (*"You won't see this bookmark helper again, even when the port changes."*) with **[Cancel] [OK]** in the existing beta.29 white-outline modal-button style. OK → set the global flag + close. **Cancel** → return to the bookmark modal with the global box still checked, flag NOT committed.
+- **OK with global unchecked** → existing per-port behavior.
+**Storage:** new `bookmarkDismissedGlobally: boolean` in `config.json` (beside the existing per-port `bookmarkDismissedForPort`). [SQLite migration is the separate item 37.]
+**Reset:** the Settings "reset welcome and bookmark prompts" action now clears ALL FOUR — welcome, service-mode, per-port bookmark, AND global bookmark — and its confirmation copy is updated to say so.
+**Files:** the page-load modal-routing entry point (located during planning) · the bookmark modal component · `SettingsModal` reset handler · `Config` (the new flag).
+**Test:** the precedence tree (service first-run beats bookmark; local welcome beats bookmark); the global-dismiss gate; reset clears all four.
+**Windows:** the modal tree + bookmark logic are cross-platform UI; verify the Windows service-install landing still shows the service modal (Windows installs are always a system service).
+
+### 6. Disabled scope-radio contrast
+**Evidence:** `modal.css:626` mutes the whole scope-radio label to `opacity: 0.5` when the service is installed (radios disabled), and the radios have no `accent-color`, so the native selected dot becomes invisible against the grey track.
+**Fix:** add `accent-color: #5b9aff` to the scope radios (matching the app's checkboxes/range), and lift the disabled label opacity `0.5 → ~0.65`. The bright accent keeps the selected scope legible even when muted.
+**Files:** `src/style/modal.css`.
+**Test:** manual visual (no logic test).
+**Windows:** cosmetic, cross-platform-safe.
+
+### 7. README service-name drift
+**Evidence:** README says the unit is `ws-scrcpy-web.service`; the actual name is `WsScrcpyWeb.service` (`WS_SCRCPY_SERVICE_NAME = 'WsScrcpyWeb'`, `src/common/ServiceEvents.ts`). The "don't move/rename the AppImage" warning is also now scope-specific (system scope runs the `/opt` copy, so moving the home AppImage no longer breaks it).
+**Fix:** correct the unit name + scope-qualify the warning in `README.md` (Service Mode section, ~lines 271/272/278). Folds in the item-40 README drift.
+**Files:** `README.md`.
+
+---
+
+## Out of scope (explicit)
+- **Phase 2 (item 39):** Linux service-mode in-app update apply. Gated on this smoke fully passing.
+- **Item 35:** the broader Phase-3 UX (service install/uninstall + end-shell confirm-dialog buttons → white-outline). beta.31 reuses the existing white-outline modal-button style for the new global-dismiss confirmation but does not restyle the other buttons.
+- **Items 34/36/37:** the SQLite persistence arc. The new bookmark-global flag lives in `config.json` for now.
+- **Rust launcher changes:** none. (The system-scope teardown helper's benign adb-reap AVC + the now-unused-for-system-scope Rust teardown path are noted as optional future cleanup.)
+
+## Testing + verification
+- **TDD** per fix where there's logic: unit-key placement (#1); install-script + uninstall-argv builders (#2); install-exit scheduling (#3); discovery reconnect branch (#4); modal precedence + global-dismiss + reset (#5).
+- **Windows regression fence:** the existing win32 service tests stay green, unchanged. Full suite (vitest + cross + tsc + webpack + clippy) before cutting.
+- **Fedora smoke resume (user-gated):** after beta.31 builds green — re-run system-scope uninstall (expect: teardown fires, no AVC, `/opt` + fcontext gone), confirm a single instance after install (no orphans), confirm the same-port reconnect (no false timeout), confirm the service modal on first install + the bookmark global-dismiss flow + the radio contrast.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.30",
+  "version": "0.1.30-beta.31",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",

--- a/src/app/client/ConfirmModal.ts
+++ b/src/app/client/ConfirmModal.ts
@@ -1,0 +1,87 @@
+import { Modal } from '../ui/Modal';
+
+export interface ConfirmModalOptions {
+    title: string;
+    message: string;
+}
+
+/**
+ * A small reusable yes/no confirmation dialog. `ConfirmModal.confirm(opts)`
+ * resolves `true` when the user confirms and `false` on cancel / Esc /
+ * backdrop / the close button. Buttons use the white-outline `modal-button`
+ * style (matching the welcome/bookmark/service modals from beta.29).
+ *
+ * Pattern mirrors ShellCloseConfirmModal; button text is fixed ('cancel'/'ok')
+ * because the footer is built during super() before instance fields are set.
+ */
+export class ConfirmModal extends Modal {
+    private resolveFn: ((value: boolean) => void) | null = null;
+    private resolved = false;
+    private confirmOpts!: ConfirmModalOptions;
+
+    public static confirm(options: ConfirmModalOptions): Promise<boolean> {
+        return new Promise((resolve) => {
+            new ConfirmModal(options, resolve);
+        });
+    }
+
+    private constructor(options: ConfirmModalOptions, resolve: (value: boolean) => void) {
+        super({ title: options.title });
+        this.confirmOpts = options;
+        this.resolveFn = resolve;
+        this.dialog.classList.add('confirm-modal');
+        queueMicrotask(() => this.fillBody(this.bodyEl));
+    }
+
+    protected buildBody(_container: HTMLElement): void {
+        // Body rendered by fillBody() via queueMicrotask (confirmOpts set after super()).
+    }
+
+    private fillBody(container: HTMLElement): void {
+        const message = document.createElement('p');
+        message.style.cssText = 'margin: 0 0 8px;';
+        message.textContent = this.confirmOpts.message;
+        container.appendChild(message);
+    }
+
+    protected override buildFooter(): HTMLElement | null {
+        const footer = document.createElement('div');
+        footer.style.cssText = 'display: flex; gap: 8px; justify-content: flex-end;';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'modal-button';
+        cancelBtn.textContent = 'cancel';
+        cancelBtn.addEventListener('click', () => this.resolveAndClose(false));
+        footer.appendChild(cancelBtn);
+
+        const okBtn = document.createElement('button');
+        okBtn.type = 'button';
+        okBtn.className = 'modal-button modal-button-primary';
+        okBtn.textContent = 'ok';
+        okBtn.addEventListener('click', () => this.resolveAndClose(true));
+        footer.appendChild(okBtn);
+
+        return footer;
+    }
+
+    protected override onEscapeKey(_event: Event): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onBackdropClick(_event: MouseEvent): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onCloseButtonClick(): void {
+        this.resolveAndClose(false);
+    }
+
+    private resolveAndClose(value: boolean): void {
+        if (this.resolved) return;
+        this.resolved = true;
+        this.resolveFn?.(value);
+        this.resolveFn = null;
+        this.close(value);
+    }
+}

--- a/src/app/client/PortChangeModal.ts
+++ b/src/app/client/PortChangeModal.ts
@@ -1,4 +1,5 @@
 import { Modal } from '../ui/Modal';
+import { ConfirmModal } from './ConfirmModal';
 
 /**
  * v0.1.10: bookmark reminder shown whenever the page loads on a port
@@ -36,10 +37,12 @@ export class PortChangeModal extends Modal {
     private opts!: PortChangeModalOptions;
     private dismissBtn: HTMLButtonElement | null = null;
     private dontShowCheckbox: HTMLInputElement | null = null;
+    private globalCheckbox: HTMLInputElement | null = null;
 
     constructor(options: PortChangeModalOptions) {
         super({ title: 'bookmark this URL' });
         this.opts = options;
+        this.dialog.classList.add('port-change-modal');
         // Same deferred-fill pattern as WelcomeModal/ServiceFirstRunModal:
         // queueMicrotask so this.opts is set before fillBody reads it.
         queueMicrotask(() => {
@@ -56,7 +59,7 @@ export class PortChangeModal extends Modal {
         const btn = document.createElement('button');
         btn.textContent = 'got it';
         btn.className = 'modal-button modal-button-primary';
-        btn.addEventListener('click', () => this.dismiss());
+        btn.addEventListener('click', () => void this.dismiss());
         footer.appendChild(btn);
         this.dismissBtn = btn;
         return footer;
@@ -104,9 +107,45 @@ export class PortChangeModal extends Modal {
         );
         this.dontShowCheckbox = checkbox;
         container.appendChild(dontShowLabel);
+
+        // v0.1.30-beta.31 #5c: a stronger "never, even when the port changes"
+        // (global) dismissal. Checking it supersedes — and disables — the
+        // per-port box. Committing it goes through a confirmation (see dismiss).
+        const globalLabel = document.createElement('label');
+        globalLabel.style.cssText = dontShowLabel.style.cssText + ' margin-top: 8px;';
+        const globalCheckbox = document.createElement('input');
+        globalCheckbox.type = 'checkbox';
+        globalLabel.appendChild(globalCheckbox);
+        globalLabel.appendChild(
+            document.createTextNode("don't show again — ever, even when the port changes"),
+        );
+        this.globalCheckbox = globalCheckbox;
+        container.appendChild(globalLabel);
+        globalCheckbox.addEventListener('change', () => {
+            checkbox.disabled = globalCheckbox.checked;
+            dontShowLabel.style.opacity = globalCheckbox.checked ? '0.5' : '1';
+        });
     }
 
-    private dismiss(): void {
+    private async dismiss(): Promise<void> {
+        // Global dismissal is the stronger choice — gate it behind a confirmation
+        // so it isn't committed by an accidental tick. Cancel leaves the modal
+        // open with the box still checked (nothing committed).
+        if (this.globalCheckbox?.checked) {
+            const ok = await ConfirmModal.confirm({
+                title: 'dismiss bookmark reminder',
+                message: "you won't see this bookmark helper again, even when the port changes.",
+            });
+            if (!ok) return;
+            void fetch('/api/config', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ bookmarkDismissedGlobally: true }),
+            }).catch(() => { /* network hiccup — re-show next load */ });
+            this.opts.onDismissed?.();
+            this.close();
+            return;
+        }
         if (this.dismissBtn) this.dismissBtn.disabled = true;
         if (this.dontShowCheckbox?.checked) {
             // Fire-and-forget; modal closes regardless of network outcome.

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -23,6 +23,42 @@ export function uninstallFollowupMessage(mode: 'user' | 'system'): string {
 }
 
 /**
+ * Classify one tick of the post-install port-discovery poll. Pure (no DOM or
+ * timers) so it is unit-testable. After a service install the web port is
+ * handed off to the service-Node:
+ * - unreachable local server -> the local instance is exiting (fix #3) and the
+ *   service is rebinding the SAME port -> reconnect (reload the current URL).
+ * - config.json mtime changed + a known disk port -> the service bound a new
+ *   port -> navigate there (the pre-existing Windows path, unchanged).
+ * - past the iteration cap -> timeout.
+ */
+export type PollOutcome =
+    | { kind: 'keep-polling' }
+    | { kind: 'navigate'; port: number }
+    | { kind: 'reconnect' }
+    | { kind: 'timeout' };
+
+export function classifyInstallPoll(args: {
+    reachable: boolean;
+    configMtime: number | null;
+    baselineMtime: number;
+    diskWebPort: number | null;
+    iterations: number;
+    maxIterations: number;
+}): PollOutcome {
+    if (!args.reachable) return { kind: 'reconnect' };
+    if (
+        args.configMtime != null &&
+        args.configMtime !== args.baselineMtime &&
+        args.diskWebPort != null
+    ) {
+        return { kind: 'navigate', port: args.diskWebPort };
+    }
+    if (args.iterations > args.maxIterations) return { kind: 'timeout' };
+    return { kind: 'keep-polling' };
+}
+
+/**
  * Settings modal — unified two-column grid layout.
  *
  * Every section is built from the same primitive:
@@ -976,38 +1012,49 @@ export class SettingsModal extends Modal {
             let iterations = 0;
             const poll = setInterval(async () => {
                 iterations++;
-                if (iterations > maxIterations) {
-                    clearInterval(poll);
-                    modal.close();
-                    btn.disabled = false;
-                    btn.textContent = prevText;
-                    this.renderServiceError(
-                        'service is running but port discovery timed out. reload the page at your usual address.',
-                        () => void this.refreshService(),
-                    );
-                    return;
-                }
+                // A thrown/aborted fetch means the local server has dropped: under
+                // fix #3 the local instance exits after a successful install, so the
+                // service is taking over the SAME port (reconnect, not an error).
+                let reachable = true;
+                let configMtime: number | null = null;
+                let diskWebPort: number | null = null;
                 try {
                     const statusResp = await fetch('/api/service/status', { signal: AbortSignal.timeout(5000) });
-                    if (!statusResp.ok) return;
-                    const statusData = await statusResp.json() as { configMtime?: number; diskWebPort?: number };
-                    if (
-                        statusData.configMtime != null &&
-                        statusData.configMtime !== baselineMtime &&
-                        statusData.diskWebPort != null
-                    ) {
-                        clearInterval(poll);
-                        window.location.href = `http://localhost:${statusData.diskWebPort}/`;
+                    if (statusResp.ok) {
+                        const statusData = await statusResp.json() as { configMtime?: number; diskWebPort?: number };
+                        configMtime = statusData.configMtime ?? null;
+                        diskWebPort = statusData.diskWebPort ?? null;
                     }
                 } catch {
-                    clearInterval(poll);
-                    modal.close();
-                    btn.disabled = false;
-                    btn.textContent = prevText;
-                    this.renderServiceError(
-                        'lost connection to local server during handoff. reload the page at the service port.',
-                        () => void this.refreshService(),
-                    );
+                    reachable = false;
+                }
+                const outcome = classifyInstallPoll({
+                    reachable, configMtime, baselineMtime, diskWebPort, iterations, maxIterations,
+                });
+                switch (outcome.kind) {
+                    case 'navigate':
+                        clearInterval(poll);
+                        window.location.href = `http://localhost:${outcome.port}/`;
+                        return;
+                    case 'reconnect':
+                        // Same-port handoff: reload the current URL after a short
+                        // grace so the service has bound the port.
+                        clearInterval(poll);
+                        btn.textContent = 'reconnecting…';
+                        setTimeout(() => { window.location.reload(); }, 2500);
+                        return;
+                    case 'timeout':
+                        clearInterval(poll);
+                        modal.close();
+                        btn.disabled = false;
+                        btn.textContent = prevText;
+                        this.renderServiceError(
+                            'service is running but port discovery timed out. reload the page at your usual address.',
+                            () => void this.refreshService(),
+                        );
+                        return;
+                    case 'keep-polling':
+                        return;
                 }
             }, pollInterval);
         } catch {

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -59,6 +59,20 @@ export function classifyInstallPoll(args: {
 }
 
 /**
+ * The config patch sent by "reset welcome and bookmark prompts" — clears all
+ * four first-run / bookmark flags so each relevant modal can re-fire. Exported
+ * (pure) for testing. (v0.1.30-beta.31 #5d adds the global bookmark flag.)
+ */
+export function resetPromptsPayload(): Record<string, boolean | null> {
+    return {
+        firstRunComplete: false,
+        serviceFirstRunSeen: false,
+        bookmarkDismissedForPort: null,
+        bookmarkDismissedGlobally: false,
+    };
+}
+
+/**
  * Settings modal — unified two-column grid layout.
  *
  * Every section is built from the same primitive:
@@ -1213,9 +1227,10 @@ export class SettingsModal extends Modal {
 
         const confirmText = document.createElement('p');
         confirmText.textContent =
-            'this resets the welcome modal, service-mode modal, and per-port bookmark ' +
-            'reminder. the page will reload so the appropriate modal can re-fire. ' +
-            'it does not affect install mode, audio preferences, or scan history.';
+            'this resets the welcome modal, service-mode modal, the per-port bookmark ' +
+            'reminder, and the global bookmark dismissal. the page will reload so the ' +
+            'appropriate modal can re-fire. it does not affect install mode, audio ' +
+            'preferences, or scan history.';
         confirmPanel.appendChild(confirmText);
 
         const confirmButtons = document.createElement('div');
@@ -1238,11 +1253,7 @@ export class SettingsModal extends Modal {
             fetch('/api/config', {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    firstRunComplete: false,
-                    serviceFirstRunSeen: false,
-                    bookmarkDismissedForPort: null,
-                }),
+                body: JSON.stringify(resetPromptsPayload()),
             }).finally(() => {
                 window.location.reload();
             });

--- a/src/app/client/__tests__/ConfirmModal.test.ts
+++ b/src/app/client/__tests__/ConfirmModal.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ConfirmModal } from '../ConfirmModal';
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+function button(label: string): HTMLButtonElement {
+    const btn = (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[])
+        .find((b) => b.textContent?.trim().toLowerCase() === label.toLowerCase());
+    expect(btn, `button "${label}"`).toBeTruthy();
+    return btn!;
+}
+
+describe('ConfirmModal.confirm', () => {
+    it('resolves true when ok is clicked', async () => {
+        const p = ConfirmModal.confirm({ title: 't', message: 'm' });
+        await Promise.resolve();
+        button('ok').click();
+        await expect(p).resolves.toBe(true);
+    });
+
+    it('resolves false when cancel is clicked', async () => {
+        const p = ConfirmModal.confirm({ title: 't', message: 'm' });
+        await Promise.resolve();
+        button('cancel').click();
+        await expect(p).resolves.toBe(false);
+    });
+
+    it('renders the message body', async () => {
+        const p = ConfirmModal.confirm({ title: 't', message: 'hello-confirm-body' });
+        await Promise.resolve();
+        expect(document.querySelector('.confirm-modal .modal-body')?.textContent).toContain('hello-confirm-body');
+        button('cancel').click();
+        await p;
+    });
+});

--- a/src/app/client/__tests__/PortChangeModal.test.ts
+++ b/src/app/client/__tests__/PortChangeModal.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PortChangeModal } from '../PortChangeModal';
+import { ConfirmModal } from '../ConfirmModal';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)));
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+function checkboxes(): HTMLInputElement[] {
+    return Array.from(document.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+}
+function gotIt(): HTMLButtonElement {
+    const btn = (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[])
+        .find((b) => b.textContent?.trim().toLowerCase() === 'got it');
+    expect(btn, 'got it button').toBeTruthy();
+    return btn!;
+}
+function fetchMock(): ReturnType<typeof vi.fn> {
+    return fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
+describe('PortChangeModal global-dismiss (#5c)', () => {
+    it('renders both the per-port and the global checkbox', async () => {
+        new PortChangeModal({ webPort: 8000 });
+        await flush();
+        expect(checkboxes().length).toBe(2);
+        const body = document.querySelector('.port-change-modal .modal-body')?.textContent?.toLowerCase() ?? '';
+        expect(body).toContain('for this port');
+        expect(body).toContain('ever, even when the port changes');
+    });
+
+    it('checking the global box disables the per-port box', async () => {
+        new PortChangeModal({ webPort: 8000 });
+        await flush();
+        const boxes = checkboxes();
+        const perPort = boxes[0]!;
+        const global = boxes[1]!;
+        global.checked = true;
+        global.dispatchEvent(new Event('change'));
+        expect(perPort.disabled).toBe(true);
+    });
+
+    it('global-checked + confirmed PATCHes bookmarkDismissedGlobally:true', async () => {
+        const confirmSpy = vi.spyOn(ConfirmModal, 'confirm').mockResolvedValue(true);
+        new PortChangeModal({ webPort: 8000 });
+        await flush();
+        const global = checkboxes()[1]!;
+        global.checked = true;
+        global.dispatchEvent(new Event('change'));
+        gotIt().click();
+        await flush();
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        const lastCall = fetchMock().mock.calls.at(-1);
+        expect(lastCall?.[0]).toBe('/api/config');
+        expect(JSON.parse((lastCall?.[1] as RequestInit).body as string)).toEqual({ bookmarkDismissedGlobally: true });
+    });
+
+    it('global-checked + cancelled does NOT PATCH and keeps the modal open', async () => {
+        vi.spyOn(ConfirmModal, 'confirm').mockResolvedValue(false);
+        new PortChangeModal({ webPort: 8000 });
+        await flush();
+        const global = checkboxes()[1]!;
+        global.checked = true;
+        global.dispatchEvent(new Event('change'));
+        gotIt().click();
+        await flush();
+        expect(fetchMock()).not.toHaveBeenCalled();
+        expect(document.querySelector('dialog.port-change-modal')?.hasAttribute('open')).toBe(true);
+    });
+
+    it('per-port only (global unchecked) PATCHes bookmarkDismissedForPort', async () => {
+        new PortChangeModal({ webPort: 8000 });
+        await flush();
+        const perPort = checkboxes()[0]!;
+        perPort.checked = true;
+        gotIt().click();
+        await flush();
+        const lastCall = fetchMock().mock.calls.at(-1);
+        expect(JSON.parse((lastCall?.[1] as RequestInit).body as string)).toEqual({ bookmarkDismissedForPort: 8000 });
+    });
+});

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { uninstallFollowupMessage } from '../SettingsModal';
+import { uninstallFollowupMessage, classifyInstallPoll } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
     it('user scope -> reconnect/relaunch message', () => {
@@ -7,5 +7,21 @@ describe('uninstallFollowupMessage', () => {
     });
     it('system scope -> service removed message', () => {
         expect(uninstallFollowupMessage('system')).toMatch(/removed|stopped/i);
+    });
+});
+
+describe('classifyInstallPoll', () => {
+    const base = { reachable: true, configMtime: 100, baselineMtime: 100, diskWebPort: null, iterations: 1, maxIterations: 30 };
+    it('navigates when config mtime changed + port known (the existing Windows path)', () => {
+        expect(classifyInstallPoll({ ...base, configMtime: 200, diskWebPort: 8002 })).toEqual({ kind: 'navigate', port: 8002 });
+    });
+    it('reconnects (not errors) when the local server becomes unreachable - same-port handoff', () => {
+        expect(classifyInstallPoll({ ...base, reachable: false })).toEqual({ kind: 'reconnect' });
+    });
+    it('keeps polling while reachable + no config change', () => {
+        expect(classifyInstallPoll(base)).toEqual({ kind: 'keep-polling' });
+    });
+    it('times out after maxIterations', () => {
+        expect(classifyInstallPoll({ ...base, iterations: 31 })).toEqual({ kind: 'timeout' });
     });
 });

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { uninstallFollowupMessage, classifyInstallPoll } from '../SettingsModal';
+import { uninstallFollowupMessage, classifyInstallPoll, resetPromptsPayload } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
     it('user scope -> reconnect/relaunch message', () => {
@@ -23,5 +23,16 @@ describe('classifyInstallPoll', () => {
     });
     it('times out after maxIterations', () => {
         expect(classifyInstallPoll({ ...base, iterations: 31 })).toEqual({ kind: 'timeout' });
+    });
+});
+
+describe('resetPromptsPayload', () => {
+    it('clears all four first-run / bookmark flags', () => {
+        expect(resetPromptsPayload()).toEqual({
+            firstRunComplete: false,
+            serviceFirstRunSeen: false,
+            bookmarkDismissedForPort: null,
+            bookmarkDismissedGlobally: false,
+        });
     });
 });

--- a/src/app/client/__tests__/bookmarkGate.test.ts
+++ b/src/app/client/__tests__/bookmarkGate.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowBookmark } from '../bookmarkGate';
+
+describe('shouldShowBookmark', () => {
+    it('hidden when globally dismissed, even if the port differs', () => {
+        expect(shouldShowBookmark({ globallyDismissed: true, dismissedForPort: null, currentPort: 8000 })).toBe(false);
+        expect(shouldShowBookmark({ globallyDismissed: true, dismissedForPort: 9999, currentPort: 8000 })).toBe(false);
+    });
+    it('hidden when the current port was dismissed per-port', () => {
+        expect(shouldShowBookmark({ globallyDismissed: false, dismissedForPort: 8000, currentPort: 8000 })).toBe(false);
+    });
+    it('shown when not dismissed, or dismissed for a different port', () => {
+        expect(shouldShowBookmark({ globallyDismissed: false, dismissedForPort: null, currentPort: 8000 })).toBe(true);
+        expect(shouldShowBookmark({ globallyDismissed: false, dismissedForPort: 8001, currentPort: 8000 })).toBe(true);
+    });
+});

--- a/src/app/client/bookmarkGate.ts
+++ b/src/app/client/bookmarkGate.ts
@@ -1,0 +1,18 @@
+/**
+ * Decide whether to show the "bookmark this URL" reminder. Pure (no DOM) so it
+ * is unit-testable and importable by the entry point without pulling the
+ * PortChangeModal bundle into the entry chunk.
+ *
+ * Precedence: a global dismissal ("don't show again, ever") wins outright;
+ * otherwise a per-port dismissal suppresses only the matching port, so a port
+ * change re-shows the reminder. (v0.1.30-beta.31 #5b.)
+ */
+export function shouldShowBookmark(args: {
+    globallyDismissed: boolean;
+    dismissedForPort: number | null;
+    currentPort: number;
+}): boolean {
+    if (args.globallyDismissed) return false;
+    if (args.dismissedForPort === args.currentPort) return false;
+    return true;
+}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -2,6 +2,7 @@ import '../style/app.css';
 import '../style/dependencies.css';
 import '../style/first-run-banner.css';
 import '../style/home.css';
+import { shouldShowBookmark } from './client/bookmarkGate';
 import { DependencyPanel } from './client/DependencyPanel';
 import { FirstRunBanner } from './client/FirstRunBanner';
 import { HostTracker } from './client/HostTracker';
@@ -106,7 +107,7 @@ function maybeShowWelcomeModal(): void {
                     });
                     return;
                 }
-                maybeShowPortChangeModal(config.bookmarkDismissedForPort, runtime.webPort);
+                maybeShowPortChangeModal(config.bookmarkDismissedGlobally, config.bookmarkDismissedForPort, runtime.webPort);
                 return;
             }
 
@@ -121,15 +122,19 @@ function maybeShowWelcomeModal(): void {
                 return;
             }
 
-            maybeShowPortChangeModal(config.bookmarkDismissedForPort, runtime.webPort);
+            maybeShowPortChangeModal(config.bookmarkDismissedGlobally, config.bookmarkDismissedForPort, runtime.webPort);
         })
         .catch(() => {
             // /api/config absent (e.g., dev server without P2 wiring) — silently bail.
         });
 }
 
-function maybeShowPortChangeModal(dismissedFor: number | null, currentPort: number): void {
-    if (dismissedFor === currentPort) return;
+function maybeShowPortChangeModal(
+    globallyDismissed: boolean,
+    dismissedFor: number | null,
+    currentPort: number,
+): void {
+    if (!shouldShowBookmark({ globallyDismissed, dismissedForPort: dismissedFor, currentPort })) return;
     void import('./client/PortChangeModal').then(({ PortChangeModal }) => {
         new PortChangeModal({ webPort: currentPort });
     });

--- a/src/common/ConfigEvents.ts
+++ b/src/common/ConfigEvents.ts
@@ -47,6 +47,13 @@ export interface AppConfig {
      * the modal because the stored port won't match the current port.
      */
     bookmarkDismissedForPort: number | null;
+    /**
+     * v0.1.30-beta.31: global "don't show the bookmark reminder again, ever,
+     * even when the port changes". When true the bookmark modal never shows,
+     * regardless of port. Distinct from the per-port `bookmarkDismissedForPort`.
+     * (Stored in config.json for now; SQLite migration is item 37.)
+     */
+    bookmarkDismissedGlobally: boolean;
 
     // Pre-existing fields (kept for backward compatibility / runtime usage)
     webPort: number;
@@ -106,6 +113,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     webPort: 8000,
     serviceFirstRunSeen: false,
     bookmarkDismissedForPort: null,
+    bookmarkDismissedGlobally: false,
 };
 
 export const VALID_INSTALL_MODES: ReadonlyArray<InstallMode> = [

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -44,6 +44,7 @@ export interface FlatConfig {
     firstRunComplete?: boolean;
     serviceFirstRunSeen?: boolean;
     bookmarkDismissedForPort?: number | null;
+    bookmarkDismissedGlobally?: boolean;
     autoUpdate?: boolean;
     updateCheckIntervalMinutes?: number;
     channel?: 'stable' | 'beta';
@@ -235,7 +236,8 @@ function validateField<K extends keyof AppConfig>(key: K, value: unknown): Valid
         }
         case 'firstRunComplete':
         case 'autoUpdate':
-        case 'serviceFirstRunSeen': {
+        case 'serviceFirstRunSeen':
+        case 'bookmarkDismissedGlobally': {
             if (typeof value !== 'boolean') {
                 return { ok: false, error: `${key} must be a boolean` };
             }
@@ -301,6 +303,11 @@ function sanitizeAppConfig(raw: FlatConfig, warn: (msg: string) => void): AppCon
         const r = validateField('bookmarkDismissedForPort', raw.bookmarkDismissedForPort);
         if (r.ok) out.bookmarkDismissedForPort = r.value;
         else warn(`config.json: ${r.error}; using default null`);
+    }
+    if (raw.bookmarkDismissedGlobally !== undefined) {
+        const r = validateField('bookmarkDismissedGlobally', raw.bookmarkDismissedGlobally);
+        if (r.ok) out.bookmarkDismissedGlobally = r.value;
+        else warn(`config.json: ${r.error}; using default false`);
     }
     if (raw.autoUpdate !== undefined) {
         const r = validateField('autoUpdate', raw.autoUpdate);

--- a/src/server/__tests__/Config.test.ts
+++ b/src/server/__tests__/Config.test.ts
@@ -55,6 +55,16 @@ describe('Config — AppConfig extension', () => {
         expect(c).toEqual(APP_CONFIG_DEFAULTS);
     });
 
+    it('persists bookmarkDismissedGlobally from config.json (#5a global bookmark dismiss)', () => {
+        setup({ bookmarkDismissedGlobally: true });
+        expect(Config.getInstance().getAppConfig().bookmarkDismissedGlobally).toBe(true);
+    });
+
+    it('defaults bookmarkDismissedGlobally to false when absent', () => {
+        setup({});
+        expect(Config.getInstance().getAppConfig().bookmarkDismissedGlobally).toBe(false);
+    });
+
     it('migrates legacy `port` → `webPort` in memory without rewriting file', () => {
         const configPath = setup({ port: 8123 });
         const before = fs.readFileSync(configPath, 'utf-8');

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1063,6 +1063,33 @@ describe('ServiceApi', () => {
             expect(body.status).toBe('shutting-down');
         });
 
+        it('schedules local-instance exit after a successful install on Linux (mirrors win32)', async () => {
+            const scheduled: number[] = [];
+            const scheduleExit = vi.fn((_fn: () => void, ms: number) => { scheduled.push(ms); });
+            const client = fakeClient({
+                install: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'running' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            // Constructor: factory, scope, existsCheck, spawnDetached, scheduleExit
+            const api = new ServiceApi(
+                () => factoryResult,
+                () => 'user',
+                () => true,
+                vi.fn(), // spawnDetached (unused by install path)
+                scheduleExit,
+            );
+            const { req, res } = makeReqRes('/api/service/install', 'POST', JSON.stringify({ scope: 'user' }));
+            await api.handle(req, res);
+            expect((res as any).getStatus()).toBe(200);
+            expect(scheduleExit).toHaveBeenCalledTimes(1);
+            expect(scheduled[0]).toBe(15_000);
+        });
+
         it('user-scope uninstall is UNCHANGED (home helper, systemd-run --user, no pkexec)', async () => {
             // The existing user-scope test is the canonical; this twin makes the
             // regression explicit alongside the new system-scope tests.

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -775,6 +775,109 @@ describe('ServiceApi', () => {
             }
         });
 
+        // ── Linux system-scope install: launcher helper staging (#2 install) ───
+        //
+        // At system-scope install, ServiceApi resolves the home launcher helper
+        // from <dataRoot>/control/operation-server/ws-scrcpy-web-launcher.exe and
+        // passes it as linuxHelperSource to client.install(). The existing
+        // /opt/ws-scrcpy-web fcontext rule then labels it bin_t alongside the
+        // AppImage so init_t can exec it during uninstall teardown (SELinux AVC fix).
+
+        it('POST /install on Linux system scope passes linuxHelperSource when the helper candidate exists', async () => {
+            const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
+            const client = fakeClient({
+                install: installFn,
+                status: vi.fn(async () => 'running' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            // Create the helper candidate in the tmp dataRoot so existsCheck hits.
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const helperDir = path.join(dataRoot, 'control', 'operation-server');
+            fs.mkdirSync(helperDir, { recursive: true });
+            const helperPath = path.join(helperDir, 'ws-scrcpy-web-launcher.exe');
+            fs.writeFileSync(helperPath, '', 'utf8');
+
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            const { req, res } = makeReqRes(
+                '/api/service/install',
+                'POST',
+                JSON.stringify({ scope: 'system' }),
+            );
+            await api.handle(req, res);
+            expect((res as any).getStatus()).toBe(200);
+
+            const opts = installFn.mock.calls[0]?.[0];
+            expect(opts?.scope).toBe('system');
+            expect(opts?.linuxHelperSource).toBe(helperPath);
+        });
+
+        it('POST /install on Linux system scope passes undefined linuxHelperSource when helper is absent', async () => {
+            const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
+            const client = fakeClient({
+                install: installFn,
+                status: vi.fn(async () => 'running' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            // Do NOT create the helper — existsCheck returns false.
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            const { req, res } = makeReqRes(
+                '/api/service/install',
+                'POST',
+                JSON.stringify({ scope: 'system' }),
+            );
+            await api.handle(req, res);
+            expect((res as any).getStatus()).toBe(200);
+
+            const opts = installFn.mock.calls[0]?.[0];
+            expect(opts?.scope).toBe('system');
+            expect(opts?.linuxHelperSource).toBeUndefined();
+        });
+
+        it('POST /install on Linux user scope does NOT pass linuxHelperSource (user scope has no /opt staging)', async () => {
+            const installFn = vi.fn<(opts: Parameters<ServiceClient['install']>[0]) => Promise<void>>(async () => undefined);
+            const client = fakeClient({
+                install: installFn,
+                status: vi.fn(async () => 'running' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            // Create helper so we can confirm it is NOT passed for user scope.
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const helperDir = path.join(dataRoot, 'control', 'operation-server');
+            fs.mkdirSync(helperDir, { recursive: true });
+            const helperPath = path.join(helperDir, 'ws-scrcpy-web-launcher.exe');
+            fs.writeFileSync(helperPath, '', 'utf8');
+
+            const api = new ServiceApi(() => factoryResult, () => 'user');
+            const { req, res } = makeReqRes(
+                '/api/service/install',
+                'POST',
+                JSON.stringify({ scope: 'user' }),
+            );
+            await api.handle(req, res);
+            expect((res as any).getStatus()).toBe(200);
+
+            const opts = installFn.mock.calls[0]?.[0];
+            expect(opts?.scope).toBe('user');
+            expect(opts?.linuxHelperSource).toBeUndefined();
+        });
+
         // ── Linux uninstall — systemd-run teardown handoff (item 32) ───────────
         //
         // On Linux, uninstall MUST NOT call client.uninstall() because this Node

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -974,6 +974,141 @@ describe('ServiceApi', () => {
             expect(body.ok).toBe(true);
             expect(body.status).toBe('not-installed');
         });
+
+        // ── Linux system-scope uninstall: /opt bin_t helper + pkexec (#2 uninstall) ──
+        //
+        // System-scope uninstall must exec the /opt-staged launcher copy (labelled
+        // bin_t by the install-side fcontext rule) rather than the home-copy
+        // (data_home_t) — init_t may NOT exec data_home_t → SELinux AVC → teardown
+        // never runs → service persists after uninstall. Uses systemd-run --system
+        // (not --user) so it escapes the service cgroup. Wraps in pkexec when the
+        // serving process is NOT already root (system service itself runs as root).
+
+        it('system-scope uninstall execs the /opt helper (bin_t) via systemd-run --system, root → no pkexec', async () => {
+            Object.defineProperty(process, 'getuid', { value: () => 0, configurable: true });
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'running' as const),
+                getInstalledScope: vi.fn(async () => 'system' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            let spawnedCmd = '';
+            let spawnedArgs: string[] = [];
+            const spawnDetached = vi.fn((cmd: string, args: string[]) => {
+                spawnedCmd = cmd;
+                spawnedArgs = args;
+            });
+
+            Config.getInstance().updateAppConfig({ installMode: 'system-service' });
+
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnDetached);
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            // Root → cmd is systemd-run directly (no pkexec wrapper)
+            expect(spawnedCmd).toMatch(/systemd-run$/);
+            expect(spawnedArgs).toContain('--system');
+            expect(spawnedArgs).not.toContain('--user');
+            // Execs the /opt-staged helper (bin_t), not the home copy (data_home_t)
+            expect(spawnedArgs.some((a) => a.endsWith('/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe'))).toBe(true);
+            // --scope value forwarded to the helper
+            expect(spawnedArgs).toContain('system');
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
+        });
+
+        it('system-scope uninstall wraps in pkexec when the serving process is NOT root', async () => {
+            Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
+            const client = fakeClient({
+                uninstall: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'running' as const),
+                getInstalledScope: vi.fn(async () => 'system' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            let spawnedCmd = '';
+            let spawnedArgs: string[] = [];
+            const spawnDetached = vi.fn((cmd: string, args: string[]) => {
+                spawnedCmd = cmd;
+                spawnedArgs = args;
+            });
+
+            Config.getInstance().updateAppConfig({ installMode: 'system-service' });
+
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnDetached);
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            // Non-root → cmd is pkexec; systemd-run is the first arg
+            expect(spawnedCmd).toMatch(/pkexec$/);
+            expect(spawnedArgs[0]).toMatch(/systemd-run$/);
+            expect(spawnedArgs).toContain('--system');
+            expect(spawnedArgs.some((a) => a.endsWith('/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe'))).toBe(true);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
+        });
+
+        it('user-scope uninstall is UNCHANGED (home helper, systemd-run --user, no pkexec)', async () => {
+            // The existing user-scope test is the canonical; this twin makes the
+            // regression explicit alongside the new system-scope tests.
+            const uninstallSpy = vi.fn(async () => undefined);
+            const client = fakeClient({
+                uninstall: uninstallSpy,
+                status: vi.fn(async () => 'running' as const),
+                getInstalledScope: vi.fn(async () => 'user' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+
+            let spawnedCmd = '';
+            let spawnedArgs: string[] = [];
+            const spawnDetached = vi.fn((cmd: string, args: string[]) => {
+                spawnedCmd = cmd;
+                spawnedArgs = args;
+            });
+
+            Config.getInstance().updateAppConfig({ installMode: 'user-service' });
+
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnDetached);
+            const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+            await api.handle(req, res);
+
+            // client.uninstall must NOT be called (cgroup-escape handoff)
+            expect(uninstallSpy).not.toHaveBeenCalled();
+            // User scope → systemd-run --user, no pkexec
+            expect(spawnedCmd).toMatch(/systemd-run$/);
+            expect(spawnedArgs).toContain('--user');
+            expect(spawnedArgs).not.toContain('--system');
+            // Helper is the home copy (operation-server), NOT the /opt copy.
+            // Use the same two-check pattern as the canonical user-scope test above
+            // so the assertion works with both / and \ separators (test host is Windows).
+            const userHelperArg = spawnedArgs.find((a) => a.endsWith('ws-scrcpy-web-launcher.exe'));
+            expect(userHelperArg).toBeDefined();
+            expect(userHelperArg).toContain('operation-server');
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
+        });
     });
 
     it('returns 404 for unrecognized /api/service/* paths', async () => {

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -267,6 +267,24 @@ export class ServiceApi {
             }
         }
 
+        // System-scope install only: resolve the home launcher helper so it can
+        // be staged into /opt/ws-scrcpy-web/ at install time. The fcontext rule
+        // `/opt/ws-scrcpy-web(/.*)? -> bin_t` + restorecon will label it bin_t,
+        // allowing init_t to exec it during system-scope uninstall teardown
+        // (SELinux AVC fix, item #2 install side). Best-effort: if the helper
+        // isn't present (from-source / unavailable), log and skip — the install
+        // itself still succeeds, system uninstall may need manual cleanup.
+        let linuxHelperSource: string | undefined;
+        if (result.platform === 'linux' && scope === 'system') {
+            const dr = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const cand = path.join(dr, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            if (this.existsCheck(cand)) {
+                linuxHelperSource = cand;
+            } else {
+                log.warn(`linux system install: teardown helper not found at ${cand}; /opt staging skipped (system uninstall may need manual cleanup)`);
+            }
+        }
+
         // v0.1.24-beta.7: service.log moves under <dataRoot>/logs/ to
         // colocate with launcher.log + server.log + ws-scrcpy-web.log.
         // Pre-beta.7 it lived at <dataRoot>/dependencies/service.log,
@@ -328,6 +346,9 @@ export class ServiceApi {
                 dataRoot: Config.getInstance().dataRoot ?? undefined,
                 // Linux SystemdClient consumes scope; Windows ServyClient ignores it.
                 scope,
+                // Linux system-scope only: home helper path to stage into /opt (bin_t).
+                // Windows ServyClient ignores this field.
+                linuxHelperSource,
             });
         } catch (err) {
             // Install failed — revert installMode so the next page load

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -58,6 +58,7 @@ export class ServiceApi {
             child.on('error', (err) => log.warn(`spawnDetached ${cmd} error: ${err.message}`));
             child.unref();
         },
+        private scheduleExit: (fn: () => void, ms: number) => void = (fn, ms) => { setTimeout(fn, ms).unref(); },
     ) {}
 
     public async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
@@ -383,14 +384,17 @@ export class ServiceApi {
         const disk = this.readDiskConfig();
 
         // Schedule local-Node exit. This instance is useless once the service
-        // is running. The frontend navigates to the service port once it
-        // detects config.json mtime change — this timer is a safety cap, not
-        // a timing mechanism.
-        if (result.platform === 'win32') {
-            setTimeout(() => {
+        // is running; it also holds the web port. The frontend navigates to the
+        // service port once it detects config.json mtime change — this timer is
+        // a safety cap, not a timing mechanism. Fire on win32 AND linux: the
+        // local instance lingers on Linux too, causing concurrent-instance and
+        // port-discovery-timeout symptoms (beta.31 fix #3). win32 behavior is
+        // byte-for-byte identical to before (same 15 s, same log message).
+        if (result.platform === 'win32' || result.platform === 'linux') {
+            this.scheduleExit(() => {
                 log.info('install-flow: local instance exiting (service is running)');
                 process.exit(0);
-            }, 15_000).unref();
+            }, 15_000);
         }
 
         const body: ServiceActionSuccess = {

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -23,6 +23,7 @@ import {
     type ServiceClientFactoryResult,
 } from '../service';
 import { resolveSystemTool } from '../service/systemTools';
+import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_HELPER } from '../service/SystemdClient';
 import { readJsonBody } from './utils';
 
 const log = Logger.for('ServiceApi');
@@ -447,18 +448,39 @@ export class ServiceApi {
             }
 
             const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
-            // Same staged out-of-mount helper UpdateService.applyUpdate uses — note the
-            // `.exe` suffix is the fixed staged name even on Linux (refresh_helper_binary).
-            const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
             const systemdRun = resolveSystemTool('systemd-run');
-            const sdArgs = [
-                ...(scope === 'user' ? ['--user'] : []),
-                '--collect',
-                `--unit=wsscrcpy-teardown-${Date.now()}`,
-                helper,
-                '--linux-service-teardown', '--scope', scope, '--unit', WS_SCRCPY_SERVICE_NAME,
-            ];
-            this.spawnDetached(systemdRun, sdArgs);
+            const teardownUnit = `--unit=wsscrcpy-teardown-${Date.now()}`;
+            let cmd: string;
+            let sdArgs: string[];
+            if (scope === 'system') {
+                // System scope: exec the /opt-staged helper (bin_t — init_t may exec
+                // it, unlike the data_home_t home copy SELinux blocks), out-of-cgroup
+                // via systemd-run --system, elevated by pkexec when the serving process
+                // isn't already root (the system service itself runs as root).
+                const optHelper = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_HELPER}`;
+                const runArgs = [
+                    '--system', '--collect', teardownUnit,
+                    optHelper, '--linux-service-teardown', '--scope', 'system', '--unit', WS_SCRCPY_SERVICE_NAME,
+                ];
+                if (process.getuid?.() === 0) {
+                    cmd = systemdRun;
+                    sdArgs = runArgs;
+                } else {
+                    cmd = resolveSystemTool('pkexec');
+                    sdArgs = [systemdRun, ...runArgs];
+                }
+            } else {
+                // User scope: UNCHANGED — home helper, user manager, includes relaunch.
+                // Same staged out-of-mount helper UpdateService.applyUpdate uses — note
+                // the `.exe` suffix is the fixed staged name even on Linux.
+                const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+                cmd = systemdRun;
+                sdArgs = [
+                    '--user', '--collect', teardownUnit,
+                    helper, '--linux-service-teardown', '--scope', 'user', '--unit', WS_SCRCPY_SERVICE_NAME,
+                ];
+            }
+            this.spawnDetached(cmd, sdArgs);
             log.info(`uninstall(linux): spawned teardown helper via systemd-run (${scope} scope)`);
 
             const body: ServiceActionSuccess = { ok: true, status: 'shutting-down', installMode: newMode };

--- a/src/server/service/ServiceClient.ts
+++ b/src/server/service/ServiceClient.ts
@@ -79,6 +79,16 @@ export interface ServiceInstallOptions {
      * Windows — ServyClient runs the service as Local System.
      */
     scope?: 'user' | 'system' | undefined;
+    /**
+     * Linux system-scope only: absolute path to the home-directory launcher
+     * helper (`ws-scrcpy-web-launcher.exe`) to stage into `/opt/ws-scrcpy-web/`
+     * alongside the AppImage. The existing fcontext rule labels the whole dir
+     * `bin_t`, so `init_t` can exec the staged helper during system-scope
+     * uninstall teardown. Omit when the helper is not available (from-source
+     * runs); SystemdClient logs a warning and skips the staging step.
+     * Windows ServyClient ignores this field.
+     */
+    linuxHelperSource?: string | undefined;
 }
 
 /**

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -80,3 +80,27 @@ describe('absolute-path OS tools', () => {
         expect(argv.args).toEqual(['--user', 'daemon-reload']);
     });
 });
+
+describe('renderUnitFile', () => {
+    const baseOpts = {
+        name: 'WsScrcpyWeb',
+        displayName: 'ws-scrcpy-web',
+        description: 'desc',
+        binPath: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
+        startupDir: '/home/u/Apps',
+        startType: 'Automatic' as const,
+        maxRestartAttempts: 3,
+        envVars: { DEPS_PATH: '/home/u/.local/share/WsScrcpyWeb/dependencies' },
+        logPath: '/home/u/.local/share/WsScrcpyWeb/logs/service.log',
+    };
+
+    it('places StartLimit keys in [Unit], not [Service] (systemd ignores them in [Service])', () => {
+        const unit = renderUnitFile(baseOpts, 'system');
+        const unitSection = unit.slice(unit.indexOf('[Unit]'), unit.indexOf('[Service]'));
+        const serviceSection = unit.slice(unit.indexOf('[Service]'), unit.indexOf('[Install]'));
+        expect(unitSection).toContain('StartLimitIntervalSec=300');
+        expect(unitSection).toContain('StartLimitBurst=3');
+        expect(serviceSection).not.toContain('StartLimitIntervalSec');
+        expect(serviceSection).not.toContain('StartLimitBurst');
+    });
+});

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -39,6 +39,28 @@ describe('buildSystemInstallScript', () => {
         name: 'WsScrcpyWeb',
     };
 
+    it('stages the launcher helper into /opt alongside the AppImage (bin_t via the fcontext rule)', () => {
+        const script = buildSystemInstallScript({
+            sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
+            sourceHelper: '/home/u/.local/share/WsScrcpyWeb/control/operation-server/ws-scrcpy-web-launcher.exe',
+            unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
+            unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
+            name: 'WsScrcpyWeb',
+        });
+        expect(script).toContain('cp "/home/u/.local/share/WsScrcpyWeb/control/operation-server/ws-scrcpy-web-launcher.exe" "/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe"');
+        expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe"');
+        const helperCp = script.indexOf('/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe');
+        const relabel = script.indexOf('restorecon -Rv');
+        expect(helperCp).toBeLessThan(relabel);
+    });
+
+    it('omits the helper cp when no sourceHelper is provided (from-source / unavailable)', () => {
+        const script = buildSystemInstallScript({
+            sourceAppImage: '/a.AppImage', unitTmpPath: '/t', unitPath: '/u', name: 'WsScrcpyWeb',
+        });
+        expect(script).not.toContain('ws-scrcpy-web-launcher.exe');
+    });
+
     it('stages the AppImage to /opt, chmods, labels bin_t, then installs the unit', () => {
         const script = buildSystemInstallScript(args);
         expect(script).toContain('mkdir -p /opt/ws-scrcpy-web');

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -70,6 +70,12 @@ const TRAY_AUTOSTART_FILE = 'ws-scrcpy-web-tray.desktop';
 export const STAGED_SYSTEM_DIR = '/opt/ws-scrcpy-web';
 /** Stable, channel-agnostic filename for the staged system-scope AppImage. */
 export const STAGED_SYSTEM_APPIMAGE = 'WsScrcpyWeb.AppImage';
+/**
+ * Stable filename for the staged launcher helper in /opt (system-scope).
+ * Staged alongside the AppImage so the fcontext rule labels it bin_t —
+ * allowing init_t to exec it during system-scope uninstall teardown.
+ */
+export const STAGED_SYSTEM_HELPER = 'ws-scrcpy-web-launcher.exe';
 
 /**
  * Run a command via pkexec for graphical privilege escalation. The user
@@ -219,11 +225,12 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
  * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
  */
 export function buildSystemInstallScript(
-    args: { sourceAppImage: string; unitTmpPath: string; unitPath: string; name: string },
+    args: { sourceAppImage: string; sourceHelper?: string; unitTmpPath: string; unitPath: string; name: string },
     binTool: (t: string) => string = (t) => resolveSystemTool(t),
     sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
 ): string {
     const staged = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const stagedHelper = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_HELPER}`;
     const mkdir = binTool('mkdir');
     const cp = binTool('cp');
     const chmod = binTool('chmod');
@@ -231,11 +238,20 @@ export function buildSystemInstallScript(
     const systemctl = binTool('systemctl');
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
-    return [
+    const steps: string[] = [
         // 1. stage the AppImage into /opt (root-owned)
         `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
         `${cp} "${args.sourceAppImage}" "${staged}"`,
         `${chmod} 0755 "${staged}"`,
+    ];
+    // 1b. optionally stage the teardown helper alongside the AppImage so the
+    //     existing fcontext rule labels it bin_t — allowing init_t to exec it
+    //     during system-scope uninstall teardown (SELinux AVC fix, item #2).
+    if (args.sourceHelper) {
+        steps.push(`${cp} "${args.sourceHelper}" "${stagedHelper}"`);
+        steps.push(`${chmod} 0755 "${stagedHelper}"`);
+    }
+    steps.push(
         // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
         //    available; restorecon applies it; chcon is the transient fallback
         //    for minimal images without policycoreutils-python-utils. The whole
@@ -244,12 +260,14 @@ export function buildSystemInstallScript(
         //    a label failure on a non-SELinux host (semanage absent + chcon
         //    erroring on a non-SELinux fs) would break the outer `&&` chain and
         //    silently skip the unit cp + enable below.
+        //    restorecon covers the whole dir — labels the helper bin_t too when present.
         `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         // 3. install + enable the unit (ExecStart already points at ${staged})
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
         `${systemctl} daemon-reload`,
         `${systemctl} enable --now ${args.name}.service`,
-    ].join(' && ');
+    );
+    return steps.join(' && ');
 }
 
 /**
@@ -344,6 +362,7 @@ export class SystemdClient implements ServiceClient {
             try {
                 const cmd = buildSystemInstallScript({
                     sourceAppImage: opts.binPath,
+                    ...(opts.linuxHelperSource ? { sourceHelper: opts.linuxHelperSource } : {}),
                     unitTmpPath: tmpFile,
                     unitPath,
                     name: opts.name,

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -184,12 +184,16 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
         ? `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`
         : opts.binPath;
     const workingDir = scope === 'system' ? STAGED_SYSTEM_DIR : opts.startupDir;
-    // StartLimitIntervalSec=300 means: count restart attempts in a rolling
-    // 5-minute window; if maxRestartAttempts is exceeded, systemd gives up.
     return [
         '[Unit]',
         `Description=${opts.description}`,
         'After=network.target',
+        // systemd reads StartLimit* from [Unit], NOT [Service] (it silently
+        // ignores them in [Service] -> the restart cap never applies).
+        // StartLimitIntervalSec=300 means: count restart attempts in a rolling
+        // 5-minute window; if maxRestartAttempts is exceeded, systemd gives up.
+        'StartLimitIntervalSec=300',
+        `StartLimitBurst=${opts.maxRestartAttempts}`,
         '',
         '[Service]',
         'Type=simple',
@@ -197,8 +201,6 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
         `WorkingDirectory=${workingDir}`,
         'Restart=on-failure',
         'RestartSec=5',
-        `StartLimitBurst=${opts.maxRestartAttempts}`,
-        'StartLimitIntervalSec=300',
         ...(envLines ? [envLines] : []),
         `StandardOutput=append:${opts.logPath}`,
         `StandardError=append:${opts.logPath}`,

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -617,6 +617,12 @@ dialog.settings-modal .settings-control .settings-radio-label {
     margin: 0;
 }
 
+/* Bright accent so the radio's selected dot stays visible even when the label
+ * is muted (disabled scope). Matches the app's checkboxes/range controls. */
+dialog.settings-modal .settings-control .settings-radio-label input[type="radio"] {
+    accent-color: #5b9aff;
+}
+
 /*
  * Disabled radio (e.g. service scope while installed): mute the whole
  * label, not just the radio circle, so the read-only state reads at a
@@ -624,7 +630,7 @@ dialog.settings-modal .settings-control .settings-radio-label {
  * (Chrome 105+ / Firefox 121+ / Safari 15.4+).
  */
 dialog.settings-modal .settings-control .settings-radio-label:has(input:disabled) {
-    opacity: 0.5;
+    opacity: 0.65;
     cursor: not-allowed;
 }
 


### PR DESCRIPTION
## v0.1.30-beta.31 — Linux service-mode fixes (Fedora smoke follow-up)

Fixes the 7 issues found smoke-testing **beta.30**'s Linux service mode on real Fedora 44 (SELinux enforcing), plus a bookmark global-dismiss option. Implements `docs/plans/2026-06-02-linux-service-mode-beta31-fixes.md` (spec: `docs/specs/2026-06-01-linux-service-mode-beta31-fixes-design.md`).

### Smoke results that motivated this (Fedora 44, SELinux enforcing)
- ✅ Item 33 (system-scope SELinux **install**) — verified fixed in beta.30.
- ✅ Item 32 **user-scope** uninstall — works.
- ❌ Item 32 **system-scope** uninstall — `init_t` AVC on the teardown helper (`data_home_t` in `~/.local/share`).
- ❌ Install handoff left the local instance running → 3 concurrent instances + a false "port discovery timed out".
- ❌ user-scope install showed the bookmark modal instead of the service modal; disabled scope-radios unreadable.

### Fixes
1. **systemd `StartLimit*` keys → `[Unit]`** — they were in `[Service]` where systemd ignores them, so the restart cap never applied (5 s restart loop). (`#1`)
2. **System-scope uninstall tears down under SELinux** — install now also stages the launcher helper into `/opt/ws-scrcpy-web/` (labelled `bin_t` by the existing fcontext rule); uninstall execs that copy via `systemd-run --system`, `pkexec`-wrapped when the triggering process isn't already root. User scope unchanged. (`#2`)
3. **Local instance exits after a Linux install** — the post-install exit was win32-gated; now fires on Linux too (root of the concurrent-instances + port-hold bugs). (`#3`)
4. **Same-port reconnect, no false timeout** — when the service reclaims the same web port, the install poll detects the local server dropping and reloads after a short grace instead of erroring. Windows port-shift navigate path unchanged. (`#4`)
5. **Bookmark global-dismiss** — `PortChangeModal` gains "don't show again — ever, even when the port changes", gated behind a confirmation, persisted as `bookmarkDismissedGlobally` in `config.json`; the reset action clears it too. (`#5a–d`)
6. **Scope-radio contrast** — `accent-color:#5b9aff` + disabled opacity `0.5 → 0.65` so the selected dot stays visible when muted. (`#6`)
7. **README** — corrected unit name to `WsScrcpyWeb.service`; scope-qualified the "don't move the AppImage" caveat (system scope runs the `/opt` copy). (`#7`)

### Scope / safety
- **Principle 0 — Windows byte-for-byte unchanged.** Every fix is Linux-platform-gated or an additive client change.
- **No launcher / Rust changes** — the existing teardown helper is simply exec'd from a `bin_t` path. Rust is byte-identical to beta.30.
- **Out of scope (separate items):** Phase 2 service-mode in-app update apply (item 39, gated on this smoke); the broader Phase-3 confirm-dialog restyle (item 35); the SQLite persistence arc (items 34/36/37).

### Verification
- Full `vitest` suite: **794 passed / 73 files** (includes the unchanged win32 service tests — the regression fence — and the new beta.31 tests).
- `npm run build:types` clean · `npm run build` (webpack) compiled successfully.
- `tsc --noEmit` clean on every task.
- Version synced across `package.json` / `Cargo.toml` / `Cargo.lock` (the lock had drifted to beta.29 — item-40 gap — now synced).

### After merge
Auto-release pipeline cuts **v0.1.30-beta.31**; then the Fedora smoke resumes: system-scope uninstall (teardown fires, no AVC, `/opt`+fcontext gone), single instance after install, same-port reconnect, service modal on first install, bookmark global-dismiss, radio contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
