### PR TITLE
docs(changelog): consolidate beta.31 notes under beta.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.30-beta.32] - 2026-06-02
 
-## [0.1.30-beta.31] - 2026-06-02
+> Note: the beta.31 version number was skipped — the auto-release flow cut these changes as beta.32. There was no public beta.31 release.
 
 Fixes for issues found smoke-testing **beta.30**'s Linux service mode on real Fedora 44 (SELinux enforcing), plus a bookmark global-dismiss option. Windows service mode and Linux local mode are byte-for-byte unchanged; there are no launcher/Rust changes.
 


### PR DESCRIPTION
The auto-release version flow skipped the beta.31 number (the feature PR #257 carried a manual bump, so Mode 1 computed next=beta.32 and cut that). This left CHANGELOG with an empty [0.1.30-beta.32] section and the real notes orphaned under [0.1.30-beta.31]. This consolidates them under [0.1.30-beta.32] with a one-line note that beta.31 was skipped. No code change; **no release label** (auto-release Mode 3 exits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)