### PR TITLE
fix(linux): local-apply helper survives app cgroup teardown (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux local-mode in-app update no longer silently fails to swap (#27).** The update downloads and SHA-256-verifies the new AppImage, then hands off to an out-of-mount helper to swap `$APPIMAGE` and relaunch. That helper was spawned with a plain `detached: true`, which keeps it in the *app's* cgroup — so when the app was running inside a `systemd-run --collect` transient unit (e.g. an instance relaunched by the service-uninstall teardown), the unit's cgroup was reaped on the app's exit and the helper was **killed before it swapped**: the update appeared to hang and the app stayed on the old version (a reboot "fixed" it by returning to a normally-launched instance). The helper now runs in its **own** `systemd-run --user --collect` transient unit (separate cgroup), falling back to `setsid` then a bare detached spawn on non-systemd hosts; and it relaunches the swapped AppImage the same way so the new instance survives the helper's exit. The helper also clears the staged file + the apply-update marker on completion. A normally-launched update was unaffected; this fixes the update-after-service-uninstall case. Windows + Linux service mode unchanged.
+
 ## [0.1.30-beta.32] - 2026-06-02
 
 > Note: the beta.31 version number was skipped — the auto-release flow cut these changes as beta.32. There was no public beta.31 release.

--- a/launcher/src/linux_apply.rs
+++ b/launcher/src/linux_apply.rs
@@ -44,7 +44,7 @@ fn run(args: &[String]) -> i32 {
         wait_for_pid_exit(pid, Duration::from_secs(60));
     }
 
-    match swap_appimage(&staged, &target) {
+    let code = match swap_appimage(&staged, &target) {
         Ok(()) => {
             log::info("linux-apply: swap ok, relaunching");
             relaunch(&target);
@@ -54,7 +54,13 @@ fn run(args: &[String]) -> i32 {
             log::error(&format!("linux-apply: swap failed: {e}"));
             1
         }
-    }
+    };
+    // Best-effort cleanup so a completed OR failed apply leaves no cruft (#27):
+    // the staged .new (consumed on success, orphaned on failure) and the
+    // apply-update-pending marker (UpdateService writes it; it has no Linux
+    // consumer — Windows-only — so clearing it just keeps dataRoot tidy).
+    cleanup_apply_artifacts(&staged);
+    code
 }
 
 /// `<target>.bak`
@@ -100,16 +106,58 @@ fn wait_for_pid_exit(pid: u32, timeout: Duration) {
     log::error(&format!("linux-apply: pid {pid} still alive after {timeout:?}; proceeding anyway"));
 }
 
-/// Spawn the new AppImage detached; the helper then exits.
+/// Spawn the new AppImage so it OUTLIVES this helper. When this helper itself
+/// runs inside a systemd transient unit (launched via `systemd-run --collect`,
+/// which sets INVOCATION_ID), a plain child would live in THIS helper's cgroup
+/// and be reaped when the helper exits and `--collect` deactivates the unit — so
+/// relaunch the app in its OWN `systemd-run --user --collect` transient unit
+/// (mirrors linux_service.rs). On a non-systemd host the helper is its own
+/// session leader, so a detached spawn survives. Argv built by `relaunch_command`.
 fn relaunch(target: &Path) {
-    match std::process::Command::new(target)
+    let systemd_run = format!("{}/systemd-run", crate::linux_service::tool_dir("systemd-run"));
+    let argv = relaunch_command(target, under_systemd(), &systemd_run);
+    let (cmd, rest) = argv.split_first().expect("non-empty argv");
+    match std::process::Command::new(cmd)
+        .args(rest)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
     {
-        Ok(child) => log::info(&format!("linux-apply: relaunched {target:?} (pid {})", child.id())),
-        Err(e) => log::error(&format!("linux-apply: relaunch failed: {e}")),
+        Ok(child) => log::info(&format!("linux-apply: relaunched via `{}` (pid {})", argv.join(" "), child.id())),
+        Err(e) => log::error(&format!("linux-apply: relaunch failed (`{}`): {e}", argv.join(" "))),
+    }
+}
+
+/// True when running inside a systemd unit — `systemd-run` sets `INVOCATION_ID`
+/// for the processes it starts. Drives the relaunch escape strategy.
+fn under_systemd() -> bool {
+    std::env::var("INVOCATION_ID").map(|v| !v.is_empty()).unwrap_or(false)
+}
+
+/// argv for relaunching `target`. Under systemd → its OWN `systemd-run --user
+/// --collect` transient unit (survives this helper's exit); otherwise a bare
+/// exec (the caller detaches via stdio-null). Pure — unit-tested.
+pub fn relaunch_command(target: &Path, under_systemd: bool, systemd_run: &str) -> Vec<String> {
+    let t = target.to_string_lossy().into_owned();
+    if under_systemd {
+        vec![systemd_run.to_string(), "--user".into(), "--collect".into(), t]
+    } else {
+        vec![t]
+    }
+}
+
+/// `<data_root>/control/apply-update-pending` — the apply marker path. Pure.
+pub fn apply_marker_path(data_root: &Path) -> PathBuf {
+    data_root.join("control").join("apply-update-pending")
+}
+
+/// Best-effort removal of the staged `.new` + the apply-update-pending marker.
+/// Never fails the apply — a cleanup error is irrelevant to the swap outcome.
+fn cleanup_apply_artifacts(staged: &Path) {
+    let _ = std::fs::remove_file(staged);
+    if let Some(data_root) = common::config::data_root_from_env() {
+        let _ = std::fs::remove_file(apply_marker_path(&data_root));
     }
 }
 
@@ -148,5 +196,32 @@ mod tests {
         let args = vec!["x".to_string(), "--target".to_string(), "/a/b".to_string()];
         assert_eq!(arg_value(&args, "--target"), Some("/a/b"));
         assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn relaunch_uses_own_systemd_unit_under_systemd() {
+        // #27: under systemd the new app must run in its OWN --collect unit so it
+        // survives this helper's exit (not in this helper's reaped cgroup).
+        assert_eq!(
+            relaunch_command(Path::new("/home/u/App.AppImage"), true, "/usr/bin/systemd-run"),
+            vec!["/usr/bin/systemd-run", "--user", "--collect", "/home/u/App.AppImage"]
+        );
+    }
+
+    #[test]
+    fn relaunch_is_direct_when_not_under_systemd() {
+        // Non-systemd host: helper is its own session leader, plain exec survives.
+        assert_eq!(
+            relaunch_command(Path::new("/home/u/App.AppImage"), false, "/usr/bin/systemd-run"),
+            vec!["/home/u/App.AppImage"]
+        );
+    }
+
+    #[test]
+    fn apply_marker_path_is_under_control() {
+        assert_eq!(
+            apply_marker_path(Path::new("/d")),
+            PathBuf::from("/d/control/apply-update-pending")
+        );
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -125,7 +125,7 @@ pub fn handle(args: &[String]) -> Option<i32> {
 
 /// Probe for the absolute dir (/usr/bin then /bin) containing `tool`. Falls back
 /// to /usr/bin. Local-Dependencies-Only: never invoke a tool by bare name.
-fn tool_dir(tool: &str) -> String {
+pub(crate) fn tool_dir(tool: &str) -> String {
     for d in ["/usr/bin", "/bin"] {
         if Path::new(&format!("{d}/{tool}")).exists() {
             return d.to_string();

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -21,6 +21,7 @@ import { Logger } from './Logger';
 import { linuxAppImageAssetName, releaseAssetUrl, parseSha256Sums } from './linuxUpdateAssets';
 import { verifySha256 } from './verifySha256';
 import { downloadToFile, fetchText } from './downloadToFile';
+import { buildDetachedSpawn } from './service/systemTools';
 
 const execFileAsync = promisify(execFile);
 
@@ -488,13 +489,24 @@ export class UpdateService {
             // The launcher stages this helper copy (named *.exe even on Linux) to
             // dataRoot on every boot — outside the AppImage mount, so it survives exit.
             const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
-            const child = spawn(
-                helperPath,
-                ['--linux-apply', '--staged', stagedPath, '--target', appImagePath, '--wait-pid', String(process.pid)],
-                { detached: true, stdio: 'ignore' },
-            );
+            // Spawn the helper so it OUTLIVES this AppImage's teardown (#27). A plain
+            // detached spawn keeps the helper in the app's cgroup; when the app runs
+            // inside a `systemd-run --collect` transient unit (e.g. relaunched by the
+            // service-uninstall teardown), that unit's cgroup is reaped on the app's
+            // exit and the helper is killed BEFORE it swaps. buildDetachedSpawn wraps
+            // it in its own `systemd-run --user --collect` unit (separate cgroup),
+            // falling back to `setsid` then bare on non-systemd hosts.
+            const helperArgs = [
+                '--linux-apply', '--staged', stagedPath,
+                '--target', appImagePath, '--wait-pid', String(process.pid),
+            ];
+            const plan = buildDetachedSpawn(helperPath, helperArgs, { unit: `wsscrcpy-apply-${Date.now()}` });
+            const child = spawn(plan.cmd, plan.args, { detached: true, stdio: 'ignore' });
             child.unref();
-            log.info(`applyUpdate(linux): spawned helper pid ${child.pid} to swap ${appImagePath}`);
+            log.info(
+                `applyUpdate(linux): spawned apply helper via ${plan.cmd} ` +
+                    `(systemd=${plan.viaSystemd}, pid ${child.pid}) to swap ${appImagePath}`,
+            );
             return { redirectPort: null };
         }
 

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -774,11 +774,17 @@ describe('UpdateService', () => {
         expect(result.redirectPort).toBeNull();
         expect(applyFn).not.toHaveBeenCalled();
         expect(spawnMock).toHaveBeenCalledTimes(1);
+        // #27: the helper is spawned so it OUTLIVES the app's cgroup teardown.
+        // On a systemd host it's wrapped in `systemd-run --user --collect` (cmd =
+        // systemd-run, launcher in argv); on a non-systemd host it's spawned
+        // directly (cmd = launcher). Assert on the full command line so the test
+        // is robust across both — buildDetachedSpawn's exact wrapping (incl. the
+        // setsid/bare fallback) is covered by systemTools.test.ts.
         const [bin, argv] = spawnMock.mock.calls[0]!;
-        expect(String(bin)).toMatch(/control[\\/]operation-server[\\/]ws-scrcpy-web-launcher\.exe$/);
-        expect(argv).toEqual(
-            expect.arrayContaining(['--linux-apply', '--target', '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage']),
-        );
+        const cmdline = [String(bin), ...(argv as string[]).map(String)].join(' ');
+        expect(cmdline).toMatch(/control[\\/]operation-server[\\/]ws-scrcpy-web-launcher\.exe/);
+        expect(cmdline).toContain('--linux-apply');
+        expect(cmdline).toContain('--target /home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage');
     });
 
     it('applyUpdate (linux local): SHA mismatch aborts, no helper spawn', async () => {

--- a/src/server/service/systemTools.test.ts
+++ b/src/server/service/systemTools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSystemTool } from './systemTools';
+import { resolveSystemTool, buildDetachedSpawn } from './systemTools';
 
 describe('resolveSystemTool', () => {
     it('returns the first candidate that exists', () => {
@@ -20,5 +20,42 @@ describe('resolveSystemTool', () => {
     it('falls back to the bare name when no absolute path exists', () => {
         const exists = (_p: string) => false;
         expect(resolveSystemTool('systemctl', exists)).toBe('systemctl');
+    });
+});
+
+describe('buildDetachedSpawn', () => {
+    const prog = '/data/control/operation-server/ws-scrcpy-web-launcher.exe';
+    const pArgs = ['--linux-apply', '--staged', '/s.new', '--target', '/t.AppImage', '--wait-pid', '123'];
+
+    it('prefers systemd-run --user --collect in its own transient unit (escapes the app cgroup)', () => {
+        // systemd-run resolves to an absolute path; everything else is bare.
+        const resolve = (t: string) => (t === 'systemd-run' ? '/usr/bin/systemd-run' : t);
+        const plan = buildDetachedSpawn(prog, pArgs, { unit: 'wsscrcpy-apply-1' }, resolve);
+        expect(plan.cmd).toBe('/usr/bin/systemd-run');
+        expect(plan.args).toEqual(['--user', '--collect', '--unit=wsscrcpy-apply-1', prog, ...pArgs]);
+        expect(plan.viaSystemd).toBe(true);
+    });
+
+    it('falls back to setsid (new session) when systemd-run is absent', () => {
+        // only setsid resolves absolute; systemd-run stays bare (not found).
+        const resolve = (t: string) => (t === 'setsid' ? '/usr/bin/setsid' : t);
+        const plan = buildDetachedSpawn(prog, pArgs, { unit: 'wsscrcpy-apply-1' }, resolve);
+        expect(plan.cmd).toBe('/usr/bin/setsid');
+        expect(plan.args).toEqual([prog, ...pArgs]);
+        expect(plan.viaSystemd).toBe(false);
+    });
+
+    it('falls back to a bare exec when neither systemd-run nor setsid exist', () => {
+        const resolve = (t: string) => t; // nothing resolves to an absolute path
+        const plan = buildDetachedSpawn(prog, pArgs, { unit: 'wsscrcpy-apply-1' }, resolve);
+        expect(plan.cmd).toBe(prog);
+        expect(plan.args).toEqual(pArgs);
+        expect(plan.viaSystemd).toBe(false);
+    });
+
+    it('omits the --unit token when no unit is given', () => {
+        const resolve = (t: string) => (t === 'systemd-run' ? '/usr/bin/systemd-run' : t);
+        const plan = buildDetachedSpawn(prog, pArgs, {}, resolve);
+        expect(plan.args).toEqual(['--user', '--collect', prog, ...pArgs]);
     });
 });

--- a/src/server/service/systemTools.ts
+++ b/src/server/service/systemTools.ts
@@ -21,3 +21,47 @@ export function resolveSystemTool(
     }
     return tool;
 }
+
+/** A spawn plan: the command to exec + its args, plus whether it escapes via systemd. */
+export interface DetachedSpawnPlan {
+    cmd: string;
+    args: string[];
+    /** True when wrapped in `systemd-run` (own transient unit / cgroup). */
+    viaSystemd: boolean;
+}
+
+/**
+ * Build a spawn (cmd, args) for a helper/relaunch that MUST outlive the
+ * launching AppImage. The plain `detached: true` spawn we used before keeps the
+ * child in the *app's* cgroup, so when the app's scope/transient unit is reaped
+ * (e.g. an instance launched via `systemd-run --collect` — the service-uninstall
+ * relaunch) the child is killed mid-operation (bug #27). Preference order:
+ *   1. `systemd-run --user --collect [--unit=…]` — runs in its OWN transient unit
+ *      (separate cgroup), surviving the app's teardown. The robust path on systemd.
+ *   2. `setsid <prog>` — new session; the robust path on non-systemd hosts (no
+ *      transient-unit cgroup reaping exists there).
+ *   3. bare `<prog>` — last resort (caller still passes {detached:true}).
+ * `resolve` returns an absolute path when the tool exists, else the bare name —
+ * so `startsWith('/')` distinguishes "found" from "absent" (Local-Deps).
+ */
+export function buildDetachedSpawn(
+    program: string,
+    programArgs: string[],
+    opts: { unit?: string } = {},
+    resolve: (t: string) => string = (t) => resolveSystemTool(t),
+): DetachedSpawnPlan {
+    const systemdRun = resolve('systemd-run');
+    if (systemdRun.startsWith('/')) {
+        const unitArg = opts.unit ? [`--unit=${opts.unit}`] : [];
+        return {
+            cmd: systemdRun,
+            args: ['--user', '--collect', ...unitArg, program, ...programArgs],
+            viaSystemd: true,
+        };
+    }
+    const setsid = resolve('setsid');
+    if (setsid.startsWith('/')) {
+        return { cmd: setsid, args: [program, ...programArgs], viaSystemd: false };
+    }
+    return { cmd: program, args: programArgs, viaSystemd: false };
+}


### PR DESCRIPTION
## Fix #27 — Linux local-mode in-app update silently fails to swap

**Root cause (reproduced deterministically on Fedora):** the local-apply flow downloads + SHA-256-verifies the new AppImage, then spawns an out-of-mount helper (`--linux-apply`) to swap `$APPIMAGE` and relaunch. That helper was spawned with a plain `detached: true`, which gives it a new *session* but keeps it in the **app's cgroup**. When the app runs inside a `systemd-run --collect` transient unit — e.g. an instance **relaunched by the service-uninstall teardown** — that unit's cgroup is reaped on the app's exit and the helper is **killed before it swaps**. Result: update "hangs", app stays on the old version, `.new` stranded, no `.bak`. A reboot "fixed" it only by returning to a normally-launched instance (different cgroup).

**Reproduction (confirmed):**
- Test A — clean launch → update → **works**.
- Test B — install a user-scope service → uninstall (relaunches via `systemd-run --collect`) → update → **fails**. ← this fix targets exactly this.

Latent since beta.27 (the apply helper always shared the app's cgroup); newly *exposed* by beta.30's teardown-relaunch, which is the only thing that puts the app in a `--collect` unit. Not a beta.32 regression — beta.32's code never ran (the app stayed on the old version).

### The fix
- **`UpdateService.applyUpdate` (TS):** spawn the helper via `systemd-run --user --collect --unit=…` so it runs in its **own** transient unit (separate cgroup) and survives the app's teardown. Fallback ladder for non-systemd hosts: `setsid` → bare detached. Pure `buildDetachedSpawn` builder (`systemTools.ts`), unit-tested.
- **`linux_apply.rs` (Rust):** relaunch the swapped AppImage in its **own** `systemd-run --user --collect` unit when running under systemd (`INVOCATION_ID`), else a detached spawn — so the new instance survives the helper's exit (mirrors `linux_service.rs`). Pure `relaunch_command` builder, unit-tested.
- **Cleanup:** the helper clears the staged `.new` + the `apply-update-pending` marker on both success and failure (no orphaned cruft).

### Local-Dependencies-Only
`systemd-run`/`setsid` resolve to absolute paths (`resolveSystemTool` / `tool_dir`) — same OS-tool pattern as the service-mode helpers; no `$PATH`/env binary resolution introduced. The relaunch target is the app's own AppImage.

### Verification
- vitest **798 passed** (73 files; win32 + Linux-local guardrails unchanged) · `tsc` clean · webpack build OK.
- `cross` launcher tests **84 passed** (incl. 3 new `linux_apply` builders) · `clippy -D warnings` clean.
- **Runtime verdict is on Fedora** (the cgroup teardown can't be exercised on CI/Windows): validate **beta.33 → beta.34**, specifically the Test-B case (update right after a user-scope service uninstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
