### PR TITLE
fix(linux): relaunch waits for systemd-run unit registration (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux local-mode update now auto-relaunches after the swap (#27, follow-up to beta.33).** beta.33 made the apply helper survive and the binary swap succeed, but the *relaunch* still failed in the service-uninstall case: the helper spawned `systemd-run --user --collect <app>` with `.spawn()` and exited immediately — and because the helper itself runs in its own `--collect` transient unit, exiting reaped that unit's cgroup and killed the `systemd-run` child before it could register the relaunch unit, so the swapped new version never started (the update "succeeded" on disk but the app didn't come back). The relaunch now uses `.status()` (waits for `systemd-run` to register the user-manager-owned transient unit before the helper exits), mirroring the service-teardown relaunch; the non-systemd path still detached-spawns directly. The TS spawn side awaits `systemd-run`'s registration the same way. Net: a local update — including right after a user-scope service uninstall — now swaps **and** relaunches onto the new version unattended.
+
 ## [0.1.30-beta.34] - 2026-06-02
 
 ### Changed

--- a/launcher/src/linux_apply.rs
+++ b/launcher/src/linux_apply.rs
@@ -106,26 +106,44 @@ fn wait_for_pid_exit(pid: u32, timeout: Duration) {
     log::error(&format!("linux-apply: pid {pid} still alive after {timeout:?}; proceeding anyway"));
 }
 
-/// Spawn the new AppImage so it OUTLIVES this helper. When this helper itself
+/// Relaunch the new AppImage so it OUTLIVES this helper. When this helper itself
 /// runs inside a systemd transient unit (launched via `systemd-run --collect`,
-/// which sets INVOCATION_ID), a plain child would live in THIS helper's cgroup
-/// and be reaped when the helper exits and `--collect` deactivates the unit — so
-/// relaunch the app in its OWN `systemd-run --user --collect` transient unit
-/// (mirrors linux_service.rs). On a non-systemd host the helper is its own
-/// session leader, so a detached spawn survives. Argv built by `relaunch_command`.
+/// which sets INVOCATION_ID), the relaunched app must run in its OWN
+/// `systemd-run --user --collect` transient unit (user-manager-owned, separate
+/// cgroup) so it survives this helper's exit (mirrors linux_service.rs). On a
+/// non-systemd host the helper is its own session leader, so a detached spawn
+/// survives. Argv built by `relaunch_command`.
 fn relaunch(target: &Path) {
     let systemd_run = format!("{}/systemd-run", crate::linux_service::tool_dir("systemd-run"));
-    let argv = relaunch_command(target, under_systemd(), &systemd_run);
+    let use_systemd = under_systemd() && Path::new(&systemd_run).exists();
+    let argv = relaunch_command(target, use_systemd, &systemd_run);
     let (cmd, rest) = argv.split_first().expect("non-empty argv");
-    match std::process::Command::new(cmd)
+    let mut command = std::process::Command::new(cmd);
+    command
         .args(rest)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(child) => log::info(&format!("linux-apply: relaunched via `{}` (pid {})", argv.join(" "), child.id())),
-        Err(e) => log::error(&format!("linux-apply: relaunch failed (`{}`): {e}", argv.join(" "))),
+        .stderr(std::process::Stdio::null());
+    if use_systemd {
+        // MUST WAIT (.status), not .spawn: this helper runs in its OWN
+        // `systemd-run --collect` unit, so the instant we exit systemd reaps our
+        // cgroup. A .spawn'd `systemd-run` child would be killed mid-registration
+        // and the relaunch unit would never start — beta.33's bug (swap ok, but
+        // the app never came back). `systemd-run` returns promptly once the unit
+        // is registered+started; the unit is user-manager-owned (its own cgroup)
+        // so it outlives us. Same pattern as linux_service.rs's teardown relaunch.
+        match command.status() {
+            Ok(s) => log::info(&format!(
+                "linux-apply: relaunched via `{}` (systemd-run exit {:?})", argv.join(" "), s.code()
+            )),
+            Err(e) => log::error(&format!("linux-apply: relaunch failed (`{}`): {e}", argv.join(" "))),
+        }
+    } else {
+        // Non-systemd: we're a session leader; detached spawn, app reparents to init.
+        match command.spawn() {
+            Ok(child) => log::info(&format!("linux-apply: relaunched `{}` (pid {})", argv.join(" "), child.id())),
+            Err(e) => log::error(&format!("linux-apply: relaunch failed (`{}`): {e}", argv.join(" "))),
+        }
     }
 }
 

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -501,12 +501,27 @@ export class UpdateService {
                 '--target', appImagePath, '--wait-pid', String(process.pid),
             ];
             const plan = buildDetachedSpawn(helperPath, helperArgs, { unit: `wsscrcpy-apply-${Date.now()}` });
-            const child = spawn(plan.cmd, plan.args, { detached: true, stdio: 'ignore' });
-            child.unref();
-            log.info(
-                `applyUpdate(linux): spawned apply helper via ${plan.cmd} ` +
-                    `(systemd=${plan.viaSystemd}, pid ${child.pid}) to swap ${appImagePath}`,
-            );
+            if (plan.viaSystemd) {
+                // systemd-run registers the transient unit then exits promptly.
+                // AWAIT it so the unit is registered before THIS process exits —
+                // otherwise Node's exit can reap the systemd-run child (it's in
+                // Node's cgroup) before registration completes and the helper unit
+                // never starts. (The Rust relaunch waits the same way via .status.)
+                await new Promise<void>((resolve) => {
+                    const c = spawn(plan.cmd, plan.args, { stdio: 'ignore' });
+                    c.once('exit', () => resolve());
+                    c.once('error', () => resolve());
+                });
+                log.info(
+                    `applyUpdate(linux): registered apply helper via ${plan.cmd} (systemd) to swap ${appImagePath}`,
+                );
+            } else {
+                const child = spawn(plan.cmd, plan.args, { detached: true, stdio: 'ignore' });
+                child.unref();
+                log.info(
+                    `applyUpdate(linux): spawned apply helper via ${plan.cmd} (pid ${child.pid}) to swap ${appImagePath}`,
+                );
+            }
             return { redirectPort: null };
         }
 

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -18,7 +18,20 @@ vi.mock('child_process', async (importOriginal) => {
     const real = await importOriginal<typeof child_process>();
     return {
         ...real,
-        spawn: vi.fn(() => ({ pid: 12345, unref: vi.fn() })),
+        spawn: vi.fn(() => {
+            // Minimal ChildProcess stand-in: `unref` (detached non-systemd path)
+            // + `once` (the systemd-run path awaits 'exit' = unit registration;
+            // fire it on the next microtask so the await resolves in tests).
+            const child: { pid: number; unref: () => void; once: (e: string, cb: () => void) => unknown } = {
+                pid: 12345,
+                unref: vi.fn(),
+                once: vi.fn((event: string, cb: () => void) => {
+                    if (event === 'exit') queueMicrotask(cb);
+                    return child;
+                }),
+            };
+            return child;
+        }),
     };
 });
 


### PR DESCRIPTION
## Fix #27 (follow-up to beta.33) — local update now auto-relaunches after the swap

beta.33 made the apply helper **survive** and the binary **swap** succeed, but on Fedora the **relaunch** still failed in the service-uninstall case (verified beta.33→beta.34): the helper spawned `systemd-run --user --collect <app>` with `.spawn()` and exited immediately. Because the helper itself runs in its own `--collect` transient unit, exiting reaped that unit's cgroup and **killed the `systemd-run` child before it registered the relaunch unit** — so the swapped new version never started (update succeeded on disk; app didn't come back). The teardown relaunch never hit this because it uses `.status()`.

### Fix
- **`linux_apply.rs` relaunch:** use `.status()` on the systemd path (wait for `systemd-run` to register the user-manager-owned transient unit — its own cgroup, outlives the helper) before exiting; keep detached `.spawn()` on the non-systemd path.
- **`UpdateService.applyUpdate` (TS):** await `systemd-run`'s registration on the systemd path instead of detached+unref (same race; previously won only by the deferred-exit timing).

### Verification
- vitest **798**, `tsc` clean, webpack build OK; `cross` launcher tests + `clippy -D warnings` clean.
- Runtime verdict is Fedora: **beta.35 → beta.36**, through the full failing path (install user-scope service → uninstall → update → confirm swap **and** unattended relaunch onto beta.36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
