### PR TITLE
chore: v0.1.30-beta.36 no-op companion (validate #27 relaunch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **v0.1.30-beta.36 is a no-op companion to beta.35** — identical code, published as the update *target* to validate the #27 relaunch fix end-to-end. From a beta.35 instance, run the full failing path — install a user-scope service → uninstall it (relaunch via `systemd-run --collect`) → update — and confirm it swaps **and auto-relaunches** onto beta.36 unattended.
+
 ## [0.1.30-beta.35] - 2026-06-02
 
 ### Fixed


### PR DESCRIPTION
No-op companion to beta.35 (identical code) — the update **target** to validate the #27 relaunch fix end-to-end: update **beta.35 → beta.36** through the user-scope-uninstall path and confirm swap **and** unattended auto-relaunch. No version bump; auto-release Mode 1 cuts the bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)