### PR TITLE
fix(release): commit Cargo.lock in the auto-release bump + resync

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -136,9 +136,10 @@ jobs:
           }
           PKG_BLOB=$(create_blob package.json)
           CARGO_BLOB=$(create_blob Cargo.toml)
+          LOCK_BLOB=$(create_blob Cargo.lock)
           CL_BLOB=$(create_blob CHANGELOG.md)
 
-          # Create a new tree with the three updated files
+          # Create a new tree with the four updated files
           NEW_TREE=$(gh api "repos/$GITHUB_REPOSITORY/git/trees" \
             --input - --jq '.sha' <<TREEOF
           {
@@ -146,6 +147,7 @@ jobs:
             "tree": [
               {"path": "package.json", "mode": "100644", "type": "blob", "sha": "$PKG_BLOB"},
               {"path": "Cargo.toml", "mode": "100644", "type": "blob", "sha": "$CARGO_BLOB"},
+              {"path": "Cargo.lock", "mode": "100644", "type": "blob", "sha": "$LOCK_BLOB"},
               {"path": "CHANGELOG.md", "mode": "100644", "type": "blob", "sha": "$CL_BLOB"}
             ]
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The auto-release version-bump now commits `Cargo.lock`.** beta.37 taught `npm run version:bump` to sync the workspace crate versions in `Cargo.lock`, but the auto-release bump-PR commit was assembled from a fixed three-file list (`package.json`/`Cargo.toml`/`CHANGELOG.md`) that dropped the lock change — so the lockfile still lagged through CI-cut releases. `Cargo.lock` is now part of the bump commit, and the beta.37 lag has been resynced.
+
 ## [0.1.30-beta.37] - 2026-06-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.30-beta.36"
+version = "0.1.30-beta.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.30-beta.36"
+version = "0.1.30-beta.37"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.30-beta.36"
+version = "0.1.30-beta.37"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",


### PR DESCRIPTION
Completes item 40 (the beta.37 lock-sync). beta.37 taught `npm run version:bump` to sync the workspace crate versions in `Cargo.lock`, but **auto-release.yml assembled the bump-PR commit from a hardcoded three-file list** (`package.json`/`Cargo.toml`/`CHANGELOG.md`) — so the script lock edit was computed in CI and dropped. Result: beta.37 `Cargo.lock` shipped with the workspace crates still at beta.36.

## Changes
- `.github/workflows/auto-release.yml`: add a `Cargo.lock` blob + tree entry to the bump commit (now four files), so future bumps carry the lock sync. Mirrors the existing pattern; the web-flow-signed commit is unchanged.
- `Cargo.lock`: one-time resync of the workspace crates beta.36 → beta.37 (matches the current `Cargo.toml`).
- `CHANGELOG.md`: `[Unreleased]` note.

No `release:beta` label — auto-release Mode 3 skips this (no new beta cut). The workflow fix takes effect on the next bump.