### PR TITLE
feat(linux): in-app update apply in service mode (user + system scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **In-app updates now apply in Linux service mode (user and system scope).** Previously only local-mode Linux updates applied; service mode silently no-op'd (it routed to Velopack's AppImage-incompatible apply). The same download → SHA-256-verify → swap machinery is now used for service mode: a launcher helper, launched out-of-cgroup via `systemd-run`, stops the unit → swaps the AppImage → (system scope) re-applies the `bin_t` SELinux label → starts the unit. **user-service** updates the home AppImage via the user manager; **system-service** updates the `/opt` staged copy as root via the system manager — no polkit prompt, so a system service can self-update headlessly. Windows and Linux-local apply paths are unchanged.
+
 ### Fixed
 
 - **The auto-release version-bump now commits `Cargo.lock`.** beta.37 taught `npm run version:bump` to sync the workspace crate versions in `Cargo.lock`, but the auto-release bump-PR commit was assembled from a fixed three-file list (`package.json`/`Cargo.toml`/`CHANGELOG.md`) that dropped the lock change — so the lockfile still lagged through CI-cut releases. `Cargo.lock` is now part of the bump commit, and the beta.37 lag has been resynced.

--- a/launcher/src/linux_apply.rs
+++ b/launcher/src/linux_apply.rs
@@ -8,6 +8,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use crate::linux_service::{self, Scope};
 use crate::log;
 
 /// Dispatch: if argv contains `--linux-apply`, handle it and return Some(exit_code).
@@ -37,8 +38,19 @@ fn run(args: &[String]) -> i32 {
             return 2;
         }
     };
+
+    // Service-mode apply (Phase 2): if --service-restart is present, the helper
+    // stops the unit (synchronous, reaps the in-cgroup app), settles for the
+    // FUSE unmount, swaps, relabels (system scope), and starts the unit — no
+    // --wait-pid, no bare relaunch. Reached for user-service (user manager,
+    // home $APPIMAGE) and system-service (system manager, root, /opt + bin_t).
+    if let Some((scope, unit, relabel)) = parse_service_restart(args) {
+        return run_service_restart(&staged, &target, scope, &unit, relabel);
+    }
+
+    // Local-mode apply (unchanged #27 path): wait for the app pid, swap, relaunch.
     let wait_pid = arg_value(args, "--wait-pid").and_then(|s| s.parse::<u32>().ok());
-    log::info(&format!("linux-apply: staged={staged:?} target={target:?} wait_pid={wait_pid:?}"));
+    log::info(&format!("linux-apply(local): staged={staged:?} target={target:?} wait_pid={wait_pid:?}"));
 
     if let Some(pid) = wait_pid {
         wait_for_pid_exit(pid, Duration::from_secs(60));
@@ -61,6 +73,68 @@ fn run(args: &[String]) -> i32 {
     // consumer — Windows-only — so clearing it just keeps dataRoot tidy).
     cleanup_apply_artifacts(&staged);
     code
+}
+
+/// Service-mode apply: stop the unit (synchronous, reaps the in-cgroup app +
+/// unmounts the AppImage), settle until the file is swappable, swap, relabel
+/// (system scope), start the unit. No bare relaunch — the unit start brings the
+/// app back. Runs from inside a `systemd-run` transient unit (own cgroup), so it
+/// survives stopping the service unit. Exec orchestration over the pure builders
+/// (those are unit-tested; this path is Fedora-verified per the Phase 2 spec).
+fn run_service_restart(staged: &Path, target: &Path, scope: Scope, unit: &str, relabel: bool) -> i32 {
+    let bindir = linux_service::tool_dir("systemctl");
+    log::info(&format!(
+        "linux-apply(service): scope={scope:?} unit={unit} target={target:?} relabel={relabel}"
+    ));
+
+    // 1. Stop the unit (synchronous): reaps the in-cgroup launcher+Node+children
+    //    and unmounts the running AppImage so its file becomes swappable.
+    run_cmd(&service_unit_command(scope, "stop", unit, &bindir));
+
+    // 2. Settle: retry the swap until it succeeds (the FUSE unmount can lag the
+    //    stop). swap_appimage is self-healing on failure (restores the .bak), so
+    //    retrying is safe. Give up after 15s rather than start a stale version.
+    let start = Instant::now();
+    loop {
+        match swap_appimage(staged, target) {
+            Ok(()) => break,
+            Err(e) => {
+                if start.elapsed() >= Duration::from_secs(15) {
+                    log::error(&format!("linux-apply(service): swap failed after settle: {e}"));
+                    cleanup_apply_artifacts(staged);
+                    // Do NOT start into a broken binary; swap_appimage left the old one in place.
+                    return 1;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+        }
+    }
+
+    // 3. System scope only: re-apply the bin_t label so init_t may exec the
+    //    swapped /opt copy. restorecon (persistent rule) preferred, else chcon.
+    if relabel {
+        let restorecon = format!("{}/restorecon", linux_service::sbindir_from(&bindir));
+        let present = Path::new(&restorecon).exists();
+        run_cmd(&relabel_command(target, &bindir, present));
+    }
+
+    // 4. Start the unit on the new version (rebinds the same web port).
+    run_cmd(&service_unit_command(scope, "start", unit, &bindir));
+    cleanup_apply_artifacts(staged);
+    0
+}
+
+/// Run one argv vector, logging the outcome (best-effort). Shared by the service path.
+fn run_cmd(argv: &[String]) {
+    let (cmd, rest) = match argv.split_first() {
+        Some(v) => v,
+        None => return,
+    };
+    match std::process::Command::new(cmd).args(rest).status() {
+        Ok(s) if s.success() => log::info(&format!("linux-apply(service) ok: {}", argv.join(" "))),
+        Ok(s) => log::error(&format!("linux-apply(service) non-zero ({:?}): {}", s.code(), argv.join(" "))),
+        Err(e) => log::error(&format!("linux-apply(service) spawn failed: {} ({e})", argv.join(" "))),
+    }
 }
 
 /// `<target>.bak`
@@ -165,6 +239,41 @@ pub fn relaunch_command(target: &Path, under_systemd: bool, systemd_run: &str) -
     }
 }
 
+/// `systemctl [--user] <action> <unit>.service` — `--user` for user scope, the
+/// system manager for system scope. Absolute systemctl path (Local-Deps). Pure.
+pub fn service_unit_command(scope: Scope, action: &str, unit: &str, bindir: &str) -> Vec<String> {
+    let systemctl = format!("{bindir}/systemctl");
+    let pre = linux_service::scope_prefix(scope);
+    [vec![systemctl], pre, vec![action.to_string(), format!("{unit}.service")]].concat()
+}
+
+/// Re-apply the `bin_t` SELinux label to the system-staged target after a swap,
+/// so `init_t` may exec it. `restorecon` (sbin) re-applies the persistent
+/// fcontext rule set at install; when absent, fall back to `chcon -t bin_t`
+/// (bin). `restorecon_present` is the availability the caller probed. Pure.
+pub fn relabel_command(target: &Path, bindir: &str, restorecon_present: bool) -> Vec<String> {
+    let t = target.to_string_lossy().into_owned();
+    if restorecon_present {
+        let sbindir = linux_service::sbindir_from(bindir);
+        vec![format!("{sbindir}/restorecon"), "-v".into(), t]
+    } else {
+        vec![format!("{bindir}/chcon"), "-t".into(), "bin_t".into(), t]
+    }
+}
+
+/// Parse `--service-restart <user|system> --unit <name> [--relabel]`. Returns
+/// None when `--service-restart` is absent (the local-mode apply path). Pure.
+pub fn parse_service_restart(args: &[String]) -> Option<(Scope, String, bool)> {
+    let scope = arg_value(args, "--service-restart").and_then(|s| match s {
+        "user" => Some(Scope::User),
+        "system" => Some(Scope::System),
+        _ => None,
+    })?;
+    let unit = arg_value(args, "--unit")?.to_string();
+    let relabel = args.iter().any(|a| a == "--relabel");
+    Some((scope, unit, relabel))
+}
+
 /// `<data_root>/control/apply-update-pending` — the apply marker path. Pure.
 pub fn apply_marker_path(data_root: &Path) -> PathBuf {
     data_root.join("control").join("apply-update-pending")
@@ -241,5 +350,61 @@ mod tests {
             apply_marker_path(Path::new("/d")),
             PathBuf::from("/d/control/apply-update-pending")
         );
+    }
+
+    #[test]
+    fn service_unit_command_user_scope() {
+        assert_eq!(
+            service_unit_command(linux_service::Scope::User, "stop", "WsScrcpyWeb", "/usr/bin"),
+            vec!["/usr/bin/systemctl", "--user", "stop", "WsScrcpyWeb.service"]
+        );
+        assert_eq!(
+            service_unit_command(linux_service::Scope::User, "start", "WsScrcpyWeb", "/usr/bin"),
+            vec!["/usr/bin/systemctl", "--user", "start", "WsScrcpyWeb.service"]
+        );
+    }
+
+    #[test]
+    fn service_unit_command_system_scope_has_no_user_flag() {
+        assert_eq!(
+            service_unit_command(linux_service::Scope::System, "stop", "WsScrcpyWeb", "/usr/bin"),
+            vec!["/usr/bin/systemctl", "stop", "WsScrcpyWeb.service"]
+        );
+    }
+
+    #[test]
+    fn relabel_command_prefers_restorecon_then_chcon() {
+        // restorecon present -> use it (re-applies the persistent fcontext rule).
+        assert_eq!(
+            relabel_command(Path::new("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"), "/usr/bin", true),
+            vec!["/usr/sbin/restorecon", "-v", "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"]
+        );
+        // restorecon absent -> chcon -t bin_t fallback (bin dir).
+        assert_eq!(
+            relabel_command(Path::new("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"), "/usr/bin", false),
+            vec!["/usr/bin/chcon", "-t", "bin_t", "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"]
+        );
+    }
+
+    #[test]
+    fn parse_service_restart_reads_scope_unit_relabel() {
+        let args: Vec<String> = ["--linux-apply", "--service-restart", "system", "--unit", "WsScrcpyWeb", "--relabel"]
+            .iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            parse_service_restart(&args),
+            Some((linux_service::Scope::System, "WsScrcpyWeb".to_string(), true))
+        );
+
+        let user: Vec<String> = ["--linux-apply", "--service-restart", "user", "--unit", "WsScrcpyWeb"]
+            .iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            parse_service_restart(&user),
+            Some((linux_service::Scope::User, "WsScrcpyWeb".to_string(), false))
+        );
+
+        // absent -> None (the local-mode path)
+        let local: Vec<String> = ["--linux-apply", "--staged", "/a", "--target", "/b"]
+            .iter().map(|s| s.to_string()).collect();
+        assert_eq!(parse_service_restart(&local), None);
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -15,7 +15,7 @@ pub enum Scope {
 }
 
 /// `--user` prefix tokens for user scope, empty for system scope.
-fn scope_prefix(scope: Scope) -> Vec<String> {
+pub(crate) fn scope_prefix(scope: Scope) -> Vec<String> {
     match scope {
         Scope::User => vec!["--user".to_string()],
         Scope::System => vec![],
@@ -36,7 +36,7 @@ pub fn unit_path(scope: Scope, name: &str) -> PathBuf {
 
 /// Derive the sbin dir from the bin dir (`/usr/bin` -> `/usr/sbin`, `/bin` -> `/sbin`).
 /// semanage/restorecon live in sbin; everything else in bin.
-fn sbindir_from(bindir: &str) -> String {
+pub(crate) fn sbindir_from(bindir: &str) -> String {
     bindir
         .strip_suffix("/bin")
         .map(|p| format!("{p}/sbin"))

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -15,6 +15,7 @@ import {
 import { getAppVersion } from './appVersion';
 import type { UpdateChannel } from '../common/ConfigEvents';
 import type { UpdateState } from '../common/UpdateEvents';
+import { WS_SCRCPY_SERVICE_NAME } from '../common/ServiceEvents';
 import { AdbClient } from './AdbClient';
 import { Config } from './Config';
 import { Logger } from './Logger';
@@ -444,7 +445,10 @@ export class UpdateService {
 
         await this.writeApplyUpdatePendingMarker();
 
-        if (isServiceMode) {
+        // Windows service mode keeps Velopack's apply (the operation-server
+        // handoff below). Linux service mode falls through to the download-based
+        // apply (item 39) — branched by installMode in the Linux block.
+        if (isServiceMode && this.platform === 'win32') {
             this.mgr.waitExitThenApplyUpdate(this.state.pendingUpdate, true, false);
             return { redirectPort: null };
         }
@@ -485,22 +489,39 @@ export class UpdateService {
                 throw new Error(`apply: SHA-256 mismatch for ${assetName} — aborting`);
             }
 
-            const appImagePath = process.env['APPIMAGE'] ?? '';
+            const homeAppImage = process.env['APPIMAGE'] ?? '';
             // The launcher stages this helper copy (named *.exe even on Linux) to
             // dataRoot on every boot — outside the AppImage mount, so it survives exit.
             const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
-            // Spawn the helper so it OUTLIVES this AppImage's teardown (#27). A plain
-            // detached spawn keeps the helper in the app's cgroup; when the app runs
-            // inside a `systemd-run --collect` transient unit (e.g. relaunched by the
-            // service-uninstall teardown), that unit's cgroup is reaped on the app's
-            // exit and the helper is killed BEFORE it swaps. buildDetachedSpawn wraps
-            // it in its own `systemd-run --user --collect` unit (separate cgroup),
-            // falling back to `setsid` then bare on non-systemd hosts.
-            const helperArgs = [
-                '--linux-apply', '--staged', stagedPath,
-                '--target', appImagePath, '--wait-pid', String(process.pid),
-            ];
-            const plan = buildDetachedSpawn(helperPath, helperArgs, { unit: `wsscrcpy-apply-${Date.now()}` });
+            // installMode selects the apply shape (item 39). The helper always
+            // OUTLIVES this AppImage's teardown — buildDetachedSpawn wraps it in
+            // its own `systemd-run --collect` transient unit (separate cgroup; #27),
+            // falling back to `setsid` then bare on non-systemd hosts:
+            //  - local ('user'): swap $APPIMAGE, wait for our pid, bare relaunch.
+            //  - user-service:  the helper stops/swaps/starts the --user unit;
+            //    target = home $APPIMAGE (user manager).
+            //  - system-service: the helper (root) stops/swaps/relabels/starts the
+            //    system unit; target = the /opt staged copy; system-manager
+            //    systemd-run (no --user). No pkexec — root self-update, headless.
+            const STAGED_SYSTEM_TARGET = '/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage';
+            let target: string;
+            let helperArgs: string[];
+            let spawnSystem = false;
+            if (installMode === 'system-service') {
+                target = STAGED_SYSTEM_TARGET;
+                helperArgs = ['--linux-apply', '--staged', stagedPath, '--target', target,
+                    '--service-restart', 'system', '--unit', WS_SCRCPY_SERVICE_NAME, '--relabel'];
+                spawnSystem = true;
+            } else if (installMode === 'user-service') {
+                target = homeAppImage;
+                helperArgs = ['--linux-apply', '--staged', stagedPath, '--target', target,
+                    '--service-restart', 'user', '--unit', WS_SCRCPY_SERVICE_NAME];
+            } else {
+                target = homeAppImage;
+                helperArgs = ['--linux-apply', '--staged', stagedPath, '--target', target,
+                    '--wait-pid', String(process.pid)];
+            }
+            const plan = buildDetachedSpawn(helperPath, helperArgs, { unit: `wsscrcpy-apply-${Date.now()}`, system: spawnSystem });
             if (plan.viaSystemd) {
                 // systemd-run registers the transient unit then exits promptly.
                 // AWAIT it so the unit is registered before THIS process exits —
@@ -513,13 +534,13 @@ export class UpdateService {
                     c.once('error', () => resolve());
                 });
                 log.info(
-                    `applyUpdate(linux): registered apply helper via ${plan.cmd} (systemd) to swap ${appImagePath}`,
+                    `applyUpdate(linux): registered apply helper via ${plan.cmd} (systemd) to swap ${target}`,
                 );
             } else {
                 const child = spawn(plan.cmd, plan.args, { detached: true, stdio: 'ignore' });
                 child.unref();
                 log.info(
-                    `applyUpdate(linux): spawned apply helper via ${plan.cmd} (pid ${child.pid}) to swap ${appImagePath}`,
+                    `applyUpdate(linux): spawned apply helper via ${plan.cmd} (pid ${child.pid}) to swap ${target}`,
                 );
             }
             return { redirectPort: null };

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -644,6 +644,10 @@ describe('UpdateService', () => {
             waitExitThenApplyUpdate: applyFn,
         });
         const svc = new UpdateService({
+            // Windows service mode keeps Velopack's waitExitThenApplyUpdate. Linux
+            // service mode now uses the download-based apply (item 39), so this
+            // assertion is win32-specific — without the pin it breaks on Linux CI.
+            platform: 'win32',
             installRoot: '/fake',
             existsSync: () => true,
             updateManagerFactory: () => mgr,
@@ -822,6 +826,63 @@ describe('UpdateService', () => {
         await svc.checkForUpdates();
         await expect(svc.applyUpdate()).rejects.toThrow(/mismatch/i);
         expect(spawnMock).not.toHaveBeenCalled();
+    });
+
+    // Linux SERVICE-mode apply (Phase 2 / item 39): the early-return to
+    // Velopack is now win32-only, so Linux service mode falls through to the
+    // download->verify->spawn-helper path with a --service-restart directive
+    // (the helper stops/swaps/starts the unit). user-service targets the home
+    // $APPIMAGE (user manager); system-service targets the /opt staged copy and
+    // passes --relabel (root, system manager). On the (non-systemd) test host
+    // buildDetachedSpawn falls back to a bare exec, so we assert the helper argv.
+    it.each([
+        ['user-service' as const, 'user' as const],
+        ['system-service' as const, 'system' as const],
+    ])('applyUpdate (linux %s): spawns helper with --service-restart; no waitExitThenApplyUpdate', async (installMode, scope) => {
+        const { createHash } = await import('crypto');
+        Config.getInstance().updateAppConfig({ autoUpdate: false, installMode, channel: 'beta', githubOwner: 'bilbospocketses' });
+        const appImageBytes = Buffer.from('NEW-APPIMAGE-CONTENT');
+        const goodHash = createHash('sha256').update(appImageBytes).digest('hex');
+        const sums = `${goodHash}  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n`;
+        const fetchFn = vi.fn(async (url: string) =>
+            url.endsWith('.AppImage') ? new Response(appImageBytes) : new Response(sums),
+        ) as unknown as typeof fetch;
+        const applyFn = vi.fn();
+        const mgr = fakeMgr({ checkForUpdatesAsync: async () => fakeUpdateInfo('0.1.30-beta.40'), waitExitThenApplyUpdate: applyFn });
+        const spawnMock = vi.mocked(child_process.spawn);
+        spawnMock.mockClear();
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: () => mgr,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+            fetchFn,
+        });
+        process.env['APPIMAGE'] = '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage';
+        svc.init();
+        await svc.checkForUpdates();
+        expect(svc.getStatus().status).toBe('ready');
+
+        const result = await svc.applyUpdate();
+        expect(result.redirectPort).toBeNull();
+        // Linux service mode no longer routes to Velopack's (broken) apply.
+        expect(applyFn).not.toHaveBeenCalled();
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+        const [bin, argv] = spawnMock.mock.calls[0]!;
+        const cmdline = [String(bin), ...(argv as string[]).map(String)].join(' ');
+        expect(cmdline).toMatch(/control[\\/]operation-server[\\/]ws-scrcpy-web-launcher\.exe/);
+        expect(cmdline).toContain('--linux-apply');
+        expect(cmdline).toContain(`--service-restart ${scope}`);
+        expect(cmdline).toContain('--unit WsScrcpyWeb');
+        if (scope === 'system') {
+            expect(cmdline).toContain('--target /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');
+            expect(cmdline).toContain('--relabel');
+        } else {
+            expect(cmdline).toContain('--target /home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage');
+            expect(cmdline).not.toContain('--relabel');
+        }
     });
 
     // ── reconfigure ─────────────────────────────────────────────────────

--- a/src/server/service/systemTools.test.ts
+++ b/src/server/service/systemTools.test.ts
@@ -58,4 +58,12 @@ describe('buildDetachedSpawn', () => {
         const plan = buildDetachedSpawn(prog, pArgs, {}, resolve);
         expect(plan.args).toEqual(['--user', '--collect', prog, ...pArgs]);
     });
+
+    it('omits --user for the system manager when system:true (root system-scope apply)', () => {
+        const resolve = (t: string) => (t === 'systemd-run' ? '/usr/bin/systemd-run' : t);
+        const plan = buildDetachedSpawn(prog, pArgs, { unit: 'wsscrcpy-apply-1', system: true }, resolve);
+        expect(plan.cmd).toBe('/usr/bin/systemd-run');
+        expect(plan.args).toEqual(['--collect', '--unit=wsscrcpy-apply-1', prog, ...pArgs]);
+        expect(plan.viaSystemd).toBe(true);
+    });
 });

--- a/src/server/service/systemTools.ts
+++ b/src/server/service/systemTools.ts
@@ -47,15 +47,18 @@ export interface DetachedSpawnPlan {
 export function buildDetachedSpawn(
     program: string,
     programArgs: string[],
-    opts: { unit?: string } = {},
+    opts: { unit?: string; system?: boolean } = {},
     resolve: (t: string) => string = (t) => resolveSystemTool(t),
 ): DetachedSpawnPlan {
     const systemdRun = resolve('systemd-run');
     if (systemdRun.startsWith('/')) {
+        // System scope runs as root -> the system manager (no --user). User
+        // scope keeps --user (a user-manager-owned transient unit).
+        const scopeArg = opts.system ? [] : ['--user'];
         const unitArg = opts.unit ? [`--unit=${opts.unit}`] : [];
         return {
             cmd: systemdRun,
-            args: ['--user', '--collect', ...unitArg, program, ...programArgs],
+            args: [...scopeArg, '--collect', ...unitArg, program, ...programArgs],
             viaSystemd: true,
         };
     }


### PR DESCRIPTION
Item 39 / Phase 2 of the Linux service-mode design, implemented per the TDD plan (`docs/plans/2026-06-02-linux-service-mode-phase2-update-apply.md`). Makes in-app updates apply + restart the systemd service in BOTH `user-service` and `system-service` modes, reusing the shipped beta.27 download→verify→swap machinery instead of Velopack's (AppImage-incompatible) apply.

No manual version bump — the `release:beta` label drives auto-release Mode 1 to cut the next beta.

## What changed
- **`UpdateService.applyUpdate`**: the service-mode early-return to Velopack is now **win32-only**; Linux service mode falls through to the download path, branched by `installMode`.
- **`linux_apply.rs`**: new `--service-restart <user|system> --unit <name> [--relabel]` — the helper (out-of-cgroup via `systemd-run`) does stop → settle (FUSE unmount) → swap → (relabel `bin_t`) → start, instead of a bare relaunch.
- **`systemTools.buildDetachedSpawn`**: `system` option → system-manager `systemd-run` (no `--user`) for the root system-scope apply.
- **`linux_service.rs`**: `scope_prefix`/`sbindir_from` promoted to `pub(crate)` for reuse.

### Scope behavior
- **user-service**: stop/swap/start the `--user` unit; target = home `$APPIMAGE`; user manager, no privilege.
- **system-service**: stop/swap/relabel/start the system unit as **root**; target = the `/opt` staged copy; system manager; **no polkit prompt → headless self-update**.

Windows + Linux-local apply paths are byte-for-byte unchanged.

## Verification
- TDD throughout (RED→GREEN). Full vitest **813 passed**; launcher + workspace `cross test` green on `x86_64-unknown-linux-gnu`; `cross clippy --workspace -D warnings` clean; webpack build green.
- Pure command builders unit-tested; the win32 service-mode freeze guard is pinned + green.

## Fedora smoke (post-publish — the runtime oracle)
Run the Phase-2 section of `docs/smoke-tests/v0.1.30-beta.37-linux-service-mode.md`:
- [ ] **user-scope update**: unit stops, home AppImage swaps, restarts on the same web port, browser reconnects.
- [ ] **system-scope update (open risk)**: headless (no prompt), `/opt` swaps, `restorecon` re-applies `bin_t`, restarts, **no AVC**. If enforcing SELinux blocks it → narrow targeted policy (never broad `audit2allow`).
- [ ] out-of-cgroup helper survives `systemctl stop` of the unit it restarts.