### PR TITLE
chore(deps): sync velopack to 1.1.1 (Rust crate + vpk CLI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,10 @@ jobs:
         with:
           dotnet-version: 10.x
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      # vpk 1.0.1 (stable GA) has --msi / --instLocation and produces
+      # vpk 1.1.1 (stable) has --msi / --instLocation and produces
       # true Windows Installer MSIs. Match the npm `velopack` package
       # version to keep client/server serialization in sync.
-      - run: dotnet tool install -g vpk --version 1.0.1
+      - run: dotnet tool install -g vpk --version 1.1.1
       - run: npm ci --omit=dev
       - run: npm run build
       - run: cargo build --release --workspace
@@ -178,10 +178,10 @@ jobs:
           targets: x86_64-unknown-linux-musl
       - name: Install musl-tools (linker for musl target)
         run: sudo apt-get update && sudo apt-get install -y musl-tools
-      # vpk 1.0.1 (stable GA) has --msi / --instLocation and produces
+      # vpk 1.1.1 (stable) has --msi / --instLocation and produces
       # true Windows Installer MSIs. Match the npm `velopack` package
       # version to keep client/server serialization in sync.
-      - run: dotnet tool install -g vpk --version 1.0.1
+      - run: dotnet tool install -g vpk --version 1.1.1
       - run: npm ci --omit=dev
       - run: npm run build
       - name: Build launcher (musl-static — no glibc dependency)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **In-app updates now apply in Linux service mode (user and system scope).** Previously only local-mode Linux updates applied; service mode silently no-op'd (it routed to Velopack's AppImage-incompatible apply). The same download → SHA-256-verify → swap machinery is now used for service mode: a launcher helper, launched out-of-cgroup via `systemd-run`, stops the unit → swaps the AppImage → (system scope) re-applies the `bin_t` SELinux label → starts the unit. **user-service** updates the home AppImage via the user manager; **system-service** updates the `/opt` staged copy as root via the system manager — no polkit prompt, so a system service can self-update headlessly. Windows and Linux-local apply paths are unchanged.
 
+### Changed
+
+- **Velopack synced to 1.1.1 across all touchpoints.** Dependabot (#279) bumped only the npm SDK to 1.1.1, leaving the Rust crate (`Cargo.lock`) and the `vpk` CLI pin (`release.yml`) at 1.0.1 — a 3-way skew (the SDK and CLI share a serialization protocol). The Rust crate and `vpk` CLI are now 1.1.1 too. 1.1.1 ships the type-2 AppImage runtime (embedded FUSE), which paves the way to drop the `libfuse2` first-run gate in a follow-up, once verified on a no-libfuse2 distro.
+
 ### Fixed
 
 - **The auto-release version-bump now commits `Cargo.lock`.** beta.37 taught `npm run version:bump` to sync the workspace crate versions in `Cargo.lock`, but the auto-release bump-PR commit was assembled from a fixed three-file list (`package.json`/`Cargo.toml`/`CHANGELOG.md`) that dropped the lock change — so the lockfile still lagged through CI-cut releases. `Cargo.lock` is now part of the bump commit, and the beta.37 lag has been resynced.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "velopack"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a63e87596838808d60b09631c5c640a11ea68edc56a238e634cb739fa3c0f5"
+checksum = "2ccc718589add249fc811d1a824b4f9110d95893aca6ded683becbf38ccb3b83"
 dependencies = [
  "anyhow",
  "bitflags",


### PR DESCRIPTION
Completes item 31's velopack bump as an isolated PR — the npm SDK was bumped to 1.1.1 by Dependabot #279; this syncs the lagging Rust crate + `vpk` CLI. `release:beta` so it cuts a beta to verify the 1.1.1 runtime.

## Changes
- `Cargo.lock`: velopack `1.0.1` → `1.1.1` (`cargo update -p velopack --precise 1.1.1`; `Cargo.toml` `"1.0"` range already permits it; 26 transitive deps unchanged).
- `.github/workflows/release.yml` (×2): `vpk --version 1.0.1` → `1.1.1` + comment.

npm SDK is already 1.1.1 (#279). All three velopack touchpoints now match.

## Verification
- `cargo check --workspace` (Windows) + `cross test --workspace` (Linux) green with velopack 1.1.1.
- npm side already green (813 vitest, on the #279 base).

## Post-publish (item 31 — Fedora/Windows runtime oracle)
- [ ] Windows MSI still packs (`vpk pack --msi --instLocation PerMachine`) on the 1.1.1 CLI.
- [ ] Linux 1.1.1 AppImage launches + in-app updates on the **type-2 runtime**.
- [ ] Then (separate step): confirm launch on a **no-libfuse2** distro → remove the libfuse2 gate.