### PR TITLE
feat: stop-server-exit button + item-40 residuals (DATA_ROOT, uninstall message)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **"Stop server & exit" button (Settings → App).** A new button cleanly stops the server and closes the app on every platform. It confirms first, then runs graceful teardown — stopping the adb daemon and releasing active device streams — before exiting, and closes the browser tab (falling back to an "app stopped — you can close this tab" page when the browser blocks self-close). On Windows it also reaps the standalone tray helper, which is spawned detached and would otherwise be left orphaned pointing at a dead launcher (the reap is skipped during an in-app update / uninstall handoff, which relaunch and keep their tray). The button is disabled with an explanatory note in service mode, where the OS service manager owns the lifecycle. It reuses the existing `/api/server/shutdown` endpoint, which now runs the same graceful teardown the `SIGINT`/`SIGTERM` path does — fixing a latent case where a tray- or endpoint-initiated shutdown exited directly and left the adb daemon orphaned.
+
+### Fixed
+
+- **The Linux Rust data-root resolver now honors `DATA_ROOT`.** `data_root_for_linux` followed only `XDG_DATA_HOME > HOME`, while the Node side (`resolveDataRoot`) honors `DATA_ROOT > XDG_DATA_HOME > ~/.local/share`. An explicit `DATA_ROOT` override is now respected on the Rust side too, across **both** of its callers — the launcher spawn path (`Paths::compute`) and the service-teardown / tray-reap path (`data_root_from_env`) — so they cannot diverge from the Node child's data root.
+- **The system-scope service uninstall confirmation renders as neutral info, not an error.** The "service removed — relaunch the app manually" follow-up was shown through the error renderer (red text + a "retry" button) though it is an informational success; it now renders as a plain status line.
+
 ## [0.1.30-beta.38] - 2026-06-02
 
 ### Added

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -25,11 +25,21 @@ pub fn data_root_for_windows(programdata: Option<&str>) -> PathBuf {
     PathBuf::from(pd).join("WsScrcpyWeb")
 }
 
-/// Pure resolver for the writable-state root on Linux. Follows the XDG
-/// Base Directory spec: `$XDG_DATA_HOME/WsScrcpyWeb` if set, otherwise
-/// `~/.local/share/WsScrcpyWeb`. Mirrors `resolveDataRoot` in
-/// `src/server/Config.ts`. Parameters are injectable for testing.
-pub fn data_root_for_linux(xdg_data_home: Option<&str>, home: Option<&str>) -> PathBuf {
+/// Pure resolver for the writable-state root on Linux. Precedence mirrors
+/// `resolveDataRoot` in `src/server/Config.ts`: an explicit `DATA_ROOT`
+/// override (used verbatim — it is already the full path, NOT joined with
+/// `WsScrcpyWeb`), then `$XDG_DATA_HOME/WsScrcpyWeb`, then
+/// `~/.local/share/WsScrcpyWeb`. Honoring `DATA_ROOT` here keeps the Rust side
+/// (launcher spawn + service teardown + tray reap) aligned with the Node side,
+/// which already reads `DATA_ROOT`. Parameters are injectable for testing.
+pub fn data_root_for_linux(
+    data_root: Option<&str>,
+    xdg_data_home: Option<&str>,
+    home: Option<&str>,
+) -> PathBuf {
+    if let Some(dr) = data_root.filter(|s| !s.is_empty()) {
+        return PathBuf::from(dr);
+    }
     if let Some(xdg) = xdg_data_home.filter(|s| !s.is_empty()) {
         return PathBuf::from(xdg).join("WsScrcpyWeb");
     }
@@ -47,9 +57,10 @@ pub fn data_root_from_env() -> Option<PathBuf> {
         let pd = std::env::var("PROGRAMDATA").ok();
         Some(data_root_for_windows(pd.as_deref()))
     } else {
+        let data_root = std::env::var("DATA_ROOT").ok();
         let xdg = std::env::var("XDG_DATA_HOME").ok();
         let home = std::env::var("HOME").ok();
-        Some(data_root_for_linux(xdg.as_deref(), home.as_deref()))
+        Some(data_root_for_linux(data_root.as_deref(), xdg.as_deref(), home.as_deref()))
     }
 }
 
@@ -249,19 +260,33 @@ mod tests {
 
     #[test]
     fn data_root_for_linux_uses_xdg_data_home_when_set() {
-        let result = data_root_for_linux(Some("/custom/data"), Some("/home/user"));
+        let result = data_root_for_linux(None, Some("/custom/data"), Some("/home/user"));
         assert_eq!(result, PathBuf::from("/custom/data/WsScrcpyWeb"));
     }
 
     #[test]
     fn data_root_for_linux_falls_back_to_home_local_share() {
-        let result = data_root_for_linux(None, Some("/home/user"));
+        let result = data_root_for_linux(None, None, Some("/home/user"));
         assert_eq!(result, PathBuf::from("/home/user/.local/share/WsScrcpyWeb"));
     }
 
     #[test]
     fn data_root_for_linux_ignores_empty_xdg_data_home() {
-        let result = data_root_for_linux(Some(""), Some("/home/user"));
+        let result = data_root_for_linux(None, Some(""), Some("/home/user"));
+        assert_eq!(result, PathBuf::from("/home/user/.local/share/WsScrcpyWeb"));
+    }
+
+    #[test]
+    fn data_root_for_linux_honors_data_root_override_verbatim() {
+        // DATA_ROOT wins over XDG/HOME and is used as-is (no WsScrcpyWeb join),
+        // mirroring TS resolveDataRoot which returns env.DATA_ROOT directly.
+        let result = data_root_for_linux(Some("/explicit/root"), Some("/xdg"), Some("/home/user"));
+        assert_eq!(result, PathBuf::from("/explicit/root"));
+    }
+
+    #[test]
+    fn data_root_for_linux_ignores_empty_data_root() {
+        let result = data_root_for_linux(Some(""), None, Some("/home/user"));
         assert_eq!(result, PathBuf::from("/home/user/.local/share/WsScrcpyWeb"));
     }
 

--- a/docs/smoke-tests/v0.1.30-beta.39-stop-server-exit-and-residuals.md
+++ b/docs/smoke-tests/v0.1.30-beta.39-stop-server-exit-and-residuals.md
@@ -1,0 +1,86 @@
+# v0.1.30-beta.39 — Stop-Server-&-Exit + item-40 residuals smoke
+
+**Goal:** Validate the new §27 "stop server & exit" button (all platforms,
+service-mode gating, Windows tray reap, browser fallback) and the §40b neutral
+system-scope uninstall message. Items 40a (DATA_ROOT precedence) and 40c
+(comment) are unit-/review-covered; 40a has an optional Linux spot-check below.
+
+**Scope:** This doc covers the beta.39 NEW items only. The combined beta.39
+"full smoke" also runs:
+- the Linux service-mode Phase-2 pass in [`v0.1.30-beta.37-linux-service-mode.md`](./v0.1.30-beta.37-linux-service-mode.md) (item 39 apply, velopack 1.1.1), and
+- the Windows multi-user / MSI / tray pass in [`v0.1.25-beta.3.md`](./v0.1.25-beta.3.md).
+
+**Prerequisites:**
+- A Win11 VM (for the tray-reap sections) and a Fedora VM (for the Linux + service-mode sections).
+- Published **v0.1.30-beta.39**: Windows MSI/installer; `WsScrcpyWeb-linux-beta.AppImage` (Linux).
+- A device connected (wireless ADB) for at least one run, so there's a live adb daemon + stream to tear down.
+
+**How to read this:** each test has setup / action / expected. Check off as you go; on failure, note the test id and what diverged.
+
+---
+
+## SE-1 — Windows local mode: stop server & exit reaps everything
+
+**Setup:** beta.39 on Win11 in **local mode** (no service). Connect a device and start a stream so `node.exe`, `adb.exe`, and the tray icon are all live. Confirm the **tray icon** is present in the notification area.
+
+**Action:** Settings → App → **"stop server & exit"** → ConfirmModal → **ok**.
+
+**Expected:**
+- [ ] The confirm dialog appears (title "stop server & exit"), `ok`/`cancel` styled like the other modals.
+- [ ] The server exits: the browser tab self-closes, or (if the browser blocks it) the page blanks to **"app stopped — you can close this tab."**
+- [ ] **The tray icon disappears** (the launcher reaped it on terminal exit).
+- [ ] No orphans: Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe`, `node.exe`, `ws-scrcpy-web-tray.exe`, or bundled `adb.exe` from this instance.
+- [ ] `cancel` on the dialog leaves everything running (no shutdown).
+
+## SE-2 — Windows in-app update keeps the tray (marker gate)
+
+**Setup:** beta.39 local mode on Win11, with a newer beta published to update to. Tray icon present.
+
+**Action:** Settings → Updates → **check / apply** an in-app update; let it swap + relaunch.
+
+**Expected:**
+- [ ] The update applies and the app relaunches onto the new version.
+- [ ] **The tray persists across the update** (the `apply-update-pending` marker gates the reap off — the tray is NOT killed mid-update, then the relaunched launcher keeps it).
+- [ ] No duplicate/orphaned tray after relaunch (one icon).
+
+## SE-3 — Linux local mode: clean exit + adb teardown
+
+**Setup:** beta.39 `WsScrcpyWeb-linux-beta.AppImage` in **local mode** on Fedora. Connect a device (wireless ADB) and start a stream.
+
+**Action:** Settings → App → **"stop server & exit"** → confirm.
+
+**Expected:**
+- [ ] The browser tab self-closes or blanks to the "app stopped" notice.
+- [ ] The process tree exits cleanly (no orphaned `node`, `adb`, AppImage mount): `pgrep -fa WsScrcpyWeb` and `pgrep -fa adb` show nothing from this instance.
+- [ ] `journalctl --user` / the app log shows `Stopping adb daemon (kill-server)` (graceful teardown ran — not bypassed).
+- [ ] The launcher does **not** restart (clean exit 0, not the 75 restart sentinel).
+
+## SE-4 — Service-mode gating (Windows + Linux)
+
+**Setup:** beta.39 with a service **installed** (run once per OS: Win system service; Linux user- or system-scope service). Open Settings → App.
+
+**Expected:**
+- [ ] The **"stop server & exit"** button is **disabled (greyed)**.
+- [ ] A neutral note is shown: *"managed by the system service — stop it via your service manager, or uninstall the service."*
+- [ ] Clicking does nothing (no shutdown POST fires).
+- [ ] After **uninstalling** the service (back to local mode), the button becomes **enabled** again (no reload needed — it re-gates when the service status refreshes).
+
+## SE-5 — §40b: system-scope uninstall shows neutral info (not red/retry)
+
+**Setup:** Fedora, beta.39, a **system-scope** service installed.
+
+**Action:** Settings → Service → **uninstall**.
+
+**Expected:**
+- [ ] After uninstall, the follow-up message ("service removed. … relaunch the app manually …") renders as a **neutral info line** — **not** red, and with **no "retry" button** (regression check for 40b; pre-fix it used the error styling).
+
+## SE-6 (optional) — §40a: DATA_ROOT override honored on Linux
+
+**Setup:** Fedora, launch the AppImage (or `node dist/index.js`) with `DATA_ROOT=/tmp/wssw-dataroot` exported.
+
+**Expected:**
+- [ ] Config/deps/logs land under `/tmp/wssw-dataroot` (both the Node side and the launcher agree — same root for spawn and for adb-reap/tray paths). Mostly unit-covered; this just confirms the env wiring end-to-end.
+
+---
+
+**On completion:** if all green, the beta.39 new-item surface is validated; combine with the beta.37 Phase-2 and v0.1.25 Windows passes for the full beta.39 sign-off.

--- a/docs/specs/2026-06-02-stop-server-exit-and-residuals-design.md
+++ b/docs/specs/2026-06-02-stop-server-exit-and-residuals-design.md
@@ -117,15 +117,19 @@ This is a general orphan-tray-after-terminal-exit fix, not just the button path.
 
 ### 40a — Rust `data_root` honors `DATA_ROOT` (Linux)
 
-`common/src/config.rs`. TS `resolveDataRoot` (Config.ts:151) resolves
-`DATA_ROOT > XDG_DATA_HOME > ~/.local/share` on non-Windows, but
-`data_root_for_linux` / `data_root_from_env` only do `XDG_DATA_HOME > HOME` — the
-explicit `DATA_ROOT` launcher-bridge override is ignored. Add an injectable
-`data_root` override param to the pure `data_root_for_linux` (mirrors the existing
-injectable-param test pattern) and read `DATA_ROOT` first in the non-Windows branch of
-`data_root_from_env`. Windows branch unchanged (TS also ignores `DATA_ROOT` on win32).
-Confirm the launcher's own `DATA_ROOT`-set site so honoring it here is not circular.
-Add Rust unit tests mirroring the TS precedence. `cross test --workspace` is authoritative.
+`common/src/config.rs` + `launcher/src/paths.rs`. TS `resolveDataRoot`
+(Config.ts:151) resolves `DATA_ROOT > XDG_DATA_HOME > ~/.local/share` on
+non-Windows, but `data_root_for_linux` only does `XDG_DATA_HOME > HOME` — the
+explicit `DATA_ROOT` override is ignored. Add an injectable `data_root` override
+param to the pure `data_root_for_linux` (used verbatim, mirroring TS), then pass
+`DATA_ROOT` from **both** of its callers: `data_root_from_env` (common — service
+teardown / tray reap / local-appimage marker) **and** `Paths::compute`
+(launcher spawn path). Fixing only one would diverge the teardown root from the
+spawn root when `DATA_ROOT` is set — a new asymmetry. Windows branch unchanged
+(TS also ignores `DATA_ROOT` on win32). `spawn.rs` sets `DATA_ROOT` for the Node
+child from the computed root, so honoring it here is not circular. Rust unit
+tests mirror the TS precedence; `cross test --workspace` is authoritative for the
+non-Windows paths.
 
 ### 40b — neutral `renderServiceInfo` for system-scope uninstall
 

--- a/docs/specs/2026-06-02-stop-server-exit-and-residuals-design.md
+++ b/docs/specs/2026-06-02-stop-server-exit-and-residuals-design.md
@@ -1,0 +1,172 @@
+# Stop-Server-&-Exit button + item-40 residuals — design
+
+**Date:** 2026-06-02
+**Items:** todo §27 (in-app exit for Linux / all platforms) + §40 residuals (40a, 40b, 40c)
+**Ships in:** v0.1.30-beta.39 (combined vehicle for the next Fedora smoke)
+
+---
+
+## Background — two corrections from reading the current code
+
+The §27 todo entry was written from assumptions that the code does not support. Both
+were verified against the tree before this design:
+
+1. **"exit code 75 signals the launcher to quit cleanly" — INVERTED.**
+   `launcher/src/supervisor.rs:25` defines `const EXIT_RESTART: i32 = 75`, and
+   `decide_restart(exit_code, marker_exists)` *restarts* on `exit_code == 75` or a
+   `.restart` marker. `src/server/index.ts:295` documents it: "process.exit(75)
+   (restart-for-update) bypasses [cleanup] so the daemon stays alive across
+   supervisor-driven restarts." **A clean quit is `process.exit(0)` with no restart
+   marker** → `decide_restart(0, false) == None` → supervisor logs "clean exit; not
+   restarting" and returns. **No new launcher exit-signal is needed for the quit.**
+
+2. **"new `/api/app/quit` + `AppApi` + `ExitAppModal`" — mostly already exists.**
+   `src/server/api/ServerShutdownApi.ts` already serves `POST /api/server/shutdown`
+   → `process.exit(0)`, and its own doc comment says it exists for *"the Settings
+   'Stop Server & Exit' button, lands later."* This item **is** that button.
+   `src/app/client/ConfirmModal.ts` (`ConfirmModal.confirm({title,message})`) already
+   covers the dialog. No dedicated modal, no new endpoint.
+
+### The real problem to solve
+
+`ServerShutdownApi` calls `process.exit(0)` **directly**, which does **not** run the
+SIGINT/SIGTERM cleanup in `index.ts:267 exit()` — the part that does
+`scanAdb.killServer()` + `runningServices.forEach(s => s.release())`. So the existing
+quit path **orphans the adb daemon** (and any running services). Item 27 is therefore:
+a frontend button + making the quit path run the existing cleanup + reaping the
+Windows tray, which is otherwise left behind.
+
+---
+
+## Decisions (locked with user, 2026-06-02)
+
+- Reuse + fix `/api/server/shutdown` (one cleanup path), **not** a new endpoint.
+- Button lives in the existing Settings service/updates area, **all platforms**.
+- **Windows:** the quit must also reap the tray helper.
+- **Service mode:** the button is **disabled + a neutral note**, not actionable.
+
+---
+
+## Design
+
+### Layer 1 — server: shared `gracefulShutdown()`
+
+`src/server/index.ts`
+
+- Extract the cleanup body of `exit(signal)` into an exported, awaitable
+  `gracefulShutdown(): Promise<void>` that performs the existing steps:
+  `scanAdb.killServer()` (await, best-effort) + `runningServices.forEach(s => s.release())`,
+  preserving the `interrupted` double-invoke guard and the 10s exit watchdog.
+- SIGINT/SIGTERM handlers call `gracefulShutdown()` then exit (current behavior,
+  unchanged observable result).
+- **Exit-75 path stays bypassed** — restart-for-update must not kill the adb daemon.
+
+`src/server/api/ServerShutdownApi.ts`
+
+- Before scheduling `process.exit(0)`, `await gracefulShutdown()` so the adb daemon +
+  services are torn down on the button/tray path too. Response is still written first
+  (200 `{ok:true}`), then cleanup + exit on the scheduled tick. Keep the injected
+  `schedule`/`exit` seams for unit tests; inject the cleanup fn too so tests assert it
+  ran without killing the Vitest worker.
+- This also fixes the latent orphan on the existing Windows-tray shutdown path
+  (no-accepted-tech-debt).
+
+### Layer 2 — frontend: the button + gating
+
+`src/app/client/SettingsModal.ts` (+ reuse `ConfirmModal`)
+
+- Add a **`stop server & exit`** button (lowercase, app motif) in the service/updates
+  area of Settings.
+- Flow: click → `ConfirmModal.confirm({title, message})` → on `true`, `POST
+  /api/server/shutdown` → then `window.close()`; if the tab can't self-close, navigate
+  to `about:blank` and show inline "app stopped — close this tab".
+- **Service-mode gating:** when `/api/service/status` reports an installed service
+  (the signal the modal already consumes for scope pre-selection), render the button
+  **disabled** with a neutral note: *"managed by the system service — stop via your
+  service manager, or uninstall the service."* (Clicking it in service mode would
+  fight the service manager / trigger a restart, so it must not be actionable.)
+
+### Layer 3 — launcher: Windows tray reap
+
+`launcher/src/main.rs` (`#[cfg(windows)]`)
+
+The tray helper is spawned **detached** (`DETACHED_PROCESS`, `tray_supervisor.rs:276`)
+and is **not** adopted into the kill-on-close Job Object, so it deliberately survives
+launcher exit; the supervisor also respawns it every 10s. A clean `process.exit(0)`
+therefore leaves an orphaned tray pointing at a dead launcher.
+
+- At the launcher's **terminal exit** — after `supervisor::run()` returns (it loops
+  internally for restarts and only returns on a real terminal exit) and before
+  `std::process::exit(exit_code)` — reap the tray with
+  `taskkill /F /IM ws-scrcpy-web-tray.exe` (the same call the supervisor already uses
+  for stale-tray cleanup, `tray_supervisor.rs:140`).
+- **Gate:** skip the reap when an `apply-update-pending` **or** `uninstall-pending`
+  marker is present under `<dataRoot>/control/` — those terminal exits are
+  exit-to-relaunch (update apply / uninstall handoff) and the tray must persist /
+  is handled by that flow. A plain quit has no marker → tray reaped.
+- Set the tray-supervisor `stop_flag` (returned by `start_background`) before the
+  reap if it's held at that scope, so no respawn races the kill; the immediate
+  `process::exit` makes this belt-and-suspenders. Confirm `start_background`'s
+  `stop_flag` is reachable at the exit site during implementation.
+
+This is a general orphan-tray-after-terminal-exit fix, not just the button path.
+
+---
+
+## Item 40 — residuals
+
+### 40a — Rust `data_root` honors `DATA_ROOT` (Linux)
+
+`common/src/config.rs`. TS `resolveDataRoot` (Config.ts:151) resolves
+`DATA_ROOT > XDG_DATA_HOME > ~/.local/share` on non-Windows, but
+`data_root_for_linux` / `data_root_from_env` only do `XDG_DATA_HOME > HOME` — the
+explicit `DATA_ROOT` launcher-bridge override is ignored. Add an injectable
+`data_root` override param to the pure `data_root_for_linux` (mirrors the existing
+injectable-param test pattern) and read `DATA_ROOT` first in the non-Windows branch of
+`data_root_from_env`. Windows branch unchanged (TS also ignores `DATA_ROOT` on win32).
+Confirm the launcher's own `DATA_ROOT`-set site so honoring it here is not circular.
+Add Rust unit tests mirroring the TS precedence. `cross test --workspace` is authoritative.
+
+### 40b — neutral `renderServiceInfo` for system-scope uninstall
+
+`src/app/client/SettingsModal.ts`. The system-scope uninstall **success** follow-up
+(`uninstallFollowupMessage('system')`, ~line 1172) is rendered through
+`renderServiceError` (red label + "retry" button) though it is informational. Add a
+neutral `renderServiceInfo(msg)` sibling (no error class, no retry) and use it for that
+path. Add a test.
+
+### 40c — fix stale comment
+
+`src/server/UpdateService.ts:592`. The comment cites
+`launcher/src/post_stop_handler.rs::marker_path`, which does not exist. Correct it: the
+marker path is `<dataRoot>/control/apply-update-pending`, produced/consumed by
+`launcher/src/linux_apply.rs::apply_marker_path` (Linux) and the bat written by
+`launcher/src/elevated_runner.rs::write_post_stop_bat` (Windows), with
+`Config.applyUpdatePendingMarkerPath` as the Node-side source of truth. Comment-only.
+
+---
+
+## Testing
+
+- **vitest:** `gracefulShutdown` runs on the `/api/server/shutdown` path (injected
+  cleanup spy); SettingsModal button (confirm → POST → close path) + service-mode
+  disabled+note; `renderServiceInfo` neutral styling.
+- **cross test --workspace** (Linux, authoritative for cfg-gated Rust): `data_root`
+  `DATA_ROOT`-precedence cases; Windows tray-reap marker-gate is `#[cfg(windows)]`
+  pure-logic where extractable (the `taskkill` itself is VM-smoke-verified).
+- **clippy** `-D warnings`.
+
+## Smoke additions (before the run)
+
+- 27 / Windows local: quit → app fully exits, **tray icon gone**, no orphaned
+  `node.exe` / `adb.exe` / tray.
+- 27 / Windows update: an in-app update still **keeps** the tray (marker gate).
+- 27 / Linux local: quit → clean exit, `adb kill-server` ran, no orphans;
+  `window.close()` fallback notice shows.
+- 27 / service mode (both OS): button **greyed with the note**, not actionable.
+- 40b: system-scope uninstall follow-up renders as **neutral info**, not red/retry.
+
+## Out of scope
+
+- Linux tray (none exists). macOS (not shipped).
+- Any change to the exit-75 restart/update path.

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -292,6 +292,16 @@ fn main() {
         )),
     }
 
+    // §27 — reap the standalone tray helper on terminal exit. It is spawned
+    // detached and NOT in the kill-on-close job object, so it survives launcher
+    // exit on its own; without this a plain "stop server & exit" (or any clean
+    // exit) leaves an orphaned tray pointing at a dead launcher. Marker-gated so
+    // update-apply / uninstall handoffs (which relaunch) keep their tray.
+    #[cfg(windows)]
+    if let Some(dr) = common::config::data_root_from_env() {
+        tray_supervisor::reap_tray_on_terminal_exit(&dr);
+    }
+
     log::info(&format!("ws-scrcpy-web-launcher exiting with code {exit_code}"));
     std::process::exit(exit_code);
 }

--- a/launcher/src/paths.rs
+++ b/launcher/src/paths.rs
@@ -59,9 +59,17 @@ impl Paths {
         let data_root = if cfg!(windows) {
             common::config::data_root_for_windows(programdata_override)
         } else {
+            // Honor an explicit DATA_ROOT override (DATA_ROOT > XDG > HOME),
+            // matching common::config::data_root_from_env and the Node side, so
+            // the spawn path and the service-teardown/tray-reap path agree.
+            let data_root_override = std::env::var("DATA_ROOT").ok();
             let xdg = std::env::var("XDG_DATA_HOME").ok();
             let home = std::env::var("HOME").ok();
-            common::config::data_root_for_linux(xdg.as_deref(), home.as_deref())
+            common::config::data_root_for_linux(
+                data_root_override.as_deref(),
+                xdg.as_deref(),
+                home.as_deref(),
+            )
         };
 
         let deps_path = match deps_override {

--- a/launcher/src/tray_supervisor.rs
+++ b/launcher/src/tray_supervisor.rs
@@ -48,7 +48,40 @@ use crate::log;
 use crate::user_session_spawn::{spawn_in_active_user_session, SpawnUserLauncherArgs};
 
 const TRAY_POLL_INTERVAL_SECS: u64 = 10;
-const TRAY_PROCESS_NAME: &str = "ws-scrcpy-web-tray.exe";
+pub(crate) const TRAY_PROCESS_NAME: &str = "ws-scrcpy-web-tray.exe";
+
+/// Decide whether the launcher's terminal exit should reap the tray helper.
+/// Skipped when an update-apply or uninstall handoff is pending: those exits
+/// relaunch the launcher (which respawns the tray) or are handled by that flow,
+/// so the tray must persist across them. A plain quit (Settings "stop server &
+/// exit", Ctrl+C, Servy stop) has no marker and reaps the tray — otherwise it
+/// is orphaned, since the tray is spawned detached and NOT in the launcher's
+/// kill-on-close job object, so it survives launcher exit on its own. Pure (no
+/// I/O) so it is unit-testable, like `supervisor::decide_restart`.
+pub(crate) fn should_reap_tray_on_exit(apply_pending: bool, uninstall_pending: bool) -> bool {
+    !apply_pending && !uninstall_pending
+}
+
+/// Reap the standalone tray helper on the launcher's terminal exit. Marker-
+/// gated via `should_reap_tray_on_exit` (markers live under
+/// `<data_root>/control/`). Best-effort `taskkill`; failure is logged, not
+/// fatal — the launcher is exiting regardless. The tray-supervisor poll thread
+/// dies with this process, so there is no respawn after the kill.
+pub(crate) fn reap_tray_on_terminal_exit(data_root: &Path) {
+    let control = data_root.join("control");
+    let apply_pending = control.join("apply-update-pending").exists();
+    let uninstall_pending = control.join("uninstall-pending").exists();
+    if !should_reap_tray_on_exit(apply_pending, uninstall_pending) {
+        log::info(
+            "tray-supervisor: terminal exit with update/uninstall handoff pending; leaving tray for relaunch",
+        );
+        return;
+    }
+    log::info("tray-supervisor: terminal exit; reaping tray helper");
+    let _ = crate::elevated_runner::silent_command("taskkill")
+        .args(["/F", "/IM", TRAY_PROCESS_NAME])
+        .output();
+}
 
 /// Start a background thread that ensures a tray exists in the user
 /// session at all times. Returns immediately. The thread runs for the
@@ -382,5 +415,30 @@ fn is_tray_running_in_session(session_id: u32) -> bool {
         );
 
         found
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reaps_tray_on_plain_terminal_exit() {
+        assert!(should_reap_tray_on_exit(false, false));
+    }
+
+    #[test]
+    fn skips_reap_when_update_apply_pending() {
+        assert!(!should_reap_tray_on_exit(true, false));
+    }
+
+    #[test]
+    fn skips_reap_when_uninstall_pending() {
+        assert!(!should_reap_tray_on_exit(false, true));
+    }
+
+    #[test]
+    fn skips_reap_when_both_markers_present() {
+        assert!(!should_reap_tray_on_exit(true, true));
     }
 }

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -1,5 +1,6 @@
 import { Modal } from '../ui/Modal';
 import { AdminConfirmModal, type AdminConfirmOptions } from './AdminConfirmModal';
+import { ConfirmModal } from './ConfirmModal';
 import { ServiceOperationModal } from './ServiceOperationModal';
 import { runUpgradingHandoff } from './UpgradingOverlay';
 import type { AppConfigEnvelope, AppConfigPatchResponse, UpdateChannel } from '../../common/ConfigEvents';
@@ -117,6 +118,27 @@ export function scopeRadioState(resp: ScopeRadioInputs): ScopeRadioState {
 }
 
 /**
+ * Gate the App-section "stop server & exit" button by service mode. When a
+ * service is installed (service mode), the OS service manager owns the app's
+ * lifecycle — a browser-initiated quit would fight it (or be restarted), so the
+ * button is disabled with an explanatory note. In local mode (no service) the
+ * button is enabled. Pure (no DOM) so it is unit-testable; mirrors
+ * scopeRadioState's "installed" derivation.
+ */
+export function stopServerButtonState(resp: ScopeRadioInputs): {
+    disabled: boolean;
+    note: string | null;
+} {
+    const isInstalled = (resp.status ?? 'not-installed') !== 'not-installed';
+    return isInstalled
+        ? {
+              disabled: true,
+              note: 'managed by the system service — stop it via your service manager, or uninstall the service.',
+          }
+        : { disabled: false, note: null };
+}
+
+/**
  * Lock a service-scope radio as read-only WITHOUT the `disabled` attribute.
  * Chromium desaturates `accent-color` on :disabled form controls, which made
  * the selected dot invisible against the muted track (item 42 — the active
@@ -159,6 +181,10 @@ export class SettingsModal extends Modal {
     private currentWebPort: number | null = null;
     private serviceScopeSystemRadio: HTMLInputElement | null = null;
     private servicePlatform: 'win32' | 'linux' | null = null;
+
+    // ── App section state ─────────────────────────────────────────────────
+    private stopServerButton: HTMLButtonElement | null = null;
+    private stopServerNote: HTMLElement | null = null;
 
     // ── Updates section state ─────────────────────────────────────────────
     private updatesBody!: HTMLElement;
@@ -926,6 +952,8 @@ export class SettingsModal extends Modal {
     private renderServiceState(resp: ServiceStatusResponse): void {
         this.serviceSection.replaceChildren();
         this.servicePlatform = (resp.platform as 'win32' | 'linux') ?? null;
+        // Gate the App-section "stop server & exit" button off in service mode.
+        this.applyStopServerButtonState(resp);
 
         if (!resp.supported) {
             const notice = document.createElement('p');
@@ -1262,6 +1290,27 @@ export class SettingsModal extends Modal {
     private buildAppSection(): HTMLElement {
         const { section, body } = this.buildSection('App');
 
+        // §27 — stop the server and exit the app. Backs the existing
+        // /api/server/shutdown endpoint (which now runs graceful teardown
+        // before exiting 0 — a clean exit the launcher supervisor will NOT
+        // restart). Gated off in service mode (the OS service manager owns the
+        // lifecycle) by applyStopServerButtonState, driven from
+        // renderServiceState once /api/service/status resolves.
+        const stopBtn = document.createElement('button');
+        stopBtn.type = 'button';
+        stopBtn.className = 'settings-btn settings-btn-primary';
+        stopBtn.textContent = 'stop server & exit';
+        stopBtn.addEventListener('click', () => void this.onStopServerExit(stopBtn));
+        this.stopServerButton = stopBtn;
+        body.appendChild(this.buildRow('stop the server and close the app', stopBtn));
+
+        const stopNote = document.createElement('p');
+        stopNote.className = 'settings-status';
+        stopNote.style.gridColumn = '1 / -1';
+        stopNote.hidden = true;
+        this.stopServerNote = stopNote;
+        body.appendChild(stopNote);
+
         const resetBtn = document.createElement('button');
         resetBtn.type = 'button';
         resetBtn.className = 'settings-btn settings-btn-primary';
@@ -1316,5 +1365,61 @@ export class SettingsModal extends Modal {
         });
 
         return section;
+    }
+
+    /**
+     * Reflect the (unit-tested) stopServerButtonState decision onto the App
+     * section's button + note. Called from renderServiceState once
+     * /api/service/status resolves, so the button is disabled with a note when
+     * a service is installed (service mode) and enabled otherwise.
+     */
+    private applyStopServerButtonState(resp: ScopeRadioInputs): void {
+        if (!this.stopServerButton) return;
+        const state = stopServerButtonState(resp);
+        this.stopServerButton.disabled = state.disabled;
+        if (this.stopServerNote) {
+            this.stopServerNote.textContent = state.note ?? '';
+            this.stopServerNote.hidden = state.note === null;
+        }
+    }
+
+    /**
+     * Confirm, then POST /api/server/shutdown (graceful teardown + exit 0),
+     * then try to self-close the tab. Falls back to a full-page "app stopped"
+     * notice when the browser blocks window.close() (tabs not opened by script).
+     */
+    private async onStopServerExit(btn: HTMLButtonElement): Promise<void> {
+        const confirmed = await ConfirmModal.confirm({
+            title: 'stop server & exit',
+            message:
+                'the app will shut down and this browser tab will try to close. ' +
+                'any active device connections will end. continue?',
+        });
+        if (!confirmed) return;
+
+        btn.disabled = true;
+        btn.textContent = 'stopping…';
+        try {
+            await fetch('/api/server/shutdown', { method: 'POST' });
+        } catch {
+            // The server drops the connection as it exits — expected, not an error.
+        }
+        // window.close() only succeeds for tabs the script itself opened;
+        // otherwise it is a silent no-op. Show the notice regardless — if the
+        // tab does close the overlay is moot, if not the user gets clear closure.
+        window.close();
+        this.showAppStoppedOverlay();
+    }
+
+    /** Blank the page with a centered "app stopped" notice (window.close fallback). */
+    private showAppStoppedOverlay(): void {
+        const overlay = document.createElement('div');
+        overlay.style.cssText =
+            'position:fixed;inset:0;display:flex;align-items:center;justify-content:center;' +
+            'padding:1rem;text-align:center;opacity:0.85;';
+        const msg = document.createElement('p');
+        msg.textContent = 'app stopped — you can close this tab.';
+        overlay.appendChild(msg);
+        document.body.replaceChildren(overlay);
     }
 }

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -153,6 +153,22 @@ export function lockScopeRadioControl(label: HTMLLabelElement, radio: HTMLInputE
 }
 
 /**
+ * Build a neutral (non-error) full-width service status line — a plain label,
+ * no error styling, no retry button. Used for informational follow-ups like the
+ * system-scope uninstall success message (item 40b — previously mis-rendered
+ * through renderServiceError as red + a retry button, though it is an
+ * informational success, not an error). Pure DOM so it is unit-testable, like
+ * lockScopeRadioControl.
+ */
+export function buildServiceInfoRow(message: string): HTMLElement {
+    const p = document.createElement('p');
+    p.className = 'settings-status';
+    p.style.gridColumn = '1 / -1';
+    p.textContent = message;
+    return p;
+}
+
+/**
  * Settings modal — unified two-column grid layout.
  *
  * Every section is built from the same primitive:
@@ -1054,6 +1070,16 @@ export class SettingsModal extends Modal {
         this.serviceSection.appendChild(row);
     }
 
+    /**
+     * Render a neutral informational message in the service section (no error
+     * styling, no retry button) — for informational follow-ups like the
+     * system-scope uninstall success message. See buildServiceInfoRow (item 40b).
+     */
+    private renderServiceInfo(msg: string): void {
+        this.serviceSection.replaceChildren();
+        this.serviceSection.appendChild(buildServiceInfoRow(msg));
+    }
+
     private async onInstallService(btn: HTMLButtonElement): Promise<void> {
         const isLinux = this.servicePlatform === 'linux';
         const isSystemScope = this.serviceScopeSystemRadio?.checked ?? false;
@@ -1197,10 +1223,7 @@ export class SettingsModal extends Modal {
                     modal.close();
                     btn.disabled = false;
                     btn.textContent = prevText;
-                    this.renderServiceError(
-                        uninstallFollowupMessage('system'),
-                        () => void this.refreshService(),
-                    );
+                    this.renderServiceInfo(uninstallFollowupMessage('system'));
                     return;
                 }
                 // User scope on Linux (or Windows): a fresh local instance is

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -7,6 +7,7 @@ import {
     resetPromptsPayload,
     scopeRadioState,
     lockScopeRadioControl,
+    stopServerButtonState,
 } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
@@ -107,5 +108,30 @@ describe('lockScopeRadioControl', () => {
         expect(radio.disabled).toBe(false);
         expect(radio.tabIndex).toBe(-1);
         expect(label.classList.contains('settings-radio-locked')).toBe(true);
+    });
+});
+
+describe('stopServerButtonState', () => {
+    it('not installed (local mode) -> enabled, no note', () => {
+        expect(stopServerButtonState({ status: 'not-installed' })).toEqual({
+            disabled: false,
+            note: null,
+        });
+    });
+
+    it('absent status (unknown) -> treated as not-installed -> enabled', () => {
+        expect(stopServerButtonState({})).toEqual({ disabled: false, note: null });
+    });
+
+    it('running user-scope service -> disabled with a service-mode note', () => {
+        const s = stopServerButtonState({ status: 'running', scope: 'user' });
+        expect(s.disabled).toBe(true);
+        expect(s.note).toMatch(/service/i);
+    });
+
+    it('running system-scope service -> disabled with a service-mode note', () => {
+        const s = stopServerButtonState({ status: 'running', scope: 'system' });
+        expect(s.disabled).toBe(true);
+        expect(s.note).toMatch(/service/i);
     });
 });

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -8,6 +8,7 @@ import {
     scopeRadioState,
     lockScopeRadioControl,
     stopServerButtonState,
+    buildServiceInfoRow,
 } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
@@ -133,5 +134,15 @@ describe('stopServerButtonState', () => {
         const s = stopServerButtonState({ status: 'running', scope: 'system' });
         expect(s.disabled).toBe(true);
         expect(s.note).toMatch(/service/i);
+    });
+});
+
+describe('buildServiceInfoRow', () => {
+    it('renders a neutral status line — no error styling, no retry button', () => {
+        const row = buildServiceInfoRow('service removed. relaunch the app manually.');
+        expect(row.textContent).toContain('service removed');
+        expect(row.className).toContain('settings-status');
+        expect(row.className).not.toContain('settings-status-error');
+        expect(row.querySelector('button')).toBeNull();
     });
 });

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -589,10 +589,13 @@ export class UpdateService {
      * user has to manually restart the service), which is a worse-but-not-
      * fatal degradation. The Velopack apply itself still proceeds.
      *
-     * Path matches `launcher/src/post_stop_handler.rs::marker_path` and
-     * `Config.applyUpdatePendingMarkerPath` (single source of truth on the
-     * Node side). Content is intentionally empty — the post-stop handler
-     * only checks for presence, not content.
+     * The marker path (`<dataRoot>/control/apply-update-pending`) is mirrored on
+     * the Rust side by `launcher/src/elevated_runner.rs::write_post_stop_bat`
+     * (the Windows post-stop bat that reads it) and
+     * `launcher/src/linux_apply.rs::apply_marker_path` (Linux);
+     * `Config.applyUpdatePendingMarkerPath` is the single source of truth on the
+     * Node side. Content is intentionally empty — the readers only check for
+     * presence, not content.
      */
     private async writeApplyUpdatePendingMarker(): Promise<void> {
         const markerPath = Config.getInstance().applyUpdatePendingMarkerPath;

--- a/src/server/__tests__/ServerShutdownApi.test.ts
+++ b/src/server/__tests__/ServerShutdownApi.test.ts
@@ -46,7 +46,7 @@ describe('ServerShutdownApi', () => {
     it('POST /api/server/shutdown writes 200 with { ok: true } envelope', async () => {
         const schedule = vi.fn();
         const exit = vi.fn();
-        const api = new ServerShutdownApi(schedule, exit);
+        const api = new ServerShutdownApi({ schedule, exit });
         const { req, res } = makeReqRes('/api/server/shutdown', 'POST');
         const handled = await api.handle(req, res);
         expect(handled).toBe(true);
@@ -57,7 +57,7 @@ describe('ServerShutdownApi', () => {
     it('schedules process.exit(0) via setTimeout after responding', async () => {
         const schedule = vi.fn();
         const exit = vi.fn();
-        const api = new ServerShutdownApi(schedule, exit);
+        const api = new ServerShutdownApi({ schedule, exit });
         const { req, res } = makeReqRes('/api/server/shutdown', 'POST');
         await api.handle(req, res);
 
@@ -70,7 +70,34 @@ describe('ServerShutdownApi', () => {
         expect(exit).not.toHaveBeenCalled();
 
         // Manually invoke the scheduled callback; verify exit(0) is then called.
-        (cb as () => void)();
+        // The callback now returns a promise (awaits cleanup first), so await it.
+        await (cb as () => Promise<void>)();
         expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    it('awaits cleanup before exiting (cleanup runs, then exit 0)', async () => {
+        const order: string[] = [];
+        const cleanup = vi.fn(async () => {
+            order.push('cleanup');
+        });
+        const schedule = vi.fn();
+        const exit = vi.fn(() => {
+            order.push('exit');
+        });
+        const api = new ServerShutdownApi({ cleanup, schedule, exit });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST');
+        await api.handle(req, res);
+
+        // Cleanup must NOT run until the scheduled tick (response flushes first).
+        expect(cleanup).not.toHaveBeenCalled();
+        expect(schedule).toHaveBeenCalledTimes(1);
+        const [cb] = schedule.mock.calls[0]!;
+
+        await (cb as () => Promise<void>)();
+
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(0);
+        // Ordering is the whole point: adb daemon + services torn down first.
+        expect(order).toEqual(['cleanup', 'exit']);
     });
 });

--- a/src/server/api/ServerShutdownApi.ts
+++ b/src/server/api/ServerShutdownApi.ts
@@ -9,30 +9,55 @@ const log = Logger.for('ServerShutdownApi');
  *
  *   POST /api/server/shutdown -> 200 { ok: true }
  *
- * Used by the Windows tray helper (and the Settings "Stop Server & Exit"
- * button, lands later) to request a clean process exit without killing the
- * Node process from the outside (which would skip flush hooks).
+ * Used by the Windows tray helper and the Settings "stop server & exit" button
+ * (§27) to request a clean process exit without killing the Node process from
+ * the outside (which would skip flush hooks).
  *
  * Contract (per docs/plans/sp3-p4a-contracts.md):
  *   - Body-less request; payload is ignored.
- *   - Response is sent first, then `process.exit(0)` is scheduled via
- *     setTimeout so the response gets flushed to the socket before the
+ *   - Response is sent first, then teardown + `process.exit(0)` are scheduled
+ *     via setTimeout so the response gets flushed to the socket before the
  *     event loop shuts down.
  *   - 100 ms is empirically enough on localhost; the tray helper's
  *     ureq POST has its own 5 s timeout and exits regardless of reply.
+ *   - On the scheduled tick we run `cleanup()` (the shared gracefulShutdown
+ *     from index.ts — stops the adb daemon + releases running services) and
+ *     await it BEFORE exiting, so a button/tray quit doesn't orphan the adb
+ *     daemon. process.exit(0) is a clean exit; the launcher's supervisor sees
+ *     `decide_restart(0, false) == None` and does NOT restart (exit 75 is the
+ *     restart sentinel — deliberately NOT used here).
  *   - No auth: localhost-only intent. Future hardening if exposed remotely.
  */
 const SHUTDOWN_DELAY_MS = 100;
 
-export class ServerShutdownApi {
+export interface ServerShutdownApiOptions {
     /**
-     * Override hooks for unit tests so we can verify scheduling without
-     * actually killing the Vitest worker. Production callers omit both args.
+     * Async teardown run on the scheduled tick BEFORE process exit — stops the
+     * adb daemon + releases running services so a graceful quit doesn't orphan
+     * them. Production passes the shared `gracefulShutdown()` from index.ts;
+     * the default no-op keeps tests that don't exercise cleanup terse.
      */
-    constructor(
-        private readonly schedule: (cb: () => void, ms: number) => unknown = setTimeout,
-        private readonly exit: (code: number) => void = (code: number) => process.exit(code),
-    ) {}
+    cleanup?: () => Promise<void>;
+    /** setTimeout seam — tests inject to capture the scheduled callback. */
+    schedule?: (cb: () => void, ms: number) => unknown;
+    /** process.exit seam — tests inject to avoid killing the worker. */
+    exit?: (code: number) => void;
+}
+
+export class ServerShutdownApi {
+    private readonly cleanup: () => Promise<void>;
+    private readonly schedule: (cb: () => void, ms: number) => unknown;
+    private readonly exit: (code: number) => void;
+
+    /**
+     * Production callers pass `{ cleanup }`; the schedule/exit seams default to
+     * the real `setTimeout` / `process.exit` and are overridden only in tests.
+     */
+    constructor(options: ServerShutdownApiOptions = {}) {
+        this.cleanup = options.cleanup ?? (async () => {});
+        this.schedule = options.schedule ?? setTimeout;
+        this.exit = options.exit ?? ((code: number) => process.exit(code));
+    }
 
     public async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
         if (req.url !== '/api/server/shutdown' || req.method !== 'POST') return false;
@@ -42,11 +67,25 @@ export class ServerShutdownApi {
         res.writeHead(200);
         res.end(JSON.stringify({ ok: true }));
 
-        this.schedule(() => {
-            log.info('exiting (process.exit 0)');
-            this.exit(0);
-        }, SHUTDOWN_DELAY_MS);
+        // Return the promise from the scheduled callback so tests can await the
+        // full teardown→exit chain; production setTimeout ignores the return.
+        this.schedule(() => this.shutdown(), SHUTDOWN_DELAY_MS);
 
         return true;
+    }
+
+    /**
+     * Run graceful cleanup (best-effort), then exit 0. Cleanup failure is
+     * logged and swallowed — a stuck teardown must not block the exit, and the
+     * exit watchdog in index.ts backstops any hang.
+     */
+    private async shutdown(): Promise<void> {
+        try {
+            await this.cleanup();
+        } catch (err) {
+            log.warn(`graceful cleanup failed during shutdown: ${(err as Error)?.message ?? String(err)}`);
+        }
+        log.info('exiting (process.exit 0)');
+        this.exit(0);
     }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -99,7 +99,7 @@ HttpServer.addApiHandler(configApi);
 const serviceApi = new ServiceApi();
 HttpServer.addApiHandler(serviceApi);
 
-const shutdownApi = new ServerShutdownApi();
+const shutdownApi = new ServerShutdownApi({ cleanup: gracefulShutdown });
 HttpServer.addApiHandler(shutdownApi);
 
 const updateService = new UpdateService();
@@ -263,6 +263,33 @@ process.on('unhandledRejection', (reason) => {
 
 const EXIT_WATCHDOG_MS = 10_000;
 
+let cleanupStarted = false;
+/**
+ * Shared graceful teardown: stop the adb daemon we own + release running
+ * services. Idempotent so the SIGINT/SIGTERM handler and the
+ * /api/server/shutdown path (Settings "stop server & exit" button / Windows
+ * tray) can both call it without double-teardown. The shutdown API awaits it
+ * before process.exit(0); the signal handler fires it best-effort and relies
+ * on the exit watchdog below. NOT used on the exit-75 restart-for-update path,
+ * which deliberately keeps the adb daemon alive across supervisor-driven
+ * restarts.
+ */
+async function gracefulShutdown(): Promise<void> {
+    if (cleanupStarted) return;
+    cleanupStarted = true;
+    serverLog.info('Stopping adb daemon (kill-server) ...');
+    try {
+        await scanAdb.killServer();
+    } catch (err) {
+        serverLog.warn(`adb kill-server during exit failed: ${(err as Error).message}`);
+    }
+    runningServices.forEach((service: Service) => {
+        const serviceName = service.getName();
+        serverLog.info(`Stopping ${serviceName} ...`);
+        service.release();
+    });
+}
+
 let interrupted = false;
 function exit(signal: string) {
     // Force stdout/stderr to blocking mode so every subsequent log line
@@ -289,23 +316,12 @@ function exit(signal: string) {
         return;
     }
     interrupted = true;
-    // Tear down our adb daemon on clean shutdown. We started it via
-    // AdbClient.startServer; per the "own the daemon's lifetime" stance,
-    // a clean SIGINT/SIGTERM should not leave the daemon orphaned holding
-    // port 5037. This path is for clean exit ONLY — process.exit(75)
-    // (restart-for-update) bypasses this function so the daemon stays
-    // alive across supervisor-driven restarts. Fire-and-forget; the
-    // watchdog below catches any hang, and a stuck adb is no worse than
-    // today's behavior.
-    serverLog.info('Stopping adb daemon (kill-server) ...');
-    scanAdb.killServer().catch((err: Error) => {
-        serverLog.warn(`adb kill-server during exit failed: ${err.message}`);
-    });
-    runningServices.forEach((service: Service) => {
-        const serviceName = service.getName();
-        serverLog.info(`Stopping ${serviceName} ...`);
-        service.release();
-    });
+    // Fire-and-forget the shared teardown (idempotent — the /api/server/shutdown
+    // path may have already run it). The 2000ms hold + watchdog below backstop
+    // any hang. process.exit(75) (restart-for-update) bypasses this function
+    // entirely, so the daemon stays alive across supervisor-driven restarts —
+    // see gracefulShutdown's doc.
+    void gracefulShutdown();
     // setBlocking(true) at top of exit() makes the console.log calls in
     // serverLog / Logger synchronous-to-the-TTY, so by the time control
     // reaches here every "Stopping X" line is already on the console.


### PR DESCRIPTION
## Summary

Implements item 27 (in-app "stop server & exit") and the item-40 residuals — the three items queued for the combined beta.39 smoke. Reading the code first corrected two wrong assumptions in item 27's todo (see the spec): **exit-75 is the _restart_ sentinel, not quit**, and the `/api/server/shutdown` endpoint + `ConfirmModal` already existed. So this is mostly a button + making the quit path run the existing cleanup + reaping the Windows tray.

- Spec: `docs/specs/2026-06-02-stop-server-exit-and-residuals-design.md`
- Smoke: `docs/smoke-tests/v0.1.30-beta.39-stop-server-exit-and-residuals.md`

## item 27 — stop server & exit
- **Server:** shared idempotent `gracefulShutdown()` (adb kill-server + service release); `/api/server/shutdown` awaits it before `process.exit(0)`. Fixes a latent adb-orphan on the existing tray-shutdown path. Clean exit(0), so the supervisor does not restart.
- **Frontend:** "stop server & exit" button in Settings -> App -> confirm -> POST -> `window.close()` with an "app stopped" fallback. Disabled with a note in service mode (`stopServerButtonState`, unit-tested).
- **Launcher (Windows):** reap the detached tray helper on terminal exit, marker-gated so update/uninstall handoffs keep their tray (`should_reap_tray_on_exit`, unit-tested).

## item 40 residuals
- **40a:** Linux Rust `data_root` honors `DATA_ROOT` (DATA_ROOT > XDG > HOME), across **both** callers (`Paths::compute` spawn path + `data_root_from_env`) so spawn and teardown cannot diverge.
- **40b:** system-scope uninstall follow-up renders as neutral info (was red + a retry button).
- **40c:** fix a stale comment referencing a nonexistent `post_stop_handler.rs`.

## Verification (local)
- `vitest`: 819 passed.
- `cargo test` (Windows) + `cross test --workspace` (Linux): green.
- `cargo clippy --workspace -- -D warnings` + `tsc --noEmit`: clean.

`release:beta` -> on merge, auto-release cuts **v0.1.30-beta.39** for the combined smoke.