### PR TITLE
fix: system-scope install /opt paths + bookmark reset clobber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux system-scope service install now uses persistent, self-contained `/opt` paths instead of `/tmp` + the installing user's home.** A system-scope install left the root service mis-pathed: its `config.json` landed in `/tmp/WsScrcpyWeb` (ephemeral — wiped on reboot) because the unit set no `DATA_ROOT` and a root service has no `HOME`, and it ran `node`/`adb` from the installing user's `~/.local/share/.../dependencies` (fragile, a root-executing-user-writable-binary surface, and a Local-Dependencies-Only violation). The install now points the unit's `DATA_ROOT` + `DEPS_PATH` at `/opt/ws-scrcpy-web/{data,dependencies}`, copies the deps into `/opt` (the tree is `bin_t`-labelled so `init_t` can exec them; the data dir gets a more-specific `var_lib_t` rule so the service can write it under SELinux), and seeds the service's `config.json` (`installMode`, `firstRunComplete`, the user's web port) — so the service reads a correct, persistent config (no stray WelcomeModal), survives reboots, runs the app's own deps, and the post-install browser hand-off lands on the same port. As defense-in-depth, Rust `data_root_for_linux` no longer silently falls back to `/tmp` when nothing is set; it fails loudly so a misconfiguration is caught. (The system-scope uninstall→relaunch hand-off is a separate follow-up.)
+- **"Reset welcome and bookmark prompts" now fully clears the per-port bookmark dismissal.** `WelcomeModal` and `ServiceFirstRunModal` eagerly PATCHed `bookmarkDismissedForPort` to the current port in their constructors. Because the reset re-shows the welcome modal (it sets `firstRunComplete: false`), that eager write re-stamped the current port over the reset's `null` — so the bookmark reminder stayed suppressed for that port. The eager stamp was redundant (modal priority is already gated in `index.ts`, and each modal's completion path stamps the port legitimately) and has been removed.
+- **README points to the real "stop server & exit" location.** The Linux "no tray icon" note directed users to a nonexistent "Settings → Server → Stop Server"; it now points to "Settings → App → stop server & exit" (where the button shipped in beta.39), and the button is listed in the Configuration section.
+
 ## [0.1.30-beta.39] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ When Velopack ships its type-2 runtime (post-1.0.1), this dependency will be emb
 
 #### Tray icon
 
-ws-scrcpy-web does not currently expose a tray icon on Linux. On Windows the launcher provides a tray for quick stop/restart, but the Linux launcher has no tray surface yet — when one is added it will mirror the Windows behavior. For now use Settings → Server → Stop Server in the web UI to stop the app cleanly.
+ws-scrcpy-web does not currently expose a tray icon on Linux. On Windows the launcher provides a tray for quick stop/restart, but the Linux launcher has no tray surface yet — when one is added it will mirror the Windows behavior. For now use Settings → App → stop server & exit in the web UI to stop the app cleanly.
 
 ## Configuration
 
@@ -314,6 +314,8 @@ Almost all configuration is managed through the in-app **Settings** panel (gear 
 | `updateCheckIntervalMinutes` | `60` | Settings → Updates → Check interval |
 | `channel` | `stable` | Settings → Updates → Channel |
 | `githubOwner` | `bilbospocketses` | Settings → Updates → GitHub owner (override for forks) |
+
+Not a stored field, but reached the same way: **Settings → App → stop server & exit** cleanly stops the server and quits the app — the primary clean-exit path on Linux (no tray there), disabled in service mode.
 
 **Update channels are baked into the installation.** Velopack tracks the channel (stable or beta) at the package level — it's part of the installed identity, not just a config preference. Changing the `channel` setting changes which feed the updater *queries*, but the in-app updater cannot cross from one channel to another. A beta installation will not successfully apply a stable update (or vice versa), even if the updater detects and downloads it. **To switch channels, uninstall the current version and fresh-install the desired channel's MSI/AppImage.** This is a Velopack platform constraint, not a ws-scrcpy-web limitation.
 

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -45,7 +45,16 @@ pub fn data_root_for_linux(
     }
     match home {
         Some(h) => PathBuf::from(h).join(".local").join("share").join("WsScrcpyWeb"),
-        None => PathBuf::from("/tmp").join("WsScrcpyWeb"),
+        // #36: never silently fall back to ephemeral, world-writable /tmp. A
+        // system service must set DATA_ROOT (ServiceApi system-scope install);
+        // any other no-HOME context is a real misconfiguration — fail loudly so
+        // it's caught, not silently corrupted into /tmp (which a root service
+        // loses on every reboot).
+        None => panic!(
+            "data_root_for_linux: none of DATA_ROOT, XDG_DATA_HOME, or HOME is set; \
+             cannot resolve a persistent data root (refusing the old /tmp fallback). \
+             A systemd service must set Environment=DATA_ROOT."
+        ),
     }
 }
 
@@ -288,6 +297,14 @@ mod tests {
     fn data_root_for_linux_ignores_empty_data_root() {
         let result = data_root_for_linux(Some(""), None, Some("/home/user"));
         assert_eq!(result, PathBuf::from("/home/user/.local/share/WsScrcpyWeb"));
+    }
+
+    #[test]
+    #[should_panic(expected = "DATA_ROOT")]
+    fn data_root_for_linux_panics_instead_of_tmp_when_nothing_set() {
+        // #36 defense: the old `None => /tmp/WsScrcpyWeb` silently landed a
+        // no-HOME root service in ephemeral /tmp. It now fails loudly instead.
+        let _ = data_root_for_linux(None, None, None);
     }
 
     #[test]

--- a/docs/specs/2026-06-02-system-scope-service-paths-fix-design.md
+++ b/docs/specs/2026-06-02-system-scope-service-paths-fix-design.md
@@ -1,0 +1,55 @@
+# Linux system-scope service: correct paths + install handoff — design
+
+**Status:** approved 2026-06-02. Found during the v0.1.30-beta.39 Fedora smoke (Smoke 6). Pre-existing (system-scope install never ran end-to-end before); not a beta.39 regression.
+
+## Problem
+
+Installing the **system-scope** systemd service on Linux produces a service that *runs* but is mis-pathed:
+
+- Its `config.json` / state lands in **`/tmp/WsScrcpyWeb`** — ephemeral (tmpfs, wiped on reboot), so the service forgets its config every boot.
+- It runs `node`/`adb` from the **installing user's home** (`/home/<u>/.local/share/WsScrcpyWeb/dependencies`) — fragile + a root-executing-user-writable-binary surface, and a violation of Local-Dependencies-Only (deps must live in the app's own folder).
+- The browser shows the **local WelcomeModal** in system mode (the install writes `installMode` to the *user's* config, but the service reads `/tmp`).
+- After install the **browser doesn't hand off** — it stays on the user's old port while the service binds a different one, so the app looks dead.
+
+## Root cause (code-confirmed)
+
+Two env vars the install gets wrong, plus one skipped step:
+
+1. `ServiceApi.ts:304-306` builds the unit env as `{ DEPS_PATH: cfg.dependenciesPath }` **unconditionally** — `cfg.dependenciesPath` is the installing user's deps. → deps-from-home.
+2. That env block sets **no `DATA_ROOT`**. The root systemd service has no `HOME`, so `common/src/config.rs:48` `data_root_for_linux` hits its last-resort arm `None => /tmp/WsScrcpyWeb`; the launcher bridges that to node. → config-in-`/tmp`.
+3. The system service's config is **never seeded**, so `installMode`/`firstRunComplete`/`webPort` are defaults → WelcomeModal + a port mismatch that breaks `classifyInstallPoll` (`SettingsModal.ts:42`), whose `navigate`/`reconnect` signals both assume one shared config + the same port.
+
+## Design
+
+Layout decision: **everything under `/opt/ws-scrcpy-web`** (single self-contained tree), SELinux-correct via a *targeted* fcontext.
+
+### This pass (the bigger part)
+
+1. **Layout + SELinux.** AppImage + deps → `/opt/ws-scrcpy-web/{WsScrcpyWeb.AppImage, dependencies/}` (`bin_t`, exec). State → `/opt/ws-scrcpy-web/data/{config.json, logs/}` with a **more-specific** fcontext rule `/opt/ws-scrcpy-web/data(/.*)? -> var_lib_t` (beats the general `…(/.*)? -> bin_t`, so the data dir is writable). `restorecon -R /opt/ws-scrcpy-web` applies both after staging.
+2. **Deps copied to `/opt` at install** (Local-Dependencies-Only compliant). Extend the existing `/opt` AppImage staging to also copy the user's `dependencies/` → `/opt/ws-scrcpy-web/dependencies`, then `restorecon` (`bin_t`). Deterministic; labeled before the service starts. Edge: if the user's deps are incomplete, the service's dep-manager backfills on first run.
+3. **Scope-aware unit env + config seed** (the core). For **system** scope: `envVars = { DATA_ROOT: '/opt/ws-scrcpy-web/data', DEPS_PATH: '/opt/ws-scrcpy-web/dependencies' }` (user scope unchanged). Seed `/opt/ws-scrcpy-web/data/config.json` at install with `{ installMode:'system-service', firstRunComplete:true, webPort:<the user's current port> }`. → persistent config, no `/tmp`, no WelcomeModal, survives reboot.
+4. **Install handoff falls out of #3.** Seeding `webPort` = the user's current port → the service binds the **same** port the user is on; when the local instance exits, the existing `reconnect` path (`classifyInstallPoll` → reload current URL) just works. No new discovery code.
+6. **Defense.** Change `config.rs:48` `None => /tmp/WsScrcpyWeb` to fail loudly (return an error / explicit non-ephemeral default) so no future no-`DATA_ROOT` context silently lands in `/tmp` again.
+7. **Bookmark clobber (bug #35).** Remove the eager constructor `bookmarkDismissedForPort` PATCH from `WelcomeModal.ts:44-48` + `ServiceFirstRunModal.ts:44-48` — redundant with `index.ts` modal gating + the completion-path stamp; it was clobbering "reset welcome and bookmark prompts".
+
+### Fast follow (separate, after the above lands)
+
+5. **Uninstall handoff.** Make the root teardown best-effort relaunch the user's local AppImage **into the originating user's graphical session** (recorded `local-appimage` marker + the user's `DISPLAY`/`XDG_RUNTIME_DIR`), then reuse the user-scope uninstall poll to navigate. Graceful fallback to today's "relaunch manually" guidance when headless / no session. Deferred because of the root→user-session OS edge cases.
+
+## Files (anticipated)
+
+- `src/server/api/ServiceApi.ts` — scope-aware `envVars`; seed system `config.json`; trigger deps copy + restorecon for system scope.
+- `src/server/service/SystemdClient.ts` — the `/opt/ws-scrcpy-web/data -> var_lib_t` fcontext rule alongside the existing `bin_t` rule; staging of deps.
+- `common/src/config.rs` — `data_root_for_linux` `/tmp` last-resort hardening.
+- `src/app/client/WelcomeModal.ts`, `src/app/client/ServiceFirstRunModal.ts` — drop the eager bookmark stamp.
+- Tests alongside each.
+
+## Testing
+
+- **Unit (TDD, failing-test-first):** scope-aware `envVars` (system → `/opt` paths; user unchanged); system `config.json` seed shape (incl. `webPort` = caller's port); the fcontext/`restorecon` command builders (data dir → `var_lib_t`); `data_root_for_linux` no-HOME behavior (no silent `/tmp`); the bookmark fix (reset clears `bookmarkDismissedForPort`, survives the reload).
+- **Runtime verification:** re-run **Smoke 6 + Smoke 7** on Fedora (SELinux enforcing) — the authoritative proof: `/opt/ws-scrcpy-web/data` config persists across reboot, deps run from `/opt`, no WelcomeModal, install hand-off lands on the same port, zero AVC.
+
+## Non-goals
+
+- The uninstall handoff (#5) — fast follow.
+- Changing user-scope or Windows behavior — the fix is system-scope-Linux-branched.

--- a/src/app/client/ServiceFirstRunModal.ts
+++ b/src/app/client/ServiceFirstRunModal.ts
@@ -34,18 +34,11 @@ export class ServiceFirstRunModal extends Modal {
     constructor(options: ServiceFirstRunModalOptions) {
         super({ title: 'ws-scrcpy-web is running as a service' });
         this.opts = options;
-        // v0.1.14: same eager bookmark-port flag as WelcomeModal — the
-        // service first-run copy includes a bookmark hint, so the
-        // PortChangeModal would be redundant. State-level enforcement
-        // of "first-run overrides port modal" beyond just the if/else
-        // ordering in index.ts. Fire-and-forget: priority order in
-        // index.ts also gates this, so a failed PATCH doesn't cause
-        // double-modal stacking on this page load.
-        void fetch('/api/config', {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ bookmarkDismissedForPort: this.opts.webPort }),
-        }).catch(() => { /* belt-and-suspenders only — silent */ });
+        // No eager bookmarkDismissedForPort stamp here (removed — bug #35).
+        // Redundant with index.ts modal gating + the dismiss-completion stamp
+        // (which PATCHes bookmarkDismissedForPort on dismiss), and it clobbered
+        // "reset welcome and bookmark prompts": the reset re-shows this modal,
+        // which re-stamped the current port over the reset's null.
         // Defer body fill past class-field init phase
         // (ES2022 useDefineForClassFields). Same pattern as
         // WelcomeModal. The footer is set up via buildFooter() which

--- a/src/app/client/WelcomeModal.ts
+++ b/src/app/client/WelcomeModal.ts
@@ -32,20 +32,13 @@ export class WelcomeModal extends Modal {
         super({ title: 'Welcome to ws-scrcpy-web' });
         this.opts = options;
         this.dialog.classList.add('welcome-modal');
-        // v0.1.14: eagerly mark the bookmark-port as "covered" the moment
-        // this modal is constructed. The Welcome copy already includes a
-        // bookmark hint, so a port modal would be redundant noise on the
-        // same page load. State-level enforcement (the flag itself) of the
-        // "first-run overrides port modal" rule, in addition to the
-        // priority order in index.ts. If the user later changes ports,
-        // the saved port mismatches and the port modal correctly returns.
-        // Fire-and-forget — modal still renders correctly if the PATCH
-        // fails (priority order in index.ts also gates this).
-        void fetch('/api/config', {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ bookmarkDismissedForPort: this.opts.webPort }),
-        }).catch(() => { /* belt-and-suspenders only — silent */ });
+        // No eager bookmarkDismissedForPort stamp here (removed — bug #35).
+        // It was redundant: index.ts already gates modal priority on the same
+        // load (WelcomeModal shows; PortChangeModal early-returns), and the
+        // decision-completion path below stamps the port legitimately. The
+        // eager stamp also clobbered "reset welcome and bookmark prompts" —
+        // the reset re-shows this modal (firstRunComplete=false), which
+        // re-stamped the current port over the reset's null.
         // Defer body/footer fill past class-field init phase (ES2022 useDefineForClassFields).
         queueMicrotask(() => {
             this.fillBody(this.bodyEl);

--- a/src/app/client/__tests__/firstRunBookmarkStamp.test.ts
+++ b/src/app/client/__tests__/firstRunBookmarkStamp.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+/**
+ * Bug #35: "reset welcome and bookmark prompts" left bookmarkDismissedForPort
+ * stale. Root cause: WelcomeModal + ServiceFirstRunModal eagerly PATCH
+ * bookmarkDismissedForPort=<webPort> in their constructors. The reset sets
+ * firstRunComplete=false -> the reload re-shows the modal -> the constructor
+ * re-stamps the current port, clobbering the reset's null.
+ *
+ * The eager stamp is redundant: index.ts already gates modal priority on the
+ * same load (welcome/service-first-run shows, port-change early-returns), and
+ * the modal's COMPLETION path stamps the port legitimately. So neither modal
+ * should issue the bookmark PATCH at construction time.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WelcomeModal } from '../WelcomeModal';
+import { ServiceFirstRunModal } from '../ServiceFirstRunModal';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({}),
+            } as unknown as Response),
+        ),
+    );
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+function bookmarkPortWasStamped(): boolean {
+    const calls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls as unknown[][];
+    return calls.some((args) => {
+        const init = args[1] as RequestInit | undefined;
+        const body = typeof init?.body === 'string' ? init.body : '';
+        return body.includes('bookmarkDismissedForPort');
+    });
+}
+
+describe('first-run modals do not eagerly stamp bookmarkDismissedForPort (#35)', () => {
+    it('WelcomeModal construction issues no bookmarkDismissedForPort PATCH', async () => {
+        new WelcomeModal({ webPort: 8000, portWasAutoShifted: false, onDecision: () => {} });
+        await flush();
+        expect(bookmarkPortWasStamped()).toBe(false);
+    });
+
+    it('ServiceFirstRunModal construction issues no bookmarkDismissedForPort PATCH', async () => {
+        new ServiceFirstRunModal({ webPort: 8000 });
+        await flush();
+        expect(bookmarkPortWasStamped()).toBe(false);
+    });
+});

--- a/src/server/__tests__/systemScopePaths.test.ts
+++ b/src/server/__tests__/systemScopePaths.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildServiceUnitEnv, buildSystemSeedConfig } from '../service/SystemdClient';
+
+/**
+ * Bug #36: the system-scope service ran node/adb from the installing user's
+ * home (DEPS_PATH=cfg.dependenciesPath, unconditionally) and landed its config
+ * in /tmp (no DATA_ROOT -> Rust /tmp fallback). The unit env must instead point
+ * at the app's OWN /opt tree (Local-Dependencies-Only) and set DATA_ROOT so the
+ * root service (no HOME) doesn't fall back to ephemeral /tmp.
+ */
+describe('buildServiceUnitEnv (#36 system-scope /opt paths)', () => {
+    const userDeps = '/home/jamie/.local/share/WsScrcpyWeb/dependencies';
+
+    it('linux + system: DATA_ROOT + DEPS_PATH under /opt, NOT the user home', () => {
+        expect(buildServiceUnitEnv('linux', 'system', userDeps)).toEqual({
+            DATA_ROOT: '/opt/ws-scrcpy-web/data',
+            DEPS_PATH: '/opt/ws-scrcpy-web/dependencies',
+        });
+    });
+
+    it('linux + user: the caller deps path, no DATA_ROOT override', () => {
+        expect(buildServiceUnitEnv('linux', 'user', userDeps)).toEqual({ DEPS_PATH: userDeps });
+    });
+
+    it('win32 + system: user deps, no /opt (Windows path is unaffected)', () => {
+        const winDeps = 'C:\\ProgramData\\WsScrcpyWeb\\dependencies';
+        expect(buildServiceUnitEnv('win32', 'system', winDeps)).toEqual({ DEPS_PATH: winDeps });
+    });
+});
+
+describe('buildSystemSeedConfig (#36 seed)', () => {
+    it('seeds system-service mode, first-run-complete, and the caller web port', () => {
+        // installMode + firstRunComplete => the service reads a correct config
+        // (ServiceFirstRunModal, not WelcomeModal); webPort = the user's current
+        // port => the post-install browser hand-off lands on the same URL.
+        expect(buildSystemSeedConfig(8002)).toEqual({
+            installMode: 'system-service',
+            firstRunComplete: true,
+            webPort: 8002,
+        });
+    });
+});

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -23,7 +23,7 @@ import {
     type ServiceClientFactoryResult,
 } from '../service';
 import { resolveSystemTool } from '../service/systemTools';
-import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_HELPER } from '../service/SystemdClient';
+import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_HELPER, buildServiceUnitEnv, buildSystemSeedConfig } from '../service/SystemdClient';
 import { readJsonBody } from './utils';
 
 const log = Logger.for('ServiceApi');
@@ -301,9 +301,10 @@ export class ServiceApi {
             // if the directory truly can't be created.
         }
         const logPath = path.join(logsDir, 'service.log');
-        const envVars: Record<string, string> = {
-            DEPS_PATH: cfg.dependenciesPath,
-        };
+        // Scope-aware unit env (#36): linux system-scope points DATA_ROOT +
+        // DEPS_PATH at the app's own /opt tree (not the installing user's home,
+        // and not the /tmp the root service would otherwise fall back to).
+        const envVars = buildServiceUnitEnv(result.platform, scope, cfg.dependenciesPath);
 
         // Persist installMode to disk BEFORE invoking the install. The
         // service-instance's Node process loads Config from config.json
@@ -351,6 +352,15 @@ export class ServiceApi {
                 // Linux system-scope only: home helper path to stage into /opt (bin_t).
                 // Windows ServyClient ignores this field.
                 linuxHelperSource,
+                // Linux system-scope only (#36): copy the user's deps into /opt
+                // and seed the service config so it doesn't run deps from home or
+                // land its config in /tmp. Windows + user-scope ignore these.
+                ...(result.platform === 'linux' && scope === 'system'
+                    ? {
+                          sourceDeps: cfg.dependenciesPath,
+                          seedConfig: buildSystemSeedConfig(cfg.getAppConfig().webPort),
+                      }
+                    : {}),
             });
         } catch (err) {
             // Install failed — revert installMode so the next page load

--- a/src/server/service/ServiceClient.ts
+++ b/src/server/service/ServiceClient.ts
@@ -89,6 +89,22 @@ export interface ServiceInstallOptions {
      * Windows ServyClient ignores this field.
      */
     linuxHelperSource?: string | undefined;
+
+    /**
+     * Linux system-scope only (#36): the installing user's `dependencies/` dir.
+     * Copied into `/opt/ws-scrcpy-web/dependencies` at install so the root
+     * service runs the app's OWN deps (Local-Dependencies-Only) rather than
+     * reaching into a user's home. Windows + Linux user-scope ignore this.
+     */
+    sourceDeps?: string | undefined;
+
+    /**
+     * Linux system-scope only (#36): the config.json seeded into the staged
+     * `/opt/ws-scrcpy-web/data` dir so the service boots with a correct,
+     * persistent config (system-service mode, first-run-complete, the user's
+     * web port) instead of a fresh one in ephemeral /tmp. Ignored elsewhere.
+     */
+    seedConfig?: Record<string, unknown> | undefined;
 }
 
 /**

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -93,6 +93,36 @@ describe('buildSystemInstallScript', () => {
         expect(script).toContain('|| true');
         expect(script.indexOf('cp "/tmp/WsScrcpyWeb.service.tmp"')).toBeGreaterThan(script.indexOf('chcon'));
     });
+
+    it('copies the user deps into /opt and seeds the data config (#36)', () => {
+        const script = buildSystemInstallScript({
+            sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
+            sourceDeps: '/home/u/.local/share/WsScrcpyWeb/dependencies',
+            seedConfigTmpPath: '/tmp/WsScrcpyWeb.seed.json',
+            unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
+            unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
+            name: 'WsScrcpyWeb',
+        });
+        // writable state dir + deps dir created
+        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web/data');
+        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web/dependencies');
+        // deps copied from the user's dir into the app's OWN /opt tree (Local-Deps)
+        expect(script).toContain('cp -a "/home/u/.local/share/WsScrcpyWeb/dependencies/." "/opt/ws-scrcpy-web/dependencies/"');
+        // seed config written into the data dir
+        expect(script).toContain('cp "/tmp/WsScrcpyWeb.seed.json" "/opt/ws-scrcpy-web/data/config.json"');
+        // data dir gets the writable var_lib_t label (more-specific beats the tree's bin_t)
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/opt/ws-scrcpy-web/data(/.*)?'");
+        // deps + seed land before the relabel so restorecon labels them correctly
+        expect(script.indexOf('config.json')).toBeLessThan(script.indexOf('restorecon -Rv'));
+    });
+
+    it('always prepares the writable data dir, but omits deps-copy + seed when not provided', () => {
+        const script = buildSystemInstallScript(args);
+        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web/data');
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/opt/ws-scrcpy-web/data(/.*)?'");
+        expect(script).not.toContain('cp -a');
+        expect(script).not.toContain('/data/config.json');
+    });
 });
 
 describe('absolute-path OS tools', () => {

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -78,6 +78,50 @@ export const STAGED_SYSTEM_APPIMAGE = 'WsScrcpyWeb.AppImage';
 export const STAGED_SYSTEM_HELPER = 'ws-scrcpy-web-launcher.exe';
 
 /**
+ * Root-owned writable state dir for the system-scope service (config.json,
+ * logs/). A MORE-SPECIFIC fcontext (`…/data → var_lib_t`) overrides the dir's
+ * general bin_t rule so the service may write here under SELinux (#36).
+ */
+export const STAGED_SYSTEM_DATA_DIR = `${STAGED_SYSTEM_DIR}/data`;
+/**
+ * Root-owned dependencies dir for the system-scope service (node/adb/
+ * scrcpy-server). Under the bin_t-labelled /opt tree so init_t may exec them,
+ * and so the app runs its OWN deps rather than a copy from a user's home
+ * (Local-Dependencies-Only, #36).
+ */
+export const STAGED_SYSTEM_DEPS_DIR = `${STAGED_SYSTEM_DIR}/dependencies`;
+
+/**
+ * The systemd unit's Environment vars for a given platform + scope. Linux
+ * system-scope MUST point at the app's own /opt tree (Local-Dependencies-Only)
+ * and set DATA_ROOT so the root service (which has no HOME) doesn't fall back
+ * to ephemeral /tmp (#36). Every other case keeps the caller's deps path and
+ * lets the launcher bridge DATA_ROOT (Windows ProgramData, Linux user XDG/HOME).
+ */
+export function buildServiceUnitEnv(
+    platform: NodeJS.Platform,
+    scope: SystemdScope | undefined,
+    userDepsPath: string,
+): Record<string, string> {
+    if (platform === 'linux' && scope === 'system') {
+        return { DATA_ROOT: STAGED_SYSTEM_DATA_DIR, DEPS_PATH: STAGED_SYSTEM_DEPS_DIR };
+    }
+    return { DEPS_PATH: userDepsPath };
+}
+
+/**
+ * The config.json seeded into the system service's /opt data dir at install so
+ * it reads a correct, persistent config on first boot (#36): it knows it is a
+ * service (ServiceFirstRunModal, not WelcomeModal), is already first-run-
+ * complete, and binds the same web port the installing user is on (so the
+ * post-install browser hand-off lands on the same URL). Other fields fall to
+ * Config defaults when the service loads this file.
+ */
+export function buildSystemSeedConfig(currentWebPort: number): Record<string, unknown> {
+    return { installMode: 'system-service', firstRunComplete: true, webPort: currentWebPort };
+}
+
+/**
  * Run a command via pkexec for graphical privilege escalation. The user
  * sees a single password prompt for the entire shell command. Throws on
  * auth-cancel (exit 126), pkexec-not-found, or command failure.
@@ -225,7 +269,15 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
  * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
  */
 export function buildSystemInstallScript(
-    args: { sourceAppImage: string; sourceHelper?: string; unitTmpPath: string; unitPath: string; name: string },
+    args: {
+        sourceAppImage: string;
+        sourceHelper?: string;
+        sourceDeps?: string;
+        seedConfigTmpPath?: string;
+        unitTmpPath: string;
+        unitPath: string;
+        name: string;
+    },
     binTool: (t: string) => string = (t) => resolveSystemTool(t),
     sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
 ): string {
@@ -239,8 +291,11 @@ export function buildSystemInstallScript(
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
     const steps: string[] = [
-        // 1. stage the AppImage into /opt (root-owned)
+        // 1. stage dirs: the /opt root + the writable data dir (always — the
+        //    system service writes its config + logs there). The deps dir is
+        //    added below only when we have deps to copy.
         `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
+        `${mkdir} -p ${STAGED_SYSTEM_DATA_DIR}`,
         `${cp} "${args.sourceAppImage}" "${staged}"`,
         `${chmod} 0755 "${staged}"`,
     ];
@@ -250,6 +305,19 @@ export function buildSystemInstallScript(
     if (args.sourceHelper) {
         steps.push(`${cp} "${args.sourceHelper}" "${stagedHelper}"`);
         steps.push(`${chmod} 0755 "${stagedHelper}"`);
+    }
+    // 1c. copy the installing user's deps into the app's OWN /opt tree so the
+    //     root service runs them (Local-Dependencies-Only) instead of reaching
+    //     into a user's home. restorecon below labels them bin_t (init_t exec).
+    if (args.sourceDeps) {
+        steps.push(`${mkdir} -p ${STAGED_SYSTEM_DEPS_DIR}`);
+        steps.push(`${cp} -a "${args.sourceDeps}/." "${STAGED_SYSTEM_DEPS_DIR}/"`);
+    }
+    // 1d. seed the system config so the service reads a correct, persistent
+    //     config on first boot (system-service mode, first-run-complete, the
+    //     user's web port). Written before restorecon so it gets var_lib_t.
+    if (args.seedConfigTmpPath) {
+        steps.push(`${cp} "${args.seedConfigTmpPath}" "${STAGED_SYSTEM_DATA_DIR}/config.json"`);
     }
     steps.push(
         // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
@@ -261,7 +329,7 @@ export function buildSystemInstallScript(
         //    erroring on a non-SELinux fs) would break the outer `&&` chain and
         //    silently skip the unit cp + enable below.
         //    restorecon covers the whole dir — labels the helper bin_t too when present.
-        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${semanage} fcontext -a -t var_lib_t '${STAGED_SYSTEM_DATA_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         // 3. install + enable the unit (ExecStart already points at ${staged})
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
         `${systemctl} daemon-reload`,
@@ -359,10 +427,19 @@ export class SystemdClient implements ServiceClient {
             // copies unit + enables — all under a single graphical prompt.
             const tmpFile = path.join(os.tmpdir(), `${opts.name}.service.tmp`);
             fs.writeFileSync(tmpFile, unitContent, { mode: 0o644 });
+            // Seed config -> temp file; the pkexec script cp's it into the staged
+            // /opt/.../data dir (root-owned) under the single graphical prompt.
+            let seedTmpFile: string | undefined;
+            if (opts.seedConfig) {
+                seedTmpFile = path.join(os.tmpdir(), `${opts.name}.seed.json`);
+                fs.writeFileSync(seedTmpFile, JSON.stringify(opts.seedConfig, null, 2) + '\n', { mode: 0o644 });
+            }
             try {
                 const cmd = buildSystemInstallScript({
                     sourceAppImage: opts.binPath,
                     ...(opts.linuxHelperSource ? { sourceHelper: opts.linuxHelperSource } : {}),
+                    ...(opts.sourceDeps ? { sourceDeps: opts.sourceDeps } : {}),
+                    ...(seedTmpFile ? { seedConfigTmpPath: seedTmpFile } : {}),
                     unitTmpPath: tmpFile,
                     unitPath,
                     name: opts.name,
@@ -370,6 +447,9 @@ export class SystemdClient implements ServiceClient {
                 await runPkexec(cmd, 'install (system scope)');
             } finally {
                 try { fs.unlinkSync(tmpFile); } catch { /* best-effort cleanup */ }
+                if (seedTmpFile) {
+                    try { fs.unlinkSync(seedTmpFile); } catch { /* best-effort cleanup */ }
+                }
             }
         } else {
             // User scope (no elevation) or already root.


### PR DESCRIPTION
Found during the v0.1.30-beta.39 Fedora smoke (Smoke 6); the system-scope service install worked at the SELinux level but was mis-pathed.

**System-scope install paths.** The root service landed its config in ephemeral `/tmp` (no `DATA_ROOT` + no `HOME`) and ran `node`/`adb` from the installing user's home (fragile + a Local-Dependencies-Only violation). The unit now sets `DATA_ROOT` + `DEPS_PATH` to `/opt/ws-scrcpy-web/{data,dependencies}`; the install copies deps into `/opt` (`bin_t` tree, with a more-specific `var_lib_t` rule on the data dir so the service can write it under SELinux) and seeds a correct `config.json` — so the service is persistent across reboots, runs its own deps, shows no stray WelcomeModal, and the post-install browser hand-off lands on the same port. `data_root_for_linux` now fails loudly instead of silently using `/tmp`.

**Bookmark reset.** Removed the eager `bookmarkDismissedForPort` constructor stamp in `WelcomeModal` + `ServiceFirstRunModal` so "reset welcome and bookmark prompts" no longer gets clobbered on the reload.

Plus the README "stop server & exit" pointer fix and a design spec (`docs/specs/2026-06-02-system-scope-service-paths-fix-design.md`).

**Verification:** TDD throughout — vitest 827/827, tsc 0, cargo (common) 48/48, clippy 0, `cross test --workspace` 0. Runtime re-smoke of Smoke 6+7 on Fedora is the next gate. The system-scope uninstall->relaunch hand-off is a deferred fast-follow.