### PR TITLE
docs: correct README/TECHNICAL_GUIDE drift + add Linux coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **README:** corrected the Linux AppImage download name to the channel-suffixed `WsScrcpyWeb-linux-stable.AppImage` / `WsScrcpyWeb-linux-beta.AppImage`, and rewrote the libfuse2 section — the AppImage now bundles the static type-2 runtime, so it launches without host `libfuse2`; the libfuse2 note now scopes to the in-app updater only.
+- **TECHNICAL_GUIDE:** documented Linux service mode (systemd; user/system scopes; SELinux `/opt` staging), the Linux launcher subcommands, and the Linux download-and-swap update apply (sections 19/20/22); corrected the reset-prompts field list (23.4) and the dependency version table (12).
+- **THIRD-PARTY-NOTICES:** added attribution for the bundled MIT runtime dependencies (`ws`, `@xterm/*`, `node-pty`, `velopack`).
+- Misc: self-contained the SignPath disclosure (RELEASING) and removed references to an internal-only file from RELEASING / PROGRAMDATA-MIGRATION; fixed the spec/plan paths in CONTRIBUTING; completed the localStorage inventory in PRIVACY.
+
 ## [0.1.30-beta.40] - 2026-06-03
 
 ### Fixed
@@ -1659,7 +1666,7 @@ The honest accounting of how we got here:
 ### Privacy and code signing
 
 - `PRIVACY.md` documents outbound traffic (update checks, optional dep installs from `nodejs.org`, `dl.google.com`, `github.com`). No telemetry. No analytics. No project-operated server.
-- ~~Code signing via [SignPath Foundation](https://signpath.org)'s free OSS program — application is in review. Once approved, the next release will be the first signed release. Until then, integrity is verifiable via the `SHA256SUMS` file shipped with each release.~~ *(Retracted 2026-05-07: SignPath Foundation declined the application — see [Unreleased].)*
+- ~~Code signing via [SignPath Foundation](https://signpath.org)'s free OSS program — application is in review. Once approved, the next release will be the first signed release. Until then, integrity is verifiable via the `SHA256SUMS` file shipped with each release.~~ *(Retracted 2026-05-07: SignPath Foundation declined the application — see docs/RELEASING.md "Future signer setup".)*
 
 ## [0.1.3] - 2026-04-27 [YANKED]
 
@@ -1723,7 +1730,7 @@ The honest accounting of how we got here:
 ### Privacy and code signing
 
 - `PRIVACY.md` documents outbound traffic (update checks, optional dep installs from `nodejs.org`, `dl.google.com`, `github.com`). No telemetry. No analytics. No project-operated server.
-- ~~Code signing via [SignPath Foundation](https://signpath.org)'s free OSS program — application is in review. Once approved, the next release will be the first signed release. Until then, integrity is verifiable via the `SHA256SUMS` file shipped with each release.~~ *(Retracted 2026-05-07: SignPath Foundation declined the application — see [Unreleased].)*
+- ~~Code signing via [SignPath Foundation](https://signpath.org)'s free OSS program — application is in review. Once approved, the next release will be the first signed release. Until then, integrity is verifiable via the `SHA256SUMS` file shipped with each release.~~ *(Retracted 2026-05-07: SignPath Foundation declined the application — see docs/RELEASING.md "Future signer setup".)*
 
 ## [0.1.1] - 2026-04-27 [YANKED]
 
@@ -1791,7 +1798,7 @@ First public release.
 ### Privacy and code signing
 
 - New `PRIVACY.md` documenting outbound traffic (update checks, optional dep installs from nodejs.org / dl.google.com / github.com). No telemetry. No analytics. No project-operated server.
-- ~~Code signing via [SignPath Foundation](https://signpath.org)'s free OSS program — application is in review at v0.1.0 release. Once approved, **v0.1.1** will be the first signed release. Until then, integrity is verifiable via the `SHA256SUMS` file shipped with the release.~~ *(Retracted 2026-05-07: SignPath Foundation declined the application — see [Unreleased].)*
+- ~~Code signing via [SignPath Foundation](https://signpath.org)'s free OSS program — application is in review at v0.1.0 release. Once approved, **v0.1.1** will be the first signed release. Until then, integrity is verifiable via the `SHA256SUMS` file shipped with the release.~~ *(Retracted 2026-05-07: SignPath Foundation declined the application — see docs/RELEASING.md "Future signer setup".)*
 
 ### Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,10 @@ Any PR that changes protocol code or control-message encoding MUST include or up
 
 Larger features go through a spec → plan → implementation cycle:
 
-- **Specs:** `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
-- **Plans:** `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`
+- **Specs:** `docs/specs/YYYY-MM-DD-<topic>-design.md`
+- **Plans:** `docs/plans/YYYY-MM-DD-<topic>.md`
 
-Existing specs and plans in `docs/` are a useful read before proposing architectural changes.
+Existing specs and plans under `docs/specs/`, `docs/plans/`, and the earlier `docs/superpowers/` tree are a useful read before proposing architectural changes.
 
 ## Commit Messages
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -14,7 +14,7 @@ Everything you do with ws-scrcpy-web stays on your computer:
 - **scrcpy stream data** (video, audio, touch/keyboard input) -- bounces between the device, the local server, and your browser. Never leaves the LAN.
 - **Network device discovery** (mDNS + TCP port-5555 sweep) -- your machine talks to your local network only.
 - **Web UI** -- served from `localhost`. No third-party scripts, no analytics, no tracking pixels.
-- **localStorage preferences** -- theme choice (dark/light), per-device audio settings, saved subnets for network scans. All `localStorage`, no cookies.
+- **localStorage preferences** -- theme choice (dark/light), per-device video/audio stream settings, file-browser icon size, and saved subnets for network scans. All `localStorage`, no cookies.
 
 ## What leaves your machine
 
@@ -55,7 +55,7 @@ Release artifacts are currently unsigned, so there is no code-signing revocation
 - **No analytics.** We don't send page views, click events, or session times anywhere.
 - **No crash reporting.** We don't ship Sentry, Bugsnag, or anything similar. If we add this in the future, the change will be flagged in `CHANGELOG.md` and this file will be updated.
 - **No project-operated server.** There is no ws-scrcpy-web cloud account, no login, no sync. The app is local-only.
-- **No cookies.** The web UI sets a `localStorage` theme preference. That's it. No cookies of any kind.
+- **No cookies.** The web UI stores only `localStorage` UI preferences (theme, stream/scan settings — see below). No cookies of any kind.
 
 ## Third-party operators
 
@@ -73,9 +73,11 @@ When traffic does leave your machine, it goes to one of these well-known operato
 
 The browser side of the app uses `localStorage` only, no cookies. Stored keys are limited to:
 
-- Theme preference (`dark` or `light`)
+- Theme preference (`ws-scrcpy-web-theme`: `dark` or `light`)
+- Per-device video/stream settings (codec, encoder, fps, bitrate; keyed per device/display)
 - Per-device audio settings (`ws-scrcpy-web:audio:<udid>`)
-- Saved network-scan subnets
+- File-browser icon-size preference
+- Saved network-scan subnets (`ws-scrcpy-web:scan-subnets`)
 
 No third-party scripts. No fonts loaded from CDNs. No analytics SDKs. The browser bundle ships from your local server only.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Get the latest release from the [Releases page](https://github.com/bilbospockets
 
 - **Windows MSI** (recommended) — installs per-machine to `C:\Program Files\WsScrcpyWeb\` with writable runtime state at `C:\ProgramData\WsScrcpyWeb\`. Requires admin (UAC) to install and to apply each subsequent update. Multi-user friendly; service mode and local mode share configuration.
 - **Windows portable ZIP** — unzip and run; no install required, no auto-updates. Useful for air-gapped setups.
-- **Linux AppImage** — `chmod +x ws-scrcpy-web-<version>.AppImage` and run. See [Linux install](#linux-install-appimage) below.
+- **Linux AppImage** — download `WsScrcpyWeb-linux-stable.AppImage` (or `WsScrcpyWeb-linux-beta.AppImage` for the beta channel), `chmod +x` it, and run. See [Linux install](#linux-install-appimage) below.
 
 **Upgrading from v0.1.20 or earlier on Windows:** the install layout changed. See [docs/PROGRAMDATA-MIGRATION.md](docs/PROGRAMDATA-MIGRATION.md) for the uninstall-then-reinstall steps.
 
@@ -261,9 +261,9 @@ In dev mode, `start.cmd` / `start.sh` provide a simpler restart loop for the sam
 
 Linux releases ship as a single self-contained AppImage built with [Velopack](https://velopack.io/). No package manager, no sudo (for user-scope installs), no system-wide changes.
 
-1. Download `WsScrcpyWeb-linux.AppImage` from the [Releases](https://github.com/bilbospocketses/ws-scrcpy-web/releases) page.
-2. Make it executable: `chmod +x WsScrcpyWeb-linux.AppImage`
-3. Run it: `./WsScrcpyWeb-linux.AppImage`
+1. Download `WsScrcpyWeb-linux-stable.AppImage` (stable channel) or `WsScrcpyWeb-linux-beta.AppImage` (beta channel) from the [Releases](https://github.com/bilbospocketses/ws-scrcpy-web/releases) page.
+2. Make it executable: `chmod +x WsScrcpyWeb-linux-stable.AppImage`
+3. Run it: `./WsScrcpyWeb-linux-stable.AppImage`
 4. Open `http://localhost:8000` in your browser.
 
 The first-run welcome modal offers to install ws-scrcpy-web as a systemd service. Two scopes are available:
@@ -285,17 +285,17 @@ AppImage signing is currently under evaluation; releases ship **unsigned** for n
 
 The bundled `node-pty` native binary is built against glibc. Musl-based distros (Alpine and similar) are not supported. Run on glibc-based distros: Ubuntu, Debian, Fedora, Arch, openSUSE, etc. — anything that ships glibc 2.31+ should work.
 
-#### libfuse2 (for in-app updates)
+#### libfuse2 (only for in-app updates)
 
-The AppImage runtime in Velopack 1.0.1 (the type-1 AppImageKit runtime) requires `libfuse.so.2` to mount its squashfs filesystem at launch. If your distro doesn't have it installed, the AppImage itself will refuse to start (this is an AppImageKit-level error, before any of our code runs). The in-app updater also relies on libfuse2 to extract update bundles.
+**The AppImage no longer needs libfuse2 to launch.** Our packaging swaps in the static [type-2 AppImage runtime](https://github.com/AppImage/type2-runtime) (it statically links libfuse), so the AppImage starts on any glibc-based distro — including fresh Ubuntu 24+, Fedora 40+, and Arch installs that no longer ship libfuse2 by default. Just `chmod +x` and run.
 
-If you launch the AppImage successfully but Settings → Updates shows a libfuse2 warning, click **install libfuse2** to invoke `pkexec sudo <pkg-manager> install` for your distro (auto-detected: `dnf`, `apt-get`, or `yum`). Or install manually:
+The **in-app updater** is the one remaining piece that still needs host `libfuse2`: it mounts the downloaded update AppImage to extract the new build. If Settings → Updates shows a libfuse2 warning, click **install libfuse2** to invoke `pkexec <pkg-manager> install` for your distro (auto-detected: `dnf`, `apt-get`, or `yum`). Or install manually:
 
 - **Debian/Ubuntu**: `sudo apt-get install libfuse2`
 - **Fedora/RHEL**: `sudo dnf install fuse-libs`
 - **Arch**: `sudo pacman -S fuse2`
 
-When Velopack ships its type-2 runtime (post-1.0.1), this dependency will be embedded in the AppImage and this step will go away.
+> This updater-side dependency is slated for removal: Velopack 1.1.1 (now bundled) ships its own type-2 runtime, so once it's verified on a no-libfuse2 distro the gate goes away entirely.
 
 #### Tray icon
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -52,3 +52,66 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+---
+
+## Bundled runtime dependencies (npm)
+
+The release artifacts bundle the following MIT-licensed npm packages: `ws` and
+`@xterm/xterm` (with the `@xterm/addon-attach` and `@xterm/addon-fit` addons)
+are compiled into the `dist/` bundles by webpack; `velopack` (the update SDK)
+is bundled into the server bundle; and the `node-pty` prebuilt native binary
+ships with the app. Their copyright notices are reproduced below; all are
+distributed under the MIT License (text reproduced once at the end).
+
+**ws** — https://github.com/websockets/ws
+
+```
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+Copyright (c) 2013 Arnout Kazemier and contributors
+Copyright (c) 2016 Luigi Pinca and contributors
+```
+
+**@xterm/xterm, @xterm/addon-attach, @xterm/addon-fit** — https://github.com/xtermjs/xterm.js
+
+```
+Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
+Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
+Copyright (c) 2012-2013, Christopher Jeffrey (https://github.com/chjj/)
+```
+
+**node-pty** — https://github.com/microsoft/node-pty
+
+```
+Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
+Copyright (c) 2016, Daniel Imms (http://www.growingwiththeweb.com)
+Copyright (c) 2018 - present Microsoft Corporation
+```
+
+**velopack** — https://github.com/velopack/velopack
+
+```
+Copyright (c) the Velopack authors
+```
+
+All four packages are distributed under the MIT License:
+
+```
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/docs/PROGRAMDATA-MIGRATION.md
+++ b/docs/PROGRAMDATA-MIGRATION.md
@@ -116,10 +116,10 @@ complete the upgrade no matter how many times you click apply.
 | Long-lived `adb start-server` daemon's CWD-lock on `current\` blocks Velopack swap rename | Update.exe gives up with "Unable to start the update, because one or more running processes prevented it." | v0.1.23-beta.13 (pre-apply `adb kill-server` + AdbClient cwd anchored at `<dataRoot>/dependencies/adb/`) |
 | webpack's `import { createRequire } from 'module'` tree-shaken to `void 0` | Shell button greyed out; resolver fails to load node-pty after first install. | v0.1.23-beta.23 (switched to `process.getBuiltinModule('module').createRequire(...)`) |
 
-The full per-bug diagnosis lives in `feedback_velopack_permachine_lessons.md`
-(Gotchas 1–11) and in the per-beta CHANGELOG entries v0.1.23-beta.1 through
-beta.13. None of those fixes are reachable via the in-app updater on a
-broken-chain build — Velopack's apply step itself is what's broken.
+The full per-bug diagnosis lives in the per-beta CHANGELOG entries
+v0.1.23-beta.1 through beta.13. None of those fixes are reachable via the
+in-app updater on a broken-chain build — Velopack's apply step itself is
+what's broken.
 
 ## How to migrate
 
@@ -150,6 +150,5 @@ and the `current\` swap completes automatically without the user needing
 to relaunch. Settings → Updates → "apply update v0.1.X" handles the full
 flow including auto-relaunch into the new version.
 
-If a future update fails: the `feedback_velopack_permachine_lessons.md`
-diagnostic checklist + the per-build `velopack.log` + `ws-scrcpy-web.log`
-are the right starting points.
+If a future update fails: the per-build `velopack.log` + `ws-scrcpy-web.log`
+(plus the v0.1.23-beta.1–13 CHANGELOG entries) are the right starting points.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -87,7 +87,7 @@ Reasoning: Velopack feed entries are append-only; deleting an entry breaks any c
 
 ## Future signer setup (placeholder)
 
-Release artifacts are currently unsigned. SignPath Foundation declined the OSS application (see [Unreleased] in CHANGELOG.md for the disclosure). Code-signing is under evaluation; when a signer is selected, this section will document:
+Release artifacts are currently unsigned. SignPath Foundation declined the OSS application on 2026-05-07. Code-signing is under evaluation; when a signer is selected, this section will document:
 
 - The CI secret(s) and repository variable(s) needed to enable the signed-mode branch in `.github/workflows/release.yml`.
 - The first signed release version + cut procedure.
@@ -114,7 +114,7 @@ When cutting a stable release after a chain of yanked or partially-broken beta r
 - **README.md** `## Downloads` — short paragraph identifying which versions need a fresh-MSI install vs which can in-app update.
 - **docs/PROGRAMDATA-MIGRATION.md** — full step-by-step migration including any per-bug fix-version table.
 
-Existing precedent: the v0.1.23 stable cut migration covers v0.1.21 / v0.1.22 / v0.1.23-beta.{1..6} → v0.1.23, since the in-app updater on those builds was broken at varying severity (Velopack PerMachine + ACL + Job Object + auto-apply paths). The full diagnosis chain is captured in CHANGELOG entries v0.1.23-beta.1 through beta.13 and in `feedback_velopack_permachine_lessons.md` (Gotchas 1–11).
+Existing precedent: the v0.1.23 stable cut migration covers v0.1.21 / v0.1.22 / v0.1.23-beta.{1..6} → v0.1.23, since the in-app updater on those builds was broken at varying severity (Velopack PerMachine + ACL + Job Object + auto-apply paths). The full diagnosis chain is captured in CHANGELOG entries v0.1.23-beta.1 through beta.13.
 
 For future stable cuts after broken-beta chains: keep the same shape — README has a short pointer, MIGRATION doc has the full story.
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -889,15 +889,15 @@ Run `npm outdated` to check all at once. Update one at a time, build + test afte
 |---|---------|---------|---------|--------------|
 | 1 | `typescript` | 6.0.2 | Compiles TypeScript source to JavaScript | Major versions may need `tsconfig.json` changes |
 | 2 | `webpack` | 5.106.2 | Bundles source into server and browser output | Patch updates are safe |
-| 3 | `webpack-cli` | 7.0.2 | Command-line interface for webpack | Major versions usually just drop old Node support |
+| 3 | `webpack-cli` | 7.0.3 | Command-line interface for webpack | Major versions usually just drop old Node support |
 | 4 | `css-loader` | 7.1.4 | Processes CSS imports for webpack bundling | Major versions may need webpack config changes |
 | 5 | `mini-css-extract-plugin` | 2.10.2 | Extracts CSS into separate .css files | Tied to webpack version |
-| 6 | `ts-loader` | 9.5.7 | Lets webpack process TypeScript files | Must be compatible with TypeScript version |
+| 6 | `ts-loader` | 9.6.0 | Lets webpack process TypeScript files | Must be compatible with TypeScript version |
 | 7 | `ts-node` | 10.9.2 | Runs webpack config files written in TypeScript | Must be compatible with TypeScript version |
-| 8 | `@biomejs/biome` | 2.4.12 | Linter and code formatter (replaces ESLint + Prettier) | Major versions need config migration (`npx @biomejs/biome migrate`) |
+| 8 | `@biomejs/biome` | 2.4.16 | Linter and code formatter (replaces ESLint + Prettier) | Major versions need config migration (`npx @biomejs/biome migrate`) |
 | 9 | `@types/node` | 24.12.2 | TypeScript type definitions for Node.js APIs | Must match target Node.js LTS major version (even numbers only, never odd) |
 | 10 | `@types/ws` | 8.18.1 | TypeScript type definitions for ws library | Must match `ws` major version |
-| 11 | `vitest` | 4.1.4 | Test runner for unit and integration tests | Usually safe to update |
+| 11 | `vitest` | 4.1.8 | Test runner for unit and integration tests | Usually safe to update |
 | 12 | `@xterm/xterm` | 6.0.0 | Terminal emulator rendered in the browser (Microsoft) | Major versions may have API changes affecting `ShellClient.ts` and `ShellModal.ts` |
 | 13 | `@xterm/addon-attach` | 0.12.0 | Connects xterm to a WebSocket for remote shell | Must match `@xterm/xterm` major version |
 | 14 | `@xterm/addon-fit` | 0.11.0 | Auto-resizes terminal to fit its container | Must match `@xterm/xterm` major version |
@@ -906,7 +906,7 @@ Run `npm outdated` to check all at once. Update one at a time, build + test afte
 
 | # | Package | Current | Purpose | Update notes |
 |---|---------|---------|---------|--------------|
-| 15 | `ws` | 8.20.0 | WebSocket server powering all browser-to-server communication | Bundled into webpack output; not user-updatable. Stable, rarely updates. Check before every release. |
+| 15 | `ws` | 8.21.0 | WebSocket server powering all browser-to-server communication | Bundled into webpack output; not user-updatable. Stable, rarely updates. Check before every release. |
 
 ### Runtime dependencies managed by in-app updater
 
@@ -1558,9 +1558,12 @@ card as disabled-via-CSS + `aria-disabled` + tooltip when
 
 ## 19. Service Mode Architecture
 
-Service mode lets ws-scrcpy-web run as a Windows service (via [Servy](https://github.com/nicedayzhu/servy)) or a Linux systemd unit, so the app starts at boot and survives logouts. The architecture uses an **operation-server pattern** for seamless install/uninstall transitions with no UAC prompts on uninstall and no port-sweep delays.
+Service mode lets ws-scrcpy-web run as a Windows service (via [Servy](https://github.com/nicedayzhu/servy)) or a Linux **systemd** unit, so the app starts at boot and survives logouts. Both platforms share the same browser UI and `/api/service/*` endpoints (sections 19.3–19.4) but use different OS mechanics:
 
-### 19.1 Install Flow
+- **Windows** (sections 19.1–19.2) uses an **operation-server pattern** — privileged work is deferred to a `post-stop.bat` Servy hook, so uninstall needs no UAC prompt and there is no port-sweep delay.
+- **Linux** (section 19.5) drives **systemd** directly, with an out-of-cgroup `systemd-run` teardown helper so an uninstall can stop the very unit that triggered it. User and system scopes are both supported; system scope is hardened for SELinux and Local-Dependencies-Only.
+
+### 19.1 Windows Install Flow (Servy)
 
 1. User clicks "Install as service" in the welcome modal or Settings.
 2. Browser calls `POST /api/service/install`.
@@ -1569,7 +1572,7 @@ Service mode lets ws-scrcpy-web run as a Windows service (via [Servy](https://gi
 5. The modal polls `GET /api/service/status` until it detects that the service-mode Node has started and written a new `webPort` to `config.json`.
 6. On detection, the modal auto-navigates to the service-mode URL.
 
-### 19.2 Uninstall Flow (Operation-Server Pattern)
+### 19.2 Windows Uninstall Flow (Operation-Server Pattern)
 
 The uninstall flow avoids UAC by deferring privileged work to a `post-stop.bat` script that Servy runs after the service Node exits:
 
@@ -1598,21 +1601,45 @@ The mtime-based discovery mechanism replaces the old `discoverServicePort` appro
 - **Uninstall:** `ServiceOperationModal` monitors `config.json` mtime. When the fresh user-session launcher writes its port, the mtime changes and the modal reads the new value.
 - The operation-server exposes `/api/discover` for the browser to detect when the fresh launcher is ready.
 
-### 19.5 Components
+### 19.5 Linux Service Mode (systemd)
+
+On Linux the service is a systemd unit managed by `SystemdClient` (`src/server/service/SystemdClient.ts`) — the cross-platform `ServiceClient` counterpart to the Windows `ServyClient`. The install UI offers two **scopes**:
+
+| Scope | Unit file | Elevation | Starts | Notes |
+|-------|-----------|-----------|--------|-------|
+| **user** | `~/.config/systemd/user/<name>.service` | none | at login | `loginctl enable-linger` (best-effort) keeps it running after logout; a `~/.config/autostart/ws-scrcpy-web-tray.desktop` autostarts the tray |
+| **system** | `/etc/systemd/system/<name>.service` | `pkexec` (one prompt) | at boot | hardened for SELinux + Local-Dependencies-Only (below); no tray autostart (headless-dominant) |
+
+The unit body (`renderUnitFile`) is `Type=simple`, `Restart=on-failure` / `RestartSec=5`, with `StartLimitIntervalSec`/`StartLimitBurst` in `[Unit]` (systemd silently ignores them in `[Service]`), and `StandardOutput`/`StandardError=append:` to the log. `WantedBy` is `default.target` (user) or `multi-user.target` (system). Running state is read with `systemctl is-active` (machine-readable), not `systemctl status`.
+
+**System scope — SELinux + Local-Dependencies-Only.** A system unit runs under the `init_t` domain, which SELinux (e.g. Fedora enforcing) forbids from exec'ing a `user_home_t` AppImage — and a root service has no `HOME`. So a system install (`buildSystemInstallScript`, run under one `pkexec` prompt) stages everything into a root-owned `/opt/ws-scrcpy-web/` tree:
+
+- `WsScrcpyWeb.AppImage`, the launcher helper, and a copy of the user's `dependencies/` → labelled **`bin_t`** (persistent `semanage fcontext` + `restorecon`, with a transient `chcon` fallback) so `init_t` may exec them, and so the service runs its **own** deps instead of reaching into a user's home.
+- `…/data/` (config + logs) gets a more-specific **`var_lib_t`** rule so the service may write there under SELinux.
+- The unit's `Environment=` sets `DATA_ROOT=/opt/ws-scrcpy-web/data` + `DEPS_PATH=/opt/ws-scrcpy-web/dependencies` (`buildServiceUnitEnv`), and a seeded `config.json` (`buildSystemSeedConfig`: `installMode=system-service`, `firstRunComplete=true`, the installing user's `webPort`) lands in `…/data/` so the service boots a correct, persistent config on the same port — no stray WelcomeModal, and it survives reboot. The whole label step is isolated with a trailing `|| true` so a non-SELinux host doesn't abort the install.
+
+**Uninstall — out-of-cgroup teardown.** Calling `systemctl stop` from inside the service unit's own cgroup would kill the calling process mid-operation (item 32). So `ServiceApi` launches the launcher helper via `systemd-run` (its own transient unit / separate cgroup) with `--linux-service-teardown --scope <user|system> --unit <name>`; `linux_service.rs` then runs, best-effort: `stop` → `disable` → `reset-failed` → remove the unit file → (system scope) `rm -rf /opt/ws-scrcpy-web` + `semanage fcontext -d` the `bin_t` rule → `daemon-reload` → reap the escaped adb daemon. **User scope** then relaunches the home AppImage in local mode via `systemd-run --user --collect` (path read from the `<dataRoot>/control/local-appimage` marker); **system scope** does not auto-relaunch (the admin relaunches their own AppImage).
+
+### 19.6 Components
 
 | File | Purpose |
 |------|---------|
-| `src/server/api/ServiceApi.ts` | REST endpoints for install/uninstall |
+| `src/server/api/ServiceApi.ts` | REST endpoints; Windows `post-stop` handoff + Linux `systemd-run` teardown launch |
+| `src/server/service/ServiceClient.ts` | Cross-platform service interface (`install`/`uninstall`/`status`/scope) |
+| `src/server/service/ServyClient.ts` | Windows implementation (servy-cli) |
+| `src/server/service/SystemdClient.ts` | Linux implementation (systemd; both scopes; `/opt` staging + SELinux labelling) |
+| `src/server/service/systemTools.ts` | Absolute-path resolver for OS tools (`systemctl`, `pkexec`, `semanage`, …) — Local-Dependencies-Only |
 | `src/app/client/ServiceOperationModal.ts` | Browser-side transition modal with polling |
-| `src/app/client/SettingsModal.ts` | Service install/uninstall controls in the Settings panel |
-| `launcher/src/operation_server.rs` | Rust binary that serves the transition page during uninstall/update |
-| `launcher/src/elevated_runner.rs` | Generates `post-stop.bat` with uninstall/update-apply logic |
+| `src/app/client/SettingsModal.ts` | Service install/uninstall controls + scope radios in the Settings panel |
+| `launcher/src/operation_server.rs` | Rust binary that serves the transition page during uninstall/update (Windows) |
+| `launcher/src/elevated_runner.rs` | Generates `post-stop.bat` with uninstall/update-apply logic (Windows) |
+| `launcher/src/linux_service.rs` | Out-of-cgroup systemd teardown + user-scope local relaunch (Linux) |
 
 ---
 
 ## 20. Launcher Architecture
 
-The Rust launcher (`ws-scrcpy-web-launcher.exe` on Windows) is the production entry point for MSI and AppImage installs. It replaces the `start.cmd` / `start.sh` scripts (which remain for dev mode only).
+The Rust launcher is the production entry point for MSI and AppImage installs — `ws-scrcpy-web-launcher.exe` on Windows, the same binary (no `.exe`) wired as the AppImage's `mainExe` on Linux. It replaces the `start.cmd` / `start.sh` scripts (which remain for dev mode only). The supervisor loop (20.1) is cross-platform; sections 20.2–20.7 are Windows-specific OS integration, and section 20.8 covers the Linux-only subcommands.
 
 ### 20.1 Supervisor Loop
 
@@ -1660,7 +1687,20 @@ All Rust binaries use `common::session::active_interactive_session()` (in `commo
 
 `launcher/src/hooks.rs` provides a `silent_command` helper that spawns processes with the `CREATE_NO_WINDOW` creation flag. All subprocess launches (Node, tray, ADB, operation-server) use this helper to prevent console window flashes during normal operation.
 
-### 20.8 Key Files
+### 20.8 Linux Launcher Subcommands
+
+On Linux the launcher binary is also the entry point for several one-shot, out-of-process operations, dispatched by argv at startup (each returns an exit code and skips the supervisor loop):
+
+| Flag | Module | Purpose |
+|------|--------|---------|
+| `--linux-apply --staged <p> --target <p>` | `linux_apply.rs` | Swap a downloaded AppImage over `$APPIMAGE` and relaunch (local-mode update apply). Launched via `systemd-run --collect` so it survives the app's exit (item #27). |
+| `--linux-apply … --service-restart <user\|system> --unit <name> [--relabel]` | `linux_apply.rs` | Service-mode update apply (item 39): stop the unit → swap → (`--relabel`, system scope) re-apply the `bin_t` label → start the unit. System scope runs as root via `systemd-run` (no `--user`), so it self-updates headlessly with no `pkexec`. |
+| `--linux-service-teardown --scope <user\|system> --unit <name>` | `linux_service.rs` | Out-of-cgroup service-uninstall teardown (section 19.5). |
+| `--local-takeover` | `supervisor.rs` | Forces local (non-service) mode for the instance the service-uninstall teardown relaunches. |
+
+The Linux data root is resolved by `common/src/config.rs` (`DATA_ROOT` → `XDG_DATA_HOME` → `~/.local/share/WsScrcpyWeb`), mirroring the Node `resolveDataRoot`. The AppImage runtime itself is swapped to the static type-2 runtime at **build** time (`scripts/swap-appimage-runtime.mjs`), so it launches without host `libfuse2` (see the README "libfuse2" note).
+
+### 20.9 Key Files
 
 | File | Purpose |
 |------|---------|
@@ -1671,9 +1711,12 @@ All Rust binaries use `common::session::active_interactive_session()` (in `commo
 | `launcher/src/job_object.rs` | Kill-on-close job object for child process cleanup |
 | `launcher/src/operation_server.rs` | Transition-page HTTP server for service install/uninstall |
 | `launcher/src/hooks.rs` | `silent_command` helper with `CREATE_NO_WINDOW` |
+| `launcher/src/linux_apply.rs` | Linux update-apply: local swap + relaunch, and `--service-restart` |
+| `launcher/src/linux_service.rs` | Linux service teardown + user-scope local relaunch |
 | `launcher/src/paths.rs` | Path resolution (`dataRoot`, `depsPath`, `logsDir`) |
 | `launcher/src/log.rs` | Launcher-side logging to `launcher.log` |
-| `common/src/session.rs` | `active_interactive_session()` — `WTSEnumerateSessionsW`-based resolver |
+| `common/src/config.rs` | Shared data-root resolution; Linux `DATA_ROOT`/XDG, fails loudly instead of `/tmp` |
+| `common/src/session.rs` | `active_interactive_session()` — `WTSEnumerateSessionsW`-based resolver (Windows) |
 
 ---
 
@@ -1719,7 +1762,7 @@ The in-app updater uses [Velopack](https://velopack.io/) to apply full-applicati
 
 - **Check:** Polls the GitHub release feed for new versions. The feed URL is constructed from `config.json` fields (`githubOwner`, `channel`). The `channel` field selects between `releases.json` (stable) and `releases.beta.json` (beta).
 - **Download:** Downloads the update delta/full package with progress reporting to the browser via WebSocket events.
-- **Apply:** Calls `UpdateManager.waitExitThenApplyUpdate()`, which signals the launcher to exit, apply the update, and relaunch.
+- **Apply (Windows):** Calls `UpdateManager.waitExitThenApplyUpdate()`, which signals the launcher to exit, apply the update, and relaunch. **On Linux this Velopack path is inert** — its `UpdateNix apply` aborts before touching any file — so `applyUpdate()` branches to a download-and-swap flow instead (section 22.5).
 
 ### 22.2 Upgrade Server
 
@@ -1734,20 +1777,40 @@ The upgrade-server's wind-down probe detects when the new Node process is ready:
 
 | Marker file | Written by | Read by | Purpose |
 |-------------|-----------|---------|---------|
-| `apply-update-pending` | Node (UpdateService) | `post-stop.bat` | Tells the post-stop script to run the Velopack apply step |
+| `control/apply-update-pending` | Node (UpdateService) | `post-stop` handler | (Windows) tells the post-stop step to run the Velopack apply |
+| `control/local-appimage` | Node (install) | `linux_service.rs` | (Linux) home AppImage path, used to relaunch local mode after a user-scope service uninstall |
 | `.restart` | Node (DependencyManager) | Launcher supervisor | Triggers a Node respawn after dep updates |
 
 ### 22.4 Dev-Mode Safety
 
 The `requiresLauncher` flag in `DependencyDefinitions.ts` gates Node.js and ADB updates in dev mode. When running without the Rust launcher (i.e., `npm start`), these updates are blocked because there is no supervisor to handle the restart. The browser UI shows the updates as available but disables the apply button with an explanatory tooltip.
 
-### 22.5 Key Files
+### 22.5 Linux Apply (download + swap)
+
+Velopack's `UpdateNix apply` is inert on the AppImage layout — it re-derives its own locator and aborts in under a millisecond, before touching any file (diagnosed on Fedora; see CHANGELOG v0.1.30-beta.27). So on Linux `applyUpdate()` does **not** delegate to Velopack. For every Linux install mode it instead:
+
+1. Downloads the published AppImage for the target version from the GitHub release and verifies it against the release `SHA256SUMS`.
+2. Hands off to the launcher's `--linux-apply` helper (section 20.8), launched via `systemd-run --collect` so it survives the app's own exit (separate cgroup — item #27).
+3. Spawns the operation-server (22.2) to serve the "updating…" transition page.
+
+The helper shape is selected by `installMode`:
+
+| Mode | Helper args | Behaviour |
+|------|-------------|-----------|
+| local | `--linux-apply --staged <s> --target <t>` | back up + swap `$APPIMAGE`, relaunch |
+| user-service | `… --service-restart user --unit <name>` | stop unit → swap home AppImage → start (user manager) |
+| system-service | `… --service-restart system --unit <name> --relabel` | stop unit → swap the `/opt` copy → re-apply `bin_t` → start (system manager, root, no `pkexec`) |
+
+Windows and the Windows-service apply path are unchanged (Velopack `waitExitThenApplyUpdate`).
+
+### 22.6 Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/server/UpdateService.ts` | Velopack wrapper: check, download, apply |
+| `src/server/UpdateService.ts` | Velopack wrapper (check, download); Windows apply + Linux download-and-swap branch |
 | `src/server/api/UpdatesApi.ts` | REST + WebSocket endpoints for the browser update UI |
-| `src/server/Config.ts` | `autoUpdate`, `updateCheckIntervalMinutes`, `channel` fields |
+| `src/server/Config.ts` | `autoUpdate`, `updateCheckIntervalMinutes`, `channel` fields + control-marker paths |
+| `launcher/src/linux_apply.rs` | Linux AppImage swap + relaunch + `--service-restart` |
 | `launcher/src/operation_server.rs` | Upgrade-server and uninstall-server (shared binary) |
 
 ---
@@ -1774,7 +1837,7 @@ else
 Shown on the first page load of a local-mode (non-service) instance. Lets the user choose their install mode:
 
 - **Just for me (local)** — runs as a user-session process, starts when the user launches the app
-- **Install as a service** — triggers service installation (section 19.1)
+- **Install as a service** — triggers service installation (section 19.1 on Windows, 19.5 on Linux)
 
 On dismissal, `firstRunComplete = true` is persisted to `config.json` server-side. This survives port shifts and browser clears because it is stored on the server, not in localStorage.
 
@@ -1789,14 +1852,16 @@ On dismissal, `serviceFirstRunSeen = true` is persisted to `config.json`.
 
 ### 23.4 Config.json Persistence
 
-Both dismissal flags are stored in `config.json` rather than localStorage:
+The first-run and bookmark-dismissal flags are stored in `config.json` rather than localStorage:
 
 | Field | Default | Set by |
 |-------|---------|--------|
 | `firstRunComplete` | `false` | WelcomeModal dismissal |
 | `serviceFirstRunSeen` | `false` | ServiceFirstRunModal dismissal |
+| `bookmarkDismissedForPort` | `null` | PortChangeModal "got it" (stamps the current port) |
+| `bookmarkDismissedGlobally` | `false` | PortChangeModal "don't show again — ever" |
 
-This design means the first-run state survives port changes, browser cache clears, and machine reboots. The Settings panel includes a "Reset welcome prompts" button that resets both flags, allowing the user to re-trigger the first-run flow.
+This design means the state survives port changes, browser cache clears, and machine reboots (localStorage is unreliable on the Linux AppImage, which can treat each launch as a different origin). The **Settings → App** panel includes a **"reset welcome and bookmark prompts"** button (`resetPromptsPayload()`) that clears all four fields at once — `firstRunComplete` and `serviceFirstRunSeen` back to `false`, `bookmarkDismissedForPort` to `null`, and `bookmarkDismissedGlobally` to `false` — re-triggering the first-run flow.
 
 ### 23.5 Port Change Modal
 


### PR DESCRIPTION
Documentation-only sweep (no code). Corrects drift against current code and fills the Linux coverage gap in the technical guide.

**README**
- AppImage download name → channel-suffixed `WsScrcpyWeb-linux-stable.AppImage` / `-beta.AppImage`
- libfuse2 section rewritten: the AppImage bundles the static type-2 runtime, so it launches without host `libfuse2`; the libfuse2 note now scopes to the in-app updater only (Velopack 1.0.1 → 1.1.1)

**TECHNICAL_GUIDE**
- §19 Linux Service Mode (systemd; user/system scopes; SELinux `/opt` staging; out-of-cgroup teardown)
- §20 Linux launcher subcommands; §22 Linux download-and-swap update apply
- §23.4 reset-prompts field list + §12 dependency version table

**Other**
- THIRD-PARTY-NOTICES: attribution for bundled MIT deps (`ws`, `@xterm/*`, `node-pty`, `velopack`)
- RELEASING / PROGRAMDATA-MIGRATION: self-contained the SignPath disclosure; dropped internal-only file refs
- CONTRIBUTING spec/plan paths; PRIVACY localStorage inventory; CHANGELOG `[Unreleased]` Docs entry

No `release:*` label — docs-only, should not cut a release.