### PR TITLE
feat(linux): machine-wide /opt install for Windows PerMachine parity (Path 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Linux machine-wide install (`/opt`) — parity with the Windows PerMachine MSI.** ws-scrcpy-web can now install system-wide for all users. On first launch the home AppImage offers to install system-wide; accepting relocates the binary to `/opt/ws-scrcpy-web/` via a single `pkexec` and drops a system-wide `/usr/share/applications` desktop entry, so every user launches it under their own login with their own per-user data. Declining runs the app in place and is remembered (no re-nag) — you re-opt-in only through an explicit "install system-wide" action. The home AppImage doubles as a bootstrapper: when a machine-wide install is present it execs the shared `/opt` binary.
+- **Uninstall now relaunches in the active user's desktop session (Linux).** Mirroring the Windows active-session model, uninstalling the machine-wide app — by any administrator — relaunches it for the active graphical desktop user on the same web port, discovered via `loginctl`. When there is no active session (headless), it falls back to on-screen guidance instead of leaving an orphaned process.
+- **Per-user single-instance guard and service-aware launch (Linux).** A per-user `flock` on `$XDG_RUNTIME_DIR` now blocks the same user from double-launching (whether from `/opt` or from home) — the previous Linux single-instance path was a no-op stub. A local launch while an active system service is running defers to the service (opens its URL) instead of starting a second server.
+
+### Changed
+
+- **Linux system-scope state moved to `/var/opt` (FHS), and the system service install is gated on a machine-wide install.** The binary and bundled dependencies live in `/opt/ws-scrcpy-web/` (SELinux `bin_t`); variable state — config, logs, and auto-updated dependencies — now lives in `/var/opt/ws-scrcpy-web/` (`var_lib_t`), replacing the former `/opt/ws-scrcpy-web/data`. The **system**-scope service radio is disabled (with an explanatory note) until the app is installed system-wide; the user-scope service stays available in both modes.
+- **In-app updates and migration for machine-wide installs.** In system-service mode the root service updates `/opt` + `/var/opt` directly with no prompt (headless self-update); in machine-wide-but-no-service mode an app-binary update takes a single `pkexec` and swaps the running `/opt` binary by rename (avoiding `ETXTBSY`), relaunching after exit so the single-instance lock releases first. A newer home AppImage over an older `/opt` install is detected and offered as an update. An existing legacy system install under `/opt/ws-scrcpy-web/data` is detected and migrated to `/var/opt` on upgrade in a single `pkexec` (stop/disable the old unit, remove the old tree and its SELinux rule, set up `/var/opt`, reinstall the unit), carrying over your web port and install mode.
+
+### Fixed
+
+- **System-scope uninstall now removes both SELinux `fcontext` rules.** A system install registers two `semanage fcontext` rules (the `/opt` tree and the variable-state path), but uninstall removed only the tree rule, leaving a stale `var_lib_t` entry behind. Uninstall now deletes both.
+
 ### Docs
 
 - **README:** corrected the Linux AppImage download name to the channel-suffixed `WsScrcpyWeb-linux-stable.AppImage` / `WsScrcpyWeb-linux-beta.AppImage`, and rewrote the libfuse2 section — the AppImage now bundles the static type-2 runtime, so it launches without host `libfuse2`; the libfuse2 note now scopes to the in-app updater only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ version = "0.1.30-beta.40"
 dependencies = [
  "anyhow",
  "ctrlc",
+ "rustix",
  "serde",
  "serde_json",
  "tempfile",

--- a/docs/plans/2026-06-05-machine-wide-opt-install-phase1-foundation.md
+++ b/docs/plans/2026-06-05-machine-wide-opt-install-phase1-foundation.md
@@ -170,6 +170,12 @@ git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): teardo
 
 ## Group B — Machine-wide binary install + bootstrapper
 
+**Launch decision tree** (Linux, user context — the order the launcher applies these guards before any local server starts):
+1. **Active system service?** → open its URL + exit (Task B5). No local server.
+2. **Already an instance for THIS user?** → exit 0 (Task B4 — per-user flock).
+3. **Shared `/opt` binary present + we're the home AppImage?** → exec `/opt` (Task B2).
+4. **Else** → run in place; the first-run modal (Group C) offers system-wide install when `/opt` is absent + not declined.
+
 ### Task B1: `buildMachineWideInstallScript` (binary-only relocate to `/opt`)
 
 Stages **only** the AppImage into `/opt` (deps stay per-user `~/.local`), labels `bin_t`, writes `VERSION`, drops the `.desktop`. Mirrors `buildSystemInstallScript`'s pkexec-script shape (`SystemdClient.ts:271-339`) but is the smaller binary-only variant used by the first-launch "install system-wide" path.
@@ -192,7 +198,8 @@ it('machine-wide install stages just the binary + label + desktop + VERSION', ()
     expect(s).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
     expect(s).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
     expect(s).toContain('/opt/ws-scrcpy-web/VERSION');           // VERSION written (Phase-3 version-compare reads it)
-    expect(s).toContain('/usr/share/applications/ws-scrcpy-web.desktop');
+    expect(s).toContain('/usr/share/applications/ws-scrcpy-web.desktop');   // SYSTEM-WIDE menu (all users)
+    expect(s).toContain('Exec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');     // every user launches the shared /opt binary under their own login
     // binary-only: NO deps copy, NO unit install
     expect(s).not.toContain('dependencies');
     expect(s).not.toContain('systemctl');
@@ -205,7 +212,7 @@ it('machine-wide install stages just the binary + label + desktop + VERSION', ()
 ```
 [Desktop Entry]\nType=Application\nName=ws-scrcpy-web\nExec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage\nIcon=ws-scrcpy-web\nCategories=Utility;
 ```
-Steps joined with ` && `: `mkdir -p /opt/ws-scrcpy-web` · `cp <src> <staged>` · `chmod 0755 <staged>` · `printf '%s' '<version>' > /opt/ws-scrcpy-web/VERSION` · the bin_t label subshell + `restorecon -Rv /opt/ws-scrcpy-web` · write `.desktop` (best-effort, trailing `|| true`).
+Steps joined with ` && `: `mkdir -p /opt/ws-scrcpy-web` · `cp <src> <staged>` · `chmod 0755 <staged>` · `printf '%s' '<version>' > /opt/ws-scrcpy-web/VERSION` · the bin_t label subshell + `restorecon -Rv /opt/ws-scrcpy-web` · write the **system-wide** `.desktop` to `/usr/share/applications/` (best-effort `|| true`) · refresh the menu cache via `update-desktop-database /usr/share/applications` (best-effort `|| true`, so it appears without re-login). The `.desktop` lands in the **system-wide** apps dir → it shows in **every** user's application menu; `Exec` = the shared `/opt` binary, so each user launches it **under their own login** (their `~/.local/share/WsScrcpyWeb` dataRoot + deps).
 
 - [ ] **Step 4: Run, verify pass** — `npm test -- src/server/service/SystemdClient.test.ts` → PASS.
 
@@ -302,6 +309,130 @@ git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/ServiceApi
 git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(api): install-system-wide + decline-system-wide endpoints"
 ```
 
+### Task B4: Linux per-user single-instance guard (flock)
+
+The shared `/opt` binary + the Start-Menu item introduce exactly the "shortcut double-launch" failure mode the existing `single_instance.rs` Linux stub (lines 135-149) said it would add "a PID-file approach later if needed" for. Implement it now, **PER-USER** (different users each get one instance; a user can't double-launch — whether the running instance is the `/opt` binary OR a home AppImage). A `flock` on `$XDG_RUNTIME_DIR/ws-scrcpy-web.lock` (`/run/user/<uid>` is uid-scoped + wiped on logout); fall back to `<dataRoot>/control/instance.lock`.
+
+**Files:** Modify `launcher/src/single_instance.rs` (`#[cfg(not(windows))] mod imp`); `launcher/Cargo.toml` (`rustix` — already in the tree per the clippy build; add as a direct dep if missing).
+
+- [ ] **Step 1: Write the failing test** (gate `#[cfg(all(test, not(windows)))]`):
+
+```rust
+#[test]
+fn linux_lock_path_prefers_xdg_runtime_dir() {
+    assert_eq!(lock_path(Some("/run/user/1000"), Some("/home/u/.local/share/WsScrcpyWeb")),
+               PathBuf::from("/run/user/1000/ws-scrcpy-web.lock"));
+    assert_eq!(lock_path(None, Some("/home/u/.local/share/WsScrcpyWeb")),
+               PathBuf::from("/home/u/.local/share/WsScrcpyWeb/control/instance.lock"));
+}
+
+#[test]
+fn flock_blocks_same_user_second_launch() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join("instance.lock");
+    let first = acquire_at(&p).unwrap();
+    assert!(first.is_some(), "first acquire holds the lock");
+    assert!(acquire_at(&p).unwrap().is_none(), "second acquire on a held flock returns None");
+    drop(first);
+    assert!(acquire_at(&p).unwrap().is_some(), "after drop, re-acquire succeeds");
+}
+```
+
+- [ ] **Step 2: Run, verify fail** — `cross test -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu single_instance` → FAIL (`lock_path`/`acquire_at` undefined; stub always returns `Some`).
+
+- [ ] **Step 3: Implement** — replace the non-windows `mod imp` stub:
+
+```rust
+#[cfg(not(windows))]
+mod imp {
+    use anyhow::Result;
+    use std::fs::{File, OpenOptions};
+    use std::path::{Path, PathBuf};
+    use rustix::fs::{flock, FlockOperation};
+
+    pub struct InstanceGuard { _file: File }  // Drop closes the fd -> releases the flock
+
+    pub fn lock_path(xdg_runtime_dir: Option<&str>, data_root: Option<&str>) -> PathBuf {
+        if let Some(x) = xdg_runtime_dir.filter(|s| !s.is_empty()) {
+            return PathBuf::from(x).join("ws-scrcpy-web.lock");
+        }
+        PathBuf::from(data_root.unwrap_or("/tmp")).join("control").join("instance.lock")
+    }
+
+    pub fn acquire_at(path: &Path) -> Result<Option<InstanceGuard>> {
+        if let Some(parent) = path.parent() { let _ = std::fs::create_dir_all(parent); }
+        let file = OpenOptions::new().create(true).write(true).open(path)?;
+        match flock(&file, FlockOperation::NonBlockingLockExclusive) {
+            Ok(()) => Ok(Some(InstanceGuard { _file: file })),
+            Err(e) if e == rustix::io::Errno::WOULDBLOCK => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn acquire(_name: &str) -> Result<Option<InstanceGuard>> {
+        let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        let dr = common::config::data_root_from_env().map(|p| p.to_string_lossy().into_owned());
+        acquire_at(&lock_path(xdg.as_deref(), dr.as_deref()))
+    }
+
+    pub fn is_elevated() -> bool { false }
+}
+```
+`main()` already calls `single_instance::acquire(&current_mutex_name())` and exits 0 on `None` (per the module contract) — no `main()` change; the Linux path now actually guards. Verify `main()` acquires the guard on the normal-launch path (after the sub-command dispatches) before reading the source.
+
+- [ ] **Step 4: Run, verify pass + clippy** — `cross test … single_instance` PASS; `cross clippy … -- -D warnings` clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/single_instance.rs launcher/Cargo.toml
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): per-user single-instance guard via flock on XDG_RUNTIME_DIR"
+```
+
+### Task B5: Defer to an active system service (menu no-op in service mode)
+
+When a system-scope service is active, a local launch (e.g. the Start-Menu item) must NOT spawn a second server (PortPicker would bind `webPort+1` → a confusing duplicate). Detect the active service and open the browser at its URL, then exit. Detection (user context, no privilege): read the system-service config at `/var/opt/ws-scrcpy-web/config.json`; if `installMode == "system-service"`, TCP-probe `127.0.0.1:<webPort>`; if live, defer.
+
+**Files:** Modify `launcher/src/linux_service.rs` (pure decision fn) + `launcher/src/main.rs` (wire FIRST in the Linux launch path, before the Task B2 bootstrap seam).
+
+- [ ] **Step 1: Write the failing test** (pure fn):
+
+```rust
+#[test]
+fn defer_to_service_only_when_system_service_and_port_live() {
+    assert_eq!(service_defer_url(Some("system-service"), Some(8000), true),
+               Some("http://localhost:8000".to_string()));
+    assert_eq!(service_defer_url(Some("system-service"), Some(8000), false), None); // installed but down
+    assert_eq!(service_defer_url(Some("user"), Some(8000), true), None);            // not service mode
+    assert_eq!(service_defer_url(None, None, true), None);
+}
+```
+
+- [ ] **Step 2: Run, verify fail** — `cross test … linux_service` → FAIL.
+
+- [ ] **Step 3: Implement** — pure fn in `linux_service.rs`:
+
+```rust
+/// The service URL to open (then exit) when an ACTIVE system service owns the
+/// app, so a local launch doesn't spawn a duplicate. `install_mode` + `web_port`
+/// come from the /var/opt system-service config; `port_live` is a TCP-probe
+/// result the caller supplies. Pure.
+pub fn service_defer_url(install_mode: Option<&str>, web_port: Option<u16>, port_live: bool) -> Option<String> {
+    match (install_mode, web_port) {
+        (Some("system-service"), Some(port)) if port_live => Some(format!("http://localhost:{port}")),
+        _ => None,
+    }
+}
+```
+Wire in `main.rs` (Linux), BEFORE the `bootstrap_target` check: load `common::config::AppConfig::load(Path::new("/var/opt/ws-scrcpy-web"))`, TCP-probe `127.0.0.1:<web_port>` (≈200ms connect timeout), and if `service_defer_url(...)` is `Some(url)`, best-effort `xdg-open <url>` (absolute path via the existing tool resolver) + `std::process::exit(0)`.
+
+- [ ] **Step 4: Run, verify pass** — `cross test … linux_service` PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/linux_service.rs launcher/src/main.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): local launch defers to an active system service (no duplicate instance)"
+```
+
 ---
 
 ## Group C — Service-install gating + first-run modal (frontend)
@@ -390,6 +521,9 @@ Not unit-coverable; run on the Hyper-V Fedora VM after the unit work is green:
 - Fresh AppImage, first run → **system-wide install modal**; **install** → app relocates to `/opt`, `.desktop` appears, relaunches from `/opt`, `ls -Z /opt/ws-scrcpy-web` → `bin_t`; **not now** → runs in place, marker written, **no re-prompt** next launch.
 - System-scope service install **gated** until machine-wide install is done (greyed + modal); after machine-wide install, the system service installs, state lands in **`/var/opt/ws-scrcpy-web`** (`ls -Z` → `var_lib_t`), config persists across reboot, **zero AVC**.
 - Uninstall the system service → `semanage fcontext -l | grep ws-scrcpy-web` is **empty** (both rules gone — fix (a)); `/opt` + `/var/opt` removed.
+- **Multi-user launch:** a SECOND user logs in → ws-scrcpy-web is in their application menu → launching it runs the shared `/opt` binary **under that user's login** (their own `~/.local/share/WsScrcpyWeb` data + deps), independent of the installer.
+- **No same-user double-launch:** with the app already running for a user (from `/opt` OR home), clicking the menu item again is a no-op (`flock` held); a *different* user can still launch their own.
+- **Service-mode menu = no-op:** with the system service active, the menu item opens the browser at the service URL and spawns **no** second server (PortPicker does not bind `webPort+1`).
 
 ---
 

--- a/docs/plans/2026-06-05-machine-wide-opt-install-phase1-foundation.md
+++ b/docs/plans/2026-06-05-machine-wide-opt-install-phase1-foundation.md
@@ -1,0 +1,406 @@
+# Machine-wide `/opt` Install — Phase 1 (Foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish the machine-wide Linux layout — `/opt/ws-scrcpy-web` (binary, `bin_t`) ÷ `/var/opt/ws-scrcpy-web` (system-service state, `var_lib_t`) ÷ `~/.local/share/WsScrcpyWeb` (per-user) — plus the auto-first-launch bootstrapper, the machine-wide binary install, and the service-install gating.
+
+**Architecture:** Extend the existing beta.40 builders (`SystemdClient.ts`) and the launcher teardown (`linux_service.rs`), following their pure-function-+-unit-test pattern. The system-service install retargets its state from `/opt/ws-scrcpy-web/data` to the FHS-correct `/var/opt/ws-scrcpy-web`; the launcher gains a bootstrapper that execs the shared `/opt` binary when present; a new machine-wide-install operation (pkexec) stages just the binary; the frontend gates system-scope service install behind machine-wide install.
+
+**Tech Stack:** TypeScript (Node server, vitest) · Rust (`ws-scrcpy-web-launcher`, `cross test --target x86_64-unknown-linux-gnu`) · systemd / SELinux (`semanage`/`restorecon`, Fedora enforcing) · pkexec/polkit.
+
+**Design spec:** `docs/specs/2026-06-05-machine-wide-opt-install-design.md`.
+
+**Phasing:** Phase 1 = Foundation (this doc). Phase 2 = `loginctl` uninstall→relaunch. Phase 3 = updates + migration. Version-compare / update-offer in the bootstrapper is **Phase 3** — out of scope here.
+
+---
+
+## File structure
+
+**Modify:**
+- `src/server/service/SystemdClient.ts` — retarget system state → `/var/opt`; add `buildMachineWideInstallScript` (binary-only); `.desktop` + VERSION emit.
+- `src/server/service/SystemdClient.test.ts` — update + add builder tests.
+- `launcher/src/linux_service.rs` — teardown removes **both** `/opt` (`bin_t`) and `/var/opt` (`var_lib_t`) rules + both trees (folds fix (a)); new `bootstrap_target` pure fn.
+- `launcher/src/main.rs` — wire the bootstrapper exec seam (Linux, normal-launch path).
+- `src/server/api/ServiceApi.ts` — `install-system-wide` + `decline-system-wide` endpoints; machine-wide-install gate on system-scope service install.
+- `src/app/client/SettingsModal.ts` — `systemServiceInstallGate` pure fn + render wiring.
+- `src/app/client/__tests__/SettingsModal.test.ts` — gate test.
+
+**Create:**
+- `src/app/client/SystemWideInstallModal.ts` — first-run "install system-wide?" modal (mirrors `WelcomeModal.ts`).
+- `src/app/client/__tests__/SystemWideInstallModal.test.ts`.
+
+**Constants introduced (in `SystemdClient.ts`):**
+```ts
+export const SYSTEM_STATE_DIR = '/var/opt/ws-scrcpy-web';   // replaces STAGED_SYSTEM_DATA_DIR's role
+export const SYSTEM_OPT_VERSION_FILE = `${STAGED_SYSTEM_DIR}/VERSION`;
+export const SYSTEM_DESKTOP_FILE = '/usr/share/applications/ws-scrcpy-web.desktop';
+export const DECLINE_MARKER_NAME = 'system-install-declined'; // under <dataRoot>/control/
+```
+
+---
+
+## Build / test commands
+
+- **TS unit:** `npm test -- src/server/service/SystemdClient.test.ts` (vitest; `npm test` for the full suite).
+- **Rust unit (cfg-gated Linux modules need cross):** from the repo root —
+  `cross test -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu <filter>` (Docker Desktop must be running).
+- **Rust lint:** `cross clippy -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu -- -D warnings`.
+- **Frontend unit:** `npm test -- src/app/client/__tests__/SettingsModal.test.ts`.
+
+> Multi-session git discipline: all git ops use `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`. Work on branch `path2-machine-wide-install` (already created; the design spec is committed there).
+
+---
+
+## Group A — `/var/opt` layout retarget + SELinux teardown (folds fix (a))
+
+### Task A1: Retarget system-service state to `/var/opt`
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts` (constants ~70-92; `buildServiceUnitEnv` 101-110; `buildSystemInstallScript` 271-339)
+- Test: `src/server/service/SystemdClient.test.ts`
+
+- [ ] **Step 1: Write the failing tests** — add to `SystemdClient.test.ts`:
+
+```ts
+import { buildServiceUnitEnv, buildSystemInstallScript, SYSTEM_STATE_DIR } from '../SystemdClient';
+
+it('system-scope unit env points DATA_ROOT at /var/opt (not /opt/.../data)', () => {
+    const env = buildServiceUnitEnv('linux', 'system', '/home/u/.local/share/WsScrcpyWeb/dependencies');
+    expect(env.DATA_ROOT).toBe('/var/opt/ws-scrcpy-web');
+    expect(env.DEPS_PATH).toBe('/opt/ws-scrcpy-web/dependencies');
+});
+
+it('system install seeds config + labels state under /var/opt (var_lib_t)', () => {
+    const script = buildSystemInstallScript(
+        { sourceAppImage: '/home/u/App.AppImage', seedConfigTmpPath: '/tmp/seed.json',
+          unitTmpPath: '/tmp/u.service', unitPath: '/etc/systemd/system/WsScrcpyWeb.service', name: 'WsScrcpyWeb' },
+        (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+    );
+    expect(script).toContain('mkdir -p /var/opt/ws-scrcpy-web');
+    expect(script).toContain('cp "/tmp/seed.json" "/var/opt/ws-scrcpy-web/config.json"');
+    expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+    expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+    // state no longer lives under /opt/.../data:
+    expect(script).not.toContain('/opt/ws-scrcpy-web/data');
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npm test -- src/server/service/SystemdClient.test.ts`
+Expected: FAIL — `DATA_ROOT` is still `/opt/ws-scrcpy-web/data`; the `/var/opt` strings are absent.
+
+- [ ] **Step 3: Implement** — in `SystemdClient.ts`:
+  - Add `export const SYSTEM_STATE_DIR = '/var/opt/ws-scrcpy-web';` near the other staged constants (keep `STAGED_SYSTEM_DEPS_DIR` = `/opt/.../dependencies`; deps stay in `/opt` per the deps-follow-run-context decision). Remove `STAGED_SYSTEM_DATA_DIR` (replaced by `SYSTEM_STATE_DIR`).
+  - `buildServiceUnitEnv` system branch → `{ DATA_ROOT: SYSTEM_STATE_DIR, DEPS_PATH: STAGED_SYSTEM_DEPS_DIR }`.
+  - `buildSystemInstallScript`: change the data-dir `mkdir`/seed-config target from `STAGED_SYSTEM_DATA_DIR` → `SYSTEM_STATE_DIR`; in the SELinux step replace the `var_lib_t '${STAGED_SYSTEM_DATA_DIR}(/.*)?'` rule with `var_lib_t '${SYSTEM_STATE_DIR}(/.*)?'`, and add `&& ${restorecon} -Rv "${SYSTEM_STATE_DIR}"` after the `/opt` restorecon (the `/var/opt` tree is outside `/opt`, so the existing `restorecon -Rv /opt/...` does not cover it). Keep `mkdir -p ${SYSTEM_STATE_DIR}` before the seed `cp`.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npm test -- src/server/service/SystemdClient.test.ts`
+Expected: PASS (all builder tests, including the existing `bin_t`/restorecon assertions retargeted as needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): retarget system-service state to /var/opt (FHS) with var_lib_t"
+```
+
+### Task A2: Teardown removes BOTH SELinux rules + both trees (folds fix (a))
+
+**Files:**
+- Modify: `launcher/src/linux_service.rs` (`teardown_commands`, System branch ~64-74)
+- Test: same file's `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test** — add to `linux_service.rs` tests:
+
+```rust
+#[test]
+fn system_scope_teardown_removes_opt_and_var_opt() {
+    let cmds = teardown_commands(Scope::System, "WsScrcpyWeb", "/usr/bin");
+    let joined: Vec<String> = cmds.iter().map(|c| c.join(" ")).collect();
+    let removes_dir = |d: &str| joined.iter().any(|c| c.contains("rm") && c.contains(d));
+    let removes_fcontext = |spec: &str|
+        joined.iter().any(|c| c.contains("semanage fcontext -d") && c.ends_with(spec));
+    assert!(removes_dir("/opt/ws-scrcpy-web"));
+    assert!(removes_dir("/var/opt/ws-scrcpy-web"));
+    assert!(removes_fcontext("/opt/ws-scrcpy-web(/.*)?"));      // bin_t tree
+    assert!(removes_fcontext("/var/opt/ws-scrcpy-web(/.*)?"));  // var_lib_t state (the fix-(a) rule)
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cross test -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu linux_service`
+Expected: FAIL on the `/var/opt` assertions (today only the single `/opt/...` rule + tree are removed).
+
+- [ ] **Step 3: Implement** — in `teardown_commands`, System branch, replace the single `rm`/`-d` with both trees and both rules:
+
+```rust
+if scope == Scope::System {
+    let semanage = format!("{}/semanage", sbindir_from(bindir));
+    for dir in ["/opt/ws-scrcpy-web", "/var/opt/ws-scrcpy-web"] {
+        cmds.push(vec![rm.clone(), "-rf".into(), dir.into()]);
+    }
+    // remove BOTH fcontext rules the install added: the /opt bin_t tree rule
+    // AND the /var/opt var_lib_t state rule (the beta.40 regression — install
+    // adds the state rule, teardown never did → `semanage fcontext -l | grep
+    // ws-scrcpy-web` stayed non-empty after uninstall).
+    for pathspec in ["/opt/ws-scrcpy-web(/.*)?", "/var/opt/ws-scrcpy-web(/.*)?"] {
+        cmds.push(vec![semanage.clone(), "fcontext".into(), "-d".into(), pathspec.to_string()]);
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify pass + lint**
+
+Run: `cross test -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu linux_service`
+Then: `cross clippy -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu -- -D warnings`
+Expected: PASS (incl. the existing `system_scope_teardown_removes_opt_and_fcontext`); clippy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/linux_service.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): teardown removes both /opt bin_t and /var/opt var_lib_t fcontext rules"
+```
+
+---
+
+## Group B — Machine-wide binary install + bootstrapper
+
+### Task B1: `buildMachineWideInstallScript` (binary-only relocate to `/opt`)
+
+Stages **only** the AppImage into `/opt` (deps stay per-user `~/.local`), labels `bin_t`, writes `VERSION`, drops the `.desktop`. Mirrors `buildSystemInstallScript`'s pkexec-script shape (`SystemdClient.ts:271-339`) but is the smaller binary-only variant used by the first-launch "install system-wide" path.
+
+**Files:** Modify `SystemdClient.ts`; Test `SystemdClient.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { buildMachineWideInstallScript, STAGED_SYSTEM_DIR } from '../SystemdClient';
+
+it('machine-wide install stages just the binary + label + desktop + VERSION', () => {
+    const s = buildMachineWideInstallScript(
+        { sourceAppImage: '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage', version: '0.1.31-beta.1' },
+        (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+    );
+    expect(s).toContain('mkdir -p /opt/ws-scrcpy-web');
+    expect(s).toContain('cp "/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+    expect(s).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+    expect(s).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+    expect(s).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
+    expect(s).toContain('/opt/ws-scrcpy-web/VERSION');           // VERSION written (Phase-3 version-compare reads it)
+    expect(s).toContain('/usr/share/applications/ws-scrcpy-web.desktop');
+    // binary-only: NO deps copy, NO unit install
+    expect(s).not.toContain('dependencies');
+    expect(s).not.toContain('systemctl');
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `npm test -- src/server/service/SystemdClient.test.ts` → FAIL (`buildMachineWideInstallScript` undefined).
+
+- [ ] **Step 3: Implement** — add to `SystemdClient.ts`, reusing the `binTool`/`sbinTool` injectable pattern from `buildSystemInstallScript`. Use `printf > VERSION` and a here-doc-free `.desktop` write (single-quoted to survive `sh -c`). Wrap the SELinux step in the same `( ( … ) || chcon … || true )` best-effort subshell as the existing builder. The `.desktop` content:
+```
+[Desktop Entry]\nType=Application\nName=ws-scrcpy-web\nExec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage\nIcon=ws-scrcpy-web\nCategories=Utility;
+```
+Steps joined with ` && `: `mkdir -p /opt/ws-scrcpy-web` · `cp <src> <staged>` · `chmod 0755 <staged>` · `printf '%s' '<version>' > /opt/ws-scrcpy-web/VERSION` · the bin_t label subshell + `restorecon -Rv /opt/ws-scrcpy-web` · write `.desktop` (best-effort, trailing `|| true`).
+
+- [ ] **Step 4: Run, verify pass** — `npm test -- src/server/service/SystemdClient.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): buildMachineWideInstallScript (binary-only /opt relocate)"
+```
+
+### Task B2: Launcher bootstrapper — exec the `/opt` binary when present
+
+Pure decision fn + exec seam. On Linux normal launch, if the shared `/opt` AppImage exists and we are NOT already it, re-exec `/opt` and exit. (No version-compare — Phase 3.)
+
+**Files:** Modify `launcher/src/linux_service.rs` (or a sibling `linux_bootstrap.rs` — keep it in `linux_service.rs` to avoid a new module); wire in `launcher/src/main.rs`.
+
+- [ ] **Step 1: Write the failing test** (pure fn) — add to `linux_service.rs` tests:
+
+```rust
+#[test]
+fn bootstrap_target_execs_opt_when_present_and_not_self() {
+    let opt = "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage";
+    // /opt present, we are a home AppImage -> Some(/opt)
+    assert_eq!(bootstrap_target(true, Some("/home/u/App.AppImage")), Some(PathBuf::from(opt)));
+    // /opt present but we ARE /opt -> None (don't re-exec ourselves)
+    assert_eq!(bootstrap_target(true, Some(opt)), None);
+    // /opt absent -> None (run in place; first-run modal handles the prompt)
+    assert_eq!(bootstrap_target(false, Some("/home/u/App.AppImage")), None);
+    // no $APPIMAGE (from-source) -> None
+    assert_eq!(bootstrap_target(true, None), None);
+}
+```
+
+- [ ] **Step 2: Run, verify fail** — `cross test -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu linux_service` → FAIL (`bootstrap_target` undefined).
+
+- [ ] **Step 3: Implement** — add to `linux_service.rs`:
+
+```rust
+/// Pure bootstrapper decision. `opt_exists` = the shared /opt AppImage is
+/// present; `appimage_env` = $APPIMAGE (the file we were launched from, if any).
+/// Returns the /opt binary to re-exec, or None to continue the in-place launch
+/// (the frontend's first-run modal offers the system-wide install when /opt is
+/// absent and the decline-marker is unset). No version-compare here — updates
+/// are Phase 3.
+pub fn bootstrap_target(opt_exists: bool, appimage_env: Option<&str>) -> Option<PathBuf> {
+    let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
+    match appimage_env {
+        Some(p) if opt_exists && p != opt.to_string_lossy() => Some(opt),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify pass** — `cross test … linux_service` → PASS.
+
+- [ ] **Step 5: Wire the exec seam in `main.rs`** — after the early sub-command dispatches (the `#[cfg(target_os="linux")]` block that handles `linux_apply`/`linux_service` teardown, ~main.rs:93-103) and BEFORE the normal supervisor start, add:
+
+```rust
+#[cfg(target_os = "linux")]
+{
+    let opt = std::path::Path::new("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
+    let appimage = std::env::var("APPIMAGE").ok();
+    if let Some(target) = linux_service::bootstrap_target(opt.exists(), appimage.as_deref()) {
+        log::info(&format!("bootstrap: exec'ing machine-wide /opt binary {target:?}"));
+        let status = std::process::Command::new(&target).status();
+        let code = status.ok().and_then(|s| s.code()).unwrap_or(0);
+        std::process::exit(code);
+    }
+}
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/linux_service.rs launcher/src/main.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(linux): bootstrapper execs the shared /opt binary when present"
+```
+
+### Task B3: `ServiceApi` — `install-system-wide` + `decline-system-wide` endpoints
+
+The first-run modal POSTs here. `install-system-wide` runs `buildMachineWideInstallScript` via the existing `runPkexec` (graphical auth); on success the next launch's bootstrapper execs `/opt`. `decline-system-wide` writes `<dataRoot>/control/system-install-declined`.
+
+**Files:** Modify `src/server/api/ServiceApi.ts`; Test `src/server/__tests__/ServiceApi.test.ts`.
+
+- [ ] **Step 1: Write failing tests** — assert (a) `POST /api/service/install-system-wide` invokes pkexec with a script containing the `/opt` cp + bin_t label (inject the pkexec runner, mirroring the existing `runPkexec` seam used in `SystemdClient`), and (b) `POST /api/service/decline-system-wide` creates the marker file at `<dataRoot>/control/system-install-declined`. Mirror the routing + injection style already in `ServiceApi.test.ts` (see the existing `--linux-service-teardown` / install tests, ~lines 646-711, 933).
+
+- [ ] **Step 2: Run, verify fail** — `npm test -- src/server/__tests__/ServiceApi.test.ts` → FAIL (routes 404 / handlers absent).
+
+- [ ] **Step 3: Implement** — add two routes to the `ServiceApi` request switch (follow the existing route-dispatch + `res.writeHead/end(JSON)` pattern in this file). `install-system-wide`: resolve `process.env.APPIMAGE` (400 if unset — from-source/non-AppImage can't relocate), read the app version from `package.json`/the version constant, build the script via `buildMachineWideInstallScript`, run it through the same pkexec helper `SystemdClient` uses (export/reuse `runPkexec`), 200 on success / 403 on auth-dismiss (exit 126) / 500 otherwise. `decline-system-wide`: `fs.mkdirSync(<dataRoot>/control, {recursive:true})` + `fs.writeFileSync(<dataRoot>/control/system-install-declined, '')`, 200.
+
+- [ ] **Step 4: Run, verify pass** — `npm test -- src/server/__tests__/ServiceApi.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/ServiceApi.ts src/server/__tests__/ServiceApi.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(api): install-system-wide + decline-system-wide endpoints"
+```
+
+---
+
+## Group C — Service-install gating + first-run modal (frontend)
+
+### Task C1: `systemServiceInstallGate` pure fn
+
+Gates the **system**-scope service install button on machine-wide install. Mirrors the existing pure fns in `SettingsModal.ts` (`scopeRadioState` 102-117, `stopServerButtonState` 121-137).
+
+**Files:** Modify `src/app/client/SettingsModal.ts`; Test `src/app/client/__tests__/SettingsModal.test.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { systemServiceInstallGate } from '../SettingsModal';
+
+it('system service install is gated on machine-wide install', () => {
+    // not machine-wide -> install disabled with the explainer
+    expect(systemServiceInstallGate({ machineWideInstalled: false })).toEqual({
+        enabled: false,
+        note: 'system service install requires installing system-wide for all users first.',
+    });
+    // machine-wide installed -> enabled, no note
+    expect(systemServiceInstallGate({ machineWideInstalled: true })).toEqual({ enabled: true, note: null });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `npm test -- src/app/client/__tests__/SettingsModal.test.ts` → FAIL (undefined).
+
+- [ ] **Step 3: Implement** — add to `SettingsModal.ts` near `stopServerButtonState`:
+
+```ts
+export interface SystemServiceInstallGate { enabled: boolean; note: string | null; }
+/** System-scope service install requires a machine-wide /opt install first
+ *  (the root service execs the /opt binary; it can't exist without it). */
+export function systemServiceInstallGate(input: { machineWideInstalled: boolean }): SystemServiceInstallGate {
+    return input.machineWideInstalled
+        ? { enabled: true, note: null }
+        : { enabled: false, note: 'system service install requires installing system-wide for all users first.' };
+}
+```
+
+- [ ] **Step 4: Run, verify pass** — `npm test -- src/app/client/__tests__/SettingsModal.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/SettingsModal.ts src/app/client/__tests__/SettingsModal.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(ui): systemServiceInstallGate — gate system service on machine-wide install"
+```
+
+### Task C2: First-run `SystemWideInstallModal`
+
+Shown on first run (Linux, no `/opt`, no decline-marker) before/around the existing WelcomeModal. Two actions: **install** (`POST /api/service/install-system-wide` → on 200, reload so the bootstrapper execs `/opt`) and **not now** (`POST /api/service/decline-system-wide` → close, continue local). Mirror `WelcomeModal.ts` structure + the project's modal conventions (scroll-lock per `feedback_modal_scroll_lock`; lowercase UI text; DOM-built, not `html\`\``).
+
+**Files:** Create `src/app/client/SystemWideInstallModal.ts` + `__tests__/SystemWideInstallModal.test.ts`.
+
+- [ ] **Step 1: Write the failing test** — assert the modal renders the two buttons (lowercase labels "install for all users" / "not now") and that clicking each calls the injected `onInstall` / `onDecline` callbacks. Mirror `WelcomeModal.test.ts` / the existing modal tests' DOM-query + click style.
+- [ ] **Step 2: Run, verify fail** — `npm test -- src/app/client/__tests__/SystemWideInstallModal.test.ts` → FAIL (module absent).
+- [ ] **Step 3: Implement** — create `SystemWideInstallModal.ts` mirroring `WelcomeModal.ts` (same base/DOM helpers, scroll-lock, lowercase copy). Copy: *"run ws-scrcpy-web for all users on this machine? installs the app to /opt (one administrator prompt). you can keep using it just for yourself instead."* Buttons wired to injected callbacks.
+- [ ] **Step 4: Run, verify pass** — PASS.
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/SystemWideInstallModal.ts src/app/client/__tests__/SystemWideInstallModal.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(ui): first-run system-wide install modal"
+```
+
+### Task C3: Render wiring — apply the gate + show the modal
+
+**Files:** Modify `src/app/client/SettingsModal.ts` (service-section render) + the first-run entry (`src/app/index.ts`, where WelcomeModal/ServiceFirstRunModal are gated).
+
+- [ ] **Step 1: Write the failing test** — extend `SettingsModal.test.ts`: when the rendered status reports `machineWideInstalled:false` and the system radio is selected, the install button carries the `disabled`-equivalent state + the gate note (assert via the same render-snapshot/DOM approach the existing service-section tests use).
+- [ ] **Step 2: Run, verify fail** — FAIL (render ignores the gate).
+- [ ] **Step 3: Implement** — in the service-section render, call `systemServiceInstallGate({ machineWideInstalled })` (read `machineWideInstalled` from the service status response — add the boolean to the status payload server-side: `/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage` exists) and apply `enabled`/`note` to the install button when the system radio is active. In `index.ts`, show `SystemWideInstallModal` on first run when Linux + `!machineWideInstalled` + decline-marker unset (server-reported), ahead of the local WelcomeModal.
+- [ ] **Step 4: Run, verify pass + full suite** — `npm test` (whole vitest suite) → PASS; `npx tsc --noEmit` clean.
+- [ ] **Step 5: Commit**
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/client/SettingsModal.ts src/app/index.ts src/server/api/ServiceApi.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(ui): wire system-wide gate + first-run modal into render/first-run flow"
+```
+
+---
+
+## Phase-1 exit criteria (runtime — Fedora VM, SELinux enforcing)
+
+Not unit-coverable; run on the Hyper-V Fedora VM after the unit work is green:
+
+- Fresh AppImage, first run → **system-wide install modal**; **install** → app relocates to `/opt`, `.desktop` appears, relaunches from `/opt`, `ls -Z /opt/ws-scrcpy-web` → `bin_t`; **not now** → runs in place, marker written, **no re-prompt** next launch.
+- System-scope service install **gated** until machine-wide install is done (greyed + modal); after machine-wide install, the system service installs, state lands in **`/var/opt/ws-scrcpy-web`** (`ls -Z` → `var_lib_t`), config persists across reboot, **zero AVC**.
+- Uninstall the system service → `semanage fcontext -l | grep ws-scrcpy-web` is **empty** (both rules gone — fix (a)); `/opt` + `/var/opt` removed.
+
+---
+
+## Self-review
+
+- **Spec coverage:** §1 layout/SELinux → A1, A2, B1 (labels) + exit criteria. §2 install/bootstrap → B1, B2, B3, C2, C3 (elevation = pkexec via existing `runPkexec`; service-gating → C1/C3). §2 deps-follow-run-context → A1 keeps `DEPS_PATH=/opt/.../dependencies` for the service while machine-wide install copies **no** deps (B1). §3 relaunch + §4 migration → **Phases 2 & 3** (out of scope, stated). Fix (a) → A2. ✓
+- **Placeholder scan:** none — every code step shows the function/test; "mirror function X at file:line" references point at concrete existing code to copy a pattern (the established way to extend this codebase), not vague TODOs.
+- **Type consistency:** `SYSTEM_STATE_DIR`, `buildMachineWideInstallScript(args, binTool, sbinTool)`, `bootstrap_target(opt_exists, appimage_env)`, `systemServiceInstallGate({machineWideInstalled})` are used identically across tasks and tests.
+
+## Notes for the implementer
+
+- The first-run modal's `install`/`decline` and the gate all key off **`machineWideInstalled`** = `/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage` exists; add that boolean to the service-status payload (C3) so the frontend doesn't probe the filesystem directly.
+- `runPkexec` currently lives inside `SystemdClient.ts` (private). Export it (or a thin wrapper) for `ServiceApi` reuse in B3 rather than duplicating the pkexec error-mapping.
+- Per-user dataRoot casing is `~/.local/share/WsScrcpyWeb` (PascalCase, per `data_root_for_linux`); `/opt` + `/var/opt` use lowercase-hyphen `ws-scrcpy-web`. Don't unify them — both are load-bearing.

--- a/docs/plans/2026-06-05-machine-wide-opt-install-phases2-3.md
+++ b/docs/plans/2026-06-05-machine-wide-opt-install-phases2-3.md
@@ -1,0 +1,271 @@
+# Machine-wide `/opt` Install — Phases 2 & 3 Implementation Plan (consolidated)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`. Each Rust task: `cross test`/`cross clippy` (Docker; plain cargo fails — no Linux linker). Each TS task: `npm test -- <file>` AND **`npx tsc --noEmit` (0 errors — vitest does NOT type-check)**. `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`; no push; branch `path2-machine-wide-install`. Verify each task's on-disk diff + the type-check yourself; IDE mid-edit diagnostics are often stale.
+
+**Goal:** Phase 2 — a system-scope uninstall relaunches the app for the active desktop user on the exact port their browser is on. Phase 3 — machine-wide installs update via one pkexec, existing beta.40 system installs migrate, and the bootstrapper is version-aware.
+
+**Architecture:** Reuse the established pure-fn-+-thin-exec-seam pattern in `linux_service.rs`/`linux_apply.rs` and the `buildMachineWideInstallScript`/`runPkexec` builders from Phase 1. Phase 2 adds loginctl discovery + a `systemd-run --uid` relaunch + a `WS_SCRCPY_WEB_PORT` server override. Phase 3 routes machine-wide updates through the install builder under pkexec, adds migration detect→reinstall, and makes the bootstrapper version-compare.
+
+**Tech Stack:** Rust launcher (`cross … x86_64-unknown-linux-gnu`), TS server (vitest + `tsc`), frontend.
+
+**Spec:** `docs/specs/2026-06-05-machine-wide-opt-install-phases2-3-design.md`.
+
+---
+
+## File structure
+- `launcher/src/linux_service.rs` — loginctl parsers + `system_relaunch_command` + `run()` System relaunch branch (P2); version-compare in `bootstrap_target` (P3c).
+- `launcher/src/main.rs` — pass the running version into the bootstrap seam (P3c).
+- `src/server/PortPicker.ts` (or wherever webPort resolves) — honor `WS_SCRCPY_WEB_PORT` (P2-3).
+- `src/server/UpdateService.ts` — machine-wide-no-service update branch (P3b).
+- `src/server/api/ServiceApi.ts` — migration-detect status flag + reinstall endpoint (P3a); version-newer flag + offer endpoint (P3c).
+- `src/app/client/SettingsModal.ts` / `src/app/index.ts` — migration notice + [reinstall now]; "update the system-wide install" offer (P3a/P3c).
+
+---
+
+# PHASE 2 — loginctl uninstall→relaunch
+
+## Task P2-1: loginctl discovery parsers (pure)
+
+**Files:** `launcher/src/linux_service.rs` (+ tests). Run: `cross test -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu linux_service`.
+
+- [ ] **Step 1 — failing tests** (add to `mod tests`):
+```rust
+#[test]
+fn parses_session_ids_from_list() {
+    let list = "   3 1000 jamie seat0 tty2\n  c1 0 root  -    -\n";
+    assert_eq!(parse_session_ids(list), vec!["3".to_string(), "c1".to_string()]);
+}
+#[test]
+fn active_graphical_uid_only_when_active_and_graphical() {
+    assert_eq!(active_graphical_uid_from_show("Active=yes\nType=wayland\nUser=1000\nDisplay="), Some(1000));
+    assert_eq!(active_graphical_uid_from_show("Active=yes\nType=x11\nUser=1001\nDisplay=:0"), Some(1001));
+    assert_eq!(active_graphical_uid_from_show("Active=no\nType=x11\nUser=1000\nDisplay=:0"), None);
+    assert_eq!(active_graphical_uid_from_show("Active=yes\nType=tty\nUser=1000\nDisplay="), None);
+}
+```
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement** (near `relaunch_target`):
+```rust
+/// First column of each `loginctl list-sessions --no-legend` line = session id.
+pub fn parse_session_ids(list_output: &str) -> Vec<String> {
+    list_output.lines().filter_map(|l| l.split_whitespace().next()).map(str::to_string).collect()
+}
+/// uid of the session from a `loginctl show-session <id> -p Active -p Type -p User -p Display`
+/// block, IFF it is active AND graphical (x11/wayland). We don't need DISPLAY — the
+/// relaunched app is a server the browser reconnects to.
+pub fn active_graphical_uid_from_show(show_output: &str) -> Option<u32> {
+    let (mut active, mut kind, mut uid) = (false, String::new(), None::<u32>);
+    for line in show_output.lines() {
+        if let Some((k, v)) = line.split_once('=') {
+            match k.trim() {
+                "Active" => active = v.trim() == "yes",
+                "Type" => kind = v.trim().to_string(),
+                "User" => uid = v.trim().parse().ok(),
+                _ => {}
+            }
+        }
+    }
+    if active && (kind == "x11" || kind == "wayland") { uid } else { None }
+}
+```
+- [ ] **Step 4 — run PASS + `cross clippy … -- -D warnings` clean. Paste both.**
+- [ ] **Step 5 — commit:** `feat(linux): loginctl active-graphical-session parsers (Phase 2)`
+
+## Task P2-2: `system_relaunch_command` builder (pure)
+
+**Files:** `launcher/src/linux_service.rs` (+ test).
+
+- [ ] **Step 1 — failing test:**
+```rust
+#[test]
+fn system_relaunch_command_runs_as_user_on_service_port() {
+    assert_eq!(
+        system_relaunch_command("/usr/bin/systemd-run", 1000, "/home/jamie", 8000, "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"),
+        vec!["/usr/bin/systemd-run", "--uid=1000", "--setenv=HOME=/home/jamie",
+             "--setenv=WS_SCRCPY_WEB_PORT=8000", "--collect", "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"]
+    );
+}
+```
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement:**
+```rust
+/// `systemd-run --uid=<uid> --setenv=HOME=<home> --setenv=WS_SCRCPY_WEB_PORT=<port>
+/// --collect <appimage>` — relaunch the shared /opt binary AS the user, with HOME
+/// (mandatory — else data_root_for_linux panics) and the service's port (so the
+/// browser reconnects). No DISPLAY (it's a server). Pure.
+pub fn system_relaunch_command(systemd_run: &str, uid: u32, home: &str, web_port: u16, appimage: &str) -> Vec<String> {
+    vec![
+        systemd_run.to_string(),
+        format!("--uid={uid}"),
+        format!("--setenv=HOME={home}"),
+        format!("--setenv=WS_SCRCPY_WEB_PORT={web_port}"),
+        "--collect".to_string(),
+        appimage.to_string(),
+    ]
+}
+```
+- [ ] **Step 4 — run PASS + clippy clean.**
+- [ ] **Step 5 — commit:** `feat(linux): system_relaunch_command (run as user, service port) (Phase 2)`
+
+## Task P2-3: server honors `WS_SCRCPY_WEB_PORT` override
+
+**Files:** READ how webPort resolves (grep `src/server` for `webPort`/`PortPicker`/`reconcileWebPort`); add the override at the front of resolution. Test: the relevant resolver's vitest. Run: `npm test -- <that test>` + `npx tsc --noEmit`.
+
+- [ ] **Step 1 — failing test:** assert that when `process.env.WS_SCRCPY_WEB_PORT` is a valid port, the resolved desired webPort is exactly that (overriding the config value); when unset/invalid, behavior is unchanged. (Mirror the existing PortPicker/webPort resolver test; set/restore the env in the test.)
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement:** in the webPort resolver, before reading config: `const ov = Number(process.env['WS_SCRCPY_WEB_PORT']); if (Number.isInteger(ov) && ov > 0 && ov < 65536) return ov;` (force this exact port — do NOT auto-shift; it's free post-uninstall). Keep the existing config/default + PortPicker path for the unset case. The bound port still persists via the existing write-back.
+- [ ] **Step 4 — run PASS + `npx tsc --noEmit` 0 errors.**
+- [ ] **Step 5 — commit:** `feat(server): WS_SCRCPY_WEB_PORT one-shot port override (Phase 2)`
+
+## Task P2-4: wire System-scope relaunch into `run()`
+
+**Files:** `launcher/src/linux_service.rs` — the `run()` relaunch section (currently: `relaunch_target(scope, marker)` → `systemd-run --user --collect` for User; System is `None` → no relaunch). Imperative seam: compile/clippy here, **Fedora-verified**.
+
+- [ ] **Step 1 — read** the current `run()` relaunch block + `relaunch_target`.
+- [ ] **Step 2 — implement** — keep the **User** path exactly as-is; add a **System** branch + an imperative discovery helper:
+```rust
+/// Best-effort: the active graphical session's uid via loginctl (absolute paths,
+/// Local-Deps). Pure parsers (P2-1) do the work; this is the exec seam.
+fn discover_active_graphical_uid() -> Option<u32> {
+    let loginctl = format!("{}/loginctl", tool_dir("loginctl"));
+    let list = std::process::Command::new(&loginctl).args(["list-sessions", "--no-legend"]).output().ok()?;
+    for id in parse_session_ids(&String::from_utf8_lossy(&list.stdout)) {
+        if let Ok(show) = std::process::Command::new(&loginctl)
+            .args(["show-session", &id, "-p", "Active", "-p", "Type", "-p", "User", "-p", "Display"]).output() {
+            if let Some(uid) = active_graphical_uid_from_show(&String::from_utf8_lossy(&show.stdout)) {
+                return Some(uid);
+            }
+        }
+    }
+    None
+}
+/// Resolve a uid's home dir from `getent passwd <uid>` (field 6). Absolute path.
+fn home_for_uid(uid: u32) -> Option<String> {
+    let getent = format!("{}/getent", tool_dir("getent"));
+    let out = std::process::Command::new(&getent).args(["passwd", &uid.to_string()]).output().ok()?;
+    String::from_utf8_lossy(&out.stdout).lines().next()?.split(':').nth(5).map(str::to_string)
+}
+```
+  In `run()`, replace the relaunch block with a scope branch — **User** = the existing `relaunch_target` + `systemd-run --user --collect`; **System** =:
+```rust
+    if scope == Scope::System {
+        let systemd_run = format!("{}/systemd-run", tool_dir("systemd-run"));
+        let appimage = "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage";
+        let web_port = common::config::AppConfig::load(std::path::Path::new("/var/opt/ws-scrcpy-web")).web_port;
+        match (discover_active_graphical_uid(), web_port) {
+            (Some(uid), Some(port)) => match home_for_uid(uid) {
+                Some(home) => {
+                    let argv = system_relaunch_command(&systemd_run, uid, &home, port, appimage);
+                    let (cmd, rest) = argv.split_first().expect("non-empty argv");
+                    match std::process::Command::new(cmd).args(rest).status() {
+                        Ok(s) => log::info(&format!("system uninstall: relaunched {appimage} as uid {uid} on port {port} (exit {:?})", s.code())),
+                        Err(e) => log::error(&format!("system uninstall: relaunch failed: {e}")),
+                    }
+                }
+                None => log::error(&format!("system uninstall: no home for uid {uid}; skipping relaunch")),
+            },
+            _ => log::info("system uninstall: no active graphical session / no service port — skipping relaunch (manual fallback)"),
+        }
+    }
+```
+- [ ] **Step 3 — verify:** `cross test … linux_service` (all green) + `cross clippy … -- -D warnings`. Paste both.
+- [ ] **Step 4 — commit:** `feat(linux): system-scope uninstall relaunches the active user on the service port (Phase 2)`
+
+---
+
+# PHASE 3 — updates + migration
+
+## Task P3a-1: migration detect + status flag
+
+**Files:** `src/server/api/ServiceApi.ts` (`handleStatus`) + a detect helper + `src/common/ServiceEvents.ts` (status field). Test: `src/server/__tests__/ServiceApi.test.ts`. Run vitest + `npx tsc --noEmit`.
+
+- [ ] **Step 1 — failing test:** a pure `systemServiceNeedsMigration({ dataRootEnv, oldDataDirExists })` returns true when `dataRootEnv === '/opt/ws-scrcpy-web/data'` OR `oldDataDirExists`, else false; and `handleStatus` (linux, system service installed) includes `serviceMigrationNeeded: boolean` from `this.existsCheck('/opt/ws-scrcpy-web/data')`.
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement:** export `systemServiceNeedsMigration(input: { dataRootEnv?: string; oldDataDirExists: boolean }): boolean` (`input.dataRootEnv === '/opt/ws-scrcpy-web/data' || input.oldDataDirExists`); add `serviceMigrationNeeded?: boolean` to `ServiceStatusResponse`; in `handleStatus` (linux) set it from `this.existsCheck('/opt/ws-scrcpy-web/data')`.
+- [ ] **Step 4 — run PASS + tsc 0.**
+- [ ] **Step 5 — commit:** `feat(api): detect legacy /opt/.../data system install (migration flag) (Phase 3)`
+
+## Task P3a-2: reinstall endpoint (uninstall→reinstall, carry config)
+
+**Files:** `src/server/api/ServiceApi.ts` — `POST /api/service/migrate-system` that reads the current service config (webPort, installMode), runs the existing uninstall, then the existing system install carrying those. Test: ServiceApi.test.ts. **READ** `handleUninstall` + `handleInstall` to reuse them (don't duplicate). If the uninstall/install internals aren't cleanly callable, factor the shared core into a private method rather than copy-paste — note it in your report.
+
+- [ ] **Step 1 — failing test:** `POST /api/service/migrate-system` (linux, old layout) triggers uninstall then a system-scope install whose seed carries the prior `webPort` + `installMode`. Use the existing test seams (injected client/existsCheck/pkexec).
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement** the route + handler reusing the uninstall + install paths; carry `webPort`/`installMode` (+ audit other persisted service-config keys and carry them too — list what you carried in your report).
+- [ ] **Step 4 — run PASS + tsc 0.**
+- [ ] **Step 5 — commit:** `feat(api): migrate-system endpoint (uninstall→reinstall at /var/opt) (Phase 3)`
+
+## Task P3b-1: machine-wide-no-service update via pkexec
+
+**Files:** `src/server/UpdateService.ts` — the Linux apply path. **READ** how it currently spawns `--linux-apply` (local vs `--service-restart`). Add a branch: when the install is **machine-wide-no-service** (target AppImage under `/opt/ws-scrcpy-web` AND not root AND no service), instead of the plain swap, run `buildMachineWideInstallScript({ sourceAppImage: <staged>, version: <new> })` via `runPkexec` (reuse the Phase 1 builders), then relaunch `/opt` in the user's context (the existing `linux_apply` relaunch pattern — `systemd-run --user --collect /opt/.../WsScrcpyWeb.AppImage`, NOT under pkexec). Test: `src/server/__tests__/UpdateService.test.ts`. Run vitest + tsc.
+
+- [ ] **Step 1 — failing test:** for a machine-wide `/opt` target (mock/inject the "running from /opt, no service" condition), `applyUpdate` invokes the injected pkexec runner with a script containing `cp "<staged>" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"` + `bin_t`, and does NOT run the pkexec under which the relaunch happens (relaunch is separate/user-context). Mirror the existing UpdateService apply tests + their injection seams.
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement** the branch (detect `/opt` target + no-service → pkexec install-script swap + user-context relaunch). Reuse `buildMachineWideInstallScript` + the exported `runPkexec`. If detecting "running from /opt, no service" needs a new signal, derive it from `process.env.APPIMAGE` starting with `/opt/ws-scrcpy-web/` + the installMode not being a service mode.
+- [ ] **Step 4 — run PASS + tsc 0.**
+- [ ] **Step 5 — commit:** `feat(server): machine-wide-no-service update via one pkexec swap + user relaunch (Phase 3)`
+
+## Task P3c-1: bootstrapper version-compare
+
+**Files:** `launcher/src/linux_service.rs` — extend `bootstrap_target`; `launcher/src/main.rs` — pass the running version. cross test/clippy.
+
+- [ ] **Step 1 — failing test** (add to `mod tests`):
+```rust
+#[test]
+fn bootstrap_decides_by_version() {
+    let opt = "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage";
+    // /opt present, /opt newer-or-equal -> exec /opt
+    assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.30", Some("0.1.31")), BootstrapAction::ExecOpt(opt.into()));
+    assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.31", Some("0.1.31")), BootstrapAction::ExecOpt(opt.into()));
+    // /opt present but HOME appimage is NEWER -> run home + offer
+    assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.32", Some("0.1.31")), BootstrapAction::RunHomeOfferUpdate);
+    // we ARE /opt -> RunHome (normal /opt run)
+    assert_eq!(bootstrap_decision(true, Some(opt), "0.1.31", Some("0.1.31")), BootstrapAction::RunHome);
+    // no /opt -> RunHome
+    assert_eq!(bootstrap_decision(false, Some("/home/u/App.AppImage"), "0.1.31", None), BootstrapAction::RunHome);
+    // missing/garbage /opt VERSION -> treat /opt as present-but-unknown -> ExecOpt (don't block)
+    assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.31", None), BootstrapAction::ExecOpt(opt.into()));
+}
+```
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement** — add a small semver-ish compare (handle `X.Y.Z-beta.N`: numeric core compare; a `-beta.N` pre-release sorts BEFORE the same core release, and by N among betas) and:
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BootstrapAction { ExecOpt(PathBuf), RunHomeOfferUpdate, RunHome }
+
+/// `self_version` = the running (home) AppImage's version; `opt_version` = parsed
+/// /opt/VERSION (None if absent/unreadable). Pure.
+pub fn bootstrap_decision(opt_exists: bool, appimage_env: Option<&str>, self_version: &str, opt_version: Option<&str>) -> BootstrapAction {
+    let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
+    let is_self_opt = appimage_env.map(|p| p == opt.to_string_lossy()).unwrap_or(false);
+    if !opt_exists || appimage_env.is_none() || is_self_opt { return BootstrapAction::RunHome; }
+    match opt_version {
+        Some(ov) if version_cmp(self_version, ov) == std::cmp::Ordering::Greater => BootstrapAction::RunHomeOfferUpdate,
+        _ => BootstrapAction::ExecOpt(opt),  // /opt >= home, or unknown /opt version -> run /opt
+    }
+}
+```
+  Wire `main.rs`: read `/opt/ws-scrcpy-web/VERSION` (if present), pass `env!("CARGO_PKG_VERSION")` as `self_version`; on `ExecOpt(p)` exec it (existing behavior); `RunHome` → continue normal launch; `RunHomeOfferUpdate` → continue normal launch but set an env/marker the frontend reads to offer the /opt update. (Keep `bootstrap_target` as a thin wrapper over `bootstrap_decision` if other call sites use it, or migrate the seam.)
+- [ ] **Step 4 — verify** cross test + clippy. Paste.
+- [ ] **Step 5 — commit:** `feat(linux): version-aware bootstrapper (offer /opt update when home is newer) (Phase 3)`
+
+## Task P3c-2: frontend offers — migration reinstall + system-wide update
+
+**Files:** `src/app/index.ts` / `src/app/client/SettingsModal.ts`. Wiring (compile + runtime-verified). READ the existing first-run/status-driven UI (the C2/C3 SystemWideInstallModal + status reads) and mirror it.
+
+- [ ] **Step 1 — failing test (the testable slice):** a pure helper `migrationNotice(status: { serviceMigrationNeeded?: boolean })` returns the notice + an action flag when true, nothing when false (mirror `systemServiceInstallGate`). Add the vitest.
+- [ ] **Step 2 — run, verify FAIL.**
+- [ ] **Step 3 — implement** the helper, then wire: when `serviceMigrationNeeded` → show the notice + [reinstall now] → `POST /api/service/migrate-system` → reload. When the launcher flagged a newer-home version (the P3c-1 marker, surfaced via status) → show "update the system-wide install? [update]" → `POST /api/service/install-system-wide` (reuses B3, which sources `$APPIMAGE` = the newer home one) → reload.
+- [ ] **Step 4 — `npm test` (full) green + `npx tsc --noEmit` 0 errors.**
+- [ ] **Step 5 — commit:** `feat(ui): migration reinstall notice + system-wide update offer (Phase 3)`
+
+---
+
+## Self-review (against the spec)
+- **Phase 2 §:** discovery (P2-1) · relaunch-as-user-with-HOME-on-service-port (P2-2) · `WS_SCRCPY_WEB_PORT` override (P2-3) · run() System wiring + headless fallback (P2-4). ✓ No DISPLAY anywhere. ✓
+- **Phase 3 §:** migration detect (P3a-1) + reinstall (P3a-2) · machine-wide-no-service pkexec update (P3b-1) · version-compare bootstrapper (P3c-1) + the two frontend offers (P3c-2). ✓
+- **Type consistency:** `active_graphical_uid_from_show`, `system_relaunch_command(systemd_run, uid, home, web_port, appimage)`, `bootstrap_decision(...) -> BootstrapAction`, `systemServiceNeedsMigration`, `WS_SCRCPY_WEB_PORT`, `serviceMigrationNeeded`, `migrate-system` used identically across tasks.
+- **Risks (from spec) to verify on Fedora, not unit-coverable:** systemd-run `--uid`+`--setenv=HOME` → `~/.local` dataRoot; the port override forcing the exact free port; semver on `-beta.N`; the migration carry-over completeness.
+
+## Exit criteria — Fedora (runtime, owed before ship)
+Per the spec's two "Exit criteria" blocks: system uninstall (same-user + different-admin) → reappears on the same port with a visible wait; headless → manual fallback. Machine-wide-no-service update → one pkexec → relaunch-as-user. Newer home AppImage over older /opt → offered + accepted. beta.40 system install upgrade → migration notice → reinstall at /var/opt, config carried, zero AVC.

--- a/docs/specs/2026-06-05-machine-wide-opt-install-design.md
+++ b/docs/specs/2026-06-05-machine-wide-opt-install-design.md
@@ -25,6 +25,7 @@ On Linux the app runs as a bare AppImage from the user's home; only the system-s
 5. **Uninstall→relaunch = `loginctl` active-session discovery + `systemd-run --uid`** (Windows parity) — resolved *fresh at uninstall*, not capture-at-install. Manual-guidance fallback when headless.
 6. **Migration = uninstall→reinstall on upgrade** for existing system-scope installs (carry `webPort`/`installMode`); local/home users get only the first-run prompt; user-scope stays home.
 7. **Folded fix (a):** the teardown `semanage fcontext -d`'s **both** the `/opt` `bin_t` and `/var/opt` `var_lib_t` rules (the beta.40 regression: install added a second rule the teardown never removed).
+8. **Single-instance + service-aware launch (per-user) — added 2026-06-05.** The shared `/opt` binary + the system-wide Start-Menu `.desktop` require a **per-user single-instance guard** (`flock` on `$XDG_RUNTIME_DIR/ws-scrcpy-web.lock`; today's `single_instance.rs` Linux path is a no-op stub) so a user can't double-launch their user-mode instance (from `/opt` or home), while different users each get one. And a local launch **defers to an active system service** (opens its URL, no second server) — the "menu no-op in service mode". Launch order: service-active → per-user-instance → `/opt`-exec → run-in-place.
 
 ---
 

--- a/docs/specs/2026-06-05-machine-wide-opt-install-design.md
+++ b/docs/specs/2026-06-05-machine-wide-opt-install-design.md
@@ -1,0 +1,176 @@
+# Machine-wide `/opt` install for Linux (PerMachine parity) — design
+
+**Status:** approved (brainstorm) 2026-06-05. Design-first; implementation via a follow-on plan. **Linux-only.** Folds the beta.41 uninstall fast-follow (todo item 44 (a) + (b)) into this initiative.
+
+**Supersedes:** the §5 capture-at-install relaunch sketch in `docs/specs/2026-06-02-system-scope-service-paths-fix-design.md`.
+
+## Problem / goal
+
+On Linux the app runs as a bare AppImage from the user's home; only the system-scope service stages a copy to `/opt`. This diverges from Windows, where Velopack installs a machine-wide (PerMachine) binary and — crucially — **"it doesn't matter who uninstalls the system service; the local user picks back up,"** via active-session discovery (`WTSEnumerateSessionsW`) + a per-user tray.
+
+**Goal:** bring that PerMachine parity to Linux — a shared machine-wide binary in `/opt`, and an uninstall→relaunch that puts the app back in front of **whoever is at the desk now** — while keeping SELinux integrity and avoiding forced elevation in the common case.
+
+## Non-goals
+
+- **Windows is untouched** — it is already PerMachine.
+- Not changing the per-user data model for local / user-scope runs beyond the binary's location (deps/config/logs stay in `~/.local`).
+- Not introducing world-writable trees (the `setfacl` route was evaluated and rejected — see Decisions).
+
+## Locked decisions (2026-06-05 brainstorm)
+
+1. **FHS layout.** Binary → `/opt/ws-scrcpy-web/` (`bin_t`); system-service variable state → `/var/opt/ws-scrcpy-web/` (`var_lib_t`); per-user deps + config + logs → `~/.local/share/ws-scrcpy-web/` (XDG).
+2. **Model A — privileged updates, no world-writable trees.** Elevation is the *exception*: a pkexec prompt appears only when a *non-root* context writes `/opt` (the one-time machine-wide install; app-binary updates in machine-wide-but-no-service mode). In system-service mode the already-root service writes directly — **no prompt** (Windows parity; = item 39, shipped beta.38). Dep updates in user-run modes hit `~/.local` and never elevate. **Rejected `setfacl`/world-writable** (the `icacls` analog): SELinux types trump POSIX ACLs on enforcing Fedora; "Authenticated Users" has no Linux twin (only `other`/world or a managed group); all-users-writable + root-service-exec = local privilege escalation — the very thing the `bin_t`/`var_lib_t` labels prevent.
+3. **Trigger = auto on first launch.** The home AppImage is a bootstrapper. Decline = run-in-place + remember (per-user; no re-nag). System-scope service install is **gated** on machine-wide install (greyed button + modal).
+4. **Deps + state follow the run context, not the binary.** As-user runs (local, user-scope service) → `~/.local` (no elevation). Root system service → its own `/opt` deps + `/var/opt` state (the beta.40 escalation fix forbids root exec'ing a user's home binaries).
+5. **Uninstall→relaunch = `loginctl` active-session discovery + `systemd-run --uid`** (Windows parity) — resolved *fresh at uninstall*, not capture-at-install. Manual-guidance fallback when headless.
+6. **Migration = uninstall→reinstall on upgrade** for existing system-scope installs (carry `webPort`/`installMode`); local/home users get only the first-run prompt; user-scope stays home.
+7. **Folded fix (a):** the teardown `semanage fcontext -d`'s **both** the `/opt` `bin_t` and `/var/opt` `var_lib_t` rules (the beta.40 regression: install added a second rule the teardown never removed).
+
+---
+
+## Section 1 — Filesystem layout + SELinux
+
+Three trees, split by **ownership / run-context**:
+
+```
+# ALWAYS present once machine-wide-installed (root-owned, static):
+/opt/ws-scrcpy-web/
+└── WsScrcpyWeb.AppImage           bin_t   ← the shared binary (the Windows-parity relaunch target)
+    + /usr/share/applications/ws-scrcpy-web.desktop   (menu entry for all users; Exec=/opt/.../AppImage)
+
+# ADDED only when a SYSTEM-scope service is installed (root-owned):
+/opt/ws-scrcpy-web/
+├── ws-scrcpy-web-launcher.exe     bin_t   ← staged teardown helper (init_t may exec it)
+└── dependencies/                  bin_t   ← the service's OWN node/adb/scrcpy-server
+/var/opt/ws-scrcpy-web/            var_lib_t ← the service's variable state
+├── config.json
+└── logs/
+
+# PER-USER, every interactive run (local mode + user-scope service), user-owned:
+~/.local/share/ws-scrcpy-web/       (XDG_DATA_HOME — the existing local dataRoot)
+├── config.json
+├── dependencies/                          ← node/adb/scrcpy-server  (no-elevation updates)
+├── logs/
+└── control/                               (markers)
+```
+
+**SELinux** (Fedora enforcing; applied by the elevated install/relocate step — mirrors the beta.40 machinery):
+
+- `/opt/ws-scrcpy-web(/.*)?` → **`bin_t`** — persistent `semanage fcontext -a` + `restorecon` (`chcon` fallback on minimal images). Lets `init_t` (the root service) exec the AppImage + deps; ordinary users can exec `bin_t` too, so machine-wide-no-service local runs work.
+- `/var/opt/ws-scrcpy-web(/.*)?` → **`var_lib_t`** — the more-specific writable rule for the service's config + logs.
+- **Uninstall teardown** `semanage fcontext -d`'s **both** rules (folded fix (a) — now `/opt/...` **and** `/var/opt/...`, replacing the old `/opt/...` + `/opt/.../data`), then `rm -rf` both root trees + `daemon-reload`. **`~/.local` is never touched.**
+
+**Invariant:** `bin_t` is never writable by non-root (SELinux + ownership) — this is what makes "all users run it, only root changes it" safe, and why the `setfacl` world-writable route was rejected.
+
+---
+
+## Section 2 — Install / bootstrap + elevation flows
+
+**The bootstrapper** (home AppImage, every launch, running as the user):
+
+```
+/opt binary present?
+├─ yes, /opt ver ≥ mine → exec /opt   (hand off + exit. Post-install the normal launch is the
+│                                       .desktop menu entry → runs /opt directly, skipping this)
+├─ yes, mine is newer   → offer "update the system-wide install" → [pkexec] → exec /opt
+└─ no:
+     decline-marker set?  (~/.local/share/ws-scrcpy-web/control/system-install-declined)
+     ├─ yes → run in place from ~/.local        (NO prompt — the "remember" path)
+     └─ no  → prompt "install system-wide for all users?"
+                accept  → [pkexec] machine-wide install → exec /opt
+                decline → write decline-marker → run in place
+```
+
+**Two distinct elevated operations** (each one pkexec from the user's app — or *zero* prompts when the root service drives it):
+
+1. **Machine-wide install** (first-launch accept) — *just the binary*: `cp home.AppImage → /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage` (0755) · `semanage bin_t` + `restorecon` · drop `/usr/share/applications/ws-scrcpy-web.desktop`. **Deps are NOT copied** — local runs use per-user `~/.local` deps.
+2. **System-service install** (the gated button, later) — adds the service's bits *on top*: `cp ~/.local/dependencies → /opt/.../dependencies` (bin_t) · seed `/var/opt/.../config.json` + the `var_lib_t` rule · install + `enable --now` the unit. (This is beta.40's `buildSystemInstallScript`, retargeted: binary's already in `/opt` via the gate; state → `/var/opt`, not `/opt/.../data`.)
+
+**Update elevation matrix:**
+
+| Action | Context | Prompt? |
+|---|---|---|
+| One-time machine-wide **install** (relocate binary → `/opt`) | user's local app (not yet root) | pkexec ×1 |
+| **App-binary** update, machine-wide-but-**no-service** | user writing root-owned `/opt` | pkexec (app updates are infrequent) |
+| **Any** update in **system-service** mode | the root service does it | **none** ← Windows parity (item 39) |
+| **Dep** update in any user-run mode | `~/.local` (user owns it) | **none** |
+
+**Error handling / edges:**
+
+- **pkexec declined, or headless / no-polkit** → can't write `/opt` → fall back to run-in-place from `~/.local` + log; a first-run decline writes the remember-marker (no re-nag).
+- **`.desktop` drop is best-effort** — its failure doesn't fail the install (bootstrapper still works).
+- **Service-install gating:** the service-scope **system** radio selected while not machine-wide → install-service button **greyed** + a small **modal**: *"system service install requires installing system-wide for all users first."* User-scope service stays available in both modes (home or `/opt` ExecStart).
+
+---
+
+## Section 3 — `loginctl` uninstall→relaunch (Windows parity)
+
+**Scope:** only the system-service path (a declined / in-place user has no service). When the system service is uninstalled — **by anyone, even a different admin** — the app should reappear for whoever's currently at the desk. Windows uses `WTSEnumerateSessionsW` + a per-user tray; Linux has no tray, so the **root teardown does the discovery + spawn itself.**
+
+**Mechanism** (inside the existing root `systemd-run --system` teardown helper):
+
+1. **Discover the active desktop user** via `loginctl` (the `WTSEnumerateSessionsW` analog, resolved by absolute path per Local-Deps):
+   - `loginctl list-sessions` → the session with `Active=yes`, `Type=x11|wayland`, `Seat=seat0`.
+   - `loginctl show-session <id> -p User -p Display` → `uid`, `DISPLAY`; derive `XDG_RUNTIME_DIR=/run/user/<uid>`.
+   - **Core output is *which user* (`uid`)** — "who's at the desk now," not who installed (the parity point).
+2. **Relaunch the shared `/opt` binary as that user:**
+   ```
+   systemd-run --uid=<uid> --setenv=XDG_RUNTIME_DIR=/run/user/<uid> [--setenv=DISPLAY=<d>] \
+               --collect /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage
+   ```
+   `--uid` drops root → the target user; `--collect` = an independent transient unit that outlives the teardown helper (same survival logic as today's user-scope relaunch). Target = the **shared `/opt` binary** (user-agnostic) — *this* is what the machine-wide binary buys us. The relaunched instance runs local mode against that user's own `~/.local` deps.
+3. **Reconnect — no new browser code.** The relaunched local server binds the same port (config seeded with the user's port, as today), so the browser already open on the old port hits the existing `classifyInstallPoll`/reload and lands on it. (The app is a server the user views in a browser, so "relaunch" = rebind the port; the open browser reconnects itself.)
+4. **Fallback:** no active graphical session (headless / SSH-only) → **don't** relaunch; log + keep the "relaunch manually" guidance. Parity with Windows' `handoff-no-target`.
+
+**Code seams** (the pure/testable parts, mirroring existing builders):
+
+- `relaunch_target(System, …)` stops returning `None` — System now resolves the `/opt` target **when** `loginctl` finds an active graphical session.
+- New pure helper `parse_active_graphical_session(loginctl_output) → Option<SessionCtx{uid, display, xdg_runtime_dir}>` — TDD-unit-tested (active / inactive / no-graphical).
+- New pure builder `system_relaunch_command(ctx, appimage) → Vec<String>` — TDD-unit-tested (uid / setenv / collect / target shape).
+- The `run()` exec seam wires discover→build→spawn (Fedora-smoke-verified — the runtime-survival point, like today's `>>> VERIFY ON FEDORA` marker). **Folded fix (a) rides here:** teardown `-d`'s both the `/opt` `bin_t` and `/var/opt` `var_lib_t` rules.
+
+**Security note:** `systemd-run --uid` is the privilege-*dropping* direction (root → user) — safe; the session context is discovered **fresh at uninstall**, never stale-captured.
+
+---
+
+## Section 4 — Migration
+
+Three existing populations; only one needs real work:
+
+- **Local / home-run users** → *no data migration.* Next launch, the bootstrapper sees no `/opt` → the first-run *"install system-wide?"* prompt (accept = relocate, decline = run-in-place + remember). Their `~/.local` is untouched.
+- **User-scope service installs** → *stay home-based.* ExecStart retargets to `/opt` only if/when they later go machine-wide. No forced migration.
+- **System-scope service installs (beta.40)** → **uninstall→reinstall on upgrade (Approach B).** On detecting the old `/opt/ws-scrcpy-web/data` layout, run the existing uninstall, then a fresh install at the new layout, carrying over `webPort`/`installMode`. Reuses the install/uninstall paths (simplest code); the beta install base is tiny (test VMs) so disruption is minimal. Risk accepted: any un-carried config customization is lost — so the carry-over list (`webPort`, `installMode`, and any other load-bearing config keys) must be explicit.
+
+---
+
+## Components / build order (for the implementation plan)
+
+1. **Layout + SELinux relabel** — extend the beta.40 builders: a binary-only machine-wide install vs the service-install (deps + `/var/opt` state); add the `/var/opt` `var_lib_t` rule; teardown removes **both** rules (fix a).
+2. **Bootstrapper + first-launch install** — the launch decision; relocate-to-`/opt` elevated op; `.desktop` drop; the per-user decline-marker.
+3. **Service-install gating UX** — the machine-wide prerequisite check; greyed button + modal.
+4. **Privileged update path** — pkexec wrap for the machine-wide-no-service app-binary update; service-mode self-update unchanged (= item 39).
+5. **`loginctl` uninstall→relaunch** — discovery parser + `system_relaunch_command` builder + `run()` wiring; folds fix (a).
+6. **Migration** — detect old layout → uninstall→reinstall on upgrade, carry config.
+
+## Testing
+
+- **Unit (cross, TDD):** SELinux command builders (the `/var/opt` rule + the both-rules teardown `-d`); the bootstrapper decision logic; `loginctl`-parse (active / inactive / no-graphical); `system_relaunch_command` argv; the migration detect→command-list + the config carry-over.
+- **Runtime (Fedora VM, SELinux enforcing):** first-launch install (accept / decline / headless); machine-wide-no-service app update (one pkexec); system-service install (gated) + self-update (no prompt); **uninstall→relaunch by the same user AND by a different admin** → app reappears in the active desktop session, browser reconnects same-port; headless → manual fallback, no orphan; `ls -Z` labels; `semanage fcontext -l | grep ws-scrcpy-web` empty after uninstall (fix a). Migration: upgrade a beta.40 system install → reinstalled at the new layout, config carried.
+
+## Files (anticipated)
+
+- `src/server/service/SystemdClient.ts` — split machine-wide-install (binary-only) vs service-install (deps + `/var/opt` + unit); the `/var/opt` rule; `.desktop` drop.
+- `src/server/api/ServiceApi.ts` — bootstrap/relocate trigger; the machine-wide gate for system-service install; migration detect.
+- `launcher/src/linux_service.rs` — `relaunch_target(System)` via loginctl; new `parse_active_graphical_session` + `system_relaunch_command`; teardown both-rules `-d` (fix a); `/var/opt` paths.
+- `launcher/src/linux_apply.rs` / `src/server/UpdateService.ts` — pkexec wrap for the machine-wide-no-service app update.
+- `common/src/config.rs` — `/var/opt` data root for system scope; XDG for user.
+- Service/settings UI (`src/app/client/…`) — greyed install-service button + modal when not machine-wide; the first-launch "install system-wide?" prompt modal.
+- Tests alongside each.
+
+## Risks / open questions (carry into the plan)
+
+- **Wayland vs X11** session env in `loginctl` discovery — `DISPLAY` may be absent on Wayland; `uid` + `XDG_RUNTIME_DIR` are the load-bearing bits (the app is a server, so the GUI env is mostly for completeness / any browser-open behavior).
+- **`.desktop` + menu-cache** refresh across desktop environments (best-effort; may need `update-desktop-database`).
+- **pkexec / polkit availability detection** + the headless fallback path (must never hang waiting on a prompt that can't appear).
+- **Config carry-over list** for migration (B) must be explicit so nothing load-bearing is lost on reinstall.
+- **Machine-wide-no-service app updates**: consider surfacing "install the system service for prompt-free updates" as guidance, since those are the only routine repeat-prompt case.

--- a/docs/specs/2026-06-05-machine-wide-opt-install-phases2-3-design.md
+++ b/docs/specs/2026-06-05-machine-wide-opt-install-phases2-3-design.md
@@ -1,0 +1,96 @@
+# Machine-wide `/opt` Install — Phases 2 & 3 design (consolidated)
+
+**Status:** approved (brainstorm) 2026-06-05. **Linux-only.** Refines §3 (relaunch) and §4 (migration) of the umbrella spec `docs/specs/2026-06-05-machine-wide-opt-install-design.md` with the per-phase detail brainstormed after Phase 1 shipped (code-complete on branch `path2-machine-wide-install`). One spec, two phase sections; one plan to follow, likewise sectioned.
+
+**Tech:** Rust launcher (`cross`), TS server (vitest), frontend. `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`; no push.
+
+---
+
+## Phase 2 — `loginctl` uninstall→relaunch
+
+**Goal:** After a **system-scope** service uninstall — by anyone — the app reappears for **whoever is at the desk**, on the **exact URL their browser is already on**, with a clear "relaunching…" wait and never a "where did it go?" dead end. Headless → graceful manual fallback.
+
+### Key decision: relaunch is "run **as the user**", not "into the graphical session"
+
+The relaunched instance is a **Node server** the browser reconnects to — it draws no GUI, and auto-open-browser only fires on first-run (`openBrowser.ts`, gated `firstRunComplete === false`), which is not our case. So we do **not** need `DISPLAY`/`XDG_RUNTIME_DIR`. We need it to run **as the active user with `HOME` set**, so it resolves its own dataRoot to `~/.local/share/WsScrcpyWeb` (the user's config + deps — exactly Phase 1's "deps+state follow the run context").
+
+### Discovery (`loginctl`)
+The root teardown (already running in its `systemd-run --system` transient unit) finds the active desktop user:
+- `loginctl list-sessions --no-legend` → session IDs (first column).
+- For each: `loginctl show-session <id> -p Active -p Type -p User -p Display` → pick the first **`Active=yes`** + **`Type=x11|wayland`** (a real graphical seat — the person physically there). Yields **uid** (and we resolve **home** via `getent passwd <uid>`, field 6).
+- `loginctl` (+ `getent`) resolved by absolute path (Local-Deps), pure parsers unit-tested.
+
+### Relaunch
+```
+systemd-run --uid=<uid> --setenv=HOME=<home> --setenv=WS_SCRCPY_WEB_PORT=<servicePort> \
+            --collect /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage
+```
+- `--uid` drops root → the user; `--setenv=HOME` is **mandatory** — without it `data_root_for_linux` *panics* (the beta.40 "never `/tmp`" guard), so a missing HOME is a hard crash, not silent drift.
+- `--collect` = an independent transient unit that outlives the teardown helper.
+- **No `DISPLAY`/`XDG_RUNTIME_DIR`.**
+
+### Reliable reconnect (the "always works, never lost")
+- **Bind the *service's* port.** The teardown reads `webPort` from the `/var/opt` service config and passes it as a one-shot override `WS_SCRCPY_WEB_PORT=<port>`. The relaunched app binds **that exact port** — which is **free** (the service just released it on stop) — so the browser lands on the precise URL it's already on. The app persists the bound port via the existing PortPicker write-back, so it's stable afterward too.
+- **Cover the gap with the existing reconnect poll.** Between service-stop and app-bind the browser sees a few seconds of refused connections; the frontend is already polling the same URL (`classifyInstallPoll` — the install hand-off + user-scope uninstall path: *"this page will reconnect shortly"*). It reloads the instant the port answers.
+- **Show the wait, system-scope too.** Surface that *"…reconnect shortly"* affordance for the system-scope uninstall (it already exists for user-scope) so the worst case is a brief, explained wait.
+
+### Fallback
+No active graphical session (headless / SSH-only) → don't relaunch; log + keep the existing "relaunch manually" guidance (no browser to strand).
+
+### New mechanism: `WS_SCRCPY_WEB_PORT` override
+The server's webPort resolution checks `WS_SCRCPY_WEB_PORT` first (force this exact port), else config `webPort`, else default. Set **only** by the Phase 2 relaunch; persisted via the normal write-back.
+
+### Components / testable seams
+- Pure (cross-unit-tested): `parse_session_ids`, `session_ctx_from_show` (Active+graphical → `SessionCtx{uid, home?, display?}`), `system_relaunch_command(systemd_run, ctx, appimage, web_port)`.
+- Imperative (Fedora-verified): `discover_active_graphical_session()` (runs loginctl/getent), the `run()` System-scope relaunch branch (User scope unchanged).
+- TS: `WS_SCRCPY_WEB_PORT` honored in webPort resolution (vitest). Frontend: system-scope reconnect affordance.
+
+### Exit criteria (Fedora, runtime)
+System service installed → uninstall **(a) as the same user** and **(b) via pkexec as a different admin** → app reappears in the **active desktop user's** session, browser reconnects **same-port** with a visible wait; **headless** uninstall → no relaunch, manual fallback, no orphan; `ls -Z`/AVC clean.
+
+---
+
+## Phase 3 — updates + migration
+
+**Goal:** machine-wide `/opt` installs update cleanly; existing beta.40 system installs migrate to the new layout without anyone getting silently stranded.
+
+### 3a — Migration of existing beta.40 system installs (**detect + one-click reinstall**)
+- **Detect** the old layout: `DATA_ROOT=/opt/ws-scrcpy-web/data` (old unit env) and/or `/opt/ws-scrcpy-web/data` present.
+- **Surface a clear in-app notice** (not a silent break): *"the system service must be reinstalled for the new layout"* + a **[reinstall now]** action.
+- On confirm, run the **existing uninstall→reinstall** at the new layout, **carrying** `webPort` + `installMode` (+ any other persisted service config). Reuses the install/uninstall paths; no in-place data shuffle.
+- Rationale: tiny, user-controlled beta base; "uninstall→reinstall" (umbrella decision 6) with a confirmed, visible trigger.
+
+### 3b — Machine-wide-no-service app update (`pkexec` the swap only)
+The user runs `/opt` locally (no service); a Velopack update must write the root-owned `/opt`.
+- **`pkexec` *only* the file swap** — reuse Phase 1's machine-wide-install elevated step: `cp` staged AppImage → `/opt/.../WsScrcpyWeb.AppImage`, re-label `bin_t` + `restorecon`, bump `/opt/VERSION`. **One prompt.**
+- **Relaunch in the user's context** — the `pkexec` covers *only* the swap; after it, the user-context process re-execs the new `/opt` (as the user, **never root**). Browser reconnects (same port, local config).
+- **Unchanged:** run-in-place home installs update with zero elevation (existing `linux_apply`); system-service installs self-update prompt-free (item 39).
+
+### 3c — Bootstrapper version-compare + offer-update
+Phase 1's bootstrapper just execs `/opt` if present. Phase 3 makes it version-aware so a manually-downloaded newer AppImage isn't silently ignored:
+- The launcher reads `/opt/VERSION` and its own `CARGO_PKG_VERSION`, semver-compares.
+- **home ≤ /opt** → exec `/opt` (normal).
+- **home > /opt** → run the **home** AppImage in place (the newer one) and flag it for the app, which **offers** *"update the system-wide install to vX? [update]"* → POST → the **3b** `pkexec` swap using the home AppImage as source. Next launch execs the updated `/opt`.
+- Reuses 3b's swap; the offer lives in the frontend (the launcher can't draw UI).
+
+### Components / testable seams
+- Rust (cross-unit): semver compare helper; the bootstrapper decision extended (`exec /opt` vs `run home + flag`).
+- TS (vitest): the machine-wide-no-service update path → pkexec swap builder (reuse `buildMachineWideInstallScript`); the migration-detect + reinstall endpoint; the version-newer status flag + offer endpoint.
+- Frontend: the migration notice + [reinstall now]; the "update the system-wide install" offer.
+- Imperative/Fedora-verified: the actual pkexec swap + user-context relaunch.
+
+### Exit criteria (Fedora, runtime)
+Machine-wide-no-service `/opt` install → in-app update → **one** pkexec → `/opt` swaps + relabels, app relaunches as the user, browser reconnects. Run a newer home AppImage over an older `/opt` → offered the update → accept → `/opt` updated. Upgrade a **beta.40** system install → migration notice → [reinstall now] → service reinstalled at `/var/opt`, config carried, zero AVC.
+
+---
+
+## Cross-cutting
+- **Linux-only** (Windows is already PerMachine).
+- Phase 2 depends only on Phase 1's `/opt` layout (shipped). Phase 3's update + version-compare depend on Phase 1's `buildMachineWideInstallScript` + `/opt/VERSION` (shipped).
+- Build order for the plan: **Phase 2** (relaunch) is independent and smaller → first; **Phase 3** (migration + update + version-compare) second.
+
+## Open risks (carry into the plan)
+- `systemd-run --uid` + `--setenv=HOME` actually yielding `~/.local` dataRoot resolution — the load-bearing runtime assumption; verify first on Fedora.
+- The `WS_SCRCPY_WEB_PORT` override must force the exact (free) port, not auto-shift away from it.
+- Migration carry-over list must be explicit (webPort, installMode, + audit other persisted service-config keys) so nothing load-bearing is lost on reinstall.
+- semver compare must handle the project's `X.Y.Z-beta.N` tags correctly (pre-release ordering).

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 common = { path = "../common", package = "ws-scrcpy-web-common" }
+rustix = { version = "1", features = ["fs"] }
 ctrlc.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/launcher/src/linux_apply.rs
+++ b/launcher/src/linux_apply.rs
@@ -24,13 +24,6 @@ fn arg_value<'a>(args: &'a [String], key: &str) -> Option<&'a str> {
 }
 
 fn run(args: &[String]) -> i32 {
-    let staged = match arg_value(args, "--staged") {
-        Some(s) => PathBuf::from(s),
-        None => {
-            log::error("linux-apply: missing --staged");
-            return 2;
-        }
-    };
     let target = match arg_value(args, "--target") {
         Some(s) => PathBuf::from(s),
         None => {
@@ -44,12 +37,42 @@ fn run(args: &[String]) -> i32 {
     // FUSE unmount, swaps, relabels (system scope), and starts the unit — no
     // --wait-pid, no bare relaunch. Reached for user-service (user manager,
     // home $APPIMAGE) and system-service (system manager, root, /opt + bin_t).
+    // It swaps the binary, so it requires --staged.
     if let Some((scope, unit, relabel)) = parse_service_restart(args) {
+        let staged = match arg_value(args, "--staged") {
+            Some(s) => PathBuf::from(s),
+            None => {
+                log::error("linux-apply(service): --service-restart requires --staged");
+                return 2;
+            }
+        };
         return run_service_restart(&staged, &target, scope, &unit, relabel);
     }
 
-    // Local-mode apply (unchanged #27 path): wait for the app pid, swap, relaunch.
     let wait_pid = arg_value(args, "--wait-pid").and_then(|s| s.parse::<u32>().ok());
+
+    // Relaunch-only apply (Phase 3, machine-wide-no-service): --staged is ABSENT.
+    // The user runs the root-owned /opt AppImage directly, so the Node server has
+    // ALREADY done the privileged RENAME-swap of the /opt binary under one pkexec
+    // (a `cp` would ETXTBSY the running file; the per-user flock blocks a fresh
+    // /opt instance until the old one exits). This helper therefore only waits for
+    // the app's pid to exit (releasing the flock) and relaunches the swapped /opt
+    // copy — no swap, no staged cleanup. The relaunch must NOT be elevated, which
+    // is why it runs here (as the user) rather than inside the pkexec script.
+    if !should_swap(args) {
+        log::info(&format!("linux-apply(relaunch-only): target={target:?} wait_pid={wait_pid:?}"));
+        if let Some(pid) = wait_pid {
+            wait_for_pid_exit(pid, Duration::from_secs(60));
+        }
+        relaunch(&target);
+        return 0;
+    }
+
+    // Local-mode apply (unchanged #27 path): wait for the app pid, swap, relaunch.
+    // should_swap(args) == true above guarantees --staged is present.
+    let staged = PathBuf::from(
+        arg_value(args, "--staged").expect("should_swap() == true guarantees --staged present"),
+    );
     log::info(&format!("linux-apply(local): staged={staged:?} target={target:?} wait_pid={wait_pid:?}"));
 
     if let Some(pid) = wait_pid {
@@ -274,6 +297,15 @@ pub fn parse_service_restart(args: &[String]) -> Option<(Scope, String, bool)> {
     Some((scope, unit, relabel))
 }
 
+/// Whether the apply must SWAP the binary (true) or is relaunch-only (false).
+/// Local + service applies pass `--staged` and swap it in. Phase 3 machine-wide-
+/// no-service applies OMIT `--staged` — the elevated pkexec RENAME-swap of the
+/// root-owned /opt binary already ran in the Node server — so the helper only
+/// waits-for-pid + relaunches the swapped /opt copy. Pure — unit-tested.
+pub fn should_swap(args: &[String]) -> bool {
+    arg_value(args, "--staged").is_some()
+}
+
 /// `<data_root>/control/apply-update-pending` — the apply marker path. Pure.
 pub fn apply_marker_path(data_root: &Path) -> PathBuf {
     data_root.join("control").join("apply-update-pending")
@@ -406,5 +438,23 @@ mod tests {
         let local: Vec<String> = ["--linux-apply", "--staged", "/a", "--target", "/b"]
             .iter().map(|s| s.to_string()).collect();
         assert_eq!(parse_service_restart(&local), None);
+    }
+
+    #[test]
+    fn should_swap_false_for_relaunch_only_missing_staged() {
+        // Phase 3 machine-wide-no-service: the helper is invoked WITHOUT --staged
+        // (the elevated pkexec rename-swap of the /opt binary already ran in the
+        // Node server). run() must then SKIP swap_appimage and only wait-for-pid +
+        // relaunch the freshly-swapped /opt copy.
+        let relaunch_only: Vec<String> =
+            ["--linux-apply", "--target", "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage", "--wait-pid", "4321"]
+                .iter().map(|s| s.to_string()).collect();
+        assert!(!should_swap(&relaunch_only), "no --staged means relaunch-only (skip swap)");
+
+        // Local + service applies carry --staged and DO swap the binary in place.
+        let local: Vec<String> =
+            ["--linux-apply", "--staged", "/d/App.new", "--target", "/home/u/App.AppImage", "--wait-pid", "4321"]
+                .iter().map(|s| s.to_string()).collect();
+        assert!(should_swap(&local), "--staged present means swap then relaunch");
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -97,10 +97,46 @@ pub fn parse_args(args: &[String]) -> Option<(Scope, String)> {
     Some((scope, unit))
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BootstrapAction { ExecOpt(PathBuf), RunHomeOfferUpdate, RunHome }
+
+/// Compare versions like "0.1.31" / "0.1.31-beta.4". Core (X.Y.Z) numeric; a
+/// `-beta.N` pre-release sorts BEFORE the same core release, and by N among betas.
+fn version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    fn parse(v: &str) -> ([u64; 3], Option<u64>) {
+        let (core, pre) = v.split_once('-').map_or((v, None), |(c, p)| (c, Some(p)));
+        let mut nums = [0u64; 3];
+        for (i, part) in core.split('.').take(3).enumerate() { nums[i] = part.parse().unwrap_or(0); }
+        let beta = pre.and_then(|p| p.rsplit('.').next()).and_then(|n| n.parse::<u64>().ok());
+        (nums, beta)
+    }
+    let (ca, ba) = parse(a);
+    let (cb, bb) = parse(b);
+    ca.cmp(&cb).then_with(|| match (ba, bb) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (Some(x), Some(y)) => x.cmp(&y),
+    })
+}
+
+/// `self_version` = the running (home) AppImage's version; `opt_version` = parsed
+/// /opt/VERSION (None if absent/unreadable). Pure.
+pub fn bootstrap_decision(opt_exists: bool, appimage_env: Option<&str>, self_version: &str, opt_version: Option<&str>) -> BootstrapAction {
+    let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
+    let is_self_opt = appimage_env.map(|p| p == opt.to_string_lossy()).unwrap_or(false);
+    if !opt_exists || appimage_env.is_none() || is_self_opt { return BootstrapAction::RunHome; }
+    match opt_version {
+        Some(ov) if version_cmp(self_version, ov) == std::cmp::Ordering::Greater => BootstrapAction::RunHomeOfferUpdate,
+        _ => BootstrapAction::ExecOpt(opt),
+    }
+}
+
 /// Pure bootstrapper decision. `opt_exists` = the shared /opt AppImage is present;
 /// `appimage_env` = $APPIMAGE (the file we were launched from). Returns the /opt
 /// binary to re-exec, or None to continue the in-place launch. No version-compare
 /// (that is a later phase).
+#[allow(dead_code)]
 pub fn bootstrap_target(opt_exists: bool, appimage_env: Option<&str>) -> Option<PathBuf> {
     let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
     match appimage_env {
@@ -402,5 +438,26 @@ mod tests {
             vec!["/usr/bin/systemd-run", "--uid=1000", "--setenv=HOME=/home/jamie",
                  "--setenv=WS_SCRCPY_WEB_PORT=8000", "--collect", "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"]
         );
+    }
+
+    #[test]
+    fn version_cmp_orders_core_and_betas() {
+        use std::cmp::Ordering::*;
+        assert_eq!(version_cmp("0.1.31", "0.1.30"), Greater);
+        assert_eq!(version_cmp("0.1.31", "0.1.31"), Equal);
+        assert_eq!(version_cmp("0.1.31", "0.1.31-beta.4"), Greater); // release > its beta
+        assert_eq!(version_cmp("0.1.31-beta.5", "0.1.31-beta.4"), Greater);
+        assert_eq!(version_cmp("0.1.30", "0.1.31-beta.1"), Less);
+    }
+
+    #[test]
+    fn bootstrap_decides_by_version() {
+        let opt = "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage";
+        assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.30", Some("0.1.31")), BootstrapAction::ExecOpt(opt.into()));
+        assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.31", Some("0.1.31")), BootstrapAction::ExecOpt(opt.into()));
+        assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.32", Some("0.1.31")), BootstrapAction::RunHomeOfferUpdate);
+        assert_eq!(bootstrap_decision(true, Some(opt), "0.1.31", Some("0.1.31")), BootstrapAction::RunHome);   // we ARE /opt
+        assert_eq!(bootstrap_decision(false, Some("/home/u/App.AppImage"), "0.1.31", None), BootstrapAction::RunHome);  // no /opt
+        assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.31", None), BootstrapAction::ExecOpt(opt.into())); // unknown /opt version -> run /opt
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -134,6 +134,22 @@ pub fn active_graphical_uid_from_show(show_output: &str) -> Option<u32> {
     if active && (kind == "x11" || kind == "wayland") { uid } else { None }
 }
 
+/// `systemd-run --uid=<uid> --setenv=HOME=<home> --setenv=WS_SCRCPY_WEB_PORT=<port>
+/// --collect <appimage>` — relaunch the shared /opt binary AS the user, with HOME
+/// (mandatory — else data_root_for_linux panics) and the service's port (so the
+/// browser reconnects). No DISPLAY (it's a server). Pure.
+#[allow(dead_code)] // wired in P2-4 (system-scope relaunch)
+pub fn system_relaunch_command(systemd_run: &str, uid: u32, home: &str, web_port: u16, appimage: &str) -> Vec<String> {
+    vec![
+        systemd_run.to_string(),
+        format!("--uid={uid}"),
+        format!("--setenv=HOME={home}"),
+        format!("--setenv=WS_SCRCPY_WEB_PORT={web_port}"),
+        "--collect".to_string(),
+        appimage.to_string(),
+    ]
+}
+
 /// User scope relaunches the home AppImage (from the install-time marker) into
 /// local mode. System scope never auto-relaunches (headless-dominant; the admin
 /// re-launches their own AppImage). Returns the path to relaunch, or None.
@@ -337,5 +353,14 @@ mod tests {
         assert_eq!(active_graphical_uid_from_show("Active=yes\nType=x11\nUser=1001\nDisplay=:0"), Some(1001));
         assert_eq!(active_graphical_uid_from_show("Active=no\nType=x11\nUser=1000\nDisplay=:0"), None);
         assert_eq!(active_graphical_uid_from_show("Active=yes\nType=tty\nUser=1000\nDisplay="), None);
+    }
+
+    #[test]
+    fn system_relaunch_command_runs_as_user_on_service_port() {
+        assert_eq!(
+            system_relaunch_command("/usr/bin/systemd-run", 1000, "/home/jamie", 8000, "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"),
+            vec!["/usr/bin/systemd-run", "--uid=1000", "--setenv=HOME=/home/jamie",
+                 "--setenv=WS_SCRCPY_WEB_PORT=8000", "--collect", "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"]
+        );
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -110,7 +110,6 @@ pub fn bootstrap_target(opt_exists: bool, appimage_env: Option<&str>) -> Option<
 }
 
 /// First column of each `loginctl list-sessions --no-legend` line = session id.
-#[allow(dead_code)] // wired in P2-4 (system-scope relaunch)
 pub fn parse_session_ids(list_output: &str) -> Vec<String> {
     list_output.lines().filter_map(|l| l.split_whitespace().next()).map(str::to_string).collect()
 }
@@ -118,7 +117,6 @@ pub fn parse_session_ids(list_output: &str) -> Vec<String> {
 /// uid of the session from a `loginctl show-session <id> -p Active -p Type -p User -p Display`
 /// block, IFF it is active AND graphical (x11/wayland). We don't need DISPLAY — the
 /// relaunched app is a server the browser reconnects to.
-#[allow(dead_code)] // wired in P2-4 (system-scope relaunch)
 pub fn active_graphical_uid_from_show(show_output: &str) -> Option<u32> {
     let (mut active, mut kind, mut uid) = (false, String::new(), None::<u32>);
     for line in show_output.lines() {
@@ -138,7 +136,6 @@ pub fn active_graphical_uid_from_show(show_output: &str) -> Option<u32> {
 /// --collect <appimage>` — relaunch the shared /opt binary AS the user, with HOME
 /// (mandatory — else data_root_for_linux panics) and the service's port (so the
 /// browser reconnects). No DISPLAY (it's a server). Pure.
-#[allow(dead_code)] // wired in P2-4 (system-scope relaunch)
 pub fn system_relaunch_command(systemd_run: &str, uid: u32, home: &str, web_port: u16, appimage: &str) -> Vec<String> {
     vec![
         systemd_run.to_string(),
@@ -199,6 +196,29 @@ pub(crate) fn tool_dir(tool: &str) -> String {
     "/usr/bin".to_string()
 }
 
+/// Best-effort: the active graphical session's uid via loginctl (absolute paths,
+/// Local-Deps). Pure parsers (P2-1) do the work; this is the exec seam.
+fn discover_active_graphical_uid() -> Option<u32> {
+    let loginctl = format!("{}/loginctl", tool_dir("loginctl"));
+    let list = std::process::Command::new(&loginctl).args(["list-sessions", "--no-legend"]).output().ok()?;
+    for id in parse_session_ids(&String::from_utf8_lossy(&list.stdout)) {
+        if let Ok(show) = std::process::Command::new(&loginctl)
+            .args(["show-session", &id, "-p", "Active", "-p", "Type", "-p", "User", "-p", "Display"]).output() {
+            if let Some(uid) = active_graphical_uid_from_show(&String::from_utf8_lossy(&show.stdout)) {
+                return Some(uid);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a uid's home dir from `getent passwd <uid>` (field 6). Absolute path.
+fn home_for_uid(uid: u32) -> Option<String> {
+    let getent = format!("{}/getent", tool_dir("getent"));
+    let out = std::process::Command::new(&getent).args(["passwd", &uid.to_string()]).output().ok()?;
+    String::from_utf8_lossy(&out.stdout).lines().next()?.split(':').nth(5).map(str::to_string)
+}
+
 fn run(scope: Scope, unit: &str) -> i32 {
     let bd = tool_dir("systemctl");
     log::info(&format!("linux-service-teardown: scope={scope:?} unit={unit}"));
@@ -247,6 +267,26 @@ fn run(scope: Scope, unit: &str) -> i32 {
                 "teardown: relaunched local {target_str} via systemd-run (exit {:?})", s.code()
             )),
             Err(e) => log::error(&format!("teardown: relaunch via systemd-run failed: {e}")),
+        }
+    }
+
+    if scope == Scope::System {
+        let systemd_run = format!("{}/systemd-run", tool_dir("systemd-run"));
+        let appimage = "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage";
+        let web_port = common::config::AppConfig::load(std::path::Path::new("/var/opt/ws-scrcpy-web")).web_port;
+        match (discover_active_graphical_uid(), web_port) {
+            (Some(uid), Some(port)) => match home_for_uid(uid) {
+                Some(home) => {
+                    let argv = system_relaunch_command(&systemd_run, uid, &home, port, appimage);
+                    let (cmd, rest) = argv.split_first().expect("non-empty argv");
+                    match std::process::Command::new(cmd).args(rest).status() {
+                        Ok(s) => log::info(&format!("system uninstall: relaunched {appimage} as uid {uid} on port {port} (exit {:?})", s.code())),
+                        Err(e) => log::error(&format!("system uninstall: relaunch failed: {e}")),
+                    }
+                }
+                None => log::error(&format!("system uninstall: no home for uid {uid}; skipping relaunch")),
+            },
+            _ => log::info("system uninstall: no active graphical session / no service port — skipping relaunch (manual fallback)"),
         }
     }
     0

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -109,6 +109,31 @@ pub fn bootstrap_target(opt_exists: bool, appimage_env: Option<&str>) -> Option<
     }
 }
 
+/// First column of each `loginctl list-sessions --no-legend` line = session id.
+#[allow(dead_code)] // wired in P2-4 (system-scope relaunch)
+pub fn parse_session_ids(list_output: &str) -> Vec<String> {
+    list_output.lines().filter_map(|l| l.split_whitespace().next()).map(str::to_string).collect()
+}
+
+/// uid of the session from a `loginctl show-session <id> -p Active -p Type -p User -p Display`
+/// block, IFF it is active AND graphical (x11/wayland). We don't need DISPLAY — the
+/// relaunched app is a server the browser reconnects to.
+#[allow(dead_code)] // wired in P2-4 (system-scope relaunch)
+pub fn active_graphical_uid_from_show(show_output: &str) -> Option<u32> {
+    let (mut active, mut kind, mut uid) = (false, String::new(), None::<u32>);
+    for line in show_output.lines() {
+        if let Some((k, v)) = line.split_once('=') {
+            match k.trim() {
+                "Active" => active = v.trim() == "yes",
+                "Type" => kind = v.trim().to_string(),
+                "User" => uid = v.trim().parse().ok(),
+                _ => {}
+            }
+        }
+    }
+    if active && (kind == "x11" || kind == "wayland") { uid } else { None }
+}
+
 /// User scope relaunches the home AppImage (from the install-time marker) into
 /// local mode. System scope never auto-relaunches (headless-dominant; the admin
 /// re-launches their own AppImage). Returns the path to relaunch, or None.
@@ -298,5 +323,19 @@ mod tests {
         assert_eq!(service_defer_url(Some("system-service"), Some(8000), false), None); // installed but down
         assert_eq!(service_defer_url(Some("user"), Some(8000), true), None);            // not service mode
         assert_eq!(service_defer_url(None, None, true), None);
+    }
+
+    #[test]
+    fn parses_session_ids_from_list() {
+        let list = "   3 1000 jamie seat0 tty2\n  c1 0 root  -    -\n";
+        assert_eq!(parse_session_ids(list), vec!["3".to_string(), "c1".to_string()]);
+    }
+
+    #[test]
+    fn active_graphical_uid_only_when_active_and_graphical() {
+        assert_eq!(active_graphical_uid_from_show("Active=yes\nType=wayland\nUser=1000\nDisplay="), Some(1000));
+        assert_eq!(active_graphical_uid_from_show("Active=yes\nType=x11\nUser=1001\nDisplay=:0"), Some(1001));
+        assert_eq!(active_graphical_uid_from_show("Active=no\nType=x11\nUser=1000\nDisplay=:0"), None);
+        assert_eq!(active_graphical_uid_from_show("Active=yes\nType=tty\nUser=1000\nDisplay="), None);
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -121,6 +121,17 @@ pub fn relaunch_target(scope: Scope, marker: Option<String>) -> Option<PathBuf> 
     }
 }
 
+/// The service URL to open (then exit) when an ACTIVE system service owns the
+/// app, so a local launch doesn't spawn a duplicate. `install_mode` + `web_port`
+/// come from the /var/opt system-service config; `port_live` is a TCP-probe
+/// result the caller supplies. Pure.
+pub fn service_defer_url(install_mode: Option<&str>, web_port: Option<u16>, port_live: bool) -> Option<String> {
+    match (install_mode, web_port) {
+        (Some("system-service"), Some(port)) if port_live => Some(format!("http://localhost:{port}")),
+        _ => None,
+    }
+}
+
 /// Dispatch: handle `--linux-service-teardown`, return Some(exit_code).
 pub fn handle(args: &[String]) -> Option<i32> {
     if !args.iter().any(|a| a == "--linux-service-teardown") {
@@ -278,5 +289,14 @@ mod tests {
         assert_eq!(bootstrap_target(true, Some(opt)), None);              // we ARE /opt -> don't re-exec self
         assert_eq!(bootstrap_target(false, Some("/home/u/App.AppImage")), None); // no /opt -> run in place
         assert_eq!(bootstrap_target(true, None), None);                  // from-source (no $APPIMAGE) -> None
+    }
+
+    #[test]
+    fn defer_to_service_only_when_system_service_and_port_live() {
+        assert_eq!(service_defer_url(Some("system-service"), Some(8000), true),
+                   Some("http://localhost:8000".to_string()));
+        assert_eq!(service_defer_url(Some("system-service"), Some(8000), false), None); // installed but down
+        assert_eq!(service_defer_url(Some("user"), Some(8000), true), None);            // not service mode
+        assert_eq!(service_defer_url(None, None, true), None);
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -97,6 +97,18 @@ pub fn parse_args(args: &[String]) -> Option<(Scope, String)> {
     Some((scope, unit))
 }
 
+/// Pure bootstrapper decision. `opt_exists` = the shared /opt AppImage is present;
+/// `appimage_env` = $APPIMAGE (the file we were launched from). Returns the /opt
+/// binary to re-exec, or None to continue the in-place launch. No version-compare
+/// (that is a later phase).
+pub fn bootstrap_target(opt_exists: bool, appimage_env: Option<&str>) -> Option<PathBuf> {
+    let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
+    match appimage_env {
+        Some(p) if opt_exists && p != opt.to_string_lossy() => Some(opt),
+        _ => None,
+    }
+}
+
 /// User scope relaunches the home AppImage (from the install-time marker) into
 /// local mode. System scope never auto-relaunches (headless-dominant; the admin
 /// re-launches their own AppImage). Returns the path to relaunch, or None.
@@ -257,5 +269,14 @@ mod tests {
         assert_eq!(relaunch_target(Scope::System, Some("/home/u/Apps/App.AppImage".into())), None);
         // user scope, missing marker -> None
         assert_eq!(relaunch_target(Scope::User, None), None);
+    }
+
+    #[test]
+    fn bootstrap_target_execs_opt_when_present_and_not_self() {
+        let opt = "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage";
+        assert_eq!(bootstrap_target(true, Some("/home/u/App.AppImage")), Some(PathBuf::from(opt)));
+        assert_eq!(bootstrap_target(true, Some(opt)), None);              // we ARE /opt -> don't re-exec self
+        assert_eq!(bootstrap_target(false, Some("/home/u/App.AppImage")), None); // no /opt -> run in place
+        assert_eq!(bootstrap_target(true, None), None);                  // from-source (no $APPIMAGE) -> None
     }
 }

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -61,16 +61,17 @@ pub fn teardown_commands(scope: Scope, name: &str, bindir: &str) -> Vec<Vec<Stri
         [vec![systemctl.clone()], pre.clone(), vec!["reset-failed".into(), unit.clone()]].concat(),
         vec![rm.clone(), "-f".into(), unit_file.to_string_lossy().into_owned()],
     ];
-    // system scope also removes the /opt staging + the semanage fcontext rule
+    // system scope also removes the /opt staging + /var/opt state + BOTH fcontext rules
     if scope == Scope::System {
         let semanage = format!("{}/semanage", sbindir_from(bindir));
-        cmds.push(vec![rm.clone(), "-rf".into(), "/opt/ws-scrcpy-web".into()]);
-        cmds.push(vec![
-            semanage,
-            "fcontext".into(),
-            "-d".into(),
-            "/opt/ws-scrcpy-web(/.*)?".into(),
-        ]);
+        for dir in ["/opt/ws-scrcpy-web", "/var/opt/ws-scrcpy-web"] {
+            cmds.push(vec![rm.clone(), "-rf".into(), dir.into()]);
+        }
+        // remove BOTH fcontext rules the install added: the /opt bin_t tree rule
+        // AND the /var/opt var_lib_t state rule (else the rule lingers post-uninstall).
+        for pathspec in ["/opt/ws-scrcpy-web(/.*)?", "/var/opt/ws-scrcpy-web(/.*)?"] {
+            cmds.push(vec![semanage.clone(), "fcontext".into(), "-d".into(), pathspec.to_string()]);
+        }
     }
     // reload
     cmds.push([vec![systemctl.clone()], pre.clone(), vec!["daemon-reload".into()]].concat());
@@ -230,6 +231,19 @@ mod tests {
     fn sbindir_derivation() {
         assert_eq!(sbindir_from("/usr/bin"), "/usr/sbin");
         assert_eq!(sbindir_from("/bin"), "/sbin");
+    }
+
+    #[test]
+    fn system_scope_teardown_removes_opt_and_var_opt() {
+        let cmds = teardown_commands(Scope::System, "WsScrcpyWeb", "/usr/bin");
+        let joined: Vec<String> = cmds.iter().map(|c| c.join(" ")).collect();
+        let removes_dir = |d: &str| joined.iter().any(|c| c.contains("rm") && c.contains(d));
+        let removes_fcontext = |spec: &str|
+            joined.iter().any(|c| c.contains("semanage fcontext -d") && c.ends_with(spec));
+        assert!(removes_dir("/opt/ws-scrcpy-web"));
+        assert!(removes_dir("/var/opt/ws-scrcpy-web"));
+        assert!(removes_fcontext("/opt/ws-scrcpy-web(/.*)?"));      // bin_t tree
+        assert!(removes_fcontext("/var/opt/ws-scrcpy-web(/.*)?"));  // var_lib_t state
     }
 
     #[test]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -102,6 +102,22 @@ fn main() {
         std::process::exit(code);
     }
 
+    // Bootstrapper: if the shared machine-wide /opt binary exists and we are a
+    // home AppImage (not /opt itself), re-exec the /opt copy and exit. MUST run
+    // before single_instance::acquire so the /opt child — not this wrapper — owns
+    // the per-user lock.
+    #[cfg(target_os = "linux")]
+    {
+        let opt = std::path::Path::new("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
+        let appimage = std::env::var("APPIMAGE").ok();
+        if let Some(target) = linux_service::bootstrap_target(opt.exists(), appimage.as_deref()) {
+            log::info(&format!("bootstrap: exec'ing machine-wide /opt binary {target:?}"));
+            let status = std::process::Command::new(&target).status();
+            let code = status.ok().and_then(|s| s.code()).unwrap_or(0);
+            std::process::exit(code);
+        }
+    }
+
     // Cross-session user-launcher spawn dispatch. Invoked from post-stop.bat
     // after `servy-cli uninstall` completes, to drop a fresh user-session
     // launcher so the user lands on local-mode UI post-uninstall. Wraps

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -125,15 +125,39 @@ fn main() {
     // home AppImage (not /opt itself), re-exec the /opt copy and exit. MUST run
     // before single_instance::acquire so the /opt child — not this wrapper — owns
     // the per-user lock.
+    //
+    // Version-aware (Phase 3): reads /opt/ws-scrcpy-web/VERSION; if the home
+    // AppImage is NEWER than /opt, runs in-place and sets
+    // WS_SCRCPY_OPT_UPDATE_AVAILABLE=1 so the frontend can offer an /opt upgrade.
     #[cfg(target_os = "linux")]
     {
         let opt = std::path::Path::new("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
         let appimage = std::env::var("APPIMAGE").ok();
-        if let Some(target) = linux_service::bootstrap_target(opt.exists(), appimage.as_deref()) {
-            log::info(&format!("bootstrap: exec'ing machine-wide /opt binary {target:?}"));
-            let status = std::process::Command::new(&target).status();
-            let code = status.ok().and_then(|s| s.code()).unwrap_or(0);
-            std::process::exit(code);
+        let opt_version = std::fs::read_to_string("/opt/ws-scrcpy-web/VERSION")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let action = linux_service::bootstrap_decision(
+            opt.exists(),
+            appimage.as_deref(),
+            env!("CARGO_PKG_VERSION"),
+            opt_version.as_deref(),
+        );
+        match action {
+            linux_service::BootstrapAction::ExecOpt(target) => {
+                log::info(&format!("bootstrap: exec'ing machine-wide /opt binary {target:?}"));
+                let status = std::process::Command::new(&target).status();
+                let code = status.ok().and_then(|s| s.code()).unwrap_or(0);
+                std::process::exit(code);
+            }
+            linux_service::BootstrapAction::RunHomeOfferUpdate => {
+                log::info("bootstrap: home AppImage is newer than /opt; running in-place, flagging update offer");
+                std::env::set_var("WS_SCRCPY_OPT_UPDATE_AVAILABLE", "1");
+                // fall through to normal launch
+            }
+            linux_service::BootstrapAction::RunHome => {
+                // no /opt, or we ARE /opt, or no $APPIMAGE — launch in place
+            }
         }
     }
 

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -102,6 +102,25 @@ fn main() {
         std::process::exit(code);
     }
 
+    // Service-defer: if an ACTIVE system-scope service owns the app, open the
+    // browser at its URL and exit instead of spawning a duplicate local server.
+    #[cfg(target_os = "linux")]
+    {
+        let cfg = common::config::AppConfig::load(std::path::Path::new("/var/opt/ws-scrcpy-web"));
+        if let (Some(mode), Some(port)) = (cfg.install_mode.as_deref(), cfg.web_port) {
+            let live = std::net::TcpStream::connect_timeout(
+                &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+                std::time::Duration::from_millis(200),
+            ).is_ok();
+            if let Some(url) = linux_service::service_defer_url(Some(mode), Some(port), live) {
+                log::info(&format!("service-defer: active system service; opening {url}"));
+                let xdg = format!("{}/xdg-open", linux_service::tool_dir("xdg-open"));
+                let _ = std::process::Command::new(&xdg).arg(&url).status();
+                std::process::exit(0);
+            }
+        }
+    }
+
     // Bootstrapper: if the shared machine-wide /opt binary exists and we are a
     // home AppImage (not /opt itself), re-exec the /opt copy and exit. MUST run
     // before single_instance::acquire so the /opt child — not this wrapper — owns

--- a/launcher/src/single_instance.rs
+++ b/launcher/src/single_instance.rs
@@ -135,20 +135,63 @@ mod imp {
 #[cfg(not(windows))]
 mod imp {
     use anyhow::Result;
+    use std::fs::{File, OpenOptions};
+    use std::path::{Path, PathBuf};
+    use rustix::fs::{flock, FlockOperation};
 
-    /// Stub guard on non-Windows. Linux service mode goes through systemd
-    /// which has its own duplicate-instance handling, and the AppImage
-    /// install layout doesn't have the same Start Menu / shortcut
-    /// double-launch failure mode. We could add a PID-file approach later
-    /// if needed; for now this is a no-op that always says "yes, you're
-    /// the only instance."
-    pub struct InstanceGuard;
-
-    pub fn acquire(_name: &str) -> Result<Option<InstanceGuard>> {
-        Ok(Some(InstanceGuard))
+    /// Holds the open file descriptor for the lock file.
+    /// Drop closes the fd, which releases the flock automatically.
+    pub struct InstanceGuard {
+        _file: File,
     }
 
-    /// Stub: always false on non-Windows.
+    /// Compute the path to the per-user instance lock file.
+    ///
+    /// Prefers `$XDG_RUNTIME_DIR` (e.g. `/run/user/1000`) because it is
+    /// uid-scoped and wiped on logout — perfect lifetime semantics.
+    /// Falls back to `<dataRoot>/control/instance.lock` when XDG is absent.
+    pub fn lock_path(xdg_runtime_dir: Option<&str>, data_root: Option<&str>) -> PathBuf {
+        if let Some(x) = xdg_runtime_dir.filter(|s| !s.is_empty()) {
+            return PathBuf::from(x).join("ws-scrcpy-web.lock");
+        }
+        PathBuf::from(data_root.unwrap_or("/tmp"))
+            .join("control")
+            .join("instance.lock")
+    }
+
+    /// Try to acquire an exclusive non-blocking flock on `path`.
+    ///
+    /// Returns:
+    /// - `Ok(Some(guard))` — lock acquired; we are the sole instance.
+    /// - `Ok(None)` — another instance already holds the lock; caller should exit.
+    /// - `Err(e)` — unexpected I/O error.
+    pub fn acquire_at(path: &Path) -> Result<Option<InstanceGuard>> {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+        match flock(&file, FlockOperation::NonBlockingLockExclusive) {
+            Ok(()) => Ok(Some(InstanceGuard { _file: file })),
+            Err(e) if e == rustix::io::Errno::WOULDBLOCK => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Public entry point called from `main()`.
+    ///
+    /// Resolves the lock path from environment and acquires it.
+    pub fn acquire(_name: &str) -> Result<Option<InstanceGuard>> {
+        let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        let dr = common::config::data_root_from_env()
+            .map(|p| p.to_string_lossy().into_owned());
+        acquire_at(&lock_path(xdg.as_deref(), dr.as_deref()))
+    }
+
+    /// Always false on non-Windows (no elevation concept).
     pub fn is_elevated() -> bool {
         false
     }
@@ -169,6 +212,41 @@ const MUTEX_BASE: &str = r"Local\WsScrcpyWeb-SingleInstance";
 pub fn current_mutex_name() -> String {
     let suffix = if imp::is_elevated() { "Admin" } else { "User" };
     format!("{MUTEX_BASE}-{suffix}")
+}
+
+#[cfg(all(test, not(windows)))]
+mod linux_tests {
+    use super::imp::{acquire_at, lock_path};
+    use std::path::PathBuf;
+
+    #[test]
+    fn lock_path_prefers_xdg_runtime_dir() {
+        assert_eq!(
+            lock_path(Some("/run/user/1000"), Some("/home/u/.local/share/WsScrcpyWeb")),
+            PathBuf::from("/run/user/1000/ws-scrcpy-web.lock")
+        );
+        assert_eq!(
+            lock_path(None, Some("/home/u/.local/share/WsScrcpyWeb")),
+            PathBuf::from("/home/u/.local/share/WsScrcpyWeb/control/instance.lock")
+        );
+    }
+
+    #[test]
+    fn flock_blocks_same_user_second_launch() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("instance.lock");
+        let first = acquire_at(&p).unwrap();
+        assert!(first.is_some(), "first acquire holds the lock");
+        assert!(
+            acquire_at(&p).unwrap().is_none(),
+            "second acquire on a held flock returns None"
+        );
+        drop(first);
+        assert!(
+            acquire_at(&p).unwrap().is_some(),
+            "after drop, re-acquire succeeds"
+        );
+    }
 }
 
 #[cfg(all(test, windows))]

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -138,6 +138,15 @@ export function stopServerButtonState(resp: ScopeRadioInputs): {
         : { disabled: false, note: null };
 }
 
+export interface SystemServiceInstallGate { enabled: boolean; note: string | null; }
+/** System-scope service install requires a machine-wide /opt install first
+ *  (the root service execs the /opt binary; it can't exist without it). */
+export function systemServiceInstallGate(input: { machineWideInstalled: boolean }): SystemServiceInstallGate {
+    return input.machineWideInstalled
+        ? { enabled: true, note: null }
+        : { enabled: false, note: 'system service install requires installing system-wide for all users first.' };
+}
+
 /**
  * Lock a service-scope radio as read-only WITHOUT the `disabled` attribute.
  * Chromium desaturates `accent-color` on :disabled form controls, which made

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -148,6 +148,28 @@ export function systemServiceInstallGate(input: { machineWideInstalled: boolean 
 }
 
 /**
+ * Apply the system-scope install gate to the Linux service-install button and
+ * its note element. When the 'system' scope radio is the selected scope and the
+ * app is NOT yet installed machine-wide (/opt), system-scope service install
+ * can't work, so disable the button and surface the gate note; otherwise the
+ * button is enabled and the note hidden. Pure DOM mutation on the passed
+ * elements (mirrors lockScopeRadioControl) so it is unit-testable; the gate
+ * logic itself lives in the unit-tested systemServiceInstallGate.
+ */
+export function applySystemInstallGate(
+    btn: HTMLButtonElement,
+    note: HTMLElement,
+    systemSelected: boolean,
+    machineWideInstalled: boolean,
+): void {
+    const gate = systemServiceInstallGate({ machineWideInstalled });
+    const blocked = systemSelected && !gate.enabled;
+    btn.disabled = blocked;
+    note.textContent = blocked ? (gate.note ?? '') : '';
+    note.hidden = !blocked;
+}
+
+/**
  * Lock a service-scope radio as read-only WITHOUT the `disabled` attribute.
  * Chromium desaturates `accent-color` on :disabled form controls, which made
  * the selected dot invisible against the muted track (item 42 — the active
@@ -1002,6 +1024,10 @@ export class SettingsModal extends Modal {
         // name). Pre-v0.1.30 the row was only rendered when not installed,
         // leaving no in-UI way to tell which scope was active.
         this.serviceScopeSystemRadio = null;
+        // Captured for the system-scope install gate wired after the button is
+        // built (both radios drive its re-evaluation on toggle).
+        let scopeUserRadio: HTMLInputElement | null = null;
+        let scopeSystemRadio: HTMLInputElement | null = null;
         if (resp.platform === 'linux') {
             // Detection + lock state (pure, unit-tested in scopeRadioState).
             // Locked radios stay ENABLED and are made non-interactive via
@@ -1041,6 +1067,8 @@ export class SettingsModal extends Modal {
             // out when locked so the install handler (unreachable in that state
             // anyway) can't accidentally consume a stale value.
             this.serviceScopeSystemRadio = st.locked ? null : sysRadio;
+            scopeUserRadio = userRadio;
+            scopeSystemRadio = sysRadio;
         }
 
         // One row: label = informational blurb (left column, wraps),
@@ -1065,6 +1093,27 @@ export class SettingsModal extends Modal {
         this.serviceSection.appendChild(
             this.buildRow('installs/uninstalls server service', btn),
         );
+
+        // Linux: gate the system-scope install button on a prior machine-wide
+        // (/opt) install — the root service execs the shared /opt binary, which
+        // must exist first. Only relevant in the not-installed state (the
+        // install button); when a service is installed the button is uninstall
+        // and the radios are locked. Re-evaluated whenever the scope radio
+        // toggles. Gate logic is the unit-tested applySystemInstallGate.
+        if (status === 'not-installed' && resp.platform === 'linux' && scopeSystemRadio) {
+            const systemRadio = scopeSystemRadio;
+            const machineWideInstalled = resp.machineWideInstalled ?? false;
+            const gateNote = document.createElement('p');
+            gateNote.className = 'settings-status';
+            gateNote.style.gridColumn = '1 / -1';
+            gateNote.hidden = true;
+            this.serviceSection.appendChild(gateNote);
+            const applyGate = (): void =>
+                applySystemInstallGate(btn, gateNote, systemRadio.checked, machineWideInstalled);
+            systemRadio.addEventListener('change', applyGate);
+            scopeUserRadio?.addEventListener('change', applyGate);
+            applyGate();
+        }
     }
 
     private renderServiceError(msg: string, onRetry: () => void): void {

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -139,6 +139,18 @@ export function stopServerButtonState(resp: ScopeRadioInputs): {
 }
 
 export interface SystemServiceInstallGate { enabled: boolean; note: string | null; }
+/**
+ * Derive whether the migration reinstall notice should be shown. Pure (no DOM)
+ * so it is unit-testable; mirrors systemServiceInstallGate's shape. When true,
+ * the caller should render the notice text and a [reinstall now] action button
+ * that POSTs /api/service/migrate-system.
+ */
+export function migrationNotice(input: { serviceMigrationNeeded?: boolean }): { show: boolean; text: string } {
+    return input.serviceMigrationNeeded
+        ? { show: true, text: 'this service uses the old layout. reinstall it to update to the new layout.' }
+        : { show: false, text: '' };
+}
+
 /** System-scope service install requires a machine-wide /opt install first
  *  (the root service execs the /opt binary; it can't exist without it). */
 export function systemServiceInstallGate(input: { machineWideInstalled: boolean }): SystemServiceInstallGate {

--- a/src/app/client/SystemWideInstallModal.ts
+++ b/src/app/client/SystemWideInstallModal.ts
@@ -1,0 +1,86 @@
+import { Modal } from '../ui/Modal';
+
+export interface SystemWideInstallModalOptions {
+    /**
+     * Called when the user clicks "install for all users". The caller is
+     * responsible for initiating the machine-wide install flow.
+     */
+    onInstall: () => void;
+    /**
+     * Called when the user clicks "not now". The caller can record the
+     * decline so the modal is not shown again this session.
+     */
+    onDecline: () => void;
+}
+
+/**
+ * First-run modal offering to install the app machine-wide (system scope,
+ * /opt). Shown once per session when the install-gate determines the app
+ * is not yet installed system-wide and the user hasn't previously declined.
+ *
+ * Two actions:
+ *   - "install for all users" → calls onInstall, then closes.
+ *   - "not now"              → calls onDecline, then closes.
+ *
+ * Mirrors WelcomeModal: same base class, same DOM-construction helpers,
+ * same queueMicrotask body-fill pattern, same lowercase copy convention.
+ */
+export class SystemWideInstallModal extends Modal {
+    private opts!: SystemWideInstallModalOptions;
+    private installBtn!: HTMLButtonElement;
+    private declineBtn!: HTMLButtonElement;
+
+    constructor(options: SystemWideInstallModalOptions) {
+        super({ title: 'install for all users?' });
+        this.opts = options;
+        this.dialog.classList.add('system-wide-install-modal');
+        // Defer body fill past class-field init phase (ES2022 useDefineForClassFields).
+        // Same pattern as WelcomeModal / ServiceFirstRunModal.
+        queueMicrotask(() => {
+            this.fillBody(this.bodyEl);
+        });
+    }
+
+    protected buildBody(_container: HTMLElement): void {
+        // Body content is rendered by fillBody() from the constructor via queueMicrotask.
+    }
+
+    private fillBody(container: HTMLElement): void {
+        const body = document.createElement('p');
+        body.style.cssText = 'margin: 0 0 16px;';
+        body.textContent =
+            'run ws-scrcpy-web for all users on this machine? installs the app to /opt with one administrator prompt. ' +
+            'you can keep using it just for yourself instead.';
+        container.appendChild(body);
+
+        const buttons = document.createElement('div');
+        buttons.style.cssText = 'display: flex; gap: 12px; justify-content: flex-end; flex-wrap: wrap;';
+
+        this.installBtn = document.createElement('button');
+        this.installBtn.textContent = 'install for all users';
+        this.installBtn.className = 'modal-button modal-button-primary';
+        this.installBtn.addEventListener('click', () => {
+            this.opts.onInstall();
+            this.close();
+        });
+        buttons.appendChild(this.installBtn);
+
+        this.declineBtn = document.createElement('button');
+        this.declineBtn.textContent = 'not now';
+        this.declineBtn.className = 'modal-button';
+        this.declineBtn.addEventListener('click', () => {
+            this.opts.onDecline();
+            this.close();
+        });
+        buttons.appendChild(this.declineBtn);
+
+        container.appendChild(buttons);
+    }
+
+    /** No-op: Modal base shows the dialog from its constructor. Provided for caller ergonomics. */
+    public show(): void {
+        if (!this.dialog.open) {
+            this.dialog.showModal();
+        }
+    }
+}

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -11,6 +11,7 @@ import {
     buildServiceInfoRow,
     systemServiceInstallGate,
     applySystemInstallGate,
+    migrationNotice,
 } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
@@ -187,5 +188,19 @@ describe('buildServiceInfoRow', () => {
         expect(row.className).toContain('settings-status');
         expect(row.className).not.toContain('settings-status-error');
         expect(row.querySelector('button')).toBeNull();
+    });
+});
+
+describe('migrationNotice', () => {
+    it('show=true with reinstall text when serviceMigrationNeeded=true', () => {
+        const result = migrationNotice({ serviceMigrationNeeded: true });
+        expect(result.show).toBe(true);
+        expect(result.text).toMatch(/old layout|reinstall|new layout/i);
+    });
+    it('show=false with empty text when serviceMigrationNeeded=false', () => {
+        expect(migrationNotice({ serviceMigrationNeeded: false })).toEqual({ show: false, text: '' });
+    });
+    it('show=false with empty text when serviceMigrationNeeded is undefined', () => {
+        expect(migrationNotice({})).toEqual({ show: false, text: '' });
     });
 });

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -10,6 +10,7 @@ import {
     stopServerButtonState,
     buildServiceInfoRow,
     systemServiceInstallGate,
+    applySystemInstallGate,
 } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
@@ -147,6 +148,35 @@ describe('systemServiceInstallGate', () => {
     });
     it('enables it (no note) once machine-wide installed', () => {
         expect(systemServiceInstallGate({ machineWideInstalled: true })).toEqual({ enabled: true, note: null });
+    });
+});
+
+describe('applySystemInstallGate', () => {
+    it('disables the install button + shows the gate note when system selected and not machine-wide', () => {
+        const btn = document.createElement('button');
+        const note = document.createElement('p');
+        note.hidden = true;
+        applySystemInstallGate(btn, note, /* systemSelected */ true, /* machineWideInstalled */ false);
+        expect(btn.disabled).toBe(true);
+        expect(note.hidden).toBe(false);
+        expect(note.textContent).toMatch(/system-wide/i);
+    });
+
+    it('enables the button + hides the note when user scope is selected (gate only applies to system)', () => {
+        const btn = document.createElement('button');
+        const note = document.createElement('p');
+        applySystemInstallGate(btn, note, /* systemSelected */ false, /* machineWideInstalled */ false);
+        expect(btn.disabled).toBe(false);
+        expect(note.hidden).toBe(true);
+        expect(note.textContent).toBe('');
+    });
+
+    it('enables the button (no note) when machine-wide is installed even if system is selected', () => {
+        const btn = document.createElement('button');
+        const note = document.createElement('p');
+        applySystemInstallGate(btn, note, /* systemSelected */ true, /* machineWideInstalled */ true);
+        expect(btn.disabled).toBe(false);
+        expect(note.hidden).toBe(true);
     });
 });
 

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -9,6 +9,7 @@ import {
     lockScopeRadioControl,
     stopServerButtonState,
     buildServiceInfoRow,
+    systemServiceInstallGate,
 } from '../SettingsModal';
 
 describe('uninstallFollowupMessage', () => {
@@ -134,6 +135,18 @@ describe('stopServerButtonState', () => {
         const s = stopServerButtonState({ status: 'running', scope: 'system' });
         expect(s.disabled).toBe(true);
         expect(s.note).toMatch(/service/i);
+    });
+});
+
+describe('systemServiceInstallGate', () => {
+    it('disables system service install with explainer when not machine-wide', () => {
+        expect(systemServiceInstallGate({ machineWideInstalled: false })).toEqual({
+            enabled: false,
+            note: 'system service install requires installing system-wide for all users first.',
+        });
+    });
+    it('enables it (no note) once machine-wide installed', () => {
+        expect(systemServiceInstallGate({ machineWideInstalled: true })).toEqual({ enabled: true, note: null });
     });
 });
 

--- a/src/app/client/__tests__/SystemWideInstallModal.test.ts
+++ b/src/app/client/__tests__/SystemWideInstallModal.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SystemWideInstallModal } from '../SystemWideInstallModal';
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        if (this.hasAttribute('open')) {
+            throw new DOMException(
+                "Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.",
+                'InvalidStateError',
+            );
+        }
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+function getButton(label: string): HTMLButtonElement {
+    const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+    const btn = btns.find((b) => b.textContent?.trim().toLowerCase() === label.toLowerCase());
+    expect(btn, `button labeled "${label}" should be in the DOM`).toBeTruthy();
+    return btn!;
+}
+
+describe('SystemWideInstallModal', () => {
+    it('renders both buttons with the correct lowercase labels', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        // Wait one microtask so the queueMicrotask body-fill runs.
+        await Promise.resolve();
+        getButton('install for all users');
+        getButton('not now');
+    });
+
+    it('clicking "install for all users" calls onInstall', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        getButton('install for all users').click();
+        expect(onInstall).toHaveBeenCalledTimes(1);
+        expect(onDecline).not.toHaveBeenCalled();
+    });
+
+    it('clicking "not now" calls onDecline', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        getButton('not now').click();
+        expect(onDecline).toHaveBeenCalledTimes(1);
+        expect(onInstall).not.toHaveBeenCalled();
+    });
+
+    it('clicking "install for all users" closes the modal', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        const dialog = document.querySelector('dialog')!;
+        expect(dialog.hasAttribute('open')).toBe(true);
+        getButton('install for all users').click();
+        expect(dialog.hasAttribute('open')).toBe(false);
+    });
+
+    it('clicking "not now" closes the modal', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        const dialog = document.querySelector('dialog')!;
+        expect(dialog.hasAttribute('open')).toBe(true);
+        getButton('not now').click();
+        expect(dialog.hasAttribute('open')).toBe(false);
+    });
+
+    it('body contains the required lowercase copy', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        const body = document.querySelector('.modal-body');
+        const text = body?.textContent?.toLowerCase() ?? '';
+        expect(text).toContain('all users');
+        expect(text).toContain('/opt');
+    });
+
+    it('calls showModal exactly once', async () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -14,6 +14,7 @@ import { createUpdateButton } from './client/UpdateButton';
 import type { Tool } from './client/Tool';
 import { WelcomeModal } from './client/WelcomeModal';
 import type { AppConfigEnvelope } from '../common/ConfigEvents';
+import type { ServiceStatusResponse } from '../common/ServiceEvents';
 import { StreamClientScrcpy } from './googDevice/client/StreamClientScrcpy';
 
 function isResumingUninstall(): boolean {
@@ -129,6 +130,62 @@ function maybeShowWelcomeModal(): void {
         });
 }
 
+/**
+ * First-run entry point. On Linux, ahead of the local WelcomeModal, offer to
+ * install the app to /opt for all users when (a) it isn't already installed
+ * machine-wide and (b) the user hasn't previously declined — both surfaced via
+ * /api/service/status. Installing reloads the page (the launcher bootstrapper
+ * then execs the /opt binary); declining records the choice server-side and
+ * falls through to the normal first-run flow. Every non-applicable case (not
+ * Linux, already installed, previously declined, or the status endpoint
+ * unreachable) proceeds straight to maybeShowWelcomeModal.
+ */
+function maybeShowFirstRunModal(): void {
+    // Never cover the uninstall-progress overlay (mirrors maybeShowWelcomeModal).
+    if (isResumingUninstall()) return;
+    fetch('/api/service/status')
+        .then((r) => (r.ok ? (r.json() as Promise<ServiceStatusResponse>) : null))
+        .then((status) => {
+            const offerMachineWide =
+                status != null &&
+                status.platform === 'linux' &&
+                status.machineWideInstalled === false &&
+                status.systemInstallDeclined === false;
+            if (!offerMachineWide) {
+                maybeShowWelcomeModal();
+                return;
+            }
+            void import('./client/SystemWideInstallModal').then(({ SystemWideInstallModal }) => {
+                new SystemWideInstallModal({
+                    onInstall: () => {
+                        void fetch('/api/service/install-system-wide', { method: 'POST' })
+                            .then((r) => {
+                                if (r.ok) {
+                                    // Reload so the launcher bootstrapper execs the /opt binary.
+                                    window.location.reload();
+                                } else {
+                                    // Install didn't take (e.g. the admin prompt was
+                                    // dismissed) — continue the normal first-run flow.
+                                    maybeShowWelcomeModal();
+                                }
+                            })
+                            .catch(() => maybeShowWelcomeModal());
+                    },
+                    onDecline: () => {
+                        // Record the decline (server marker) so we don't re-ask, then
+                        // let the normal first-run flow continue.
+                        void fetch('/api/service/decline-system-wide', { method: 'POST' }).catch(() => {});
+                        maybeShowWelcomeModal();
+                    },
+                });
+            });
+        })
+        .catch(() => {
+            // /api/service/status unreachable — fall back to the normal flow.
+            maybeShowWelcomeModal();
+        });
+}
+
 function maybeShowPortChangeModal(
     globallyDismissed: boolean,
     dismissedFor: number | null,
@@ -189,7 +246,7 @@ window.onload = async (): Promise<void> => {
         pageContainer.insertBefore(banner.getElement(), pageContainer.firstChild);
     });
 
-    maybeShowWelcomeModal();
+    maybeShowFirstRunModal();
 
     // v0.1.8 uninstall handoff: if we arrived with
     // ?resume=uninstall-service&token=..., the previous (service)

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -131,6 +131,35 @@ function maybeShowWelcomeModal(): void {
 }
 
 /**
+ * Show a sticky banner notice with a single action button. Used for the
+ * migration reinstall offer and the system-wide update offer — both are
+ * status-driven banners that live above the main content (same as
+ * FirstRunBanner), not full-screen modals.
+ *
+ * Returns the container element so the caller can append it to the page.
+ */
+function showStatusBanner(text: string, actionLabel: string, onAction: () => void): HTMLElement {
+    const banner = document.createElement('div');
+    banner.style.cssText =
+        'position:fixed;top:0;left:0;right:0;z-index:9000;background:var(--bg-color,#1e1e2e);' +
+        'color:var(--text-color,#cdd6f4);border-bottom:1px solid var(--border-color,#45475a);' +
+        'padding:0.6rem 1rem;display:flex;align-items:center;gap:1rem;font-size:0.9rem;';
+    const msg = document.createElement('span');
+    msg.textContent = text;
+    banner.appendChild(msg);
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = actionLabel;
+    btn.style.cssText =
+        'padding:0.3rem 0.8rem;border-radius:4px;border:1px solid currentColor;' +
+        'background:transparent;color:inherit;cursor:pointer;white-space:nowrap;';
+    btn.addEventListener('click', onAction);
+    banner.appendChild(btn);
+    document.body.insertBefore(banner, document.body.firstChild);
+    return banner;
+}
+
+/**
  * First-run entry point. On Linux, ahead of the local WelcomeModal, offer to
  * install the app to /opt for all users when (a) it isn't already installed
  * machine-wide and (b) the user hasn't previously declined — both surfaced via
@@ -139,6 +168,10 @@ function maybeShowWelcomeModal(): void {
  * falls through to the normal first-run flow. Every non-applicable case (not
  * Linux, already installed, previously declined, or the status endpoint
  * unreachable) proceeds straight to maybeShowWelcomeModal.
+ *
+ * Also handles two status-driven offers introduced in P3c-2:
+ * - serviceMigrationNeeded → migration reinstall banner (POST migrate-system → reload)
+ * - optUpdateAvailable → system-wide update banner (POST install-system-wide → reload)
  */
 function maybeShowFirstRunModal(): void {
     // Never cover the uninstall-progress overlay (mirrors maybeShowWelcomeModal).
@@ -146,6 +179,37 @@ function maybeShowFirstRunModal(): void {
     fetch('/api/service/status')
         .then((r) => (r.ok ? (r.json() as Promise<ServiceStatusResponse>) : null))
         .then((status) => {
+            if (status != null && status.platform === 'linux') {
+                // Migration reinstall offer (P3c-2): service uses old /opt/.../data
+                // layout → offer a one-click pkexec reinstall to /var/opt.
+                if (status.serviceMigrationNeeded === true) {
+                    showStatusBanner(
+                        'this service uses the old layout. reinstall it to update to the new layout.',
+                        'reinstall now',
+                        () => {
+                            void fetch('/api/service/migrate-system', { method: 'POST' })
+                                .then((r) => { if (r.ok) window.location.reload(); })
+                                .catch(() => {});
+                        },
+                    );
+                    // Fall through — still show the normal first-run flow below.
+                }
+                // System-wide update offer (P3c-2): a newer home AppImage is running
+                // over an older /opt copy → offer to update the system-wide install.
+                if (status.optUpdateAvailable === true) {
+                    showStatusBanner(
+                        'update the system-wide install?',
+                        'update',
+                        () => {
+                            void fetch('/api/service/install-system-wide', { method: 'POST' })
+                                .then((r) => { if (r.ok) window.location.reload(); })
+                                .catch(() => {});
+                        },
+                    );
+                    // Fall through — still show the normal first-run flow below.
+                }
+            }
+
             const offerMachineWide =
                 status != null &&
                 status.platform === 'linux' &&

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -50,6 +50,8 @@ export interface ServiceStatusResponse {
     machineWideInstalled?: boolean;
     /** Linux: the user declined the first-run system-wide install (marker present). */
     systemInstallDeclined?: boolean;
+    /** Linux: a legacy /opt/.../data system install needs migration to /var/opt. */
+    serviceMigrationNeeded?: boolean;
 }
 
 /** Success response shape for /api/service/install and /api/service/uninstall. */

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -46,6 +46,10 @@ export interface ServiceStatusResponse {
      * omitted on Windows, where scope is auto-detected from execPath.
      */
     scope?: 'user' | 'system' | null;
+    /** Linux: the shared /opt machine-wide AppImage exists. */
+    machineWideInstalled?: boolean;
+    /** Linux: the user declined the first-run system-wide install (marker present). */
+    systemInstallDeclined?: boolean;
 }
 
 /** Success response shape for /api/service/install and /api/service/uninstall. */

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -52,6 +52,8 @@ export interface ServiceStatusResponse {
     systemInstallDeclined?: boolean;
     /** Linux: a legacy /opt/.../data system install needs migration to /var/opt. */
     serviceMigrationNeeded?: boolean;
+    /** Linux: launcher detected a newer home AppImage than /opt; offer the system-wide update. */
+    optUpdateAvailable?: boolean;
 }
 
 /** Success response shape for /api/service/install and /api/service/uninstall. */

--- a/src/server/PortPicker.ts
+++ b/src/server/PortPicker.ts
@@ -34,6 +34,14 @@ function tryPort(port: number): Promise<boolean> {
     });
 }
 
+/** Parse the one-shot WS_SCRCPY_WEB_PORT override into a valid port, or null.
+ *  Set by the Phase 2 system-uninstall relaunch to force the exact (free) service
+ *  port so the user's browser reconnects. */
+export function webPortOverride(env: string | undefined): number | null {
+    const n = Number(env);
+    return Number.isInteger(n) && n > 0 && n < 65536 ? n : null;
+}
+
 /**
  * Walk [start, end] inclusive in order. Return the first port that is free,
  * or null if every port in the range is busy.

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -23,6 +23,7 @@ import { linuxAppImageAssetName, releaseAssetUrl, parseSha256Sums } from './linu
 import { verifySha256 } from './verifySha256';
 import { downloadToFile, fetchText } from './downloadToFile';
 import { buildDetachedSpawn } from './service/systemTools';
+import { buildMachineWideUpdateScript, runPkexec, STAGED_SYSTEM_DIR } from './service/SystemdClient';
 
 const execFileAsync = promisify(execFile);
 
@@ -67,6 +68,12 @@ export interface UpdateServiceOptions {
     platform?: NodeJS.Platform;
     /** Override global fetch for tests (AppImage download + SHA256SUMS). Default: global fetch. */
     fetchFn?: typeof fetch;
+    /**
+     * Override the pkexec runner for tests — used by the machine-wide-no-service
+     * apply to elevate the rename-swap of the root-owned /opt binary under a
+     * single graphical prompt. Default: the real {@link runPkexec} (SystemdClient).
+     */
+    runPkexecFn?: (shellCmd: string, label: string) => Promise<string>;
 }
 
 export interface UpdateServiceState {
@@ -111,6 +118,7 @@ export class UpdateService {
     private readonly setIntervalFn: (cb: () => void, ms: number) => NodeJS.Timeout;
     private readonly clearIntervalFn: (handle: NodeJS.Timeout) => void;
     private readonly fetchFn: typeof fetch;
+    private readonly runPkexecFn: (shellCmd: string, label: string) => Promise<string>;
 
     constructor(opts: UpdateServiceOptions = {}) {
         this.platform = opts.platform ?? process.platform;
@@ -205,6 +213,7 @@ export class UpdateService {
         this.setIntervalFn = opts.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
         this.clearIntervalFn = opts.clearIntervalFn ?? ((handle) => clearInterval(handle));
         this.fetchFn = opts.fetchFn ?? fetch;
+        this.runPkexecFn = opts.runPkexecFn ?? runPkexec;
         this.state = { isInstalled: false, currentVersion: '', status: 'idle' };
     }
 
@@ -493,17 +502,28 @@ export class UpdateService {
             // The launcher stages this helper copy (named *.exe even on Linux) to
             // dataRoot on every boot — outside the AppImage mount, so it survives exit.
             const helperPath = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
-            // installMode selects the apply shape (item 39). The helper always
-            // OUTLIVES this AppImage's teardown — buildDetachedSpawn wraps it in
-            // its own `systemd-run --collect` transient unit (separate cgroup; #27),
+            // installMode + the $APPIMAGE path select the apply shape. The helper
+            // always OUTLIVES this AppImage's teardown — buildDetachedSpawn wraps it
+            // in its own `systemd-run --collect` transient unit (separate cgroup; #27),
             // falling back to `setsid` then bare on non-systemd hosts:
-            //  - local ('user'): swap $APPIMAGE, wait for our pid, bare relaunch.
+            //  - local ('user'/'system', home $APPIMAGE): swap $APPIMAGE, wait for
+            //    our pid, bare relaunch.
+            //  - machine-wide-no-service (non-service installMode, /opt $APPIMAGE):
+            //    elevate a RENAME-swap of the root-owned /opt binary via ONE pkexec
+            //    (cp would ETXTBSY the running file), then a relaunch-ONLY helper
+            //    (no --staged) waits for our pid (flock release) + relaunches /opt.
+            //    The relaunch is NOT elevated (pkexec would come back as root).
             //  - user-service:  the helper stops/swaps/starts the --user unit;
             //    target = home $APPIMAGE (user manager).
             //  - system-service: the helper (root) stops/swaps/relabels/starts the
             //    system unit; target = the /opt staged copy; system-manager
             //    systemd-run (no --user). No pkexec — root self-update, headless.
             const STAGED_SYSTEM_TARGET = '/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage';
+            // Machine-wide-no-service discriminator: $APPIMAGE under the root-owned
+            // /opt tree while installMode is NOT a service mode (the machine-wide
+            // install leaves installMode at user/system/null — the /opt path is the
+            // real signal, not installMode).
+            const isMachineWide = !isServiceMode && homeAppImage.startsWith(`${STAGED_SYSTEM_DIR}/`);
             let target: string;
             let helperArgs: string[];
             let spawnSystem = false;
@@ -516,6 +536,18 @@ export class UpdateService {
                 target = homeAppImage;
                 helperArgs = ['--linux-apply', '--staged', stagedPath, '--target', target,
                     '--service-restart', 'user', '--unit', WS_SCRCPY_SERVICE_NAME];
+            } else if (isMachineWide) {
+                // (1) elevate ONLY the swap (root-owned /opt). One pkexec prompt does
+                //     the ETXTBSY-safe rename-swap of the /opt binary + VERSION write.
+                await this.runPkexecFn(
+                    buildMachineWideUpdateScript({ stagedAppImage: stagedPath, version }),
+                    'machine-wide-update',
+                );
+                // (2) relaunch-ONLY helper (no --staged): the swap already happened
+                //     above, so the helper just waits for our pid to exit (releasing
+                //     the per-user flock) then relaunches the freshly-swapped /opt.
+                target = homeAppImage;
+                helperArgs = ['--linux-apply', '--target', target, '--wait-pid', String(process.pid)];
             } else {
                 target = homeAppImage;
                 helperArgs = ['--linux-apply', '--staged', stagedPath, '--target', target,

--- a/src/server/__tests__/PortPicker.test.ts
+++ b/src/server/__tests__/PortPicker.test.ts
@@ -1,7 +1,7 @@
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as net from 'net';
 import { afterEach, describe, expect, it } from 'vitest';
-import { findAvailablePort } from '../PortPicker';
+import { findAvailablePort, webPortOverride } from '../PortPicker';
 
 function listenOn(port: number): Promise<net.Server> {
     return new Promise((resolve, reject) => {
@@ -40,6 +40,17 @@ async function reserveEphemeral(): Promise<number> {
     await close(srv);
     return port;
 }
+
+describe('webPortOverride', () => {
+    it('parses a valid port', () => { expect(webPortOverride('8000')).toBe(8000); });
+    it('rejects invalid/unset', () => {
+        expect(webPortOverride(undefined)).toBeNull();
+        expect(webPortOverride('')).toBeNull();
+        expect(webPortOverride('0')).toBeNull();
+        expect(webPortOverride('70000')).toBeNull();
+        expect(webPortOverride('abc')).toBeNull();
+    });
+});
 
 describe('findAvailablePort', () => {
     const opened: net.Server[] = [];

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1475,6 +1475,85 @@ describe('ServiceApi', () => {
         expect(body.serviceMigrationNeeded).toBeUndefined();
     });
 
+    // ── optUpdateAvailable — launcher env flag (P3c-2) ────────────────────────
+
+    it('GET /status on linux sets optUpdateAvailable=true when WS_SCRCPY_OPT_UPDATE_AVAILABLE=1', async () => {
+        const savedEnvVar = process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+        process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'] = '1';
+        try {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => false);
+            const { req, res } = makeReqRes('/api/service/status');
+            await api.handle(req, res);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.optUpdateAvailable).toBe(true);
+        } finally {
+            if (savedEnvVar === undefined) delete process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+            else process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'] = savedEnvVar;
+        }
+    });
+
+    it('GET /status on linux sets optUpdateAvailable=false when WS_SCRCPY_OPT_UPDATE_AVAILABLE is unset', async () => {
+        const savedEnvVar = process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+        delete process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+        try {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => false);
+            const { req, res } = makeReqRes('/api/service/status');
+            await api.handle(req, res);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.optUpdateAvailable).toBe(false);
+        } finally {
+            if (savedEnvVar === undefined) delete process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+            else process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'] = savedEnvVar;
+        }
+    });
+
+    it('GET /status on linux sets optUpdateAvailable=false when WS_SCRCPY_OPT_UPDATE_AVAILABLE=0', async () => {
+        const savedEnvVar = process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+        process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'] = '0';
+        try {
+            const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => false);
+            const { req, res } = makeReqRes('/api/service/status');
+            await api.handle(req, res);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.optUpdateAvailable).toBe(false);
+        } finally {
+            if (savedEnvVar === undefined) delete process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'];
+            else process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'] = savedEnvVar;
+        }
+    });
+
+    it('GET /status on win32 omits optUpdateAvailable (linux-only field)', async () => {
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', () => true);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.optUpdateAvailable).toBeUndefined();
+    });
+
     // ── reason discriminator + no-direct-uninstall guard (v0.1.25) ──────────
 
     it('service+LocalSystem uninstall writes marker and returns shutting-down (Phase 4 replaces handoff)', async () => {

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -7,6 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ServiceApi } from '../api/ServiceApi';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
+import {
+    DECLINE_MARKER_NAME,
+    STAGED_SYSTEM_APPIMAGE,
+    STAGED_SYSTEM_DIR,
+} from '../service/SystemdClient';
 import type {
     ServiceClient,
     ServiceClientFactoryResult,
@@ -237,6 +242,72 @@ describe('ServiceApi', () => {
         const body = JSON.parse((res as any).getBody());
         expect(body.scope).toBe('user');
         expect(client.getInstalledScope).toHaveBeenCalledWith('WsScrcpyWeb');
+    });
+
+    it('GET /status on linux reports machineWideInstalled + systemInstallDeclined from existsCheck', async () => {
+        // The frontend reads these two flags off /api/service/status to (a) gate
+        // the system-scope service-install button (machineWideInstalled) and (b)
+        // decide whether to show the first-run machine-wide-install modal
+        // (systemInstallDeclined). Both derive from the injected existsCheck so
+        // the API stays testable without touching the real filesystem.
+        const cfg = Config.getInstance();
+        const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        const optAppImage = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+        const declineMarker = path.join(dataRoot, 'control', DECLINE_MARKER_NAME);
+        // /opt AppImage present, decline marker absent.
+        const existsCheck = vi.fn((p: string) => p === optAppImage);
+
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'linux',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', existsCheck);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.machineWideInstalled).toBe(true);
+        expect(body.systemInstallDeclined).toBe(false);
+        // Confirms the two paths the impl checks (so a path-shape regression fails here).
+        expect(existsCheck).toHaveBeenCalledWith(optAppImage);
+        expect(existsCheck).toHaveBeenCalledWith(declineMarker);
+    });
+
+    it('GET /status on linux reflects the inverse existsCheck (not machine-wide, declined)', async () => {
+        const cfg = Config.getInstance();
+        const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        const declineMarker = path.join(dataRoot, 'control', DECLINE_MARKER_NAME);
+        // /opt AppImage absent, decline marker present.
+        const existsCheck = (p: string) => p === declineMarker;
+
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'linux',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', existsCheck);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.machineWideInstalled).toBe(false);
+        expect(body.systemInstallDeclined).toBe(true);
+    });
+
+    it('GET /status on win32 omits machineWideInstalled + systemInstallDeclined (linux-only fields)', async () => {
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', () => true);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.machineWideInstalled).toBeUndefined();
+        expect(body.systemInstallDeclined).toBeUndefined();
     });
 
     it('POST /install returns 501 with unsupportedReason on unsupported platforms', async () => {

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1138,6 +1138,101 @@ describe('ServiceApi', () => {
         });
     });
 
+    // ── machine-wide install + decline endpoints (B3) ────────────────────────
+    describe('install-system-wide + decline-system-wide', () => {
+        let savedPlatform: NodeJS.Platform;
+        beforeEach(() => {
+            savedPlatform = process.platform;
+            // Force linux so the platform guard passes on any test-host OS.
+            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        });
+        afterEach(() => {
+            Object.defineProperty(process, 'platform', { value: savedPlatform, configurable: true });
+        });
+
+        it('POST /api/service/install-system-wide with $APPIMAGE set invokes pkexec runner once with cp + bin_t script, returns 200', async () => {
+            const appImagePath = '/home/jamie/Applications/WsScrcpyWeb.AppImage';
+            const savedAppImage = process.env['APPIMAGE'];
+            process.env['APPIMAGE'] = appImagePath;
+            try {
+                const fakePkexec = vi.fn(async (_cmd: string, _label: string) => '');
+                const api = new ServiceApi(
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    fakePkexec,
+                );
+                const { req, res } = makeReqRes('/api/service/install-system-wide', 'POST');
+                await api.handle(req, res);
+
+                expect((res as any).getStatus()).toBe(200);
+                const body = JSON.parse((res as any).getBody());
+                expect(body.ok).toBe(true);
+
+                expect(fakePkexec).toHaveBeenCalledTimes(1);
+                const [script, label] = fakePkexec.mock.calls[0]!;
+                expect(script).toContain(`cp "${appImagePath}" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`);
+                expect(script).toContain('bin_t');
+                expect(label).toBe('install-system-wide');
+            } finally {
+                if (savedAppImage === undefined) delete process.env['APPIMAGE'];
+                else process.env['APPIMAGE'] = savedAppImage;
+            }
+        });
+
+        it('POST /api/service/install-system-wide with $APPIMAGE unset returns 400, pkexec NOT called', async () => {
+            const savedAppImage = process.env['APPIMAGE'];
+            delete process.env['APPIMAGE'];
+            try {
+                const fakePkexec = vi.fn(async (_cmd: string, _label: string) => '');
+                const api = new ServiceApi(
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    fakePkexec,
+                );
+                const { req, res } = makeReqRes('/api/service/install-system-wide', 'POST');
+                await api.handle(req, res);
+
+                expect((res as any).getStatus()).toBe(400);
+                const body = JSON.parse((res as any).getBody());
+                expect(body.ok).toBe(false);
+                expect(fakePkexec).not.toHaveBeenCalled();
+            } finally {
+                if (savedAppImage === undefined) delete process.env['APPIMAGE'];
+                else process.env['APPIMAGE'] = savedAppImage;
+            }
+        });
+
+        it('POST /api/service/decline-system-wide writes decline marker under <dataRoot>/control and returns 200', async () => {
+            const fakePkexec = vi.fn(async (_cmd: string, _label: string) => '');
+            const api = new ServiceApi(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                fakePkexec,
+            );
+            const { req, res } = makeReqRes('/api/service/decline-system-wide', 'POST');
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+
+            // Marker file must exist at <dataRoot>/control/system-install-declined
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const markerPath = path.join(dataRoot, 'control', 'system-install-declined');
+            expect(fs.existsSync(markerPath)).toBe(true);
+        });
+    });
+
     it('returns 404 for unrecognized /api/service/* paths', async () => {
         const factoryResult: ServiceClientFactoryResult = {
             client: fakeClient(),

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ServiceApi } from '../api/ServiceApi';
+import { ServiceApi, systemServiceNeedsMigration } from '../api/ServiceApi';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
 import {
@@ -1314,6 +1314,71 @@ describe('ServiceApi', () => {
         const { req, res } = makeReqRes('/api/service/bogus', 'GET');
         await api.handle(req, res);
         expect((res as any).getStatus()).toBe(404);
+    });
+
+    // ── serviceMigrationNeeded — pure helper + status flag (P3a-1) ────────────
+
+    describe('systemServiceNeedsMigration', () => {
+        it('true when DATA_ROOT is the legacy /opt/.../data', () => {
+            expect(systemServiceNeedsMigration({ dataRootEnv: '/opt/ws-scrcpy-web/data', oldDataDirExists: false })).toBe(true);
+        });
+        it('true when the legacy data dir exists', () => {
+            expect(systemServiceNeedsMigration({ oldDataDirExists: true })).toBe(true);
+        });
+        it('false otherwise', () => {
+            expect(systemServiceNeedsMigration({ dataRootEnv: '/var/opt/ws-scrcpy-web', oldDataDirExists: false })).toBe(false);
+            expect(systemServiceNeedsMigration({ oldDataDirExists: false })).toBe(false);
+        });
+    });
+
+    it('GET /status on linux with legacy /opt/.../data dir present sets serviceMigrationNeeded=true', async () => {
+        // existsCheck: the legacy dir (/opt/ws-scrcpy-web/data) is present
+        const legacyDataDir = '/opt/ws-scrcpy-web/data';
+        const existsCheck = vi.fn((p: string) => p === legacyDataDir);
+
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'linux',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', existsCheck);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.serviceMigrationNeeded).toBe(true);
+        expect(existsCheck).toHaveBeenCalledWith(legacyDataDir);
+    });
+
+    it('GET /status on linux with legacy /opt/.../data dir absent sets serviceMigrationNeeded=false', async () => {
+        // existsCheck: nothing exists (neither /opt AppImage nor legacy data dir)
+        const existsCheck = vi.fn((_p: string) => false);
+
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'linux',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', existsCheck);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.serviceMigrationNeeded).toBe(false);
+    });
+
+    it('GET /status on win32 omits serviceMigrationNeeded (linux-only field)', async () => {
+        const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
+        const factoryResult: ServiceClientFactoryResult = {
+            client,
+            supported: true,
+            platform: 'win32',
+        };
+        const api = new ServiceApi(() => factoryResult, () => 'user', () => true);
+        const { req, res } = makeReqRes('/api/service/status');
+        await api.handle(req, res);
+        const body = JSON.parse((res as any).getBody());
+        expect(body.serviceMigrationNeeded).toBeUndefined();
     });
 
     // ── reason discriminator + no-direct-uninstall guard (v0.1.25) ──────────

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1304,6 +1304,100 @@ describe('ServiceApi', () => {
         });
     });
 
+    // ── migrate-system — one-pkexec /opt/.../data -> /var/opt migration (P3a-2) ──
+    describe('migrate-system', () => {
+        let savedPlatform: NodeJS.Platform;
+        beforeEach(() => {
+            savedPlatform = process.platform;
+            // Force linux so the platform guard passes on any test-host OS.
+            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        });
+        afterEach(() => {
+            Object.defineProperty(process, 'platform', { value: savedPlatform, configurable: true });
+        });
+
+        it('POST /api/service/migrate-system invokes pkexec once with old-cleanup + /var/opt setup, carries the prior webPort, returns 200', async () => {
+            // The legacy /opt/.../data/config.json read fails on a non-Linux test
+            // host, so the endpoint falls back to the running instance's webPort —
+            // which the migration must carry forward into the new /var/opt config.
+            Config.getInstance().updateAppConfig({ webPort: 8123 });
+
+            const fakePkexec = vi.fn(async (_cmd: string, _label: string) => '');
+            const api = new ServiceApi(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                fakePkexec,
+            );
+            const { req, res } = makeReqRes('/api/service/migrate-system', 'POST');
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+
+            expect(fakePkexec).toHaveBeenCalledTimes(1);
+            const [script, label] = fakePkexec.mock.calls[0]!;
+            // old cleanup
+            expect(script).toContain('stop WsScrcpyWeb.service');
+            expect(script).toContain('disable WsScrcpyWeb.service');
+            expect(script).toContain('rm -rf /opt/ws-scrcpy-web/data');
+            expect(script).toContain("semanage fcontext -d '/opt/ws-scrcpy-web/data(/.*)?'");
+            // new /var/opt setup
+            expect(script).toContain('mkdir -p /var/opt/ws-scrcpy-web');
+            expect(script).toContain('/var/opt/ws-scrcpy-web/config.json');
+            expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+            expect(script).toContain('enable --now WsScrcpyWeb.service');
+            // carries the prior webPort into the seeded config
+            expect(script).toContain('"webPort":8123');
+            // does NOT re-copy the AppImage — the binary stays in /opt
+            expect(script).not.toContain('WsScrcpyWeb.AppImage');
+            expect(label).toBe('migrate-system');
+        });
+
+        it('POST /api/service/migrate-system on non-linux returns ok:false (unsupported), pkexec NOT called', async () => {
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+            const fakePkexec = vi.fn(async (_cmd: string, _label: string) => '');
+            const api = new ServiceApi(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                fakePkexec,
+            );
+            const { req, res } = makeReqRes('/api/service/migrate-system', 'POST');
+            await api.handle(req, res);
+
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(false);
+            expect(fakePkexec).not.toHaveBeenCalled();
+        });
+
+        it('POST /api/service/migrate-system maps a dismissed pkexec prompt to 403 (uac-declined)', async () => {
+            const fakePkexec = vi.fn(async () => {
+                throw new Error('authentication was dismissed. service install cancelled.');
+            });
+            const api = new ServiceApi(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                fakePkexec,
+            );
+            const { req, res } = makeReqRes('/api/service/migrate-system', 'POST');
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(403);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(false);
+            expect(body.reason).toBe('uac-declined');
+        });
+    });
+
     it('returns 404 for unrecognized /api/service/* paths', async () => {
         const factoryResult: ServiceClientFactoryResult = {
             client: fakeClient(),

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -885,6 +885,79 @@ describe('UpdateService', () => {
         }
     });
 
+    // Linux MACHINE-WIDE-NO-SERVICE apply (Phase 3 / P3b): the user runs the
+    // root-owned /opt AppImage directly (NOT a service), so $APPIMAGE lives under
+    // /opt/ws-scrcpy-web/ while installMode is NOT a service mode. A `cp` over /opt
+    // would ETXTBSY the running file and the per-user flock blocks a fresh /opt
+    // instance until the old one exits — so applyUpdate (1) elevates a RENAME-based
+    // swap via ONE pkexec (buildMachineWideUpdateScript), then (2) spawns a
+    // relaunch-ONLY helper (NO --staged) that waits for our pid to exit (releasing
+    // the flock) + relaunches /opt. The relaunch must NOT be elevated.
+    it.each([
+        ['user' as const],
+        ['system' as const],
+        [null],
+    ])('applyUpdate (linux machine-wide-no-service, installMode=%s): pkexec rename-swap + relaunch-only helper', async (installMode) => {
+        const { createHash } = await import('crypto');
+        Config.getInstance().updateAppConfig({ autoUpdate: false, installMode, channel: 'beta', githubOwner: 'bilbospocketses' });
+        const appImageBytes = Buffer.from('NEW-APPIMAGE-CONTENT');
+        const goodHash = createHash('sha256').update(appImageBytes).digest('hex');
+        const sums = `${goodHash}  ./linux-final/WsScrcpyWeb-linux-beta.AppImage\n`;
+        const fetchFn = vi.fn(async (url: string) =>
+            url.endsWith('.AppImage') ? new Response(appImageBytes) : new Response(sums),
+        ) as unknown as typeof fetch;
+        const applyFn = vi.fn();
+        const mgr = fakeMgr({ checkForUpdatesAsync: async () => fakeUpdateInfo('0.1.31-beta.2'), waitExitThenApplyUpdate: applyFn });
+        const pkexecMock = vi.fn<(shellCmd: string, label: string) => Promise<string>>(async () => '');
+        const spawnMock = vi.mocked(child_process.spawn);
+        spawnMock.mockClear();
+        const svc = new UpdateService({
+            platform: 'linux',
+            installRoot: path.join('/fake', 'mount', 'usr'),
+            existsSync: () => true,
+            updateManagerFactory: () => mgr,
+            setIntervalFn: () => 0 as unknown as NodeJS.Timeout,
+            clearIntervalFn: () => undefined,
+            fetchFn,
+            runPkexecFn: pkexecMock,
+        });
+        // The discriminator is the /opt $APPIMAGE path (not installMode); the
+        // machine-wide install leaves installMode at whatever it was (user/system/null).
+        process.env['APPIMAGE'] = '/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage';
+        svc.init();
+        await svc.checkForUpdates();
+        expect(svc.getStatus().status).toBe('ready');
+
+        const result = await svc.applyUpdate();
+        expect(result.redirectPort).toBeNull();
+        // Velopack's (broken) apply is never used.
+        expect(applyFn).not.toHaveBeenCalled();
+
+        // (1) the elevated RENAME-swap ran under ONE pkexec with the right label.
+        expect(pkexecMock).toHaveBeenCalledTimes(1);
+        const [script, label] = pkexecMock.mock.calls[0]!;
+        expect(label).toBe('machine-wide-update');
+        expect(script).toContain('mv -f');
+        expect(script).toContain('/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage.bak'); // old → .bak
+        expect(script).toContain('"/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');   // staged → /opt
+        expect(script).toContain('.new');                                        // the staged download moved in
+        expect(script).toContain("'0.1.31-beta.2' > /opt/ws-scrcpy-web/VERSION"); // new VERSION
+        expect(script).not.toMatch(/\bcp\b/);                                    // never cp (ETXTBSY)
+
+        // (2) the relaunch-only helper is spawned (NOT under pkexec): no --staged,
+        // no --service-restart — just --target /opt + --wait-pid <ourpid>.
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+        const [bin, argv] = spawnMock.mock.calls[0]!;
+        const cmdline = [String(bin), ...(argv as string[]).map(String)].join(' ');
+        expect(cmdline).toMatch(/control[\\/]operation-server[\\/]ws-scrcpy-web-launcher\.exe/);
+        expect(cmdline).toContain('--linux-apply');
+        expect(cmdline).toContain('--target /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');
+        expect(cmdline).toContain(`--wait-pid ${process.pid}`);
+        expect(cmdline).not.toContain('--staged');        // relaunch-only: no swap by the helper
+        expect(cmdline).not.toContain('--service-restart');
+        expect(cmdline).not.toContain('--relabel');
+    });
+
     // ── reconfigure ─────────────────────────────────────────────────────
 
     it('reconfigure: swaps internal mgr + triggers immediate check', async () => {

--- a/src/server/__tests__/systemScopePaths.test.ts
+++ b/src/server/__tests__/systemScopePaths.test.ts
@@ -11,9 +11,9 @@ import { buildServiceUnitEnv, buildSystemSeedConfig } from '../service/SystemdCl
 describe('buildServiceUnitEnv (#36 system-scope /opt paths)', () => {
     const userDeps = '/home/jamie/.local/share/WsScrcpyWeb/dependencies';
 
-    it('linux + system: DATA_ROOT + DEPS_PATH under /opt, NOT the user home', () => {
+    it('linux + system: DATA_ROOT at /var/opt (FHS state), DEPS_PATH under /opt (bin_t), NOT the user home', () => {
         expect(buildServiceUnitEnv('linux', 'system', userDeps)).toEqual({
-            DATA_ROOT: '/opt/ws-scrcpy-web/data',
+            DATA_ROOT: '/var/opt/ws-scrcpy-web',
             DEPS_PATH: '/opt/ws-scrcpy-web/dependencies',
         });
     });

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -23,7 +23,7 @@ import {
     type ServiceClientFactoryResult,
 } from '../service';
 import { resolveSystemTool } from '../service/systemTools';
-import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_HELPER, buildServiceUnitEnv, buildSystemSeedConfig, buildMachineWideInstallScript, runPkexec, DECLINE_MARKER_NAME } from '../service/SystemdClient';
+import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_APPIMAGE, STAGED_SYSTEM_HELPER, buildServiceUnitEnv, buildSystemSeedConfig, buildMachineWideInstallScript, runPkexec, DECLINE_MARKER_NAME } from '../service/SystemdClient';
 import { getAppVersion } from '../appVersion';
 import { readJsonBody } from './utils';
 
@@ -137,6 +137,22 @@ export class ServiceApi {
         const scope = result.client.getInstalledScope
             ? await result.client.getInstalledScope(WS_SCRCPY_SERVICE_NAME)
             : undefined;
+        // Linux-only machine-wide-install signals the frontend reads off status:
+        //   - machineWideInstalled gates the system-scope service-install button
+        //     (the root service execs the shared /opt binary, which must exist).
+        //   - systemInstallDeclined suppresses the first-run "install for all
+        //     users" modal once the user has declined it (persistent marker).
+        // Both go through the injected existsCheck so the API stays unit-testable.
+        // Spread conditionally (like scope/diskWebPort) so they're Linux-only.
+        let machineWide: { machineWideInstalled: boolean; systemInstallDeclined: boolean } | null = null;
+        if (result.platform === 'linux') {
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            machineWide = {
+                machineWideInstalled: this.existsCheck(`${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`),
+                systemInstallDeclined: this.existsCheck(path.join(dataRoot, 'control', DECLINE_MARKER_NAME)),
+            };
+        }
         const body: ServiceStatusResponse = {
             supported: true,
             platform: result.platform,
@@ -145,6 +161,7 @@ export class ServiceApi {
             ...(scope !== undefined ? { scope } : {}),
             ...(disk.diskWebPort != null ? { diskWebPort: disk.diskWebPort } : {}),
             ...(disk.configMtime != null ? { configMtime: disk.configMtime } : {}),
+            ...(machineWide ?? {}),
         };
         res.writeHead(200);
         res.end(JSON.stringify(body));

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -158,7 +158,7 @@ export class ServiceApi {
         //     users" modal once the user has declined it (persistent marker).
         // Both go through the injected existsCheck so the API stays unit-testable.
         // Spread conditionally (like scope/diskWebPort) so they're Linux-only.
-        let machineWide: { machineWideInstalled: boolean; systemInstallDeclined: boolean; serviceMigrationNeeded: boolean } | null = null;
+        let machineWide: { machineWideInstalled: boolean; systemInstallDeclined: boolean; serviceMigrationNeeded: boolean; optUpdateAvailable: boolean } | null = null;
         if (result.platform === 'linux') {
             const cfg = Config.getInstance();
             const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
@@ -168,6 +168,7 @@ export class ServiceApi {
                 serviceMigrationNeeded: systemServiceNeedsMigration({
                     oldDataDirExists: this.existsCheck('/opt/ws-scrcpy-web/data'),
                 }),
+                optUpdateAvailable: process.env['WS_SCRCPY_OPT_UPDATE_AVAILABLE'] === '1',
             };
         }
         const body: ServiceStatusResponse = {

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -2,6 +2,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { spawn } from 'child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { InstallMode } from '../../common/ConfigEvents';
 import {
@@ -23,7 +24,7 @@ import {
     type ServiceClientFactoryResult,
 } from '../service';
 import { resolveSystemTool } from '../service/systemTools';
-import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_APPIMAGE, STAGED_SYSTEM_HELPER, buildServiceUnitEnv, buildSystemSeedConfig, buildMachineWideInstallScript, runPkexec, DECLINE_MARKER_NAME } from '../service/SystemdClient';
+import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_APPIMAGE, STAGED_SYSTEM_HELPER, SYSTEM_STATE_DIR, buildServiceUnitEnv, buildSystemSeedConfig, buildMachineWideInstallScript, buildSystemMigrationScript, renderUnitFile, runPkexec, DECLINE_MARKER_NAME } from '../service/SystemdClient';
 import { getAppVersion } from '../appVersion';
 import { readJsonBody } from './utils';
 
@@ -94,6 +95,9 @@ export class ServiceApi {
             }
             if (req.method === 'POST' && url === '/api/service/decline-system-wide') {
                 return await this.handleDeclineSystemWide(res);
+            }
+            if (req.method === 'POST' && url === '/api/service/migrate-system') {
+                return await this.handleMigrateSystem(res);
             }
 
             res.writeHead(404);
@@ -719,6 +723,97 @@ export class ServiceApi {
             res.end(JSON.stringify({ ok: false, error: (err as Error).message, reason: 'unknown' }));
         }
         return true;
+    }
+
+    /**
+     * POST /api/service/migrate-system — one-click migration of a legacy
+     * beta.40 system-scope service (old `/opt/.../data` state layout) to the
+     * new `/var/opt/ws-scrcpy-web` layout.
+     *
+     * The /opt AppImage + deps are ALREADY staged and stay put; this only
+     * relocates the writable state dir, fixes the SELinux fcontext rules, and
+     * reinstalls the unit with `DATA_ROOT=/var/opt` — all under ONE pkexec
+     * prompt (buildSystemMigrationScript). Doing it as a single elevated script
+     * sidesteps the async coordination problem of the out-of-process uninstall
+     * teardown (handleUninstall) — nothing is torn down except the unit + the
+     * old state dir, so there's no uninstall→reinstall to sequence.
+     *
+     * Carries the legacy service's webPort forward into the seeded /var/opt
+     * config; installMode is forced to `system-service` by buildSystemSeedConfig
+     * (the migrated unit IS a system service). Status codes mirror
+     * handleInstallSystemWide (200 ok / 403 dismissed / 500 other).
+     */
+    private async handleMigrateSystem(res: ServerResponse): Promise<boolean> {
+        if (process.platform !== 'linux') {
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: false, error: 'service migration is linux-only', reason: 'unsupported' }));
+            return true;
+        }
+
+        const cfg = Config.getInstance();
+        const webPort = this.readLegacyServiceWebPort();
+        const seedConfig = buildSystemSeedConfig(webPort);
+
+        // Render the NEW unit body. System scope → renderUnitFile points
+        // ExecStart at the in-place /opt AppImage and the env now carries
+        // DATA_ROOT=/var/opt (+ DEPS_PATH=/opt/.../dependencies). binPath +
+        // startupDir are unused for system scope but the type requires them.
+        const unitContent = renderUnitFile(
+            {
+                name: WS_SCRCPY_SERVICE_NAME,
+                displayName: WS_SCRCPY_SERVICE_DISPLAY_NAME,
+                description: WS_SCRCPY_SERVICE_DESCRIPTION,
+                binPath: `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`,
+                startupDir: STAGED_SYSTEM_DIR,
+                startType: 'Automatic',
+                maxRestartAttempts: 3,
+                envVars: buildServiceUnitEnv('linux', 'system', cfg.dependenciesPath),
+                logPath: `${SYSTEM_STATE_DIR}/logs/service.log`,
+                scope: 'system',
+            },
+            'system',
+        );
+
+        const unitPath = `/etc/systemd/system/${WS_SCRCPY_SERVICE_NAME}.service`;
+        const tmpFile = path.join(os.tmpdir(), `${WS_SCRCPY_SERVICE_NAME}.service.migrate.tmp`);
+        fs.writeFileSync(tmpFile, unitContent, { mode: 0o644 });
+        try {
+            const script = buildSystemMigrationScript({
+                seedConfigJson: JSON.stringify(seedConfig),
+                unitTmpPath: tmpFile,
+                unitPath,
+                name: WS_SCRCPY_SERVICE_NAME,
+            });
+            await this.runPkexecFn(script, 'migrate-system');
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: true, status: 'migrated' }));
+        } catch (err) {
+            const msg = (err as Error).message;
+            const declined = /dismissed/i.test(msg);
+            res.writeHead(declined ? 403 : 500);
+            res.end(JSON.stringify({ ok: false, error: msg, reason: declined ? 'uac-declined' : 'unknown' }));
+        } finally {
+            try { fs.unlinkSync(tmpFile); } catch { /* best-effort cleanup */ }
+        }
+        return true;
+    }
+
+    /**
+     * Read the legacy system-service webPort so the migration can carry it
+     * forward into the new /var/opt config. Reads the old service's own
+     * `/opt/.../data/config.json` directly; on any read/parse failure (already
+     * migrated, or a non-Linux test host where that path doesn't exist) falls
+     * back to the running instance's in-memory webPort.
+     */
+    private readLegacyServiceWebPort(): number {
+        try {
+            const raw = fs.readFileSync(`${STAGED_SYSTEM_DIR}/data/config.json`, 'utf-8');
+            const parsed = JSON.parse(raw) as { webPort?: unknown };
+            if (typeof parsed.webPort === 'number') return parsed.webPort;
+        } catch {
+            // Legacy config unreadable — fall back to the running instance's config.
+        }
+        return Config.getInstance().getAppConfig().webPort;
     }
 
     /**

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -23,7 +23,8 @@ import {
     type ServiceClientFactoryResult,
 } from '../service';
 import { resolveSystemTool } from '../service/systemTools';
-import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_HELPER, buildServiceUnitEnv, buildSystemSeedConfig } from '../service/SystemdClient';
+import { STAGED_SYSTEM_DIR, STAGED_SYSTEM_HELPER, buildServiceUnitEnv, buildSystemSeedConfig, buildMachineWideInstallScript, runPkexec, DECLINE_MARKER_NAME } from '../service/SystemdClient';
+import { getAppVersion } from '../appVersion';
 import { readJsonBody } from './utils';
 
 const log = Logger.for('ServiceApi');
@@ -59,6 +60,7 @@ export class ServiceApi {
             child.unref();
         },
         private scheduleExit: (fn: () => void, ms: number) => void = (fn, ms) => { setTimeout(fn, ms).unref(); },
+        private readonly runPkexecFn: (shellCmd: string, label: string) => Promise<string> = runPkexec,
     ) {}
 
     public async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
@@ -76,6 +78,12 @@ export class ServiceApi {
             }
             if (req.method === 'POST' && url === '/api/service/uninstall') {
                 return await this.handleUninstall(req, res);
+            }
+            if (req.method === 'POST' && url === '/api/service/install-system-wide') {
+                return await this.handleInstallSystemWide(res);
+            }
+            if (req.method === 'POST' && url === '/api/service/decline-system-wide') {
+                return await this.handleDeclineSystemWide(res);
             }
 
             res.writeHead(404);
@@ -637,6 +645,49 @@ export class ServiceApi {
         };
         res.writeHead(200);
         res.end(JSON.stringify(body));
+        return true;
+    }
+
+    private async handleInstallSystemWide(res: ServerResponse): Promise<boolean> {
+        if (process.platform !== 'linux') {
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: false, error: 'machine-wide install is linux-only', reason: 'unsupported' }));
+            return true;
+        }
+        const appImage = process.env['APPIMAGE'];
+        if (!appImage) {
+            res.writeHead(400);
+            res.end(JSON.stringify({ ok: false, error: 'not running from an AppImage ($APPIMAGE unset)', reason: 'unknown' }));
+            return true;
+        }
+        const version = getAppVersion();
+        const script = buildMachineWideInstallScript({ sourceAppImage: appImage, version });
+        try {
+            await this.runPkexecFn(script, 'install-system-wide');
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: true, status: 'installed' }));
+        } catch (err) {
+            const msg = (err as Error).message;
+            const declined = /dismissed/i.test(msg);
+            res.writeHead(declined ? 403 : 500);
+            res.end(JSON.stringify({ ok: false, error: msg, reason: declined ? 'uac-declined' : 'unknown' }));
+        }
+        return true;
+    }
+
+    private async handleDeclineSystemWide(res: ServerResponse): Promise<boolean> {
+        const cfg = Config.getInstance();
+        const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+        const marker = path.join(dataRoot, 'control', DECLINE_MARKER_NAME);
+        try {
+            fs.mkdirSync(path.dirname(marker), { recursive: true });
+            fs.writeFileSync(marker, '', 'utf8');
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: true, status: 'declined' }));
+        } catch (err) {
+            res.writeHead(500);
+            res.end(JSON.stringify({ ok: false, error: (err as Error).message, reason: 'unknown' }));
+        }
         return true;
     }
 

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -30,6 +30,16 @@ import { readJsonBody } from './utils';
 const log = Logger.for('ServiceApi');
 
 /**
+ * Returns true when a beta.40-era system-scope install used the legacy
+ * `/opt/ws-scrcpy-web/data` state layout and should be migrated to
+ * `/var/opt`. Either signal is sufficient: an explicit DATA_ROOT env that
+ * points at the old path, OR the old directory still existing on disk.
+ */
+export function systemServiceNeedsMigration(input: { dataRootEnv?: string; oldDataDirExists: boolean }): boolean {
+    return input.dataRootEnv === '/opt/ws-scrcpy-web/data' || input.oldDataDirExists;
+}
+
+/**
  * HTTP API for SP3 P3 service-mode operations.
  *
  *   GET  /api/service/status     -> ServiceStatusResponse (always 200)
@@ -144,13 +154,16 @@ export class ServiceApi {
         //     users" modal once the user has declined it (persistent marker).
         // Both go through the injected existsCheck so the API stays unit-testable.
         // Spread conditionally (like scope/diskWebPort) so they're Linux-only.
-        let machineWide: { machineWideInstalled: boolean; systemInstallDeclined: boolean } | null = null;
+        let machineWide: { machineWideInstalled: boolean; systemInstallDeclined: boolean; serviceMigrationNeeded: boolean } | null = null;
         if (result.platform === 'linux') {
             const cfg = Config.getInstance();
             const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
             machineWide = {
                 machineWideInstalled: this.existsCheck(`${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`),
                 systemInstallDeclined: this.existsCheck(path.join(dataRoot, 'control', DECLINE_MARKER_NAME)),
+                serviceMigrationNeeded: systemServiceNeedsMigration({
+                    oldDataDirExists: this.existsCheck('/opt/ws-scrcpy-web/data'),
+                }),
             };
         }
         const body: ServiceStatusResponse = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,7 +13,7 @@ import { WhoamiApi } from './api/WhoamiApi';
 import { Config } from './Config';
 import { UpdateService } from './UpdateService';
 import { DependencyManager } from './DependencyManager';
-import { findAvailablePort } from './PortPicker';
+import { findAvailablePort, webPortOverride } from './PortPicker';
 import { DeviceLabelStore } from './DeviceLabelStore';
 import { DeviceProbe } from './DeviceProbe';
 import { Logger } from './Logger';
@@ -65,8 +65,10 @@ const config = Config.getInstance();
 // port is found (range = configured..+99). On shift, persist the new port and
 // flip portWasAutoShifted in firstRunStatus.
 async function reconcileWebPort(): Promise<void> {
-    const desired = config.getAppConfig().webPort;
-    const found = await findAvailablePort(desired, desired + 99);
+    const override = webPortOverride(process.env['WS_SCRCPY_WEB_PORT']);
+    const desired = override ?? config.getAppConfig().webPort;
+    // An override (Phase 2 relaunch) forces the EXACT free port; else walk forward to auto-shift.
+    const found = await findAvailablePort(desired, override !== null ? desired : desired + 99);
     if (found === null) {
         Logger.for('Server').error(`No free port available in range ${desired}..${desired + 99}`);
         return;

--- a/src/server/service/ServiceClient.ts
+++ b/src/server/service/ServiceClient.ts
@@ -99,8 +99,8 @@ export interface ServiceInstallOptions {
     sourceDeps?: string | undefined;
 
     /**
-     * Linux system-scope only (#36): the config.json seeded into the staged
-     * `/opt/ws-scrcpy-web/data` dir so the service boots with a correct,
+     * Linux system-scope only (#36): the config.json seeded into the FHS state
+     * dir `/var/opt/ws-scrcpy-web` so the service boots with a correct,
      * persistent config (system-service mode, first-run-complete, the user's
      * web port) instead of a fresh one in ephemeral /tmp. Ignored elsewhere.
      */

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript } from './SystemdClient';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -175,5 +175,24 @@ describe('renderUnitFile', () => {
         expect(unitSection).toContain('StartLimitBurst=3');
         expect(serviceSection).not.toContain('StartLimitIntervalSec');
         expect(serviceSection).not.toContain('StartLimitBurst');
+    });
+});
+
+describe('buildMachineWideInstallScript', () => {
+    it('machine-wide install stages just the binary + label + desktop + VERSION', () => {
+        const s = buildMachineWideInstallScript(
+            { sourceAppImage: '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage', version: '0.1.31-beta.1' },
+            (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+        );
+        expect(s).toContain('mkdir -p /opt/ws-scrcpy-web');
+        expect(s).toContain('cp "/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(s).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(s).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+        expect(s).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
+        expect(s).toContain('/opt/ws-scrcpy-web/VERSION');
+        expect(s).toContain('/usr/share/applications/ws-scrcpy-web.desktop');   // SYSTEM-WIDE menu (all users)
+        expect(s).toContain('Exec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');     // every user launches the shared /opt binary
+        expect(s).not.toContain('dependencies');   // binary only — deps stay per-user ~/.local
+        expect(s).not.toContain('systemctl');      // no service install here
     });
 });

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv } from './SystemdClient';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -104,24 +104,45 @@ describe('buildSystemInstallScript', () => {
             name: 'WsScrcpyWeb',
         });
         // writable state dir + deps dir created
-        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web/data');
+        expect(script).toContain('mkdir -p /var/opt/ws-scrcpy-web');
         expect(script).toContain('mkdir -p /opt/ws-scrcpy-web/dependencies');
         // deps copied from the user's dir into the app's OWN /opt tree (Local-Deps)
         expect(script).toContain('cp -a "/home/u/.local/share/WsScrcpyWeb/dependencies/." "/opt/ws-scrcpy-web/dependencies/"');
-        // seed config written into the data dir
-        expect(script).toContain('cp "/tmp/WsScrcpyWeb.seed.json" "/opt/ws-scrcpy-web/data/config.json"');
-        // data dir gets the writable var_lib_t label (more-specific beats the tree's bin_t)
-        expect(script).toContain("semanage fcontext -a -t var_lib_t '/opt/ws-scrcpy-web/data(/.*)?'");
+        // seed config written into the state dir (FHS /var/opt)
+        expect(script).toContain('cp "/tmp/WsScrcpyWeb.seed.json" "/var/opt/ws-scrcpy-web/config.json"');
+        // state dir gets the writable var_lib_t label (more-specific beats the tree's bin_t)
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
         // deps + seed land before the relabel so restorecon labels them correctly
         expect(script.indexOf('config.json')).toBeLessThan(script.indexOf('restorecon -Rv'));
     });
 
-    it('always prepares the writable data dir, but omits deps-copy + seed when not provided', () => {
+    it('always prepares the writable state dir, but omits deps-copy + seed when not provided', () => {
         const script = buildSystemInstallScript(args);
-        expect(script).toContain('mkdir -p /opt/ws-scrcpy-web/data');
-        expect(script).toContain("semanage fcontext -a -t var_lib_t '/opt/ws-scrcpy-web/data(/.*)?'");
+        expect(script).toContain('mkdir -p /var/opt/ws-scrcpy-web');
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
         expect(script).not.toContain('cp -a');
-        expect(script).not.toContain('/data/config.json');
+        expect(script).not.toContain('config.json');
+    });
+});
+
+describe('SYSTEM_STATE_DIR — FHS /var/opt retargeting', () => {
+    it('system-scope unit env points DATA_ROOT at /var/opt (not /opt/.../data)', () => {
+        const env = buildServiceUnitEnv('linux', 'system', '/home/u/.local/share/WsScrcpyWeb/dependencies');
+        expect(env['DATA_ROOT']).toBe('/var/opt/ws-scrcpy-web');
+        expect(env['DEPS_PATH']).toBe('/opt/ws-scrcpy-web/dependencies');
+    });
+
+    it('system install seeds config + labels state under /var/opt (var_lib_t)', () => {
+        const script = buildSystemInstallScript(
+            { sourceAppImage: '/home/u/App.AppImage', seedConfigTmpPath: '/tmp/seed.json',
+              unitTmpPath: '/tmp/u.service', unitPath: '/etc/systemd/system/WsScrcpyWeb.service', name: 'WsScrcpyWeb' },
+            (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+        );
+        expect(script).toContain('mkdir -p /var/opt/ws-scrcpy-web');
+        expect(script).toContain('cp "/tmp/seed.json" "/var/opt/ws-scrcpy-web/config.json"');
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+        expect(script).not.toContain('/opt/ws-scrcpy-web/data');
     });
 });
 

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript, buildSystemMigrationScript, buildSystemSeedConfig } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript, buildMachineWideUpdateScript, buildSystemMigrationScript, buildSystemSeedConfig } from './SystemdClient';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -194,6 +194,71 @@ describe('buildMachineWideInstallScript', () => {
         expect(s).toContain('Exec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');     // every user launches the shared /opt binary
         expect(s).not.toContain('dependencies');   // binary only — deps stay per-user ~/.local
         expect(s).not.toContain('systemctl');      // no service install here
+    });
+});
+
+describe('buildMachineWideUpdateScript', () => {
+    // Phase 3 — machine-wide-no-service in-app update. The user runs the
+    // root-owned /opt AppImage directly (NOT a service), so the swap needs ONE
+    // pkexec. A `cp` over /opt would ETXTBSY the running file, so the swap is a
+    // RENAME (the old inode stays alive for the running process; renames work
+    // while the AppImage is mounted). The new file gets re-labelled bin_t + a
+    // fresh VERSION.
+    const args = {
+        stagedAppImage:
+            '/home/u/.local/share/WsScrcpyWeb/control/update-staging/WsScrcpyWeb-linux-beta.AppImage.new',
+        version: '0.1.31-beta.2',
+    };
+
+    it('rename-swaps the /opt AppImage (old→.bak, staged→/opt), chmods, relabels best-effort, writes VERSION', () => {
+        const s = buildMachineWideUpdateScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        // 1. back up the RUNNING /opt binary by RENAME (cp would ETXTBSY it).
+        expect(s).toContain(
+            '/usr/bin/mv -f "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage.bak"',
+        );
+        // 2. move the staged download into place (rename, not cp).
+        expect(s).toContain(
+            `/usr/bin/mv -f "${args.stagedAppImage}" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`,
+        );
+        // 3. chmod the new binary executable.
+        expect(s).toContain('/usr/bin/chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        // 4. re-apply the bin_t label best-effort: restorecon (persistent rule),
+        //    chcon fallback, trailing `|| true` so a non-SELinux host still writes VERSION.
+        expect(s).toContain('/usr/sbin/restorecon -v "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(s).toContain('/usr/bin/chcon -t bin_t "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        // 5. write the new VERSION marker.
+        expect(s).toContain(`/usr/bin/printf '%s' '0.1.31-beta.2' > /opt/ws-scrcpy-web/VERSION`);
+    });
+
+    it('NEVER cp the AppImage (cp overwrites in place → ETXTBSY on the running file)', () => {
+        const s = buildMachineWideUpdateScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        expect(s).not.toMatch(/\bcp\b/);
+    });
+
+    it('orders the steps: backup-rename → staged-rename → chmod → relabel → VERSION', () => {
+        const s = buildMachineWideUpdateScript(args);
+        const backup = s.indexOf('.bak');
+        const stagedMove = s.indexOf(args.stagedAppImage);
+        const chmod = s.indexOf('chmod 0755');
+        const relabel = s.indexOf('restorecon -v');
+        const version = s.indexOf('VERSION');
+        expect(backup).toBeGreaterThanOrEqual(0);
+        expect(backup).toBeLessThan(stagedMove);
+        expect(stagedMove).toBeLessThan(chmod);
+        expect(chmod).toBeLessThan(relabel);
+        expect(relabel).toBeLessThan(version);
+    });
+
+    it('relabel is best-effort — restorecon → chcon → || true in one subshell (never aborts the && chain)', () => {
+        const s = buildMachineWideUpdateScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        expect(s).toMatch(/\(\s*\/usr\/sbin\/restorecon -v "[^"]+" \|\| \/usr\/bin\/chcon -t bin_t "[^"]+" \|\| true\s*\)/);
+    });
+
+    it('uses absolute tool paths (no bare names) when resolvers are injected', () => {
+        const s = buildMachineWideUpdateScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        expect(s).toContain('/usr/bin/mv -f');
+        expect(s).toContain('/usr/bin/printf');
+        expect(s).toContain('/usr/sbin/restorecon');
     });
 });
 

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, buildSystemInstallScript, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript, buildSystemMigrationScript, buildSystemSeedConfig } from './SystemdClient';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -194,5 +194,72 @@ describe('buildMachineWideInstallScript', () => {
         expect(s).toContain('Exec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');     // every user launches the shared /opt binary
         expect(s).not.toContain('dependencies');   // binary only — deps stay per-user ~/.local
         expect(s).not.toContain('systemctl');      // no service install here
+    });
+});
+
+describe('buildSystemMigrationScript', () => {
+    const args = {
+        seedConfigJson: JSON.stringify(buildSystemSeedConfig(8000)),
+        unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
+        unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
+        name: 'WsScrcpyWeb',
+    };
+
+    it('old-cleanup: stops + disables + reset-failed the unit, rm -rf the legacy /opt/.../data, deletes the legacy fcontext rule', () => {
+        const script = buildSystemMigrationScript(args);
+        expect(script).toContain('systemctl stop WsScrcpyWeb.service');
+        expect(script).toContain('systemctl disable WsScrcpyWeb.service');
+        expect(script).toContain('systemctl reset-failed WsScrcpyWeb.service');
+        expect(script).toContain('rm -rf /opt/ws-scrcpy-web/data');
+        expect(script).toContain("semanage fcontext -d '/opt/ws-scrcpy-web/data(/.*)?'");
+    });
+
+    it('new-setup: mkdir /var/opt, seeds config.json there, adds var_lib_t + restorecon, installs the unit, daemon-reload, enable --now', () => {
+        const script = buildSystemMigrationScript(args);
+        expect(script).toContain('mkdir -p /var/opt/ws-scrcpy-web');
+        expect(script).toContain('/var/opt/ws-scrcpy-web/config.json');
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+        expect(script).toContain('cp "/tmp/WsScrcpyWeb.service.tmp" "/etc/systemd/system/WsScrcpyWeb.service"');
+        expect(script).toContain('systemctl daemon-reload');
+        expect(script).toContain('systemctl enable --now WsScrcpyWeb.service');
+    });
+
+    it('carries the seeded webPort into /var/opt/.../config.json', () => {
+        const script = buildSystemMigrationScript(args);
+        expect(script).toContain('"webPort":8000');
+        // the config.json write lands BEFORE the relabel so restorecon labels it var_lib_t
+        expect(script.indexOf('config.json')).toBeLessThan(script.indexOf('restorecon -Rv'));
+    });
+
+    it('does NOT re-copy the AppImage or deps — the binary stays in /opt', () => {
+        const script = buildSystemMigrationScript(args);
+        // no cp of the binary / deps — migration only relocates state + unit
+        expect(script).not.toContain('WsScrcpyWeb.AppImage');
+        expect(script).not.toContain('cp -a');
+    });
+
+    it('old cleanup runs before the new-layout setup', () => {
+        const script = buildSystemMigrationScript(args);
+        expect(script.indexOf('rm -rf /opt/ws-scrcpy-web/data'))
+            .toBeLessThan(script.indexOf('mkdir -p /var/opt/ws-scrcpy-web'));
+        expect(script.indexOf('mkdir -p /var/opt/ws-scrcpy-web'))
+            .toBeLessThan(script.indexOf('enable --now'));
+    });
+
+    it('cleanup steps are best-effort (|| true) so a stopped/non-SELinux host still migrates', () => {
+        const script = buildSystemMigrationScript(args);
+        // stop/disable/reset-failed + the legacy fcontext delete must not abort the && chain
+        expect(script).toContain('|| true');
+        // the unit install still happens after the best-effort SELinux relabel
+        expect(script.indexOf('cp "/tmp/WsScrcpyWeb.service.tmp"'))
+            .toBeGreaterThan(script.indexOf('restorecon -Rv'));
+    });
+
+    it('uses absolute tool paths (no bare names)', () => {
+        const script = buildSystemMigrationScript(args, (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`);
+        expect(script).toContain('/usr/bin/systemctl daemon-reload');
+        expect(script).toContain('/usr/sbin/restorecon -Rv');
+        expect(script).toContain('/usr/sbin/semanage fcontext -d');
     });
 });

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -84,6 +84,10 @@ export const STAGED_SYSTEM_HELPER = 'ws-scrcpy-web-launcher.exe';
  * NOT reach this tree — it gets its own `restorecon -Rv` step at install (#36).
  */
 export const SYSTEM_STATE_DIR = '/var/opt/ws-scrcpy-web';
+/** VERSION file written into /opt at machine-wide install (binary-only relocate). */
+export const SYSTEM_OPT_VERSION_FILE = `${STAGED_SYSTEM_DIR}/VERSION`;
+/** System-wide .desktop entry for all users (machine-wide install only). */
+export const SYSTEM_DESKTOP_FILE = '/usr/share/applications/ws-scrcpy-web.desktop';
 /**
  * Root-owned dependencies dir for the system-scope service (node/adb/
  * scrcpy-server). Under the bin_t-labelled /opt tree so init_t may exec them,
@@ -339,6 +343,47 @@ export function buildSystemInstallScript(
         `${systemctl} enable --now ${args.name}.service`,
     );
     return steps.join(' && ');
+}
+
+/**
+ * Build the privileged shell script for a machine-wide install. Runs under a
+ * single pkexec prompt. Relocates ONLY the AppImage binary to /opt (no deps,
+ * no systemd unit) — deps stay per-user in ~/.local. Writes VERSION, drops a
+ * system-wide .desktop entry for all users, and refreshes the menu cache.
+ * `binTool`/`sbinTool` are injectable for testing; production resolves absolute
+ * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
+ */
+export function buildMachineWideInstallScript(
+    args: { sourceAppImage: string; version: string },
+    binTool: (t: string) => string = (t) => resolveSystemTool(t),
+    sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
+): string {
+    const staged = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const mkdir = binTool('mkdir');
+    const cp = binTool('cp');
+    const chmod = binTool('chmod');
+    const chcon = binTool('chcon');
+    const printf = binTool('printf');
+    const semanage = sbinTool('semanage');
+    const restorecon = sbinTool('restorecon');
+    const updateDesktopDb = binTool('update-desktop-database');
+    const desktop = [
+        '[Desktop Entry]',
+        'Type=Application',
+        'Name=ws-scrcpy-web',
+        `Exec=${staged}`,
+        'Icon=ws-scrcpy-web',
+        'Categories=Utility;',
+    ].join('\\n');
+    return [
+        `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
+        `${cp} "${args.sourceAppImage}" "${staged}"`,
+        `${chmod} 0755 "${staged}"`,
+        `${printf} '%s' '${args.version}' > ${SYSTEM_OPT_VERSION_FILE}`,
+        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        `( ${printf} '${desktop}\\n' > ${SYSTEM_DESKTOP_FILE} || true )`,
+        `( ${updateDesktopDb} /usr/share/applications || true )`,
+    ].join(' && ');
 }
 
 /**

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -78,11 +78,12 @@ export const STAGED_SYSTEM_APPIMAGE = 'WsScrcpyWeb.AppImage';
 export const STAGED_SYSTEM_HELPER = 'ws-scrcpy-web-launcher.exe';
 
 /**
- * Root-owned writable state dir for the system-scope service (config.json,
- * logs/). A MORE-SPECIFIC fcontext (`…/data → var_lib_t`) overrides the dir's
- * general bin_t rule so the service may write here under SELinux (#36).
+ * FHS-correct writable state dir for the system-scope service (config.json,
+ * logs/). Lives under `/var/opt` (outside `/opt`) so it is writable by root
+ * and correctly labelled `var_lib_t` by SELinux. The `/opt` restorecon does
+ * NOT reach this tree — it gets its own `restorecon -Rv` step at install (#36).
  */
-export const STAGED_SYSTEM_DATA_DIR = `${STAGED_SYSTEM_DIR}/data`;
+export const SYSTEM_STATE_DIR = '/var/opt/ws-scrcpy-web';
 /**
  * Root-owned dependencies dir for the system-scope service (node/adb/
  * scrcpy-server). Under the bin_t-labelled /opt tree so init_t may exec them,
@@ -104,7 +105,7 @@ export function buildServiceUnitEnv(
     userDepsPath: string,
 ): Record<string, string> {
     if (platform === 'linux' && scope === 'system') {
-        return { DATA_ROOT: STAGED_SYSTEM_DATA_DIR, DEPS_PATH: STAGED_SYSTEM_DEPS_DIR };
+        return { DATA_ROOT: SYSTEM_STATE_DIR, DEPS_PATH: STAGED_SYSTEM_DEPS_DIR };
     }
     return { DEPS_PATH: userDepsPath };
 }
@@ -291,11 +292,13 @@ export function buildSystemInstallScript(
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
     const steps: string[] = [
-        // 1. stage dirs: the /opt root + the writable data dir (always — the
-        //    system service writes its config + logs there). The deps dir is
-        //    added below only when we have deps to copy.
+        // 1. stage dirs: the /opt root for binaries + deps, plus the FHS-correct
+        //    writable state dir at /var/opt (always — the system service writes
+        //    its config + logs there). The /opt restorecon does NOT reach /var/opt,
+        //    so the state dir gets its own restorecon step below.
+        //    The deps dir is added below only when we have deps to copy.
         `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
-        `${mkdir} -p ${STAGED_SYSTEM_DATA_DIR}`,
+        `${mkdir} -p ${SYSTEM_STATE_DIR}`,
         `${cp} "${args.sourceAppImage}" "${staged}"`,
         `${chmod} 0755 "${staged}"`,
     ];
@@ -317,7 +320,7 @@ export function buildSystemInstallScript(
     //     config on first boot (system-service mode, first-run-complete, the
     //     user's web port). Written before restorecon so it gets var_lib_t.
     if (args.seedConfigTmpPath) {
-        steps.push(`${cp} "${args.seedConfigTmpPath}" "${STAGED_SYSTEM_DATA_DIR}/config.json"`);
+        steps.push(`${cp} "${args.seedConfigTmpPath}" "${SYSTEM_STATE_DIR}/config.json"`);
     }
     steps.push(
         // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
@@ -329,7 +332,7 @@ export function buildSystemInstallScript(
         //    erroring on a non-SELinux fs) would break the outer `&&` chain and
         //    silently skip the unit cp + enable below.
         //    restorecon covers the whole dir — labels the helper bin_t too when present.
-        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${semanage} fcontext -a -t var_lib_t '${STAGED_SYSTEM_DATA_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         // 3. install + enable the unit (ExecStart already points at ${staged})
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
         `${systemctl} daemon-reload`,

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -126,12 +126,15 @@ export function buildSystemSeedConfig(currentWebPort: number): Record<string, un
     return { installMode: 'system-service', firstRunComplete: true, webPort: currentWebPort };
 }
 
+/** Per-user decline marker filename — no leading slash, relative to <dataRoot>/control/. */
+export const DECLINE_MARKER_NAME = 'system-install-declined';
+
 /**
  * Run a command via pkexec for graphical privilege escalation. The user
  * sees a single password prompt for the entire shell command. Throws on
  * auth-cancel (exit 126), pkexec-not-found, or command failure.
  */
-async function runPkexec(shellCmd: string, label: string): Promise<string> {
+export async function runPkexec(shellCmd: string, label: string): Promise<string> {
     try {
         const { stdout } = await execFileAsync(resolveSystemTool('pkexec'), ['sh', '-c', shellCmd], {
             encoding: 'utf8',

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -389,6 +389,56 @@ export function buildMachineWideInstallScript(
     ].join(' && ');
 }
 
+/**
+ * Build the privileged shell script for an in-app update of a machine-wide-
+ * no-service install (the user runs the root-owned `/opt` AppImage directly,
+ * NOT a service). Runs under a single pkexec prompt.
+ *
+ * The swap is a RENAME, never a `cp`: `cp` overwrites the file in place, which
+ * fails with `ETXTBSY` on the running AppImage. A rename works while the old
+ * AppImage is still mounted — the old inode stays alive for the running process,
+ * and the new file lands at the same path for the next launch:
+ *
+ *   1. `mv -f <opt>/WsScrcpyWeb.AppImage <opt>/WsScrcpyWeb.AppImage.bak` — back up
+ *      the running binary (rollback). The live process keeps its mounted inode.
+ *   2. `mv -f <staged> <opt>/WsScrcpyWeb.AppImage` — move the verified download in.
+ *   3. `chmod 0755` the new file.
+ *   4. re-apply the `bin_t` label best-effort — `restorecon` re-applies the
+ *      persistent fcontext rule set at machine-wide install; `chcon -t bin_t` is
+ *      the transient fallback; the trailing `|| true` keeps a non-SELinux host
+ *      going (mirrors linux_apply.rs::relabel_command, which relabels the single
+ *      swapped file with `restorecon -v` / `chcon -t bin_t`).
+ *   5. `printf` the new VERSION marker into `/opt/ws-scrcpy-web/VERSION`.
+ *
+ * The relaunch is NOT part of this script — it must run as the user (not under
+ * pkexec, which would come back as root). The caller spawns a separate detached
+ * relaunch-only helper that waits for the old process to exit (releasing the
+ * per-user flock) before relaunching the freshly-swapped `/opt` copy.
+ *
+ * `binTool`/`sbinTool` are injectable for testing; production resolves absolute
+ * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
+ */
+export function buildMachineWideUpdateScript(
+    args: { stagedAppImage: string; version: string },
+    binTool: (t: string) => string = (t) => resolveSystemTool(t),
+    sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
+): string {
+    const target = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+    const backup = `${target}.bak`;
+    const mv = binTool('mv');
+    const chmod = binTool('chmod');
+    const chcon = binTool('chcon');
+    const printf = binTool('printf');
+    const restorecon = sbinTool('restorecon');
+    return [
+        `${mv} -f "${target}" "${backup}"`,
+        `${mv} -f "${args.stagedAppImage}" "${target}"`,
+        `${chmod} 0755 "${target}"`,
+        `( ${restorecon} -v "${target}" || ${chcon} -t bin_t "${target}" || true )`,
+        `${printf} '%s' '${args.version}' > ${SYSTEM_OPT_VERSION_FILE}`,
+    ].join(' && ');
+}
+
 /** Legacy beta.40 system-scope state dir (pre-/var/opt). Migrated away by
  *  buildSystemMigrationScript — `rm -rf`'d and its fcontext rule deleted. */
 export const LEGACY_SYSTEM_DATA_DIR = `${STAGED_SYSTEM_DIR}/data`;

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -389,6 +389,93 @@ export function buildMachineWideInstallScript(
     ].join(' && ');
 }
 
+/** Legacy beta.40 system-scope state dir (pre-/var/opt). Migrated away by
+ *  buildSystemMigrationScript — `rm -rf`'d and its fcontext rule deleted. */
+export const LEGACY_SYSTEM_DATA_DIR = `${STAGED_SYSTEM_DIR}/data`;
+
+/**
+ * Build the privileged shell script for a one-shot system-scope MIGRATION from
+ * the legacy beta.40 `/opt/ws-scrcpy-web/data` state layout to the FHS-correct
+ * `/var/opt/ws-scrcpy-web` layout. Runs under a single pkexec prompt.
+ *
+ * The /opt AppImage + deps are ALREADY staged and STAY PUT — this script only
+ * relocates the writable state dir, fixes the SELinux fcontext rules, and
+ * reinstalls the unit with `DATA_ROOT=/var/opt`. It does NOT re-copy the
+ * AppImage or deps (avoids the out-of-process uninstall→reinstall coordination
+ * problem: nothing is torn down except the unit + the old state dir).
+ *
+ * Two phases, `&&`-joined under one prompt:
+ *   1. OLD cleanup — best-effort (`|| true`): a stopped/disabled/not-failed unit
+ *      or a non-SELinux host must NOT abort the migration. stop + disable +
+ *      reset-failed the unit; `rm -rf` the legacy `/opt/.../data` state; delete
+ *      the legacy `var_lib_t` fcontext rule on `/opt/.../data`.
+ *   2. NEW setup — authoritative (a failure aborts so we never `enable` a broken
+ *      unit): mkdir the `/var/opt` state dir (+ logs/ for the unit's append:),
+ *      seed `config.json` there (carries webPort + installMode=system-service),
+ *      add the `var_lib_t` fcontext rule + restorecon (best-effort SELinux
+ *      subshell with a chcon transient fallback, mirroring
+ *      buildSystemInstallScript), install the new unit, daemon-reload, enable.
+ *
+ * `binTool`/`sbinTool` are injectable for testing; production resolves absolute
+ * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
+ */
+export function buildSystemMigrationScript(
+    args: {
+        /** Pre-stringified seed config (JSON) written inline to the new config.json. */
+        seedConfigJson: string;
+        /** Tmp path holding the freshly-rendered new (DATA_ROOT=/var/opt) unit body. */
+        unitTmpPath: string;
+        /** Destination unit path, e.g. /etc/systemd/system/WsScrcpyWeb.service. */
+        unitPath: string;
+        /** Canonical service name (e.g. 'WsScrcpyWeb'). */
+        name: string;
+    },
+    binTool: (t: string) => string = (t) => resolveSystemTool(t),
+    sbinTool: (t: string) => string = (t) => resolveSystemTool(t),
+): string {
+    const mkdir = binTool('mkdir');
+    const cp = binTool('cp');
+    const rm = binTool('rm');
+    const printf = binTool('printf');
+    const chcon = binTool('chcon');
+    const systemctl = binTool('systemctl');
+    const semanage = sbinTool('semanage');
+    const restorecon = sbinTool('restorecon');
+    const stateLogs = `${SYSTEM_STATE_DIR}/logs`;
+    return [
+        // ── 1. OLD cleanup (best-effort) ──────────────────────────────────────
+        // stop/disable/reset-failed may each fail benignly (unit not loaded /
+        // already disabled / not failed); `|| true` keeps the `&&` chain alive so
+        // the migration still proceeds to the new-layout setup. POSIX sh gives
+        // `&&`/`||` EQUAL left-assoc precedence, so `A || true && B` => `((A||true)&&B)`.
+        `${systemctl} stop ${args.name}.service || true`,
+        `${systemctl} disable ${args.name}.service || true`,
+        `${systemctl} reset-failed ${args.name}.service || true`,
+        // rm -rf is idempotent (exit 0 even when absent); drop the legacy state tree.
+        `${rm} -rf ${LEGACY_SYSTEM_DATA_DIR}`,
+        // delete the legacy var_lib_t rule on /opt/.../data — best-effort subshell
+        // (rule may be absent / host non-SELinux), isolated so it can't break the chain.
+        `( ${semanage} fcontext -d '${LEGACY_SYSTEM_DATA_DIR}(/.*)?' || true )`,
+        // ── 2. NEW setup (authoritative) ──────────────────────────────────────
+        // create the FHS state dir (+ logs/ so the unit's StandardOutput append:
+        // target's parent exists before enable --now starts the service).
+        `${mkdir} -p ${stateLogs}`,
+        // seed config.json inline (no tmp-seed file → atomic, and the carried
+        // webPort is auditable in the script). Written BEFORE the relabel so
+        // restorecon labels it var_lib_t.
+        `${printf} '%s' '${args.seedConfigJson}' > ${SYSTEM_STATE_DIR}/config.json`,
+        // label the state dir var_lib_t + restorecon. Best-effort subshell with a
+        // chcon transient fallback + trailing `|| true` so a non-SELinux host still
+        // proceeds to install the unit — mirrors buildSystemInstallScript.
+        `( ( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t var_lib_t "${SYSTEM_STATE_DIR}" || true )`,
+        // reinstall the unit (ExecStart still points at the in-place /opt AppImage;
+        // env now carries DATA_ROOT=/var/opt) + reload + enable.
+        `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
+        `${systemctl} daemon-reload`,
+        `${systemctl} enable --now ${args.name}.service`,
+    ].join(' && ');
+}
+
 /**
  * Resolve the absolute path of the tray helper binary.
  *


### PR DESCRIPTION
Brings Windows PerMachine-style machine-wide install to Linux. Merges the path2-machine-wide-install branch (24 code commits; brainstorm -> spec -> plan -> subagent-driven TDD) so it can be cut as a published beta and smoke-tested on Fedora.

## What is in it

- Phase 1 (Foundation): /opt machine-wide install (binary-only relocate via one pkexec + system-wide .desktop), home AppImage bootstrapper execs /opt, /var/opt (FHS) variable state, per-user flock single-instance (replaces the Linux no-op stub), local-launch service-defer, system-service install gated on machine-wide install + first-run modal.
- Phase 2 (Relaunch): loginctl active-session discovery -> systemd-run --uid relaunch on the service port (Linux analog of Windows WTSEnumerateSessionsW); WS_SCRCPY_WEB_PORT exact-bind override.
- Phase 3 (Updates/migration): system-service updates run prompt-free as root; machine-wide-no-service updates via one pkexec (rename-swap, avoids ETXTBSY) + relaunch-after-exit; version-aware bootstrapper; one-pkexec /opt/.../data -> /var/opt migration; migration + update UI offers.

## Verification

- Green at unit/compile/type only: tsc --noEmit 0; vitest 881; launcher cross test 99 + 1; cross clippy -D warnings clean.
- NOT yet runtime-verified. The Fedora (SELinux enforcing) smoke runs against the published beta this PR cuts.

Labeled release:beta -> auto-release cuts v0.1.30-beta.41.

Specs/plans are included on the branch under docs/specs/ + docs/plans/ (2026-06-05).