### PR TITLE
fix(ui): forced-choice system-wide install prompt with clearer copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Linux "install for all users?" first-run prompt has clearer copy and now requires an explicit choice.** The body spells out both paths — clicking "yes, all users" installs the app to `/opt` with one administrator prompt; clicking "no, me only" leaves it running from wherever you launch it — and the two buttons are labelled to match. The dialog can no longer be dismissed without deciding: the close (×) button is removed and Escape / clicking outside the dialog are ignored, so it no longer silently reappears on the next launch after an accidental dismissal.
+
 ## [0.1.30-beta.41] - 2026-06-05
 
 ### Added

--- a/src/app/client/SystemWideInstallModal.ts
+++ b/src/app/client/SystemWideInstallModal.ts
@@ -2,12 +2,12 @@ import { Modal } from '../ui/Modal';
 
 export interface SystemWideInstallModalOptions {
     /**
-     * Called when the user clicks "install for all users". The caller is
+     * Called when the user clicks "yes, all users". The caller is
      * responsible for initiating the machine-wide install flow.
      */
     onInstall: () => void;
     /**
-     * Called when the user clicks "not now". The caller can record the
+     * Called when the user clicks "no, me only". The caller can record the
      * decline so the modal is not shown again this session.
      */
     onDecline: () => void;
@@ -18,9 +18,10 @@ export interface SystemWideInstallModalOptions {
  * /opt). Shown once per session when the install-gate determines the app
  * is not yet installed system-wide and the user hasn't previously declined.
  *
- * Two actions:
- *   - "install for all users" → calls onInstall, then closes.
- *   - "not now"              → calls onDecline, then closes.
+ * Forced choice (dismissible: false) — no ×, and Escape / backdrop clicks are
+ * ignored; the user must pick one of:
+ *   - "yes, all users" → calls onInstall, then closes.
+ *   - "no, me only"    → calls onDecline, then closes.
  *
  * Mirrors WelcomeModal: same base class, same DOM-construction helpers,
  * same queueMicrotask body-fill pattern, same lowercase copy convention.
@@ -31,7 +32,7 @@ export class SystemWideInstallModal extends Modal {
     private declineBtn!: HTMLButtonElement;
 
     constructor(options: SystemWideInstallModalOptions) {
-        super({ title: 'install for all users?' });
+        super({ title: 'install for all users?', dismissible: false });
         this.opts = options;
         this.dialog.classList.add('system-wide-install-modal');
         // Defer body fill past class-field init phase (ES2022 useDefineForClassFields).
@@ -46,18 +47,28 @@ export class SystemWideInstallModal extends Modal {
     }
 
     private fillBody(container: HTMLElement): void {
-        const body = document.createElement('p');
-        body.style.cssText = 'margin: 0 0 16px;';
-        body.textContent =
-            'run ws-scrcpy-web for all users on this machine? installs the app to /opt with one administrator prompt. ' +
-            'you can keep using it just for yourself instead.';
-        container.appendChild(body);
+        const question = document.createElement('p');
+        question.style.cssText = 'margin: 0 0 12px;';
+        question.textContent = 'run ws-scrcpy-web for all users on this machine?';
+        container.appendChild(question);
+
+        const yesLine = document.createElement('p');
+        yesLine.style.cssText = 'margin: 0 0 12px;';
+        yesLine.textContent =
+            'clicking "yes, all users" installs the app to /opt with one administrator prompt.';
+        container.appendChild(yesLine);
+
+        const noLine = document.createElement('p');
+        noLine.style.cssText = 'margin: 0 0 16px;';
+        noLine.textContent =
+            'clicking "no, me only" will leave the application running from wherever you launch it from.';
+        container.appendChild(noLine);
 
         const buttons = document.createElement('div');
         buttons.style.cssText = 'display: flex; gap: 12px; justify-content: flex-end; flex-wrap: wrap;';
 
         this.installBtn = document.createElement('button');
-        this.installBtn.textContent = 'install for all users';
+        this.installBtn.textContent = 'yes, all users';
         this.installBtn.className = 'modal-button modal-button-primary';
         this.installBtn.addEventListener('click', () => {
             this.opts.onInstall();
@@ -66,7 +77,7 @@ export class SystemWideInstallModal extends Modal {
         buttons.appendChild(this.installBtn);
 
         this.declineBtn = document.createElement('button');
-        this.declineBtn.textContent = 'not now';
+        this.declineBtn.textContent = 'no, me only';
         this.declineBtn.className = 'modal-button';
         this.declineBtn.addEventListener('click', () => {
             this.opts.onDecline();

--- a/src/app/client/__tests__/SystemWideInstallModal.test.ts
+++ b/src/app/client/__tests__/SystemWideInstallModal.test.ts
@@ -37,53 +37,53 @@ describe('SystemWideInstallModal', () => {
         new SystemWideInstallModal({ onInstall, onDecline });
         // Wait one microtask so the queueMicrotask body-fill runs.
         await Promise.resolve();
-        getButton('install for all users');
-        getButton('not now');
+        getButton('yes, all users');
+        getButton('no, me only');
     });
 
-    it('clicking "install for all users" calls onInstall', async () => {
+    it('clicking "yes, all users" calls onInstall', async () => {
         const onInstall = vi.fn();
         const onDecline = vi.fn();
         new SystemWideInstallModal({ onInstall, onDecline });
         await Promise.resolve();
-        getButton('install for all users').click();
+        getButton('yes, all users').click();
         expect(onInstall).toHaveBeenCalledTimes(1);
         expect(onDecline).not.toHaveBeenCalled();
     });
 
-    it('clicking "not now" calls onDecline', async () => {
+    it('clicking "no, me only" calls onDecline', async () => {
         const onInstall = vi.fn();
         const onDecline = vi.fn();
         new SystemWideInstallModal({ onInstall, onDecline });
         await Promise.resolve();
-        getButton('not now').click();
+        getButton('no, me only').click();
         expect(onDecline).toHaveBeenCalledTimes(1);
         expect(onInstall).not.toHaveBeenCalled();
     });
 
-    it('clicking "install for all users" closes the modal', async () => {
+    it('clicking "yes, all users" closes the modal', async () => {
         const onInstall = vi.fn();
         const onDecline = vi.fn();
         new SystemWideInstallModal({ onInstall, onDecline });
         await Promise.resolve();
         const dialog = document.querySelector('dialog')!;
         expect(dialog.hasAttribute('open')).toBe(true);
-        getButton('install for all users').click();
+        getButton('yes, all users').click();
         expect(dialog.hasAttribute('open')).toBe(false);
     });
 
-    it('clicking "not now" closes the modal', async () => {
+    it('clicking "no, me only" closes the modal', async () => {
         const onInstall = vi.fn();
         const onDecline = vi.fn();
         new SystemWideInstallModal({ onInstall, onDecline });
         await Promise.resolve();
         const dialog = document.querySelector('dialog')!;
         expect(dialog.hasAttribute('open')).toBe(true);
-        getButton('not now').click();
+        getButton('no, me only').click();
         expect(dialog.hasAttribute('open')).toBe(false);
     });
 
-    it('body contains the required lowercase copy', async () => {
+    it('body contains the required lowercase copy for both paths', async () => {
         const onInstall = vi.fn();
         const onDecline = vi.fn();
         new SystemWideInstallModal({ onInstall, onDecline });
@@ -92,6 +92,7 @@ describe('SystemWideInstallModal', () => {
         const text = body?.textContent?.toLowerCase() ?? '';
         expect(text).toContain('all users');
         expect(text).toContain('/opt');
+        expect(text).toContain('wherever you launch it from');
     });
 
     it('calls showModal exactly once', async () => {
@@ -101,5 +102,45 @@ describe('SystemWideInstallModal', () => {
         new SystemWideInstallModal({ onInstall, onDecline });
         await Promise.resolve();
         expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    // ── Forced choice (dismissible: false) — must click a button ──
+
+    it('renders no × close button', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        const closeX = Array.from(document.querySelectorAll('button')).find(
+            (b) => b.textContent === '×',
+        );
+        expect(closeX, 'the × close button should not be rendered').toBeUndefined();
+    });
+
+    it('Escape (cancel) does not close the modal', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        const dialog = document.querySelector('dialog')!;
+        expect(dialog.hasAttribute('open')).toBe(true);
+        dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+        expect(dialog.hasAttribute('open')).toBe(true);
+        expect(onInstall).not.toHaveBeenCalled();
+        expect(onDecline).not.toHaveBeenCalled();
+    });
+
+    it('backdrop click does not close the modal', async () => {
+        const onInstall = vi.fn();
+        const onDecline = vi.fn();
+        new SystemWideInstallModal({ onInstall, onDecline });
+        await Promise.resolve();
+        const dialog = document.querySelector('dialog')!;
+        expect(dialog.hasAttribute('open')).toBe(true);
+        // A click whose target IS the dialog element is a backdrop click.
+        dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(dialog.hasAttribute('open')).toBe(true);
+        expect(onInstall).not.toHaveBeenCalled();
+        expect(onDecline).not.toHaveBeenCalled();
     });
 });

--- a/src/app/ui/Modal.ts
+++ b/src/app/ui/Modal.ts
@@ -4,6 +4,12 @@ import { createThemeToggle } from '../client/ThemeToggle';
 export interface ModalOptions {
     title: string;
     onClose?: ((result: unknown) => void) | undefined;
+    /**
+     * When false, the modal is a forced choice: no close (×) button is
+     * rendered, and Escape / backdrop clicks are ignored — the only way to
+     * dismiss it is an explicit in-body action. Defaults to true.
+     */
+    dismissible?: boolean;
 }
 
 export abstract class Modal {
@@ -11,11 +17,13 @@ export abstract class Modal {
     protected readonly frameEl: HTMLElement;
     protected readonly bodyEl: HTMLElement;
     private readonly headerControls: HTMLElement;
-    private readonly closeBtn: HTMLButtonElement;
+    private readonly closeBtn?: HTMLButtonElement;
+    private readonly dismissible: boolean;
     private readonly options: ModalOptions;
 
     constructor(options: ModalOptions) {
         this.options = options;
+        this.dismissible = options.dismissible !== false;
 
         // Create <dialog>
         this.dialog = document.createElement('dialog');
@@ -42,11 +50,15 @@ export abstract class Modal {
         themeBtn.classList.add('modal-close'); // reuse close button sizing
         this.headerControls.appendChild(themeBtn);
 
-        this.closeBtn = document.createElement('button');
-        this.closeBtn.classList.add('modal-close');
-        this.closeBtn.textContent = '\u00d7';
-        this.closeBtn.addEventListener('click', () => this.onCloseButtonClick());
-        this.headerControls.appendChild(this.closeBtn);
+        // Forced-choice modals (dismissible: false) render no \u00d7 \u2014 the user
+        // must pick an in-body action.
+        if (this.dismissible) {
+            this.closeBtn = document.createElement('button');
+            this.closeBtn.classList.add('modal-close');
+            this.closeBtn.textContent = '\u00d7';
+            this.closeBtn.addEventListener('click', () => this.onCloseButtonClick());
+            this.headerControls.appendChild(this.closeBtn);
+        }
 
         header.appendChild(this.headerControls);
 
@@ -71,11 +83,13 @@ export abstract class Modal {
         // Event listeners
         this.dialog.addEventListener('cancel', (e) => {
             e.preventDefault();
-            this.onEscapeKey(e);
+            if (this.dismissible) {
+                this.onEscapeKey(e);
+            }
         });
 
         this.dialog.addEventListener('click', (e) => {
-            if (e.target === this.dialog) {
+            if (this.dismissible && e.target === this.dialog) {
                 this.onBackdropClick(e as MouseEvent);
             }
         });


### PR DESCRIPTION
Reworks the Linux "install for all users?" first-run prompt (SystemWideInstallModal, shipped in beta.41).

## Changes
- Clearer copy spelling out both paths: clicking "yes, all users" installs to /opt with one administrator prompt; clicking "no, me only" leaves the app running from wherever you launch it.
- Buttons relabeled to "yes, all users" / "no, me only".
- Forced choice: the dialog can no longer be dismissed without deciding. New optional `dismissible` flag on the base Modal (defaults true, so every other modal is unchanged); SystemWideInstallModal passes `dismissible: false`, which removes the close (x) button and ignores Escape / backdrop clicks. Previously an outside click dismissed it with no decision recorded, so it reappeared on every launch.

## Verification
- tsc --noEmit: 0
- vitest: modal + base-modal suites green, including new forced-choice tests (no x button rendered, Escape no-op, backdrop no-op).

Labeled release:beta -> auto-release cuts v0.1.30-beta.42.