### PR TITLE
feat(install): remove the original home AppImage after a machine-wide install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Installing system-wide now removes the original home AppImage.** When you choose "yes, all users", the final step of the machine-wide install deletes the AppImage you launched from (a true relocate), so you don't keep a stale home copy running alongside the `/opt` one. Re-download if you want a fresh local copy.
+
 ## [0.1.30-beta.42] - 2026-06-05
 
 ### Changed

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -179,7 +179,7 @@ describe('renderUnitFile', () => {
 });
 
 describe('buildMachineWideInstallScript', () => {
-    it('machine-wide install stages just the binary + label + desktop + VERSION', () => {
+    it('machine-wide install stages the binary + label + desktop + VERSION, then deletes the source', () => {
         const s = buildMachineWideInstallScript(
             { sourceAppImage: '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage', version: '0.1.31-beta.1' },
             (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
@@ -194,6 +194,7 @@ describe('buildMachineWideInstallScript', () => {
         expect(s).toContain('Exec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');     // every user launches the shared /opt binary
         expect(s).not.toContain('dependencies');   // binary only — deps stay per-user ~/.local
         expect(s).not.toContain('systemctl');      // no service install here
+        expect(s).toContain('rm -f "/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage"');  // final step: delete the original (true relocate)
     });
 });
 

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -352,7 +352,9 @@ export function buildSystemInstallScript(
  * Build the privileged shell script for a machine-wide install. Runs under a
  * single pkexec prompt. Relocates ONLY the AppImage binary to /opt (no deps,
  * no systemd unit) — deps stay per-user in ~/.local. Writes VERSION, drops a
- * system-wide .desktop entry for all users, and refreshes the menu cache.
+ * system-wide .desktop entry for all users, and refreshes the menu cache. As the
+ * final step it DELETES the original (home) AppImage — a true relocate — so the
+ * user can't end up running a stale home copy alongside the /opt one.
  * `binTool`/`sbinTool` are injectable for testing; production resolves absolute
  * paths via systemTools (Local-Dependencies-Only — no bare-name $PATH lookup).
  */
@@ -370,6 +372,7 @@ export function buildMachineWideInstallScript(
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
     const updateDesktopDb = binTool('update-desktop-database');
+    const rm = binTool('rm');
     const desktop = [
         '[Desktop Entry]',
         'Type=Application',
@@ -386,6 +389,13 @@ export function buildMachineWideInstallScript(
         `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         `( ${printf} '${desktop}\\n' > ${SYSTEM_DESKTOP_FILE} || true )`,
         `( ${updateDesktopDb} /usr/share/applications || true )`,
+        // Final step — remove the original (home) AppImage now that the binary
+        // lives in /opt: a true relocate. Runs as root (pkexec), so it can unlink
+        // the user's file; unlinking is safe while the home AppImage is still the
+        // running process (the inode stays alive for the live FUSE mount until it
+        // exits / re-execs to /opt). `|| true` so a failed cleanup never aborts an
+        // otherwise-successful install.
+        `( ${rm} -f "${args.sourceAppImage}" || true )`,
     ].join(' && ');
 }
 


### PR DESCRIPTION
On a machine-wide install ("yes, all users"), the final step of the install script now deletes the original home AppImage - a true relocate.

## Change
- buildMachineWideInstallScript appends a final, guarded delete of the source AppImage path it was given. It runs under the same pkexec/root as the rest of the install, so it can unlink the user's home file; unlinking is safe while the home AppImage is still the running process (the inode survives for the live FUSE mount until it re-execs to the staged binary). Guarded so a failed cleanup never aborts an otherwise-successful install.
- No warning or prompt, by design - re-download is on the user.

## Verification
- tsc --noEmit: 0
- vitest: SystemdClient suites green (51 tests), incl. a new assertion that the install script deletes the source AppImage.

Labeled release:beta -> auto-release cuts v0.1.30-beta.43.