### PR TITLE
docs: add full v0.1.30-beta.43 smoke test checklist

### DIFF
--- a/docs/smoke-tests/v0.1.30-beta.43-full.md
+++ b/docs/smoke-tests/v0.1.30-beta.43-full.md
@@ -1,0 +1,116 @@
+# ws-scrcpy-web — Full Smoke Test · v0.1.30-beta.43
+
+All-encompassing manual smoke, grouped by function and tagged by platform (`[Win]` / `[Linux]` / `[Both]`). Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
+
+## Pre-flight
+
+- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `semanage fcontext -l | grep ws-scrcpy-web` empty; keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage`, `chmod +x`.
+- **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi`.
+- **Devices:** an Android device with **Wireless debugging** enabled (Android 11+) reachable from the VM, plus (Windows) one USB device if available.
+
+---
+
+## Module 1 — Install & first-run
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **1.1** `[Linux]` First-run modal | Run the home AppImage on a machine with no prior install/decline marker. | "install for all users?" modal: 3 stacked lines + buttons **yes, all users** / **no, me only**; **no ×**; **Esc** and **click-outside do nothing** (forced choice). |
+| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = `0.1.30-beta.43`; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
+| **1.3** `[Linux]` Decline + remember | Fresh state / 2nd user → **no, me only**. | Runs in place from `~/.local`; **next launch does NOT re-prompt**; original AppImage **kept**. |
+| **1.4** `[Linux]` Headless first-run | Launch over SSH / no display. | No hang; graceful fallback, no crash. |
+| **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = `0.1.30-beta.43`; installs to `C:\Program Files\WsScrcpyWeb\`. |
+
+## Module 2 — Linux layout & SELinux
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **2.1** `[Linux]` Binary/deps labels | After a machine-wide (and/or system-service) install. | `ls -Z /opt/ws-scrcpy-web` → **bin_t**. |
+| **2.2** `[Linux]` State labels | Inspect the variable-state tree. | `ls -Z /var/opt/ws-scrcpy-web` → **var_lib_t** (config/logs/deps the service writes). |
+| **2.3** `[Linux]` fcontext rules registered | After a system-service install. | `semanage fcontext -l \| grep ws-scrcpy-web` shows **both** the `/opt` bin_t rule and the `/var/opt` var_lib_t rule. |
+| **2.4** `[Linux]` Zero AVC during install | Watch the `journalctl` monitor through 1.2 + a service install. | **No AVC** denials. |
+
+## Module 3 — Multi-user & single-instance
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **3.1** `[Linux]` Per-user launch | Log in as a **2nd user**; launch from the apps menu (`.desktop`). | Runs under that user's login, own `~/.local` data (independent). |
+| **3.2** `[Linux]` Single-instance (flock) | Same user, app running → launch a 2nd copy (from `/opt` and from home). | 2nd launch **blocked** (flock on `$XDG_RUNTIME_DIR`); no 2nd server; existing URL opens. |
+| **3.3** `[Linux]` Service-defer | System service running → launch locally. | Defers to the service (opens its URL); no 2nd server. |
+| **3.4** `[Win]` Per-session tray | Service installed; switch `Admin`→`User1`→`User2` via Fast User Switching. | Each session gets **exactly one** tray within ~2s; right-click → "Open" loads the app. |
+| **3.5** `[Win]` 2nd tray.exe rejected | With tray running: `start "" "C:\Program Files\WsScrcpyWeb\current\ws-scrcpy-web-tray.exe"`. | No 2nd tray; spawned proc exits ~100ms; original tray fine. |
+
+## Module 4 — Service mode
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **4.1** `[Linux]` System-scope gate | App **not** machine-wide → Settings → service → pick **system** scope. | Install greyed + modal "requires installing system-wide first"; **user** scope available; after machine-wide install → system enabled. |
+| **4.2** `[Linux]` Install user + system scope | Install each scope (user via no-elevation; system via pkexec). | user → home ExecStart; system → `/opt` ExecStart running as root, state in `/var/opt`. Zero AVC. |
+| **4.3** `[Win]` Install confirm UX | Settings → "install service" → inspect modal; test **cancel**, **Esc**, **backdrop**, then **continue**. | AdminConfirmModal "Administrative Privileges Required"; cancel/Esc/backdrop all close with **no UAC, no fetch**; continue → UAC fires → service installs, redirects, no WelcomeModal. |
+
+## Module 5 — Lifecycle: uninstall → relaunch / handoff
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **5.1** `[Linux]` Same-user uninstall → relaunch | System service installed, active user using app → uninstall **as that user**. | App reappears in the active user's session, **same port**, visible "relaunching…" wait. |
+| **5.2** `[Linux]` Different-admin uninstall | Uninstall via **pkexec as a different admin**. | App reappears in the **active desktop user's** session (not the admin's), same port. |
+| **5.3** `[Linux]` Headless uninstall | Uninstall with no active graphical session. | No relaunch; manual fallback; **no orphan**; no `data_root_for_linux` panic. |
+| **5.4** `[Linux]` fcontext cleanup *(fix a)* | After any uninstall. | `semanage fcontext -l \| grep ws-scrcpy-web` → **empty** (both rules gone). |
+| **5.5** `[Win]` Uninstall + handoff affordance | Service mode, Settings as `Admin` → "uninstall service" → continue → Yes on UAC. | Button → "uninstalling…"; if handoff >5s → "still waiting for user session…"; ends at local-mode URL. |
+| **5.6** `[Win]` Uninstall handoff-failure guard | Service mode; kill all `ws-scrcpy-web-tray.exe`; then uninstall. | ~5s → "still waiting…"; ~30s → "couldn't reach the user session…"; button freed; **service STILL installed** (no silent direct uninstall). |
+| **5.7** `[Win]` Full uninstall | Add/Remove Programs → ws-scrcpy-web → Uninstall as `Admin`. | Service stops/unregisters; `HKLM\…\Run\WsScrcpyWebTray` removed; `Program Files\WsScrcpyWeb` cleared; **user data under dataRoot preserved**; admin tray disappears. |
+
+## Module 6 — Updates
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **6.1** `[Both]` Update check | Settings → Updates → Check for updates. | Reports up-to-date / offers newer; no error spam in `server.log` / `launcher.log`. |
+| **6.2** `[Linux]` No-service update *(one pkexec)* | Machine-wide `/opt`, **no** service → trigger update to a newer build. | One pkexec; `/opt` swapped by **rename**; relabel bin_t + restorecon; VERSION bumps; relaunches **as the user**; reconnects. No `ETXTBSY`; FUSE intact. |
+| **6.3** `[Linux]` Newer home over `/opt` | Place a newer home AppImage; launch. | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
+| **6.4** `[Win]` In-app update apply | Settings → Updates → Apply (from a prior installed build). | Applies clean; app reachable post-update; one tray after settling. |
+
+## Module 7 — Devices: scan & connect
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **7.1** `[Both]` Wireless connect | Home → "scan/connect" → enter device `ip:port` (or scan a subnet). | adb connects; device card appears in "connected devices" within ~5s. |
+| **7.2** `[Both]` Scan subnet | Open the scan-network modal; run a subnet scan. | Reachable devices listed; selecting one connects; bad/empty subnets handled gracefully (no hang). |
+| **7.3** `[Win]` USB device | Plug a USB device (authorize the RSA prompt on device). | Appears in connected devices; survives a home-page reload. |
+
+## Module 8 — scrcpy streaming
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **8.1** `[Both]` Video stream | Click a device → open the stream/config modal → connect. | Live video renders smoothly; no decode errors in console. |
+| **8.2** `[Both]` Control | In the stream, click/scroll/type and use the on-screen device buttons. | Touch + key input reaches the device; navigation works. |
+| **8.3** `[Both]` Audio | Enable audio in the stream settings (Android 11+). | Audio plays; codec/source toggle works. |
+| **8.4** `[Both]` Codec/encoder settings | In the config modal, change display/codec/encoder/fps/bitrate → reconnect. | Settings apply; stream restarts with the new params; persisted per-device on next open. |
+
+## Module 9 — adb in modals
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **9.1** `[Both]` Shell modal | Device → "shell" → run `getprop ro.product.model`, a couple of commands. | Interactive terminal works; output correct; closing the modal ends the session cleanly (no orphaned adb shell). |
+| **9.2** `[Both]` File listing/transfer | Device → file-list modal → browse, change icon size, push/pull a file. | Listing loads; icon-size pref persists; transfers succeed. |
+| **9.3** `[Both]` Device actions | Use sleep/wake (and any power/nav actions) on the device card. | Buttons reflect state (green/red), actions take effect. |
+
+## Module 10 — Logs & sanity
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **10.1** `[Both]` Service status API | Browse `http://localhost:<port>/api/service/status`. | JSON with correct `platform`, `supported`, `status`. |
+| **10.2** `[Win]` Logs clean | Tail `C:\ProgramData\WsScrcpyWeb\logs\{launcher,server}.log` during normal use. | No `ERR` / `Error:` except known cosmetic node-pty AttachConsole noise. |
+| **10.3** `[Linux]` Logs clean | Tail logs under `~/.local/share/.../logs` (or `/var/opt/.../logs` for system). | No error spam; teardown logs present on stop. |
+
+---
+
+## Global pass criteria
+
+| Criterion | Holds when |
+|---|---|
+| **SELinux clean** `[Linux]` | Zero AVC all session; `semanage fcontext -l \| grep ws-scrcpy-web` empty after every uninstall. |
+| **Single instance** | Never two trays (Win) / two servers (Linux) per user/session. |
+| **Relaunch fidelity** | Every uninstall→relaunch lands on the **same port**; no orphaned processes. |
+| **Data preserved** | User config/deps/logs survive uninstall + reinstall. |
+| **Core flow** | Scan → connect → stream (video + control) → shell works on both platforms. |
+
+**If a `[Linux]` SELinux/lifecycle row or the core-flow criterion fails:** stop, capture `journalctl`/logs, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker.


### PR DESCRIPTION
Adds the all-encompassing manual smoke test for v0.1.30-beta.43 - grouped by function, platform-tagged (Win/Linux), covering install/first-run, Linux layout + SELinux, multi-user/single-instance, service mode, lifecycle (uninstall to relaunch), updates, plus device scan/connect, scrcpy streaming, and adb-in-modal coverage.

Docs only. Unlabeled on purpose so auto-release does NOT cut a beta.