### PR TITLE
chore(deps): upgrade Velopack to 1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,10 @@ jobs:
         with:
           dotnet-version: 10.x
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      # vpk 1.1.1 (stable) has --msi / --instLocation and produces
+      # vpk 1.2.0 (stable) has --msi / --instLocation and produces
       # true Windows Installer MSIs. Match the npm `velopack` package
       # version to keep client/server serialization in sync.
-      - run: dotnet tool install -g vpk --version 1.1.1
+      - run: dotnet tool install -g vpk --version 1.2.0
       - run: npm ci --omit=dev
       - run: npm run build
       - run: cargo build --release --workspace
@@ -178,10 +178,10 @@ jobs:
           targets: x86_64-unknown-linux-musl
       - name: Install musl-tools (linker for musl target)
         run: sudo apt-get update && sudo apt-get install -y musl-tools
-      # vpk 1.1.1 (stable) has --msi / --instLocation and produces
+      # vpk 1.2.0 (stable) has --msi / --instLocation and produces
       # true Windows Installer MSIs. Match the npm `velopack` package
       # version to keep client/server serialization in sync.
-      - run: dotnet tool install -g vpk --version 1.1.1
+      - run: dotnet tool install -g vpk --version 1.2.0
       - run: npm ci --omit=dev
       - run: npm run build
       - name: Build launcher (musl-static — no glibc dependency)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Velopack upgraded 1.1.1 → 1.2.0 across all touchpoints** (the npm SDK in `package.json`, the Rust crate in `Cargo.lock`, and the `vpk` CLI pin in `release.yml` for both the Windows and Linux build legs). 1.2.0 is a maintenance release — notably a Linux locator root-path fix (velopack#921) on the AppImage update path and stricter semver validation (velopack#923) — with no API or CLI-flag changes (`--msi` / `--instLocation` unchanged), so the upgrade is drop-in.
+
 ## [0.1.30-beta.43] - 2026-06-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "velopack"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccc718589add249fc811d1a824b4f9110d95893aca6ded683becbf38ccb3b83"
+checksum = "bd3fd8e7b771e0d0fc4ca67249273ad4eacfabe2562617b3ca42065a5972a58c"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.37",
+  "version": "0.1.30-beta.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ws-scrcpy-web",
-      "version": "0.1.30-beta.37",
+      "version": "0.1.30-beta.43",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "velopack": "^1.1.1",
+        "velopack": "^1.2.0",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -3644,9 +3644,9 @@
       "license": "MIT"
     },
     "node_modules/velopack": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/velopack/-/velopack-1.1.1.tgz",
-      "integrity": "sha512-n2g9P0coSTzC3qOjpQNWXqEoMmLMdPYim5lzWG/16KXojvoTdtxH5wWPcXe0XF6UXb9jmPaaGSd/wYl93FTiMA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/velopack/-/velopack-1.2.0.tgz",
+      "integrity": "sha512-rWX8G9h5gv2AgrjiADhvyrrv7LpCCcFeepw+jBx80/jm1FIXW7BgmSEQtJVXt3jqC2YnCKiBD6E1i/DBWnpIyw==",
       "license": "MIT",
       "dependencies": {
         "@neon-rs/load": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release-notes": "node scripts/extract-changelog.mjs $npm_package_version"
   },
   "dependencies": {
-    "velopack": "^1.1.1",
+    "velopack": "^1.2.0",
     "ws": "^8.21.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Upgrades the Velopack dependency `1.1.1 → 1.2.0` across all touchpoints so the SDK and the `vpk` CLI stay in lockstep on the same serialization protocol:

- `package.json` + `package-lock.json` — npm SDK `^1.2.0`
- `Cargo.lock` — Rust crate `1.2.0`
- `release.yml` — `vpk` CLI pin `1.2.0` on both the Windows and Linux build legs

**Why 1.2.0:** maintenance release — a Linux locator root-path fix on the AppImage update path and stricter semver validation, with no API or CLI-flag changes (`--msi` / `--instLocation` unchanged), so it's drop-in.

**Verified locally:** `tsc --noEmit` clean and `cargo check --workspace` clean against velopack 1.2.0.

Labeled `release:beta` to cut `v0.1.30-beta.44` via the auto-release pipeline.
