### PR TITLE
docs(changelog): record release-history note (pre-0.1.30 were dev milestones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **A note on release history.** Every version below `0.1.30` was a development
+> milestone published during bring-up, while the app was not yet a working
+> cross-platform application. To avoid implying those builds were finished
+> releases, their GitHub Releases have been removed — but every git tag is
+> retained, so the full history stays browsable and the per-version entries
+> below are unchanged. **`0.1.30` is the project's first true release** — the
+> first build that is functional on both Windows and Linux — published once
+> Linux is fully verified. The **next full release** will ship alongside the
+> Docker image.
+
 ## [Unreleased]
 
 ## [0.1.30-beta.44] - 2026-06-06


### PR DESCRIPTION
Adds a permanent note at the top of the changelog (above `[Unreleased]`, so the version-bump script never sweeps it into a release section) documenting the release-history cleanup:

- Every version before `0.1.30` was a **development milestone** published during cross-platform bring-up — not a functional cross-platform release.
- Their **GitHub Releases have been removed**; **every git tag is retained**, so history stays browsable and the per-version changelog entries are unchanged.
- **`0.1.30` is the project's first true release** (Windows + Linux), published once Linux is fully verified.
- The **next full release** will ship alongside the Docker image.

Docs-only — labeled `release:none` (intentional opt-out), so the auto-release pipeline takes no action.
