### PR TITLE
docs(smoke): retitle full smoke checklist to v0.1.30-beta.44 + Velopack 1.2.0 module

### DIFF
--- a/docs/smoke-tests/v0.1.30-beta.44-full.md
+++ b/docs/smoke-tests/v0.1.30-beta.44-full.md
@@ -1,11 +1,11 @@
-# ws-scrcpy-web — Full Smoke Test · v0.1.30-beta.43
+# ws-scrcpy-web — Full Smoke Test · v0.1.30-beta.44
 
 All-encompassing manual smoke, grouped by function and tagged by platform (`[Win]` / `[Linux]` / `[Both]`). Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
 
 ## Pre-flight
 
-- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `semanage fcontext -l | grep ws-scrcpy-web` empty; keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage`, `chmod +x`.
-- **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi`.
+- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `semanage fcontext -l | grep ws-scrcpy-web` empty; keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage` from the **`v0.1.30-beta.44`** release, `chmod +x`.
+- **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi` from the **`v0.1.30-beta.44`** release.
 - **Devices:** an Android device with **Wireless debugging** enabled (Android 11+) reachable from the VM, plus (Windows) one USB device if available.
 
 ---
@@ -15,10 +15,10 @@ All-encompassing manual smoke, grouped by function and tagged by platform (`[Win
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | **1.1** `[Linux]` First-run modal | Run the home AppImage on a machine with no prior install/decline marker. | "install for all users?" modal: 3 stacked lines + buttons **yes, all users** / **no, me only**; **no ×**; **Esc** and **click-outside do nothing** (forced choice). |
-| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = `0.1.30-beta.43`; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
+| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = `0.1.30-beta.44`; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
 | **1.3** `[Linux]` Decline + remember | Fresh state / 2nd user → **no, me only**. | Runs in place from `~/.local`; **next launch does NOT re-prompt**; original AppImage **kept**. |
 | **1.4** `[Linux]` Headless first-run | Launch over SSH / no display. | No hang; graceful fallback, no crash. |
-| **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = `0.1.30-beta.43`; installs to `C:\Program Files\WsScrcpyWeb\`. |
+| **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = `0.1.30-beta.44`; installs to `C:\Program Files\WsScrcpyWeb\`. |
 
 ## Module 2 — Linux layout & SELinux
 
@@ -101,6 +101,17 @@ All-encompassing manual smoke, grouped by function and tagged by platform (`[Win
 | **10.2** `[Win]` Logs clean | Tail `C:\ProgramData\WsScrcpyWeb\logs\{launcher,server}.log` during normal use. | No `ERR` / `Error:` except known cosmetic node-pty AttachConsole noise. |
 | **10.3** `[Linux]` Logs clean | Tail logs under `~/.local/share/.../logs` (or `/var/opt/.../logs` for system). | No error spam; teardown logs present on stop. |
 
+## Module 11 — Velopack 1.2.0 / item-31 (new for beta.44)
+
+beta.44 bumped Velopack to 1.2.0. These rows close out item 31 (the libfuse2 first-run gate) and guard the 1.2.0 apply path.
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **11.1** `[Linux]` No-libfuse2 launch | On a minimal distro/container **without** `libfuse2` installed, run the beta.44 AppImage. | Launches (type-2 runtime has FUSE embedded); **no** `libfuse.so.2` / "dlopen libfuse" error. |
+| **11.2** `[Linux]` No-libfuse2 in-app update | From that no-libfuse2 host, run an in-app update (6.x flow). | Update succeeds → **clears item 31 step 3**; then the 5 libfuse2 gate files can be removed (`SystemdClient.ts`, `UpdatesApi.ts`, `UpdateEvents.ts`, `SettingsModal.ts`, README section). |
+| **11.3** `[Linux]` Locator fix watch (velopack#921) | During 6.2 / 6.3 apply + relaunch on the machine-wide `/opt` install. | Apply + relaunch land correctly; no Velopack locator root-path regression (the 1.2.0 fix targets exactly this path). |
+| **11.4** `[Win]` PerMachine intact | After the 1.5 MSI install, check the install location. | Installed PerMachine to `C:\Program Files\WsScrcpyWeb\` (vpk 1.2.0 `--msi --instLocation PerMachine` unchanged). |
+
 ---
 
 ## Global pass criteria
@@ -113,4 +124,4 @@ All-encompassing manual smoke, grouped by function and tagged by platform (`[Win
 | **Data preserved** | User config/deps/logs survive uninstall + reinstall. |
 | **Core flow** | Scan → connect → stream (video + control) → shell works on both platforms. |
 
-**If a `[Linux]` SELinux/lifecycle row or the core-flow criterion fails:** stop, capture `journalctl`/logs, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker.
+**If a `[Linux]` SELinux/lifecycle row or the core-flow criterion fails:** stop, capture `journalctl`/logs, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker. **Module 11 (no-libfuse2)** is the gate for closing item 31, not a 0.1.30-stable blocker on its own — a failure there means keep the libfuse2 gate, don't remove it.


### PR DESCRIPTION
Renames the full smoke checklist `docs/smoke-tests/v0.1.30-beta.43-full.md` → `v0.1.30-beta.44-full.md` (git tracks it as an 85%-similarity rename) and brings it current for the published `v0.1.30-beta.44`:

- **Version-specific cells → beta.44:** title, **1.2** (`/opt/VERSION = 0.1.30-beta.44`), **1.5** (Settings → About), and the pre-flight download notes ("from the `v0.1.30-beta.44` release").
- **New Module 11 — Velopack 1.2.0 / item-31:** 11.1 no-libfuse2 launch · 11.2 no-libfuse2 in-app update (closes item 31 step 3) · 11.3 velopack#921 locator-fix watch on the apply path · 11.4 Windows PerMachine intact.

Docs-only — labeled `release:none` (intentional opt-out), so the auto-release pipeline takes no action.
