### PR TITLE
fix(linux): user-scope service install — stable ExecStart, tray autostart, verify+rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux user-scope service install now works.** The user-scope systemd unit pointed `ExecStart` at the AppImage's launch path (e.g. your `~/Downloads` copy) — which systemd refuses to run when the file isn't marked executable (a browser download isn't), and which vanishes if that file is later moved or deleted. The unit now targets a stable, guaranteed-executable binary instead: the shared `/opt` binary when the app is installed machine-wide, otherwise a copy staged under `~/.local/share/WsScrcpyWeb/bin/`. (Found during the 0.1.30 Linux smoke — the service failed to start with `203/EXEC` and the app went dark.)
+- **A failed service install no longer leaves the app dead.** The install flow now confirms the service actually reaches the running state before it shuts down the local instance. If the service doesn't come up, the install is rolled back — the half-installed unit is removed, the previous mode is restored, and the app keeps running locally with a clear error — instead of exiting on a blind timer and stranding you with nothing on the port.
+- **No more stray tray autostart entry on Linux.** Installing a user-scope service wrote `~/.config/autostart/ws-scrcpy-web-tray.desktop` pointing at a `ws-scrcpy-web-tray` command resolved from `PATH`, but Linux has no tray binary, so the entry was orphaned (and wasn't cleaned up on uninstall). The autostart file is now written only when an actual tray binary is found on disk — never as a bare `PATH` name — so Linux installs no longer leave it behind.
+
 ## [0.1.30-beta.44] - 2026-06-06
 
 ### Changed

--- a/docs/specs/2026-06-07-linux-user-service-execstart-fix-design.md
+++ b/docs/specs/2026-06-07-linux-user-service-execstart-fix-design.md
@@ -1,0 +1,121 @@
+# Linux user-scope service: stable ExecStart + install rollback (beta.45)
+
+**Date:** 2026-06-07
+**Status:** Approved — implementing
+**Found by:** the `v0.1.30-beta.44` Fedora smoke (Module 4.2, user scope)
+
+## Problem
+
+Installing a **user-scope** systemd service on Linux leaves the app dead and
+unrecoverable. Three compounding bugs, all confirmed at runtime + in code during
+the beta.44 Fedora smoke:
+
+### F1 — user-scope `ExecStart` points at the volatile launch path
+
+`ServiceApi.handleInstall` sets `binPath = $APPIMAGE` (the running AppImage's
+path, e.g. `~/Downloads/WsScrcpyWeb-linux-beta.AppImage`). For **system** scope
+`renderUnitFile` overrides `ExecStart` to the staged `/opt` copy, but for **user**
+scope it uses `binPath` verbatim (`SystemdClient.ts:241-243`). That path is:
+
+- **volatile** — it is the throwaway installer artifact (machine-wide install
+  deletes it; users delete downloads), and
+- **possibly not executable** — a browser-downloaded AppImage is `-rw-r--r--`
+  (the GUI/Dolphin can still launch it, but systemd's `ExecStart` does a raw
+  `execve()` that requires `+x`).
+
+Result: the unit fails `status=203/EXEC ("Permission denied")` on every start,
+hits `StartLimitBurst`, and gives up. (Confirmed **not** SELinux — `ausearch -m
+avc` was empty; the Downloads AppImage was labeled `user_home_t` and `-rw-r--r--`,
+while a perfectly good `/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage` — `0755`, `bin_t`
+— sat unused.)
+
+### F2 — PATH-reliant tray autostart written on Linux (Local-Deps violation + residue)
+
+User-scope install calls `writeTrayAutostart` (`SystemdClient.ts:824-851`). When
+no tray binary is found on disk (`resolveTrayHelperPath()` → null), it falls back
+to `Exec=ws-scrcpy-web-tray` — a **bare name resolved via `PATH`**. On Linux that
+fallback is *always* taken (there is no Linux tray — item 27), so every install
+writes `~/.config/autostart/ws-scrcpy-web-tray.desktop` pointing at a nonexistent
+PATH binary. This violates Local-Dependencies-Only and leaves orphaned autostart
+residue (the Linux uninstall path — `systemd-run` teardown — bypasses
+`removeTrayAutostart`, so it is never cleaned).
+
+### F3 — install never verifies the service started; no rollback
+
+`handleInstall` schedules `process.exit(0)` on a fixed 15 s timer
+(`ServiceApi.ts:446-451`) **without checking the service is active**, and returns
+`ok:true`. `install()` does not throw on a failed start (systemd `Type=simple`
+reports "started" on fork, before the `execve` fails), so the existing error path
+never fires. A failed start therefore kills the local instance anyway → the app
+self-destructs with no fallback, no error, and a stale `installMode=user-service`
+left in config.
+
+## Design
+
+### F1 — resolve a stable, executable `ExecStart` for user scope (Approach A)
+
+In `SystemdClient.install()` (user-scope branch), resolve the unit's binary
+**before** rendering:
+
+1. If the machine-wide binary exists (`/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage`,
+   already `0755` / `bin_t`) → `ExecStart` = that path. No copy.
+2. Otherwise → copy the source AppImage (`opts.binPath`) to a stable per-user
+   location **`<dataRoot>/bin/WsScrcpyWeb.AppImage`**, `chmod 0755`, and
+   `ExecStart` = that copy.
+
+Either way the target is stable and guaranteed executable. `WorkingDirectory`
+becomes the directory of the resolved binary. `ServiceApi` passes `dataRoot` in
+the install options for Linux (currently omitted) so the client can compute the
+`bin/` location. This mirrors how system scope already stages to a stable path,
+and keeps everything under the app's own dataRoot (Local-Deps-clean).
+
+Rejected: (B) always copy to `<dataRoot>/bin` even when `/opt` has it — needless
+61 MB duplication; (C) just `chmod +x $APPIMAGE` in place — leaves the volatility.
+
+### F2 — never emit a PATH-reliant tray autostart
+
+In `writeTrayAutostart`, when `resolveTrayHelperPath()` returns null, **skip
+writing** (log + return) instead of falling back to the bare-name `Exec`. The
+absolute-path write stays for any future bundled tray binary. On Linux (no tray)
+this makes the call a clean no-op — no Local-Deps violation, no orphaned residue.
+
+### F3 — verify active, then roll back on failure
+
+Replace the unconditional scheduled exit in `handleInstall` with:
+
+1. Poll `client.status()` until it returns `running`, up to ~15 s
+   (condition-based wait, short interval).
+2. **Active** → proceed exactly as before (schedule the local-instance exit, hand
+   off, `ok:true`).
+3. **Never active** → roll back:
+   - `client.uninstall(WS_SCRCPY_SERVICE_NAME)` — remove the dead unit,
+   - revert `installMode` to the previous value,
+   - return `ok:false` with `reason:'service-start-failed'` (+ a short detail),
+   - **do not** schedule the exit — the local instance stays alive so the user
+     lands back in a working local app instead of a dead one.
+
+This makes *any* failed service start recoverable (not just F1's) and auto-fixes
+the stale-`installMode` artifact.
+
+## Test plan (vitest, TDD — failing first)
+
+- `renderUnitFile` user scope → `ExecStart` is the `/opt` binary when the
+  machine-wide AppImage exists; otherwise the `<dataRoot>/bin` copy. Never the
+  raw `opts.binPath`.
+- staging: when no `/opt` binary, `install()` copies the source AppImage to
+  `<dataRoot>/bin/WsScrcpyWeb.AppImage` and `chmod`s it `0755`.
+- `writeTrayAutostart`: writes nothing (and no PATH-bare `Exec`) when no tray
+  binary resolves; still writes an absolute-path entry when one is found.
+- `handleInstall`: when the service never reaches `running`, it calls
+  `uninstall`, reverts `installMode`, responds `ok:false` /
+  `reason:'service-start-failed'`, and does **not** schedule a process exit.
+
+No Rust changes — all three fixes are in TypeScript (`SystemdClient.ts`,
+`ServiceApi.ts`, `ServiceClient.ts` for the options/reason types).
+
+## Rollout
+
+`release:beta` PR (no manual version bump — Mode 1 auto-cuts it) → squash-merge →
+auto-release cuts **`v0.1.30-beta.45`** (Windows + Linux). Then delete the
+**beta.44** GitHub release (keep its tag) and re-run the Module 4 / 5 / 6
+service-mode smoke on the Fedora VM against beta.45.

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -1371,6 +1371,8 @@ export class SettingsModal extends Modal {
                 return 'Resume token is invalid or expired. Refresh the page and try again.';
             case 'servy-failure':
                 return `Service install/uninstall failed: ${fallbackError}`;
+            case 'service-start-failed':
+                return 'The service was installed but did not start, so it was removed. The app is still running locally — check the service logs and try again.';
             case 'unknown':
             case undefined:
                 return `An unexpected error occurred: ${fallbackError}`;

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -111,6 +111,9 @@ export interface ServiceActionSuccess {
  *   a recently-issued token for the requested action.
  * - `servy-failure`: servy-cli (or systemd-side equivalent) exited non-zero
  *   on the actual install/uninstall operation.
+ * - `service-start-failed`: the unit installed without error but never reached
+ *   the running state (e.g. a bad ExecStart). The failed unit is rolled back
+ *   and the app stays in local mode — the caller should surface a retry.
  * - `unknown`: catch-all for legacy / uncategorized failure paths.
  */
 export type ServiceFailureReason =
@@ -120,6 +123,7 @@ export type ServiceFailureReason =
     | 'handoff-no-target'
     | 'invalid-token'
     | 'servy-failure'
+    | 'service-start-failed'
     | 'unknown';
 
 /** Failure response shape for /api/service/install and /api/service/uninstall. */

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1161,6 +1161,81 @@ describe('ServiceApi', () => {
             expect(scheduled[0]).toBe(15_000);
         });
 
+        it('F3: rolls back when the service never becomes active — uninstall + revert installMode + ok:false, no exit', async () => {
+            // install() does NOT throw (systemd Type=simple reports "started" on
+            // fork, before execve fails), so the existing throw-path is not hit.
+            // verifyServiceActive returns false → the install must roll back
+            // instead of blindly exiting the local instance.
+            const uninstallFn = vi.fn(async () => undefined);
+            const scheduleExit = vi.fn();
+            const client = fakeClient({
+                install: vi.fn(async () => undefined),
+                uninstall: uninstallFn,
+                status: vi.fn(async () => 'stopped' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            // Pre-existing local mode → rollback must restore it.
+            Config.getInstance().updateAppConfig({ installMode: 'user' });
+            // Constructor: factory, scope, existsCheck, spawnDetached, scheduleExit, runPkexecFn, verifyServiceActive
+            const api = new ServiceApi(
+                () => factoryResult,
+                () => 'user',
+                () => true,
+                vi.fn(),            // spawnDetached
+                scheduleExit,
+                undefined,          // runPkexecFn → default
+                async () => false,  // verifyServiceActive → service never came up
+            );
+            const { req, res } = makeReqRes('/api/service/install', 'POST', JSON.stringify({ scope: 'user' }));
+            await api.handle(req, res);
+
+            // Dead unit removed; installMode reverted to the pre-install local mode.
+            expect(uninstallFn).toHaveBeenCalledWith('WsScrcpyWeb');
+            expect(Config.getInstance().getAppConfig().installMode).toBe('user');
+            // Local instance is NOT sacrificed — the app stays alive.
+            expect(scheduleExit).not.toHaveBeenCalled();
+            // Caller gets a clear, categorized failure.
+            expect((res as any).getStatus()).toBe(500);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(false);
+            expect(body.reason).toBe('service-start-failed');
+        });
+
+        it('F3: keeps the install when the service becomes active (no rollback on the happy path)', async () => {
+            const uninstallFn = vi.fn(async () => undefined);
+            const scheduleExit = vi.fn();
+            const client = fakeClient({
+                install: vi.fn(async () => undefined),
+                uninstall: uninstallFn,
+                status: vi.fn(async () => 'running' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            const api = new ServiceApi(
+                () => factoryResult,
+                () => 'user',
+                () => true,
+                vi.fn(),
+                scheduleExit,
+                undefined,
+                async () => true, // verifyServiceActive → up
+            );
+            const { req, res } = makeReqRes('/api/service/install', 'POST', JSON.stringify({ scope: 'user' }));
+            await api.handle(req, res);
+            expect(uninstallFn).not.toHaveBeenCalled();
+            expect(scheduleExit).toHaveBeenCalledTimes(1);
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+        });
+
         it('user-scope uninstall is UNCHANGED (home helper, systemd-run --user, no pkexec)', async () => {
             // The existing user-scope test is the canonical; this twin makes the
             // regression explicit alongside the new system-scope tests.

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -35,11 +35,15 @@ const existsSyncMock = vi.fn();
 const writeFileSyncMock = vi.fn();
 const unlinkSyncMock = vi.fn();
 const mkdirSyncMock = vi.fn();
+const copyFileSyncMock = vi.fn();
+const chmodSyncMock = vi.fn();
 vi.mock('node:fs', () => ({
     existsSync: (...args: unknown[]) => existsSyncMock(...args),
     writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
     unlinkSync: (...args: unknown[]) => unlinkSyncMock(...args),
     mkdirSync: (...args: unknown[]) => mkdirSyncMock(...args),
+    copyFileSync: (...args: unknown[]) => copyFileSyncMock(...args),
+    chmodSync: (...args: unknown[]) => chmodSyncMock(...args),
 }));
 
 const homedirMock = vi.fn(() => '/home/jamie');
@@ -50,7 +54,8 @@ vi.mock('node:os', () => ({
     tmpdir: () => '/tmp',
 }));
 
-import { renderUnitFile, SystemdClient } from '../service/SystemdClient';
+import * as path from 'node:path';
+import { renderUnitFile, SystemdClient, STAGED_SYSTEM_DIR, STAGED_SYSTEM_APPIMAGE } from '../service/SystemdClient';
 import type { ServiceInstallOptions } from '../service/ServiceClient';
 
 const baseOpts: ServiceInstallOptions = {
@@ -63,6 +68,9 @@ const baseOpts: ServiceInstallOptions = {
     maxRestartAttempts: 3,
     envVars: { DEPS_PATH: '/opt/ws-scrcpy-web/dependencies' },
     logPath: '/opt/ws-scrcpy-web/dependencies/service.log',
+    // F1: user-scope staging needs a dataRoot to copy a stable binary into
+    // when no machine-wide /opt binary exists.
+    dataRoot: '/home/jamie/.local/share/WsScrcpyWeb',
 };
 
 describe('SystemdClient', () => {
@@ -74,6 +82,8 @@ describe('SystemdClient', () => {
         writeFileSyncMock.mockReset();
         unlinkSyncMock.mockReset();
         mkdirSyncMock.mockReset();
+        copyFileSyncMock.mockReset();
+        chmodSyncMock.mockReset();
         homedirMock.mockReset().mockReturnValue('/home/jamie');
         userInfoMock.mockReset().mockReturnValue({ username: 'jamie' });
         savedGetuid = process.getuid;
@@ -126,15 +136,20 @@ describe('SystemdClient', () => {
             );
         });
 
-        it('user scope: writes ~/.config/systemd/user/ unit, calls daemon-reload + enable + loginctl', async () => {
-            // Tray helper resolution: pretend neither candidate exists so we
-            // hit the bare-name fallback (still writes the .desktop file, just
-            // logs a warning).
+        it('user scope (no machine-wide install): stages a stable binary under <dataRoot>/bin, points ExecStart there, daemon-reload + enable + loginctl', async () => {
+            // No /opt binary and no tray binary on disk → F1 copy branch + F2 skip.
             existsSyncMock.mockReturnValue(false);
             const client = new SystemdClient();
             await client.install({ ...baseOpts, scope: 'user' });
 
-            // Unit file written to ~/.config/systemd/user/WsScrcpyWeb.service
+            // F1: the source AppImage is copied to a stable per-user bin dir + chmod +x.
+            // NEVER ExecStart the volatile launch path. The bin path is a Linux
+            // forward-slash string regardless of test host.
+            const stableBin = '/home/jamie/.local/share/WsScrcpyWeb/bin/WsScrcpyWeb.AppImage';
+            expect(copyFileSyncMock).toHaveBeenCalledWith(baseOpts.binPath, stableBin);
+            expect(chmodSyncMock).toHaveBeenCalledWith(stableBin, 0o755);
+
+            // Unit file written to ~/.config/systemd/user/WsScrcpyWeb.service ...
             const unitWrites = writeFileSyncMock.mock.calls.filter((c) =>
                 String(c[0]).endsWith('WsScrcpyWeb.service'),
             );
@@ -145,6 +160,8 @@ describe('SystemdClient', () => {
                 '/home/jamie/.config/systemd/user/WsScrcpyWeb.service',
             );
             expect(unitWrites[0]![2]).toEqual({ mode: 0o644 });
+            // ... with ExecStart at the stable copy, not the source binPath.
+            expect(String(unitWrites[0]![1])).toContain(`ExecStart=${stableBin}`);
 
             // systemctl --user daemon-reload + enable --now
             const sysCalls = execFileSyncMock.mock.calls.filter((c) => c[0] === 'systemctl');
@@ -164,16 +181,50 @@ describe('SystemdClient', () => {
             expect(loginctlCalls).toHaveLength(1);
             expect(loginctlCalls[0]![1]).toEqual(['enable-linger', 'jamie']);
 
-            // Tray autostart .desktop written
+            // F2: NO tray autostart written when no tray binary is found (Linux
+            // has no tray — never emit a PATH-reliant bare-name Exec).
+            const desktopWrites = writeFileSyncMock.mock.calls.filter((c) =>
+                String(c[0]).endsWith('ws-scrcpy-web-tray.desktop'),
+            );
+            expect(desktopWrites).toHaveLength(0);
+        });
+
+        it('user scope with a machine-wide /opt install present: ExecStart is the /opt binary, no staging copy', async () => {
+            // F1 case A: the stable /opt binary already exists → reuse it (0755, bin_t).
+            const optBin = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+            existsSyncMock.mockImplementation(
+                (p: string) => String(p).replace(/\\/g, '/') === optBin,
+            );
+            const client = new SystemdClient();
+            await client.install({ ...baseOpts, scope: 'user' });
+
+            // No copy — the /opt binary is used directly.
+            expect(copyFileSyncMock).not.toHaveBeenCalled();
+            const unitWrites = writeFileSyncMock.mock.calls.filter((c) =>
+                String(c[0]).endsWith('WsScrcpyWeb.service'),
+            );
+            expect(String(unitWrites[0]![1])).toContain(`ExecStart=${optBin}`);
+            // never the volatile launch path
+            expect(String(unitWrites[0]![1])).not.toContain(`ExecStart=${baseOpts.binPath}`);
+        });
+
+        it('user scope: writes an ABSOLUTE-path tray autostart when a tray binary exists (never a bare PATH name)', async () => {
+            // F2 positive branch: a tray binary next to the launcher (cwd) →
+            // Exec is its absolute path; the /opt binary is absent so install
+            // still completes via the F1 copy branch.
+            const trayCandidate = path.join(process.cwd(), 'ws-scrcpy-web-tray');
+            existsSyncMock.mockImplementation((p: string) => p === trayCandidate);
+            const client = new SystemdClient();
+            await client.install({ ...baseOpts, scope: 'user' });
+
             const desktopWrites = writeFileSyncMock.mock.calls.filter((c) =>
                 String(c[0]).endsWith('ws-scrcpy-web-tray.desktop'),
             );
             expect(desktopWrites).toHaveLength(1);
-            expect(String(desktopWrites[0]![0]).replace(/\\/g, '/')).toBe(
-                '/home/jamie/.config/autostart/ws-scrcpy-web-tray.desktop',
-            );
-            expect(String(desktopWrites[0]![1])).toContain('[Desktop Entry]');
-            expect(String(desktopWrites[0]![1])).toContain('Exec=ws-scrcpy-web-tray');
+            const content = String(desktopWrites[0]![1]);
+            expect(content).toContain(`Exec=${trayCandidate}`);
+            // not the bare-name PATH fallback
+            expect(content).not.toMatch(/^Exec=ws-scrcpy-web-tray$/m);
         });
 
         it('user scope: still succeeds when loginctl throws', async () => {

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -41,6 +41,27 @@ export function systemServiceNeedsMigration(input: { dataRootEnv?: string; oldDa
 }
 
 /**
+ * F3: poll the service's is-active state until it reports `running`, up to ~15s
+ * (the old blind-exit cap). Returns true as soon as it's up; false if it never
+ * becomes active. `install()` does NOT throw on a failed start (systemd
+ * `Type=simple` reports "started" on fork, before `execve` fails), so this poll
+ * is the only signal that the service actually came up before the install-flow
+ * sacrifices the local instance.
+ */
+async function defaultVerifyServiceActive(
+    client: ServiceClientFactoryResult['client'],
+    name: string,
+): Promise<boolean> {
+    const ATTEMPTS = 30;
+    const INTERVAL_MS = 500;
+    for (let i = 0; i < ATTEMPTS; i++) {
+        if ((await client.status(name)) === 'running') return true;
+        await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
+    }
+    return (await client.status(name)) === 'running';
+}
+
+/**
  * HTTP API for SP3 P3 service-mode operations.
  *
  *   GET  /api/service/status     -> ServiceStatusResponse (always 200)
@@ -72,6 +93,12 @@ export class ServiceApi {
         },
         private scheduleExit: (fn: () => void, ms: number) => void = (fn, ms) => { setTimeout(fn, ms).unref(); },
         private readonly runPkexecFn: (shellCmd: string, label: string) => Promise<string> = runPkexec,
+        // F3: injectable so tests can force the verify outcome without a real
+        // 15s poll. Default polls is-active; tests pass async () => true|false.
+        private readonly verifyServiceActive: (
+            client: ServiceClientFactoryResult['client'],
+            name: string,
+        ) => Promise<boolean> = defaultVerifyServiceActive,
     ) {}
 
     public async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
@@ -388,8 +415,9 @@ export class ServiceApi {
                 // §32 Part 4: pass dataRoot so the elevated installer can write
                 // <dataRoot>/post-stop/post-stop.bat and register it as Servy's
                 // --postStopPath via cmd.exe (Velopack-untouchable location).
-                // Linux SystemdClient ignores this field.
-                dataRoot: Config.getInstance().dataRoot ?? undefined,
+                // F1: Linux user-scope install also uses it to stage a stable
+                // binary under <dataRoot>/bin — so guarantee it's defined.
+                dataRoot: cfg.dataRoot ?? path.dirname(cfg.dependenciesPath),
                 // Linux SystemdClient consumes scope; Windows ServyClient ignores it.
                 scope,
                 // Linux system-scope only: home helper path to stage into /opt (bin_t).
@@ -430,6 +458,39 @@ export class ServiceApi {
             const body: ServiceActionFailure = { ok: false, error: (err as Error).message, reason: 'servy-failure' };
             res.writeHead(500);
             res.end(JSON.stringify(body));
+            return true;
+        }
+
+        // F3: verify the service actually started before sacrificing this local
+        // instance. install() does NOT throw on a failed start (systemd
+        // Type=simple reports "started" on fork, before execve fails), so a
+        // blind exit here would strand the user with a dead app + no fallback.
+        const active = await this.verifyServiceActive(result.client, WS_SCRCPY_SERVICE_NAME);
+        if (!active) {
+            log.warn('install-flow: service did not become active; rolling back the failed install');
+            // Roll back the dead unit + restore the prior installMode so the
+            // user lands back in a working local app. Best-effort; surface the
+            // failure regardless. Crucially do NOT scheduleExit — keep this
+            // local instance alive.
+            try {
+                await result.client.uninstall(WS_SCRCPY_SERVICE_NAME);
+            } catch (err) {
+                log.warn(`rollback uninstall failed: ${(err as Error).message}`);
+            }
+            try {
+                cfg.updateAppConfig({ installMode: previousMode ?? null });
+            } catch (err) {
+                log.warn(`rollback installMode revert failed: ${(err as Error).message}`);
+            }
+            const failBody: ServiceActionFailure = {
+                ok: false,
+                error:
+                    'the service was installed but did not start, so it was removed; ' +
+                    'the app is still running locally. check the service logs and try again.',
+                reason: 'service-start-failed',
+            };
+            res.writeHead(500);
+            res.end(JSON.stringify(failBody));
             return true;
         }
 

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -606,6 +606,41 @@ export class SystemdClient implements ServiceClient {
         return this.resolveActiveScope(name);
     }
 
+    /**
+     * F1: resolve a STABLE, executable `ExecStart` binary for a user-scope
+     * service. The volatile launch path (`opts.binPath` = `$APPIMAGE`, e.g.
+     * `~/Downloads/...AppImage`) must NEVER be the unit's `ExecStart`: a
+     * browser-downloaded AppImage is `-rw-r--r--` (the GUI can launch it but
+     * systemd's `execve()` requires `+x` → `203/EXEC`), and that file is the
+     * throwaway installer artifact (a machine-wide install deletes it; users
+     * delete downloads).
+     *
+     *   - If the machine-wide `/opt` binary exists, reuse it (already `0755`,
+     *     `bin_t`) — no copy.
+     *   - Otherwise copy the source AppImage to `<dataRoot>/bin/` and `chmod
+     *     0755`, so the unit points at a stable, guaranteed-executable file.
+     *
+     * Returns `opts` with `binPath` + `startupDir` retargeted at the resolved
+     * stable path. Forward-slash paths on purpose (Linux unit file).
+     */
+    private withStableUserBin(opts: ServiceInstallOptions): ServiceInstallOptions {
+        const optBin = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+        if (fs.existsSync(optBin)) {
+            return { ...opts, binPath: optBin, startupDir: STAGED_SYSTEM_DIR };
+        }
+        if (!opts.dataRoot) {
+            throw new Error(
+                'SystemdClient.install: user-scope install requires dataRoot to stage a stable binary',
+            );
+        }
+        const binDir = `${opts.dataRoot}/bin`;
+        const stableBin = `${binDir}/${STAGED_SYSTEM_APPIMAGE}`;
+        fs.mkdirSync(binDir, { recursive: true });
+        fs.copyFileSync(opts.binPath, stableBin);
+        fs.chmodSync(stableBin, 0o755);
+        return { ...opts, binPath: stableBin, startupDir: binDir };
+    }
+
     public async install(opts: ServiceInstallOptions): Promise<void> {
         const scope = opts.scope;
         if (!scope) {
@@ -614,7 +649,12 @@ export class SystemdClient implements ServiceClient {
             );
         }
 
-        const unitContent = renderUnitFile(opts, scope);
+        // F1: user-scope services must ExecStart a STABLE, executable binary —
+        // never the volatile launch path ($APPIMAGE / ~/Downloads). Resolve it
+        // (prefer the machine-wide /opt binary; else stage a copy) before render.
+        const effectiveOpts = scope === 'user' ? this.withStableUserBin(opts) : opts;
+
+        const unitContent = renderUnitFile(effectiveOpts, scope);
         const unitPath = scope === 'user'
             ? this.userUnitPath(opts.name)
             : this.systemUnitPath(opts.name);
@@ -817,29 +857,27 @@ export class SystemdClient implements ServiceClient {
      * Write the tray helper autostart .desktop file under
      * `~/.config/autostart/`. The Linux equivalent of Windows's HKCU Run-key.
      *
-     * If the tray binary can't be located on disk, write a `Exec=<bare-name>`
-     * pointing at PATH lookup so a tray binary later placed on PATH still
-     * works. Logs a warning in that case.
+     * F2: only written when a tray helper binary resolves to an ABSOLUTE path on
+     * disk. If none is found, the autostart is SKIPPED entirely — we never write
+     * a bare-name `Exec=ws-scrcpy-web-tray` (a PATH lookup that violates
+     * Local-Dependencies-Only, and — since Linux has no tray binary, item 27 —
+     * only leaves an orphaned autostart entry that never resolves).
      */
     private writeTrayAutostart(): void {
-        const desktopPath = this.trayAutostartPath();
         const trayPath = resolveTrayHelperPath();
-        let exec: string;
-        if (trayPath) {
-            exec = trayPath;
-        } else {
-            exec = TRAY_HELPER_BIN;
-            log.warn(
-                `tray helper binary not found next to launcher or in publish/; ` +
-                `writing Exec=${TRAY_HELPER_BIN} (relies on PATH lookup at login)`,
+        if (!trayPath) {
+            log.info(
+                'tray helper binary not found; skipping tray autostart (no PATH-reliant Exec written)',
             );
+            return;
         }
 
+        const desktopPath = this.trayAutostartPath();
         const content = [
             '[Desktop Entry]',
             'Type=Application',
             'Name=ws-scrcpy-web tray',
-            `Exec=${exec}`,
+            `Exec=${trayPath}`,
             'Hidden=false',
             'NoDisplay=false',
             'X-GNOME-Autostart-enabled=true',


### PR DESCRIPTION
The beta.44 Fedora smoke (Module 4.2) caught a chain of three bugs that together make a Linux **user-scope service install** fail and leave the app dead. This fixes all three — fix-forward as beta.45, the gate to 0.1.30 final.

## What was broken

**F1 — `ExecStart` pointed at the volatile launch path.** The user-scope unit used `$APPIMAGE` (e.g. `~/Downloads/…AppImage`) verbatim. systemd's `ExecStart` needs the file to be `+x` (a browser download isn't — the GUI can launch it, `execve()` can't), and that file is the throwaway installer artifact (a machine-wide install deletes it). Result: `status=203/EXEC` on every start → `StartLimitBurst` → the service gives up, nothing binds the port, and the local instance had already exited.

**F2 — a PATH-reliant tray autostart.** The install wrote `~/.config/autostart/ws-scrcpy-web-tray.desktop` with `Exec=ws-scrcpy-web-tray` (a bare `PATH` name). Linux has no tray binary, so it was always an orphaned entry — and the Linux uninstall path never removed it.

**F3 — no rollback on a failed start.** The install scheduled a blind 15 s `process.exit(0)` without checking the service was actually up (`install()` doesn't throw — systemd `Type=simple` reports "started" on fork, before `execve` fails). So a failed start killed the local instance anyway → dead app, no error surfaced, stale `installMode`.

## The fix

- **F1:** resolve a stable, executable binary for the user-scope unit — the `/opt` machine-wide binary when present (already `0755`/`bin_t`), otherwise a copy staged under `~/.local/share/WsScrcpyWeb/bin/` (`chmod +x`). Never the launch path.
- **F2:** only write the tray autostart when a real tray binary resolves on disk — never a bare `PATH` name.
- **F3:** poll `is-active` until the service reports `running` before sacrificing the local instance. If it never comes up, roll back (uninstall the dead unit + revert `installMode`) and keep the app alive with a `service-start-failed` error.

## Verification

- TDD throughout — new failing tests first for each fix (`SystemdClient.test.ts`, `ServiceApi.test.ts`).
- `tsc --noEmit` clean; full vitest **888 passed**.
- Runtime re-smoke of the user + system service path happens on the Fedora VM against the published beta.45.

Spec: `docs/specs/2026-06-07-linux-user-service-execstart-fix-design.md`