### PR TITLE
fix(linux): user-scope service install hand-off + machine-wide /opt re-exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux user-scope service install now starts the service cleanly.** beta.45 fixed the unit's `ExecStart`, which exposed a deeper race: the service and the still-running local app share the same per-user single-instance lock, so the service exited "already running" before it could bind the port — and the app went dark. Installing now performs a proper hand-off — the local instance steps aside so the service can take the lock and the port — and verifies the service actually *stays up and is serving* before committing (not just that systemd forked it). If it doesn't come up, the install rolls back and the local app is relaunched, so you're never left with nothing on the port.
+- **Installing for all users no longer leaves the old process running from a deleted file.** After a machine-wide install relocated the binary to `/opt` and deleted the home AppImage, the already-running instance kept serving from the now-deleted file (it showed up as a stale `(deleted)` entry in the process list and still held the single-instance lock). It now relaunches from `/opt` once the install completes, so the deleted-file process is gone and the app runs from the installed location.
+
 ## [0.1.30-beta.45] - 2026-06-07
 
 ### Fixed

--- a/docs/specs/2026-06-07-linux-user-service-handoff-design.md
+++ b/docs/specs/2026-06-07-linux-user-service-handoff-design.md
@@ -1,0 +1,103 @@
+# Linux user-scope service: install handoff + machine-wide re-exec (beta.46)
+
+**Date:** 2026-06-07
+**Status:** Approved — implementing
+**Found by:** the `v0.1.30-beta.45` Fedora re-smoke (Module 4.2, user scope) — beta.45's F1 fix let the service get far enough to expose this.
+
+## Problem
+
+### F4 — the user-scope service loses the single-instance lock race
+A user-scope service and the local app run as the **same user**, so they share the
+per-`$XDG_RUNTIME_DIR` `flock` (`single_instance.rs`). The install fires
+`systemctl --user enable --now` while the local app is still running and holding
+the lock, so the service's `/opt` launcher starts, sees the lock held, logs
+*"another ws-scrcpy-web-launcher instance is already running; exiting"* and exits
+`0` in ~1 ms — never binding the port. Then the local instance exits too → nothing
+left on 8000.
+
+**Scope:** F4 is **user-scope only**. A system-scope service runs as **root** with
+no `XDG_RUNTIME_DIR`, so its lock falls back to `/var/opt/.../control/instance.lock`
+— a different file, no collision. (System scope may have a separate *port* handoff
+wrinkle; that's verified separately when we test it.)
+
+### F3 gap — verify was fooled
+beta.45's Node-side `verifyServiceActive` polled `systemctl is-active`, which for a
+`Type=simple` unit reports `active` the instant the process forks (systemd showed
+`Duration: 141ms`). The poll caught that flicker and treated the start-then-exit-0
+as success, so it never rolled back (the unit was left installed-but-dead).
+
+### F5 — machine-wide install leaves the running instance on the deleted home mount
+The machine-wide install relocates the binary to `/opt` and deletes the home
+AppImage, but the **already-running** instance (which started before `/opt`
+existed, so the bootstrapper ran in-place) never re-execs. It keeps serving from
+its deleted AppImage FUSE mount (`/tmp/.mount_…`), shows a `(deleted)` path in the
+process list, and holds both the FUSE mount and the single-instance lock.
+
+## Design — beta.46
+
+**Principle:** local→service is a *handoff* — the local instance must release the
+lock before the service binds. Mirror the existing **uninstall→relaunch** detached
+helper (`linux_service.rs::run` / `--linux-service-teardown`), reversed.
+
+### F4 — detached install-handoff helper
+
+1. **`SystemdClient.install` (Linux user scope):** write the unit + `systemctl
+   --user enable` — **not `--now`**. (Root/system scope and Windows keep their
+   current start-on-install.) The service is enabled but not started into a held
+   lock; the helper starts it once the lock is free.
+2. **`ServiceApi.handleInstall` (Linux user scope):** after `client.install()`,
+   spawn a detached, out-of-cgroup helper (mirrors the teardown spawn):
+   ```
+   systemd-run --user --collect --unit=wsscrcpy-install-<ts> \
+     <dataRoot>/control/operation-server/ws-scrcpy-web-launcher.exe \
+     --linux-service-install-handoff --scope user --unit WsScrcpyWeb
+   ```
+   then schedule a **prompt** local-instance exit (release lock + port) and respond
+   `{ ok: true, status: 'shutting-down', … }` so the frontend reconnects through the
+   gap (same path uninstall already uses).
+3. **New launcher handler `--linux-service-install-handoff`** (`linux_service.rs`,
+   mirrors `run()`):
+   1. **Wait for the lock to free** (the local instance exited) — poll a
+      non-blocking `flock` probe / port-closed, up to ~20 s.
+   2. `systemctl --user start WsScrcpyWeb.service`.
+   3. **Verify it STAYS up:** poll `is-active == active` **AND** a TCP connect to
+      the web port succeeds, for a few seconds (the real fix for the F3 flicker —
+      a fork-then-exit unit never satisfies the port probe).
+   4. **Success →** done (the frontend's reconnect poll lands on the service).
+   5. **Failure →** roll back: `teardown_commands` (stop/disable/rm/reload) +
+      relaunch local from the `local-appimage` marker (exactly like
+      uninstall→relaunch). The user lands back in a working local app.
+
+### F3 — verify moves to the helper (Linux user); Windows unchanged
+The "stayed up + bound the port" check now lives in the handoff helper, which
+outlives the local instance and can actually observe the post-handoff state.
+beta.45's Node-side `verifyServiceActive` + rollback **stays for Windows** (and,
+for now, Linux **system** scope). Linux user-scope routes through the helper.
+
+### F5 — re-exec to /opt after machine-wide install
+After `handleInstallSystemWide` succeeds, relaunch the running instance from
+`/opt`: exit the local instance + `systemd-run --user --collect
+/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage` (via the same helper seam), so it stops
+running the deleted home mount, releases the FUSE mount, and holds `/opt`.
+
+## Test plan
+
+**Rust (`cross`, pure helpers — `run_install_handoff` itself is the exec seam,
+Fedora-verified, like `run()`):**
+- `start_command(scope, unit, bindir)` → `systemctl --user start WsScrcpyWeb.service`.
+- `service_up(is_active, port_open)` predicate → true only when both hold.
+- install-handoff arg parsing reuses `parse_args` (`--scope` / `--unit`).
+- `single_instance`: a lock-free probe returns true when the lock is droppable.
+
+**TS (vitest):**
+- `SystemdClient.install` user scope → `enable` (no `--now`); root/system → `enable --now`.
+- `ServiceApi.handleInstall` Linux user → spawns `--linux-service-install-handoff`
+  via `systemd-run --user --collect`, schedules a prompt exit, responds
+  `shutting-down`, and does **not** run the Node-side verify. Windows + Linux
+  system scope still run the beta.45 verify/rollback.
+
+## Rollout
+`release:beta` PR (no manual bump — Mode 1) → squash-merge → **beta.46** → verify
+`/releases/latest` = beta.46 → curate the releases page (delete the beta.45
+release, keep its tag — per the established pattern) → re-smoke user-scope service
+on the Fedora VM against beta.46.

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -328,6 +328,151 @@ fn run(scope: Scope, unit: &str) -> i32 {
     0
 }
 
+// ── install handoff (F4) ────────────────────────────────────────────────────
+//
+// A user-scope service and the local app run as the same user, so they share
+// the per-$XDG_RUNTIME_DIR single-instance flock. Starting the service while the
+// local app still holds the lock makes the service launcher see "already
+// running" and exit 0 (never binding). So the install enables the unit (NOT
+// --now) and hands off to THIS out-of-cgroup helper, which waits for the local
+// instance to exit (port released → lock freed), starts the service, verifies it
+// STAYS up (active AND serving — not the Type=simple flicker), and on failure
+// rolls back + relaunches local so the user is never stranded. Mirror of `run`.
+
+/// `systemctl [--user] start <unit>.service` argv (absolute systemctl, Local-Deps).
+pub fn start_command(scope: Scope, name: &str, bindir: &str) -> Vec<String> {
+    let systemctl = format!("{bindir}/systemctl");
+    [
+        vec![systemctl],
+        scope_prefix(scope),
+        vec!["start".into(), format!("{name}.service")],
+    ]
+    .concat()
+}
+
+/// The handoff treats the service as "up" only when systemd reports it active
+/// AND the web port actually accepts a connection. `Type=simple` flips a unit to
+/// active the instant it forks, so is-active alone is fooled by a start-then-
+/// exit-0 (the beta.45 F3 flicker); the port probe is what makes the check real.
+/// Pure.
+pub fn service_up(is_active: bool, port_open: bool) -> bool {
+    is_active && port_open
+}
+
+/// TCP-probe 127.0.0.1:<port>; true when a connection succeeds within 200ms.
+fn port_is_open(port: u16) -> bool {
+    std::net::TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+        std::time::Duration::from_millis(200),
+    )
+    .is_ok()
+}
+
+/// Poll up to `secs` seconds (1s cadence) for the port to reach `want_open`.
+fn wait_port(port: u16, want_open: bool, secs: u64) -> bool {
+    for _ in 0..secs {
+        if port_is_open(port) == want_open {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+    port_is_open(port) == want_open
+}
+
+/// Poll up to `secs` seconds for the service to be active AND serving the port.
+fn verify_up(scope: Scope, unit: &str, bindir: &str, port: u16, secs: u64) -> bool {
+    let systemctl = format!("{bindir}/systemctl");
+    let pre = scope_prefix(scope);
+    let unit_svc = format!("{unit}.service");
+    for _ in 0..secs {
+        let mut a: Vec<&str> = pre.iter().map(String::as_str).collect();
+        a.push("is-active");
+        a.push(&unit_svc);
+        let is_active = std::process::Command::new(&systemctl)
+            .args(&a)
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "active")
+            .unwrap_or(false);
+        if service_up(is_active, port_is_open(port)) {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+    false
+}
+
+/// Dispatch: handle `--linux-service-install-handoff`, return Some(exit_code).
+pub fn handle_install_handoff(args: &[String]) -> Option<i32> {
+    if !args.iter().any(|a| a == "--linux-service-install-handoff") {
+        return None;
+    }
+    match parse_args(args) {
+        Some((scope, unit)) => Some(run_install_handoff(scope, &unit)),
+        None => {
+            log::error("linux-service-install-handoff: missing/invalid --scope or --unit");
+            Some(2)
+        }
+    }
+}
+
+fn run_install_handoff(scope: Scope, unit: &str) -> i32 {
+    let bd = tool_dir("systemctl");
+    log::info(&format!("install-handoff: scope={scope:?} unit={unit}"));
+
+    // Web port from the user config (default 8000). The local instance + the
+    // service share it; it's our signal for the local exit and the service bind.
+    let web_port = common::config::data_root_from_env()
+        .map(|dr| common::config::AppConfig::load(&dr))
+        .and_then(|c| c.web_port)
+        .unwrap_or(8000);
+
+    // 1. Wait for the local instance to release the port (it exits to free the
+    //    per-user single-instance lock the service needs). Best-effort.
+    if wait_port(web_port, false, 20) {
+        log::info(&format!("install-handoff: local instance released port {web_port}"));
+    } else {
+        log::error(&format!(
+            "install-handoff: port {web_port} still held after 20s; starting anyway"
+        ));
+    }
+
+    // 2. Start the service (lock now free → it acquires it + binds the port).
+    let argv = start_command(scope, unit, &bd);
+    let (cmd, rest) = argv.split_first().expect("non-empty argv");
+    match std::process::Command::new(cmd).args(rest).status() {
+        Ok(s) => log::info(&format!("install-handoff: started {unit} (exit {:?})", s.code())),
+        Err(e) => log::error(&format!("install-handoff: start spawn failed: {e}")),
+    }
+
+    // 3. Verify it STAYS up (active AND serving) — not the Type=simple flicker.
+    if verify_up(scope, unit, &bd, web_port, 12) {
+        log::info("install-handoff: service active + serving; handoff complete");
+        return 0;
+    }
+
+    // 4. Failure → roll back (teardown) + relaunch local so the user isn't stranded.
+    log::error("install-handoff: service did not come up; rolling back + relaunching local");
+    for argv in teardown_commands(scope, unit, &bd) {
+        let (cmd, rest) = argv.split_first().expect("non-empty argv");
+        let _ = std::process::Command::new(cmd).args(rest).status();
+    }
+    if let Some(target) = relaunch_target(scope, read_local_appimage_marker()) {
+        let systemd_run = format!("{}/systemd-run", tool_dir("systemd-run"));
+        let target_str = target.to_string_lossy().into_owned();
+        match std::process::Command::new(&systemd_run)
+            .args(["--user", "--collect", &target_str])
+            .status()
+        {
+            Ok(s) => log::info(&format!(
+                "install-handoff rollback: relaunched local {target_str} (exit {:?})",
+                s.code()
+            )),
+            Err(e) => log::error(&format!("install-handoff rollback: relaunch failed: {e}")),
+        }
+    }
+    0
+}
+
 fn read_local_appimage_marker() -> Option<String> {
     let data_root = common::config::data_root_from_env()?;
     let p = data_root.join("control").join("local-appimage");
@@ -459,5 +604,25 @@ mod tests {
         assert_eq!(bootstrap_decision(true, Some(opt), "0.1.31", Some("0.1.31")), BootstrapAction::RunHome);   // we ARE /opt
         assert_eq!(bootstrap_decision(false, Some("/home/u/App.AppImage"), "0.1.31", None), BootstrapAction::RunHome);  // no /opt
         assert_eq!(bootstrap_decision(true, Some("/home/u/App.AppImage"), "0.1.31", None), BootstrapAction::ExecOpt(opt.into())); // unknown /opt version -> run /opt
+    }
+
+    #[test]
+    fn start_command_user_and_system() {
+        assert_eq!(
+            start_command(Scope::User, "WsScrcpyWeb", "/usr/bin"),
+            vec!["/usr/bin/systemctl", "--user", "start", "WsScrcpyWeb.service"]
+        );
+        assert_eq!(
+            start_command(Scope::System, "WsScrcpyWeb", "/usr/bin"),
+            vec!["/usr/bin/systemctl", "start", "WsScrcpyWeb.service"]
+        );
+    }
+
+    #[test]
+    fn service_up_requires_active_and_serving() {
+        assert!(service_up(true, true));
+        assert!(!service_up(true, false)); // active but not serving — the Type=simple flicker
+        assert!(!service_up(false, true));
+        assert!(!service_up(false, false));
     }
 }

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -102,6 +102,15 @@ fn main() {
         std::process::exit(code);
     }
 
+    // Install handoff (F4): out-of-cgroup helper that starts the user-scope
+    // service AFTER the local instance exits (freeing the single-instance lock),
+    // verifies it stays up, and rolls back + relaunches local on failure.
+    #[cfg(target_os = "linux")]
+    if let Some(code) = linux_service::handle_install_handoff(&args) {
+        log::info(&format!("linux-service-install-handoff exiting with code {code}"));
+        std::process::exit(code);
+    }
+
     // Service-defer: if an ACTIVE system-scope service owns the app, open the
     // browser at its URL and exit instead of spawning a duplicate local server.
     #[cfg(target_os = "linux")]

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1134,7 +1134,7 @@ describe('ServiceApi', () => {
             expect(body.status).toBe('shutting-down');
         });
 
-        it('schedules local-instance exit after a successful install on Linux (mirrors win32)', async () => {
+        it('schedules a prompt local-instance exit on Linux user-scope install (handoff frees the lock)', async () => {
             const scheduled: number[] = [];
             const scheduleExit = vi.fn((_fn: () => void, ms: number) => { scheduled.push(ms); });
             const client = fakeClient({
@@ -1158,13 +1158,15 @@ describe('ServiceApi', () => {
             await api.handle(req, res);
             expect((res as any).getStatus()).toBe(200);
             expect(scheduleExit).toHaveBeenCalledTimes(1);
-            expect(scheduled[0]).toBe(15_000);
+            // F4: Linux user-scope now exits promptly so the handoff helper can
+            // start the service once the per-user lock is free (was 15s blind).
+            expect(scheduled[0]).toBe(1_500);
         });
 
-        it('F3: rolls back when the service never becomes active — uninstall + revert installMode + ok:false, no exit', async () => {
-            // install() does NOT throw (systemd Type=simple reports "started" on
-            // fork, before execve fails), so the existing throw-path is not hit.
-            // verifyServiceActive returns false → the install must roll back
+        it('F3 (win32): rolls back when the service never becomes active — uninstall + revert installMode + ok:false, no exit', async () => {
+            // Windows (and Linux system scope) keep the in-handler verify/rollback —
+            // they don't share the user's single-instance lock. install() doesn't
+            // surface a failed start, so verifyServiceActive=false must roll back
             // instead of blindly exiting the local instance.
             const uninstallFn = vi.fn(async () => undefined);
             const scheduleExit = vi.fn();
@@ -1176,7 +1178,7 @@ describe('ServiceApi', () => {
             const factoryResult: ServiceClientFactoryResult = {
                 client,
                 supported: true,
-                platform: 'linux',
+                platform: 'win32',
             };
             // Pre-existing local mode → rollback must restore it.
             Config.getInstance().updateAppConfig({ installMode: 'user' });
@@ -1184,7 +1186,7 @@ describe('ServiceApi', () => {
             const api = new ServiceApi(
                 () => factoryResult,
                 () => 'user',
-                () => true,
+                () => true,          // existsCheck → packaged launcher present
                 vi.fn(),            // spawnDetached
                 scheduleExit,
                 undefined,          // runPkexecFn → default
@@ -1205,7 +1207,7 @@ describe('ServiceApi', () => {
             expect(body.reason).toBe('service-start-failed');
         });
 
-        it('F3: keeps the install when the service becomes active (no rollback on the happy path)', async () => {
+        it('F3 (win32): keeps the install when the service becomes active (no rollback)', async () => {
             const uninstallFn = vi.fn(async () => undefined);
             const scheduleExit = vi.fn();
             const client = fakeClient({
@@ -1216,7 +1218,7 @@ describe('ServiceApi', () => {
             const factoryResult: ServiceClientFactoryResult = {
                 client,
                 supported: true,
-                platform: 'linux',
+                platform: 'win32',
             };
             const api = new ServiceApi(
                 () => factoryResult,
@@ -1234,6 +1236,62 @@ describe('ServiceApi', () => {
             expect((res as any).getStatus()).toBe(200);
             const body = JSON.parse((res as any).getBody());
             expect(body.ok).toBe(true);
+        });
+
+        it('F4: Linux user-scope install hands off to the detached helper (no in-handler verify)', async () => {
+            // The service can't start while THIS local instance holds the per-user
+            // lock, so handleInstall enables the unit, spawns the out-of-cgroup
+            // install-handoff helper via systemd-run, and exits promptly to free the
+            // lock. The helper (not this handler) verifies + rolls back — so
+            // verifyServiceActive must NOT be called on this path.
+            const verifySpy = vi.fn(async () => true);
+            const scheduleExit = vi.fn();
+            let spawnedCmd = '';
+            let spawnedArgs: string[] = [];
+            const spawnDetached = vi.fn((cmd: string, args: string[]) => { spawnedCmd = cmd; spawnedArgs = args; });
+            const client = fakeClient({
+                install: vi.fn(async () => undefined),
+                status: vi.fn(async () => 'running' as const),
+            });
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'linux',
+            };
+            const api = new ServiceApi(
+                () => factoryResult,
+                () => 'user',
+                () => true,
+                spawnDetached,
+                scheduleExit,
+                undefined,
+                verifySpy,
+            );
+            const { req, res } = makeReqRes('/api/service/install', 'POST', JSON.stringify({ scope: 'user' }));
+            await api.handle(req, res);
+
+            // Handoff helper spawned via systemd-run --user --collect.
+            expect(spawnDetached).toHaveBeenCalledTimes(1);
+            expect(spawnedCmd).toMatch(/systemd-run/);
+            expect(spawnedArgs).toContain('--user');
+            expect(spawnedArgs).toContain('--collect');
+            expect(spawnedArgs).toContain('--linux-service-install-handoff');
+            expect(spawnedArgs).toContain('--scope');
+            expect(spawnedArgs).toContain('user');
+            expect(spawnedArgs).toContain('--unit');
+            expect(spawnedArgs).toContain('WsScrcpyWeb');
+            const helperArg = spawnedArgs.find((a) => a.endsWith('ws-scrcpy-web-launcher.exe'));
+            expect(helperArg).toBeDefined();
+            expect(helperArg).toContain('operation-server');
+            // local exits promptly to free the lock
+            expect(scheduleExit).toHaveBeenCalledTimes(1);
+            // the in-handler verify/rollback is NOT used on the Linux user path
+            expect(verifySpy).not.toHaveBeenCalled();
+            // responds shutting-down so the frontend reconnects through the gap
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(true);
+            expect(body.status).toBe('shutting-down');
         });
 
         it('user-scope uninstall is UNCHANGED (home helper, systemd-run --user, no pkexec)', async () => {
@@ -1322,6 +1380,36 @@ describe('ServiceApi', () => {
                 expect(script).toContain(`cp "${appImagePath}" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`);
                 expect(script).toContain('bin_t');
                 expect(label).toBe('install-system-wide');
+            } finally {
+                if (savedAppImage === undefined) delete process.env['APPIMAGE'];
+                else process.env['APPIMAGE'] = savedAppImage;
+            }
+        });
+
+        it('POST /api/service/install-system-wide relaunches from /opt + exits (F5: no lingering home-mount process)', async () => {
+            const savedAppImage = process.env['APPIMAGE'];
+            process.env['APPIMAGE'] = '/home/jamie/Downloads/WsScrcpyWeb-linux-beta.AppImage';
+            try {
+                const fakePkexec = vi.fn(async (_cmd: string, _label: string) => '');
+                const scheduleExit = vi.fn();
+                let spawnedArgs: string[] = [];
+                const spawnDetached = vi.fn((_cmd: string, args: string[]) => { spawnedArgs = args; });
+                // existsCheck → relaunch helper present, so F5 hands off + exits.
+                const api = new ServiceApi(undefined, undefined, () => true, spawnDetached, scheduleExit, fakePkexec);
+                const { req, res } = makeReqRes('/api/service/install-system-wide', 'POST');
+                await api.handle(req, res);
+
+                expect((res as any).getStatus()).toBe(200);
+                const body = JSON.parse((res as any).getBody());
+                expect(body.ok).toBe(true);
+                expect(body.status).toBe('shutting-down');
+                // relaunch-only helper targeting /opt, waiting on the launcher (flock holder).
+                expect(spawnDetached).toHaveBeenCalledTimes(1);
+                expect(spawnedArgs).toContain('--linux-apply');
+                expect(spawnedArgs).toContain('--target');
+                expect(spawnedArgs.some((a) => a.endsWith('/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage'))).toBe(true);
+                expect(spawnedArgs).toContain('--wait-pid');
+                expect(scheduleExit).toHaveBeenCalledTimes(1);
             } finally {
                 if (savedAppImage === undefined) delete process.env['APPIMAGE'];
                 else process.env['APPIMAGE'] = savedAppImage;

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -167,10 +167,10 @@ describe('SystemdClient', () => {
             const sysCalls = execFileSyncMock.mock.calls.filter((c) => c[0] === 'systemctl');
             expect(sysCalls).toHaveLength(2);
             expect(sysCalls[0]![1]).toEqual(['--user', 'daemon-reload']);
+            // F4: user scope enables but does NOT --now (the handoff helper starts it).
             expect(sysCalls[1]![1]).toEqual([
                 '--user',
                 'enable',
-                '--now',
                 'WsScrcpyWeb.service',
             ]);
 

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -461,10 +461,47 @@ export class ServiceApi {
             return true;
         }
 
+        // F4: Linux user-scope can't start the service while THIS local instance
+        // holds the per-user single-instance lock — the service would exit
+        // "already running" before binding. install() above only `enable`d the
+        // unit (no --now); hand off to a detached, out-of-cgroup helper that
+        // starts it AFTER we exit (freeing the lock), verifies it stays up, and
+        // rolls back + relaunches local on failure. Mirror of the uninstall
+        // teardown spawn. (Windows + Linux system scope keep the in-handler
+        // verify/rollback below — they don't share the user's lock.)
+        if (result.platform === 'linux' && scope === 'user') {
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            const systemdRun = resolveSystemTool('systemd-run');
+            const handoffUnit = `--unit=wsscrcpy-install-${Date.now()}`;
+            this.spawnDetached(systemdRun, [
+                '--user', '--collect', handoffUnit,
+                helper, '--linux-service-install-handoff', '--scope', 'user', '--unit', WS_SCRCPY_SERVICE_NAME,
+            ]);
+            log.info('install-flow(linux user): spawned install-handoff helper; exiting local to free the lock');
+            // Exit promptly so the helper can start the service (release lock + port).
+            this.scheduleExit(() => {
+                log.info('install-flow: local instance exiting (handoff to service)');
+                process.exit(0);
+            }, 1_500);
+            const disk = this.readDiskConfig();
+            const body: ServiceActionSuccess = {
+                ok: true,
+                status: 'shutting-down',
+                installMode: newInstallMode,
+                ...(disk.configMtime != null ? { configMtime: disk.configMtime } : {}),
+                ...(disk.diskWebPort != null ? { diskWebPort: disk.diskWebPort } : {}),
+            };
+            res.writeHead(200);
+            res.end(JSON.stringify(body));
+            return true;
+        }
+
         // F3: verify the service actually started before sacrificing this local
         // instance. install() does NOT throw on a failed start (systemd
         // Type=simple reports "started" on fork, before execve fails), so a
         // blind exit here would strand the user with a dead app + no fallback.
+        // (Windows + Linux system scope; Linux user scope returns above.)
         const active = await this.verifyServiceActive(result.client, WS_SCRCPY_SERVICE_NAME);
         if (!active) {
             log.warn('install-flow: service did not become active; rolling back the failed install');
@@ -760,8 +797,31 @@ export class ServiceApi {
         const script = buildMachineWideInstallScript({ sourceAppImage: appImage, version });
         try {
             await this.runPkexecFn(script, 'install-system-wide');
-            res.writeHead(200);
-            res.end(JSON.stringify({ ok: true, status: 'installed' }));
+            // F5: the running instance launched from the home AppImage (now
+            // deleted by the install) and never re-execs to /opt — it lingers on
+            // the deleted FUSE mount and holds the per-user lock. Hand off to the
+            // relaunch-only helper (waits for our launcher to exit → flock free →
+            // runs /opt) and exit promptly so the app comes back from /opt, not the
+            // deleted mount. Reuses the linux_apply relaunch-only path.
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            const relaunchHelper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            const optBin = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
+            if (this.existsCheck(relaunchHelper)) {
+                // process.ppid is the launcher (the flock holder); the helper waits
+                // for it to exit before relaunching /opt.
+                this.spawnDetached(relaunchHelper, ['--linux-apply', '--target', optBin, '--wait-pid', String(process.ppid)]);
+                this.scheduleExit(() => {
+                    log.info('install-system-wide: local instance exiting → relaunch from /opt');
+                    process.exit(0);
+                }, 1_500);
+                res.writeHead(200);
+                res.end(JSON.stringify({ ok: true, status: 'shutting-down' }));
+            } else {
+                log.warn('install-system-wide: relaunch helper not found; app keeps running from the home mount until next launch');
+                res.writeHead(200);
+                res.end(JSON.stringify({ ok: true, status: 'installed' }));
+            }
         } catch (err) {
             const msg = (err as Error).message;
             const declined = /dismissed/i.test(msg);

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -696,10 +696,22 @@ export class SystemdClient implements ServiceClient {
 
             const baseArgs = scope === 'user' ? ['--user'] : [];
             runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload');
-            runSystemctl(
-                [...baseArgs, 'enable', '--now', `${opts.name}.service`],
-                `enable --now ${opts.name}.service`,
-            );
+            // F4: user scope must NOT start the service here — the local app still
+            // holds the per-user single-instance lock, so the service would exit
+            // "already running" before binding. Just `enable` (persist); ServiceApi
+            // spawns a detached install-handoff helper that starts it after the
+            // local instance exits and frees the lock. Root/system starts normally.
+            if (scope === 'user') {
+                runSystemctl(
+                    [...baseArgs, 'enable', `${opts.name}.service`],
+                    `enable ${opts.name}.service`,
+                );
+            } else {
+                runSystemctl(
+                    [...baseArgs, 'enable', '--now', `${opts.name}.service`],
+                    `enable --now ${opts.name}.service`,
+                );
+            }
         }
 
         if (scope === 'user') {


### PR DESCRIPTION
The beta.45 Fedora re-smoke (Module 4.2) confirmed beta.45's three fixes and then surfaced the next layer: with `ExecStart` now correct, the user-scope service got far enough to hit a single-instance lock race. This fixes that (**F4**) plus the machine-wide "lingering deleted-file process" (**F5**) the smoke also turned up.

## What was wrong

**F4 — the service lost the single-instance lock race.** A user-scope service and the local app run as the same user, so they share the per-`$XDG_RUNTIME_DIR` `flock`. `enable --now` started the service while the local app still held the lock, so the service launcher logged *"another instance already running"* and exited `0` in ~1 ms — never binding. Then the local instance exited too, leaving nothing on the port. (beta.45's verify was also fooled: `Type=simple` flips the unit "active" the instant it forks, so the `is-active` poll caught that flicker and didn't roll back.)

**F5 — machine-wide install left a process on a deleted file.** After "install for all users" relocated the binary to `/opt` and deleted the home AppImage, the already-running instance kept serving from the now-deleted FUSE mount (a stale `(deleted)` entry in the process list, still holding the lock) instead of re-running from `/opt`.

## The fix

- **F4 — install hand-off** (mirrors the existing uninstall→relaunch helper). User-scope install now `enable`s the unit (no `--now`) and hands off to a detached, out-of-cgroup helper (`--linux-service-install-handoff` via `systemd-run --user --collect`). The local instance exits to free the lock; the helper then starts the service, verifies it **stays up and is actually serving the port** (not the `Type=simple` flicker), and on failure tears down + relaunches local so you're never stranded.
- **F3** — that "stayed up + serving" check lives in the helper for Linux user scope (it outlives the local instance and can observe the real post-handoff state). Windows + Linux *system* scope keep beta.45's in-handler verify/rollback.
- **F5** — `install-system-wide` now spawns the `linux_apply` relaunch-only helper (waits for the launcher/flock-holder to exit, then runs `/opt`) and exits promptly, so the app comes back from `/opt` and the deleted-file process is gone.

## Verification

- TDD: Rust pure helpers (`start_command`, `service_up`) unit-tested; the orchestration is the Fedora-verified exec seam (same pattern as the existing teardown helper). TS via vitest.
- `tsc --noEmit` clean; full vitest **890 passed**. Rust `cargo test --workspace` + `clippy` run in CI here.
- Re-smoke of the user-scope (and now system-scope) service path happens on the Fedora VM against the published beta.46.

Spec: `docs/specs/2026-06-07-linux-user-service-handoff-design.md`