### PR TITLE
fix(linux): suppress redundant browser tab on relaunch (G1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installing for all users no longer pops a redundant browser tab.** The post-install relaunch from `/opt` (and any in-app update relaunch) now tells the freshly-launched instance to skip opening a browser — your existing tab reconnects on its own, so you no longer end up with a second one.
+
 ## [0.1.30-beta.46] - 2026-06-07
 
 ### Fixed

--- a/launcher/src/linux_apply.rs
+++ b/launcher/src/linux_apply.rs
@@ -218,6 +218,9 @@ fn relaunch(target: &Path) {
     let mut command = std::process::Command::new(cmd);
     command
         .args(rest)
+        // G1: suppress the browser-open on relaunch (the direct-exec path; the
+        // systemd-run path carries it via --setenv in relaunch_command).
+        .env("WS_SCRCPY_NO_BROWSER", "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -256,8 +259,17 @@ fn under_systemd() -> bool {
 pub fn relaunch_command(target: &Path, under_systemd: bool, systemd_run: &str) -> Vec<String> {
     let t = target.to_string_lossy().into_owned();
     if under_systemd {
-        vec![systemd_run.to_string(), "--user".into(), "--collect".into(), t]
+        // G1: suppress the browser-open on relaunch — the user already has a tab
+        // that reconnects, so the relaunched instance must not pop a new one.
+        vec![
+            systemd_run.to_string(),
+            "--user".into(),
+            "--collect".into(),
+            "--setenv=WS_SCRCPY_NO_BROWSER=1".into(),
+            t,
+        ]
     } else {
+        // Direct exec — relaunch() sets WS_SCRCPY_NO_BROWSER on the Command.
         vec![t]
     }
 }
@@ -363,7 +375,7 @@ mod tests {
         // survives this helper's exit (not in this helper's reaped cgroup).
         assert_eq!(
             relaunch_command(Path::new("/home/u/App.AppImage"), true, "/usr/bin/systemd-run"),
-            vec!["/usr/bin/systemd-run", "--user", "--collect", "/home/u/App.AppImage"]
+            vec!["/usr/bin/systemd-run", "--user", "--collect", "--setenv=WS_SCRCPY_NO_BROWSER=1", "/home/u/App.AppImage"]
         );
     }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -211,7 +211,11 @@ reconcileWebPort()
             const appCfg = config.getAppConfig();
             const isServiceMode =
                 appCfg.installMode === 'user-service' || appCfg.installMode === 'system-service';
-            if (appCfg.firstRunComplete === false && !isServiceMode) {
+            // G1: a relaunch (the post-machine-wide-install /opt re-exec, or an
+            // in-app update relaunch) sets WS_SCRCPY_NO_BROWSER=1 — the user
+            // already has a tab that reconnects, so don't pop a redundant one.
+            const suppressBrowser = process.env['WS_SCRCPY_NO_BROWSER'] === '1';
+            if (appCfg.firstRunComplete === false && !isServiceMode && !suppressBrowser) {
                 const port = config.servers[0]?.port ?? appCfg.webPort;
                 openBrowser(`http://localhost:${port}`);
             }


### PR DESCRIPTION
Follow-up from the beta.46 re-smoke: F5 (relaunch from `/opt` after "install for all users") worked, but the freshly-launched `/opt` instance — booting with `firstRunComplete=false` — opened a **second browser tab** on top of the one the user already had.

**Fix:** the relaunch now sets `WS_SCRCPY_NO_BROWSER=1` (`--setenv` on the `systemd-run` path, `.env` on the direct-exec path in `linux_apply.rs`), and the server's first-run browser-open honors it. Applies to the machine-wide-install relaunch *and* in-app update relaunches — any relaunch means the user already has a tab that reconnects.

`tsc` clean · vitest **890** · `relaunch_command` test updated (Rust verified via CI).