### PR TITLE
fix(linux): reliable post-install service hand-off detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installing a service no longer shows a false "port discovery timed out" error.** After a service install handed the web port over to the service, the settings page would occasionally spin and then report that it couldn't determine the service's port — even though the service was running fine and a manual refresh loaded it. The post-install reconnect was inferring that the hand-off had finished from two unreliable signals: a `config.json` change that never happens when the service rebinds the *same* port, and briefly catching the port unbound (a race against the 2-second poll). When the service came back quickly on the same port it caught neither and ran out the clock. The service now reports its own identity, and the page waits for that positive signal before reconnecting — so the hand-off is detected reliably regardless of timing. (Intermittent by nature; most visible on Linux user-scope installs.)
+
 ## [0.1.30-beta.47] - 2026-06-08
 
 ### Fixed

--- a/docs/smoke-tests/clear-install.sh
+++ b/docs/smoke-tests/clear-install.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# clear-install.sh — clear EVERY ws-scrcpy-web install footprint on Linux, then verify the slate.
+#
+# Smoke pre-flight for the v0.1.30 gate. Idempotent + safe to run on an already-clean VM.
+# Linux-only (Fedora/SELinux + Ubuntu). Paths/units/rules are pulled verbatim from source:
+#   SystemdClient.ts (units, autostart, /opt, /var/opt, .desktop, stable bin in dataRoot),
+#   linux_service.rs (teardown + fcontext specs), config.rs (dataRoot), single_instance.rs (lock).
+# Validated on Fedora (SELinux enforcing) 2026-06-07 — 12/12 checks → CLEAN SLATE.
+#
+# Usage on the smoke VM:   bash clear-install.sh
+set -u
+
+GREEN=$'\e[32m'; RED=$'\e[31m'; YEL=$'\e[33m'; DIM=$'\e[2m'; RST=$'\e[0m'
+PASS=0; FAIL=0
+say()  { printf '%s\n' "$*"; }
+step() { printf '\n%s== %s ==%s\n' "$DIM" "$*" "$RST"; }
+ok()   { printf '%s[ OK ]%s %s\n' "$GREEN" "$RST" "$*"; PASS=$((PASS+1)); }
+bad()  { printf '%s[FAIL]%s %s\n' "$RED"   "$RST" "$*"; FAIL=$((FAIL+1)); }
+info() { printf '%s[info]%s %s\n' "$YEL"   "$RST" "$*"; }
+
+# --- resolved footprint (verbatim from source) ---
+UNIT="WsScrcpyWeb.service"
+DATA_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/WsScrcpyWeb"
+USER_UNIT="$HOME/.config/systemd/user/$UNIT"
+SYS_UNIT="/etc/systemd/system/$UNIT"
+AUTOSTART="$HOME/.config/autostart/ws-scrcpy-web-tray.desktop"
+SYS_DESKTOP="/usr/share/applications/ws-scrcpy-web.desktop"
+OPT_DIR="/opt/ws-scrcpy-web"
+VAR_OPT_DIR="/var/opt/ws-scrcpy-web"
+LOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ws-scrcpy-web.lock"
+FCONTEXT_SPECS=( '/opt/ws-scrcpy-web(/.*)?' '/var/opt/ws-scrcpy-web(/.*)?' '/opt/ws-scrcpy-web/data(/.*)?' )
+PROC_PAT='WsScrcpyWeb|ws-scrcpy-web-tray|ws-scrcpy-web-launcher|scrcpy-server'
+
+HAVE_SEMANAGE=0; command -v semanage >/dev/null 2>&1 && HAVE_SEMANAGE=1
+HAVE_SELINUX=0; [ -d /sys/fs/selinux ] && HAVE_SELINUX=1
+
+say "Clearing ws-scrcpy-web footprint…"
+say "  dataRoot : $DATA_ROOT"
+say "  SELinux  : $([ $HAVE_SELINUX -eq 1 ] && echo present || echo absent)   semanage: $([ $HAVE_SEMANAGE -eq 1 ] && echo yes || echo no)"
+sudo -v || { say "${RED}sudo required (system-scope teardown).${RST}"; exit 1; }   # prompt once, up front
+
+step "PHASE 1 — TEARDOWN"
+
+# 1. kill running processes (server + launcher + tray + escaped adb/scrcpy-server)
+pkill -TERM -f "$PROC_PAT" 2>/dev/null || true
+pkill -TERM -x adb         2>/dev/null || true
+sleep 1
+pkill -KILL -f "$PROC_PAT" 2>/dev/null || true
+
+# 2. user-scope service
+systemctl --user stop "$UNIT" 2>/dev/null || true
+systemctl --user disable "$UNIT" 2>/dev/null || true
+systemctl --user reset-failed "$UNIT" 2>/dev/null || true
+rm -f "$USER_UNIT"
+systemctl --user daemon-reload 2>/dev/null || true
+
+# 3. system-scope service
+sudo systemctl stop "$UNIT" 2>/dev/null || true
+sudo systemctl disable "$UNIT" 2>/dev/null || true
+sudo systemctl reset-failed "$UNIT" 2>/dev/null || true
+sudo rm -f "$SYS_UNIT"
+sudo systemctl daemon-reload 2>/dev/null || true
+
+# 4. machine-wide /opt + system state /var/opt
+sudo rm -rf "$OPT_DIR" "$VAR_OPT_DIR"
+
+# 5. desktop entries
+sudo rm -f "$SYS_DESKTOP"
+command -v update-desktop-database >/dev/null 2>&1 && sudo update-desktop-database /usr/share/applications 2>/dev/null || true
+rm -f "$AUTOSTART"
+
+# 6. per-user dataRoot (config.json, logs/, dependencies/, bin/WsScrcpyWeb.AppImage, control/instance.lock)
+rm -rf "$DATA_ROOT"
+
+# 7. single-instance lock
+rm -f "$LOCK"
+
+# 8. SELinux fcontext rules (current x2 + legacy beta.40 /opt/.../data)
+if [ $HAVE_SEMANAGE -eq 1 ]; then
+  for spec in "${FCONTEXT_SPECS[@]}"; do sudo semanage fcontext -d "$spec" 2>/dev/null || true; done
+else
+  info "semanage absent — skipping fcontext cleanup (non-SELinux host)"
+fi
+say "Teardown issued."
+
+step "PHASE 2 — VERIFY (test it cleared)"
+[ ! -e "$USER_UNIT" ]   && ok "user unit removed"        || bad "user unit present: $USER_UNIT"
+[ ! -e "$SYS_UNIT"  ]   && ok "system unit removed"      || bad "system unit present: $SYS_UNIT"
+[ ! -e "$OPT_DIR"   ]   && ok "/opt removed"             || bad "/opt present: $OPT_DIR"
+[ ! -e "$VAR_OPT_DIR" ] && ok "/var/opt removed"         || bad "/var/opt present: $VAR_OPT_DIR"
+[ ! -e "$DATA_ROOT" ]   && ok "dataRoot removed"         || bad "dataRoot present: $DATA_ROOT"
+[ ! -e "$AUTOSTART" ]   && ok "tray autostart removed"   || bad "autostart present: $AUTOSTART"
+[ ! -e "$SYS_DESKTOP" ] && ok "system .desktop removed"  || bad ".desktop present: $SYS_DESKTOP"
+[ ! -e "$LOCK" ]        && ok "instance lock removed"    || bad "lock present: $LOCK"
+
+systemctl --user list-unit-files 2>/dev/null | grep -q "^$UNIT" && bad "user unit still known to systemd --user" || ok "user unit unknown to systemd --user"
+systemctl list-unit-files 2>/dev/null | grep -q "^$UNIT" && bad "system unit still known to systemd" || ok "system unit unknown to systemd"
+
+if pgrep -fa "$PROC_PAT" >/dev/null 2>&1; then bad "processes still running:"; pgrep -fa "$PROC_PAT" | sed 's/^/        /'
+else ok "no ws-scrcpy-web processes running"; fi
+
+if [ $HAVE_SEMANAGE -eq 1 ]; then   # NB: -l needs sudo (non-root semanage throws "SELinux policy is not managed")
+  leftover="$(sudo semanage fcontext -l 2>/dev/null | grep ws-scrcpy-web || true)"
+  [ -z "$leftover" ] && ok "no fcontext rules remain" || { bad "fcontext rules remain:"; printf '%s\n' "$leftover" | sed 's/^/        /'; }
+fi
+
+shopt -s nullglob; dls=( "$HOME/Downloads"/WsScrcpyWeb-linux*.AppImage "$HOME"/WsScrcpyWeb*.AppImage ); shopt -u nullglob
+[ ${#dls[@]} -gt 0 ] && info "downloaded AppImage left in place (installer, not install): ${dls[*]}"
+
+say ""
+if [ $FAIL -eq 0 ]; then printf '%sCLEAN SLATE ✓%s  %d checks passed.\n' "$GREEN" "$RST" "$PASS"; exit 0
+else printf '%sNOT CLEAN ✗%s  %d passed, %d FAILED — see [FAIL] lines.\n' "$RED" "$RST" "$PASS" "$FAIL"; exit 1; fi

--- a/docs/smoke-tests/v0.1.30-beta.44-full.md
+++ b/docs/smoke-tests/v0.1.30-beta.44-full.md
@@ -6,7 +6,7 @@ All-encompassing manual smoke, grouped by function and tagged by platform (`[Win
 
 ## Pre-flight
 
-- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `semanage fcontext -l | grep ws-scrcpy-web` empty; keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage` from the **`v0.1.30-beta.44`** release, `chmod +x`.
+- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `semanage fcontext -l | grep ws-scrcpy-web` empty (or run `clear-install.sh` beside this doc for a one-shot verified clean slate); keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage` from the **`v0.1.30-beta.44`** release, `chmod +x`.
 - **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi` from the **`v0.1.30-beta.44`** release.
 - **Devices:** an Android device with **Wireless debugging** enabled (Android 11+) reachable from the VM, plus (Windows) one USB device if available.
 
@@ -23,7 +23,9 @@ Artifacts are retained ~90 days from 2026-06-03. **No beta.45 is needed** — be
 
 - **No-libfuse2 host (Module 11.1/11.2):** a minimal Fedora container/distro **without** `libfuse2`. This is the gate for closing item 31, not a 0.1.30-stable blocker on its own.
 
-**Manual recovery** if a stuck Linux system service recurs:
+**Clean slate — `clear-install.sh` (recommended).** For a one-shot, verified teardown of the **entire** install footprint — user- *and* system-scope service, `/opt` + `/var/opt`, dataRoot, tray autostart, the system `.desktop`, **all** SELinux fcontext rules (incl. the legacy beta.40 `/opt/.../data`), the single-instance lock, and any stray processes — run `bash clear-install.sh` (sits beside this doc). It tears down, then prints a per-item PASS/FAIL ending in `CLEAN SLATE ✓` / `NOT CLEAN ✗` (exit 0/1); idempotent + safe on an already-clean VM.
+
+**Manual recovery** — the by-hand system-scope subset, if you just need to clear a single stuck service without the script:
 
 ```bash
 sudo systemctl stop WsScrcpyWeb.service; sudo systemctl disable WsScrcpyWeb.service; sudo systemctl reset-failed WsScrcpyWeb.service

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -25,13 +25,20 @@ export function uninstallFollowupMessage(mode: 'user' | 'system'): string {
 
 /**
  * Classify one tick of the post-install port-discovery poll. Pure (no DOM or
- * timers) so it is unit-testable. After a service install the web port is
- * handed off to the service-Node:
- * - unreachable local server -> the local instance is exiting (fix #3) and the
- *   service is rebinding the SAME port -> reconnect (reload the current URL).
- * - config.json mtime changed + a known disk port -> the service bound a new
- *   port -> navigate there (the pre-existing Windows path, unchanged).
- * - past the iteration cap -> timeout.
+ * timers) so it is unit-testable. After a service install the web port is handed
+ * off to the service-Node, which identifies itself via `servedByService` (the
+ * WS_SCRCPY_SERVICE env set on its unit):
+ * - reachable AND servedByService -> the service has taken over. Same port (no
+ *   config.json mtime change) -> reconnect (reload the current URL); a different
+ *   bound port (mtime changed + known disk port) -> navigate there.
+ * - otherwise (the local instance is still answering, or the brief hand-off dead
+ *   window where nothing holds the port) -> keep polling until the cap, then
+ *   timeout.
+ *
+ * Keying success on the POSITIVE servedByService signal — rather than catching a
+ * transient unreachable tick (a race against the 2s poll) or a config.json mtime
+ * change a same-port rebind never produces — removes the intermittent
+ * "port discovery timed out" failure (beta.47).
  */
 export type PollOutcome =
     | { kind: 'keep-polling' }
@@ -41,20 +48,29 @@ export type PollOutcome =
 
 export function classifyInstallPoll(args: {
     reachable: boolean;
+    servedByService: boolean;
     configMtime: number | null;
     baselineMtime: number;
     diskWebPort: number | null;
     iterations: number;
     maxIterations: number;
 }): PollOutcome {
-    if (!args.reachable) return { kind: 'reconnect' };
-    if (
-        args.configMtime != null &&
-        args.configMtime !== args.baselineMtime &&
-        args.diskWebPort != null
-    ) {
-        return { kind: 'navigate', port: args.diskWebPort };
+    // Success requires a POSITIVE signal: the instance answering /api/service/status
+    // is the service itself (WS_SCRCPY_SERVICE on its unit), not the exiting local
+    // instance and not a transient dead port.
+    if (args.reachable && args.servedByService) {
+        // Different bound port -> navigate there; same port -> reload in place.
+        if (
+            args.configMtime != null &&
+            args.configMtime !== args.baselineMtime &&
+            args.diskWebPort != null
+        ) {
+            return { kind: 'navigate', port: args.diskWebPort };
+        }
+        return { kind: 'reconnect' };
     }
+    // Still the local instance answering, or the brief hand-off dead window:
+    // keep waiting until the service identifies itself, then cap out.
     if (args.iterations > args.maxIterations) return { kind: 'timeout' };
     return { kind: 'keep-polling' };
 }
@@ -1198,24 +1214,27 @@ export class SettingsModal extends Modal {
             let iterations = 0;
             const poll = setInterval(async () => {
                 iterations++;
-                // A thrown/aborted fetch means the local server has dropped: under
-                // fix #3 the local instance exits after a successful install, so the
-                // service is taking over the SAME port (reconnect, not an error).
+                // A thrown/aborted fetch means whoever was answering has dropped —
+                // the local instance exiting, or the brief hand-off dead window. We
+                // do NOT treat that as success: we wait for the service to answer with
+                // servedByService=true (below) before reconnecting/navigating.
                 let reachable = true;
+                let servedByService = false;
                 let configMtime: number | null = null;
                 let diskWebPort: number | null = null;
                 try {
                     const statusResp = await fetch('/api/service/status', { signal: AbortSignal.timeout(5000) });
                     if (statusResp.ok) {
-                        const statusData = await statusResp.json() as { configMtime?: number; diskWebPort?: number };
+                        const statusData = await statusResp.json() as { configMtime?: number; diskWebPort?: number; servedByService?: boolean };
                         configMtime = statusData.configMtime ?? null;
                         diskWebPort = statusData.diskWebPort ?? null;
+                        servedByService = statusData.servedByService === true;
                     }
                 } catch {
                     reachable = false;
                 }
                 const outcome = classifyInstallPoll({
-                    reachable, configMtime, baselineMtime, diskWebPort, iterations, maxIterations,
+                    reachable, servedByService, configMtime, baselineMtime, diskWebPort, iterations, maxIterations,
                 });
                 switch (outcome.kind) {
                     case 'navigate':

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -24,18 +24,34 @@ describe('uninstallFollowupMessage', () => {
 });
 
 describe('classifyInstallPoll', () => {
-    const base = { reachable: true, configMtime: 100, baselineMtime: 100, diskWebPort: null, iterations: 1, maxIterations: 30 };
-    it('navigates when config mtime changed + port known (the existing Windows path)', () => {
-        expect(classifyInstallPoll({ ...base, configMtime: 200, diskWebPort: 8002 })).toEqual({ kind: 'navigate', port: 8002 });
+    // The service identifies itself via servedByService=true (the WS_SCRCPY_SERVICE
+    // env set on the systemd/Servy unit). Success REQUIRES that positive signal, so
+    // a same-port hand-off no longer hinges on catching a transient dead window or a
+    // config.json mtime change that never happens — the intermittent "port discovery
+    // timed out" race (beta.47).
+    const served = {
+        reachable: true,
+        servedByService: true,
+        configMtime: 100,
+        baselineMtime: 100,
+        diskWebPort: 8000,
+        iterations: 1,
+        maxIterations: 30,
+    };
+    it('navigates when the service answers on a new port (mtime changed)', () => {
+        expect(classifyInstallPoll({ ...served, configMtime: 200, diskWebPort: 8002 })).toEqual({ kind: 'navigate', port: 8002 });
     });
-    it('reconnects (not errors) when the local server becomes unreachable - same-port handoff', () => {
-        expect(classifyInstallPoll({ ...base, reachable: false })).toEqual({ kind: 'reconnect' });
+    it('reconnects when the service answers on the SAME port, no mtime change (the race fix)', () => {
+        expect(classifyInstallPoll(served)).toEqual({ kind: 'reconnect' });
     });
-    it('keeps polling while reachable + no config change', () => {
-        expect(classifyInstallPoll(base)).toEqual({ kind: 'keep-polling' });
+    it('keeps polling while the local instance is still answering (not yet the service)', () => {
+        expect(classifyInstallPoll({ ...served, servedByService: false })).toEqual({ kind: 'keep-polling' });
     });
-    it('times out after maxIterations', () => {
-        expect(classifyInstallPoll({ ...base, iterations: 31 })).toEqual({ kind: 'timeout' });
+    it('keeps polling through the hand-off dead window (unreachable, before the cap)', () => {
+        expect(classifyInstallPoll({ ...served, reachable: false, servedByService: false, configMtime: null, diskWebPort: null, iterations: 2 })).toEqual({ kind: 'keep-polling' });
+    });
+    it('times out only when the service never takes over', () => {
+        expect(classifyInstallPoll({ ...served, servedByService: false, iterations: 31 })).toEqual({ kind: 'timeout' });
     });
 });
 

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -30,6 +30,13 @@ export interface ServiceStatusResponse {
     /** config.json filesystem mtime in epoch milliseconds. Present when supported=true. */
     configMtime?: number | undefined;
     /**
+     * True when the answering instance is the installed service itself (its unit
+     * sets WS_SCRCPY_SERVICE=1), not the transient local instance that triggered
+     * the install. The post-install port-discovery poll keys hand-off completion
+     * off this positive signal. Present when supported=true.
+     */
+    servedByService?: boolean;
+    /**
      * Snapshot of `AppConfig.installMode` at status time. Lets the frontend
      * tell which service scope is active (`user-service` vs `system-service`)
      * without poking a second endpoint. `null` when never installed. Present

--- a/src/server/__tests__/systemScopePaths.test.ts
+++ b/src/server/__tests__/systemScopePaths.test.ts
@@ -15,16 +15,17 @@ describe('buildServiceUnitEnv (#36 system-scope /opt paths)', () => {
         expect(buildServiceUnitEnv('linux', 'system', userDeps)).toEqual({
             DATA_ROOT: '/var/opt/ws-scrcpy-web',
             DEPS_PATH: '/opt/ws-scrcpy-web/dependencies',
+            WS_SCRCPY_SERVICE: '1',
         });
     });
 
     it('linux + user: the caller deps path, no DATA_ROOT override', () => {
-        expect(buildServiceUnitEnv('linux', 'user', userDeps)).toEqual({ DEPS_PATH: userDeps });
+        expect(buildServiceUnitEnv('linux', 'user', userDeps)).toEqual({ DEPS_PATH: userDeps, WS_SCRCPY_SERVICE: '1' });
     });
 
     it('win32 + system: user deps, no /opt (Windows path is unaffected)', () => {
         const winDeps = 'C:\\ProgramData\\WsScrcpyWeb\\dependencies';
-        expect(buildServiceUnitEnv('win32', 'system', winDeps)).toEqual({ DEPS_PATH: winDeps });
+        expect(buildServiceUnitEnv('win32', 'system', winDeps)).toEqual({ DEPS_PATH: winDeps, WS_SCRCPY_SERVICE: '1' });
     });
 });
 

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -203,6 +203,11 @@ export class ServiceApi {
             platform: result.platform,
             status,
             installMode,
+            // True only inside the installed service process (its unit sets
+            // WS_SCRCPY_SERVICE=1); the transient local instance that triggers the
+            // install never has it. The post-install poll keys hand-off completion
+            // off this positive signal (no mtime-change / dead-window race).
+            servedByService: process.env['WS_SCRCPY_SERVICE'] === '1',
             ...(scope !== undefined ? { scope } : {}),
             ...(disk.diskWebPort != null ? { diskWebPort: disk.diskWebPort } : {}),
             ...(disk.configMtime != null ? { configMtime: disk.configMtime } : {}),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -319,7 +319,6 @@ function exit(signal: string) {
     if (interrupted) {
         serverLog.info('Force exit');
         process.exit(0);
-        return;
     }
     interrupted = true;
     // Fire-and-forget the shared teardown (idempotent — the /api/server/shutdown

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -132,6 +132,15 @@ describe('SYSTEM_STATE_DIR — FHS /var/opt retargeting', () => {
         expect(env['DEPS_PATH']).toBe('/opt/ws-scrcpy-web/dependencies');
     });
 
+    it('every service unit env carries WS_SCRCPY_SERVICE=1 so the service can identify itself to the post-install poll', () => {
+        const userEnv = buildServiceUnitEnv('linux', 'user', '/home/u/.local/share/WsScrcpyWeb/dependencies');
+        const sysEnv = buildServiceUnitEnv('linux', 'system', '/home/u/.local/share/WsScrcpyWeb/dependencies');
+        const winEnv = buildServiceUnitEnv('win32', undefined, 'C:\\deps');
+        expect(userEnv['WS_SCRCPY_SERVICE']).toBe('1');
+        expect(sysEnv['WS_SCRCPY_SERVICE']).toBe('1');
+        expect(winEnv['WS_SCRCPY_SERVICE']).toBe('1');
+    });
+
     it('system install seeds config + labels state under /var/opt (var_lib_t)', () => {
         const script = buildSystemInstallScript(
             { sourceAppImage: '/home/u/App.AppImage', seedConfigTmpPath: '/tmp/seed.json',

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -108,10 +108,13 @@ export function buildServiceUnitEnv(
     scope: SystemdScope | undefined,
     userDepsPath: string,
 ): Record<string, string> {
+    // WS_SCRCPY_SERVICE marks the process as the installed service so it can
+    // identify itself to the post-install port-discovery poll — the local
+    // instance that triggers the install never carries it. Set on every scope.
     if (platform === 'linux' && scope === 'system') {
-        return { DATA_ROOT: SYSTEM_STATE_DIR, DEPS_PATH: STAGED_SYSTEM_DEPS_DIR };
+        return { DATA_ROOT: SYSTEM_STATE_DIR, DEPS_PATH: STAGED_SYSTEM_DEPS_DIR, WS_SCRCPY_SERVICE: '1' };
     }
-    return { DEPS_PATH: userDepsPath };
+    return { DEPS_PATH: userDepsPath, WS_SCRCPY_SERVICE: '1' };
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
         // CSS imports are stubbed out (no stylesheet processing needed in tests)
         css: false,
         globalSetup: ['./vitest.globalSetup.ts'],
+        // Per-worker guard: neutralise stray process.exit so a leaked install/update
+        // hand-off timer can't abort an unrelated test under worker reuse. See file.
+        setupFiles: ['./vitest.setup.ts'],
     },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,20 @@
+import process from 'node:process';
+
+// Per-worker setup: a worker-lifetime guard against stray process.exit.
+//
+// A test must never terminate its vitest worker. Some production paths schedule a
+// real `setTimeout(() => process.exit(0), …).unref()` (e.g. ServiceApi's install /
+// update hand-off, where the local instance exits to free the single-instance lock
+// for the service). A test that exercises those paths without injecting a no-op
+// `scheduleExit` leaks that timer; because vitest reuses workers across files, the
+// `.unref()`'d timer can fire ~1.5s later while an UNRELATED test file is running,
+// surfacing as a confusing "process.exit unexpectedly called" failure attributed to
+// whatever test happened to be in flight.
+//
+// Neutralise process.exit for the worker's whole lifetime so a leaked call can never
+// abort an unrelated test. Tests that assert on exit still `vi.spyOn(process,'exit')`
+// locally and observe the call (the spy wraps this no-op). Kept silent so suite
+// output stays pristine.
+process.exit = ((_code?: number): never => {
+    return undefined as never;
+}) as typeof process.exit;


### PR DESCRIPTION
## What

Fixes the intermittent **"port discovery timed out"** error on the settings screen after a service install — most visible on Linux user-scope installs. The service was actually up; only the post-install reconnect mis-fired (a manual refresh always worked).

## Root cause

The post-install poll inferred the hand-off had finished from two unreliable proxies:

1. a `config.json` mtime change — which **never happens when the service rebinds the same port** (`reconcileWebPort` only rewrites config on a port shift), so the `navigate` signal was dead; and
2. momentarily catching the port **unbound** — a race against the 2-second poll. The local instance frees the port at ~1.5s and the service rebinds it shortly after; if the service came back **before the first poll tick** saw the gap, the poll never observed it.

Same-port fast rebind hit neither, so the poll ran out its 60s cap → false timeout. Intermittent by construction, and counterintuitively most likely when the service started *fast*. G1 (beta.47) did not cause this — it removed the redundant second tab that had been masking it.

## Fix

Replace the proxies with a **positive signal**:

- the service unit env sets `WS_SCRCPY_SERVICE=1` (`buildServiceUnitEnv`), inherited by Node through the launcher (no `env_clear` in `spawn.rs`);
- `GET /api/service/status` reports `servedByService`;
- `classifyInstallPoll` succeeds only when `reachable && servedByService` — the instance answering is the service itself, not the exiting local instance and not a transient dead port. `timeout` now means the service genuinely never took over.

`classifyInstallPoll` stays a pure function, so the same-port-fast-rebind case is proven by a deterministic unit test rather than by trying to catch the race live.

## Also bundled

- `index.ts`: removed a dead `return` after `process.exit` (TS7027).
- **Test isolation:** a worker-lifetime `process.exit` guard in vitest setup. The install/update hand-off tests leak a real `setTimeout -> process.exit(0)`; under vitest worker reuse it could fire mid-other-file and abort an unrelated test (a pre-existing full-suite flake). Now neutralised.
- `docs/smoke-tests/clear-install.sh`: a scripted, self-verifying clean slate for the Linux smoke, plus a pointer to it from the smoke doc.

## Verification

- vitest **892/892** green; `tsc --noEmit` clean. No Rust touched.
- Manual repro is timing-dependent and resists on-demand reproduction; the unit test is the deterministic proof.