### PR TITLE
docs(smoke): execution-ordered beta.48 smoke run-sheet

### DIFF
--- a/docs/smoke-tests/v0.1.30-beta.48-checklist.md
+++ b/docs/smoke-tests/v0.1.30-beta.48-checklist.md
@@ -1,0 +1,139 @@
+# ws-scrcpy-web — v0.1.30-beta.48 Smoke Run-Sheet
+
+Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
+[`v0.1.30-beta.44-full.md`](./v0.1.30-beta.44-full.md) by **app state** — the order you actually run them; that doc
+stays the module-organized reference. Wherever a row shows a version, expect **`0.1.30-beta.48`** (the doc's "beta.44"
+strings are the item-46 refresh).
+
+**Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.40 artifact / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot)
+
+Clear the slate before a run with [`clear-install.sh`](./clear-install.sh).
+
+---
+
+## #6 — Confirmed on beta.48 ✅
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ✅ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = `0.1.30-beta.48`; system `.desktop` present; original `~/Downloads` AppImage **gone** |
+| ✅ **4.2-user** `[L]` Install user service | Settings → service → **user** scope → install (no elevation) | Service active on 8000; stable ExecStart; **no "port discovery timed out"** (the beta.48 fix) |
+
+## #7 — Current install checks ▶ active *(machine-wide + user-service in place, no teardown)*
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ✅ **2.1** `[L]` Binary/deps labels | `ls -Z /opt/ws-scrcpy-web` | → **bin_t** — confirmed: `VERSION` + `WsScrcpyWeb.AppImage` both `unconfined_u:object_r:bin_t:s0` |
+| ☐ **2.4** `[L]` Zero AVC | Watch `sudo journalctl -f \| grep -i avc` across the installs | **No** AVC denials |
+| ☐ **4.1** `[L]` System-scope gate | Settings → service → pick **system** scope | Now **enabled** (was greyed before machine-wide); user scope available in both modes |
+| ☐ **4.4** `[L]` Scope-radio legibility | Reopen Settings | Selected dot a **clear blue**; radios non-interactive (`pointer-events:none` + `tabindex=-1`, **not** `disabled`); **user** scope shown selected |
+| ☐ **4.5** `[B]` Confirm-dialog buttons | Open the install/uninstall "privileges required" confirm | Cancel/confirm are **white-outline + white-text** |
+| ☐ **4.6** `[L]` Unit hygiene | `journalctl --user -u WsScrcpyWeb`; `pgrep -fa WsScrcpyWeb` | **No** `Unknown key 'StartLimitIntervalSec'`; **only the service** runs (no leftover home instance); no false timeout toast |
+| ☐ **3.2** `[L]` Single-instance flock | Launch a 2nd copy from `/opt` **and** from `~/Downloads` | 2nd launch **blocked** (flock on `$XDG_RUNTIME_DIR`); no 2nd server; existing URL opens |
+| ☐ **10.1** `[B]` Status API | Browse `/api/service/status` | JSON with correct `platform`, `supported`, `status` |
+| ☐ **10.3** `[L]` Logs clean | Tail `~/.local/share/WsScrcpyWeb/logs` | No error spam; teardown logs on stop |
+| ☐ **12.2** `[B]` Stop-exit gating | Settings → App (service installed) | Button **greyed** + neutral note; clicking fires **no** shutdown POST; re-enables after uninstall |
+
+## #8 — User-service uninstall → local mode
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **5.8** `[L]` Uninstall → relaunch local | Uninstall the user service **as that user** | Unit file gone (`~/.config/systemd/user/WsScrcpyWeb.service`); no straggler (`pgrep -fa "adb\|scrcpy-server\|WsScrcpyWeb"` clean); relaunches **local mode**; Settings shows not-installed |
+| ☐ **12.1** `[L]` Clean exit + adb teardown | Local mode, device + stream → Settings → App → "stop server & exit" | Tab self-closes/"app stopped"; process tree exits clean; log shows "Stopping adb daemon"; launcher **exit 0** (no 75 restart) |
+| ☐ **12.4** `[L]` DATA_ROOT override | Launch with `DATA_ROOT=/tmp/wssw-dataroot` exported | Config/deps/logs land there (Node **and** launcher agree) |
+| ☐ **13.1** `[B]` Bookmark global-dismiss | Bookmark/port-change reminder → check "don't show again — ever" | Supersedes + disables the per-port checkbox; persists `bookmarkDismissedGlobally` |
+| ☐ **13.2** `[B]` Reset prompts | Settings → "reset welcome and bookmark prompts" | Re-shows welcome **and** clears bookmark (per-port + global); welcome reset must **not** re-suppress the per-port bookmark |
+
+## #9 — System-scope service pass
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **4.2-system** `[L]` Install system service | Settings → service → **system** scope → install (pkexec) | `/opt` ExecStart **as root**; state in `/var/opt`; zero AVC |
+| ☐ **2.2** `[L]` State labels | `ls -Z /var/opt/ws-scrcpy-web` | → **var_lib_t** |
+| ☐ **2.3** `[L]` fcontext rules | `semanage fcontext -l \| grep ws-scrcpy-web` | **Both** the `/opt` bin_t rule and the `/var/opt` var_lib_t rule |
+| ☐ **3.3** `[L]` Service-defer | System service running → launch locally | Defers to the service (opens its URL); no 2nd server |
+| ☐ **5.1** `[L]` Same-user uninstall → relaunch | Uninstall as the active user | App reappears in that session, **same port**, visible "relaunching…" |
+| ☐ **5.4** `[L]` fcontext cleanup | After uninstall: `semanage fcontext -l \| grep ws-scrcpy-web` | **Empty** (both rules gone) |
+| ☐ **5.9** `[L]` Uninstall message | After a no-active-session uninstall | **Neutral** info line — not red, no "retry" button |
+
+## #10 — First-run variants 🧩 *(needs fresh snapshot / 2nd user / 2nd admin)*
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **1.1** `[L]` First-run modal | Run the home AppImage with no prior install/decline marker | 3 stacked lines + yes/no; no ×; **Esc** and **click-outside do nothing** |
+| ☐ **1.3** `[L]` Decline + remember | Fresh state / 2nd user → **no, me only** | Runs in place from `~/.local`; next launch does **not** re-prompt; AppImage kept |
+| ☐ **1.4** `[L]` Headless first-run | Launch over SSH / no display | No hang; graceful fallback |
+| ☐ **3.1** `[L]` Per-user launch | 2nd user launches from the apps menu (`.desktop`) | Own `~/.local` data; "Open" reaches the same backend port |
+| ☐ **5.2** `[L]` Different-admin uninstall | Uninstall via **pkexec as a different admin** | App reappears in the **active desktop user's** session, same port |
+| ☐ **5.3** `[L]` Headless uninstall | Uninstall with no graphical session | No relaunch; manual fallback; no orphan; no `data_root_for_linux` panic |
+
+## #11 — Updates 🧩 *(needs the beta.40 "update-from" artifact)*
+
+Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws-scrcpy-web --name linux-final`.
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **6.1** `[B]` Update check | Settings → Updates → Check | beta.40 **offers beta.48**; beta.48 = up-to-date; no log spam |
+| ☐ **6.2** `[L]` Local update apply | beta.40 home (local mode) → Apply | Verifies + swaps + **auto-relaunches** to beta.48; reconnects |
+| ☐ **6.3** `[L]` No-service /opt update | Machine-wide `/opt`, no service → update | One pkexec; **rename**-swap; relabel bin_t; **no ETXTBSY**; FUSE intact |
+| ☐ **6.4** `[L]` Newer home over /opt | `/opt` beta.40 + newer home AppImage → launch | Offers system-wide update → swap → next launch runs updated `/opt` |
+| ☐ **6.5** `[L]` User-service update | User-service → Apply | Unit stops, home swaps, restarts **same port**, **no prompt** |
+| ☐ **6.6** `[L]` System-service update | System-service → Apply | **No polkit**; `/opt` swaps; restorecon bin_t; **zero AVC**; helper survives `systemctl stop` |
+| ☐ **6.7** `[L]` Migrate legacy beta.40 | beta.40 system install → update **from a local instance** | Reinstall to `/var/opt`, carry `webPort`/`installMode`, zero AVC, only the new fcontext rule |
+
+## #12 — Velopack / no-libfuse2 🧩 *(needs a minimal Fedora host without libfuse2)*
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **11.1** `[L]` No-libfuse2 launch | Run the beta.48 AppImage on a host without `libfuse2` | Launches (type-2 FUSE embedded); no "dlopen libfuse" error |
+| ☐ **11.2** `[L]` No-libfuse2 update | In-app update from that host | Succeeds → **clears item 31 step 3** (then remove the 5 gate files) |
+| ☐ **11.3** `[L]` Locator-fix watch | During 6.3 / 6.4 / 6.6 apply + relaunch | No Velopack locator root-path regression (velopack#921) |
+
+## #13 — Devices / scrcpy / adb 📱 *(needs a real Android device, Wireless debugging)*
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **7.1** `[B]` Wireless connect | Scan/connect → device `ip:port` | adb connects; card appears within ~5s |
+| ☐ **7.2** `[B]` Subnet scan | Scan-network modal → subnet | Devices listed; bad/empty subnets handled (no hang) |
+| ☐ **8.1** `[B]` Video stream | Device → stream/config → connect | Live video renders; no decode errors |
+| ☐ **8.2** `[B]` Control | Click/scroll/type + on-screen device buttons | Input reaches the device; nav works |
+| ☐ **8.3** `[B]` Audio | Enable audio (Android 11+) | Plays; codec/source toggle works |
+| ☐ **8.4** `[B]` Codec/encoder | Change display/codec/encoder/fps/bitrate → reconnect | Applies; persists per-device |
+| ☐ **9.1** `[B]` Shell modal | Run `getprop ro.product.model` + a couple commands | Terminal works; clean close, no orphaned adb shell |
+| ☐ **9.2** `[B]` File listing/transfer | Browse, change icon size, push/pull | Loads; icon-size persists; transfers succeed |
+| ☐ **9.3** `[B]` Device actions | Sleep/wake + power/nav on the card | Buttons reflect state; actions take effect |
+
+## #14 — Windows pass 🪟 *(clean Win11 snapshot, accounts Admin/User1/User2, the MSI)*
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **1.5** `[W]` Fresh MSI install | Install `WsScrcpyWeb-beta.msi` as Admin | Auto-opens; WelcomeModal; About = beta.48; `C:\Program Files\WsScrcpyWeb\` |
+| ☐ **1.6** `[W]` Reinstall reuses config | After 5.7, reinstall the MSI | Existing `config.json` detected + reused; same saved port |
+| ☐ **3.4** `[W]` Per-session tray | Service installed; Fast User Switch Admin→User1→User2 | Exactly **one** tray/session (~2s); "Open" → same backend port |
+| ☐ **3.5** `[W]` 2nd tray rejected | Launch a 2nd `ws-scrcpy-web-tray.exe` | No 2nd tray; spawned proc exits ~100ms |
+| ☐ **4.3** `[W]` Install confirm UX | Settings → install service → test cancel/Esc/backdrop, then continue | Cancel/Esc/backdrop = **no** UAC/no fetch; continue → UAC → installs, no WelcomeModal |
+| ☐ **5.5** `[W]` Uninstall + handoff | Service mode, Admin → uninstall → continue → UAC Yes | "uninstalling…"; >5s "still waiting…"; ends at local-mode URL |
+| ☐ **5.6** `[W]` Handoff-failure guard | Kill all `tray.exe`, then uninstall | ~5s/~30s messages; button freed; **service still installed** |
+| ☐ **5.7** `[W]` Full uninstall | Add/Remove → Uninstall as Admin | Service unregistered; `HKLM…\Run\WsScrcpyWebTray` gone; Program Files cleared; **dataRoot preserved** |
+| ☐ **5.10** `[W]` UAC declined | Standard user → uninstall → **decline** UAC | 403 `reason=uac-declined`; retry message; button freed; service still installed |
+| ☐ **6.8** `[W]` Update + tray persists | beta.40 MSI → Updates → Apply | Applies; reachable; **one** tray after settling (persists across update) |
+| ☐ **7.3** `[W]` USB device | Plug USB, authorize the RSA prompt | Appears; survives a reload |
+| ☐ **10.2** `[W]` Logs clean | Tail `ProgramData\WsScrcpyWeb\logs\{launcher,server}.log` | No `ERR`/`Error:` except known node-pty AttachConsole noise |
+| ☐ **11.4** `[W]` PerMachine intact | After the MSI install, check the location | `C:\Program Files\WsScrcpyWeb\` (PerMachine) |
+| ☐ **12.3** `[W]` Stop-exit reaps tray | Local mode → stop server & exit | Tray disappears; no lingering launcher/node/tray/adb; **cancel** leaves running |
+
+---
+
+## Global pass criteria
+
+| Criterion | Holds when |
+|---|---|
+| **SELinux clean** `[L]` | Zero AVC all session; `semanage fcontext -l \| grep ws-scrcpy-web` empty after every uninstall |
+| **Single instance** | Never two trays (Win) / two servers (Linux) per user/session |
+| **Relaunch fidelity** | Every uninstall→relaunch lands on the **same port**; no orphaned processes |
+| **Updates apply everywhere** | local, machine-wide `/opt` (no-service), user-service, system-service (headless) all swap + relaunch on the same port; **zero AVC** on the system-service path |
+| **Migration** | A beta.40 system install migrates to `/var/opt` carrying `webPort`/`installMode`, zero AVC |
+| **Clean shutdown** | "stop server & exit" tears down adb (+ Win tray) with no orphans; gated off in service mode |
+| **Data preserved** | User config/deps/logs survive uninstall + reinstall |
+| **Core flow** | Scan → connect → stream (video + control) → shell works on both platforms |
+
+**Stop-and-report:** a `[Linux]` SELinux/lifecycle failure in Modules 2/4/5, the service-update rows 6.5/6.6, or migration 6.7 — capture `journalctl`/`ausearch`/logs and fix before promoting 0.1.30 stable. Cosmetic/polish → note as beta-territory. **Module 11 (no-libfuse2)** gates closing item 31, not 0.1.30-stable on its own.


### PR DESCRIPTION
Execution-ordered, tickable smoke run-sheet for the 0.1.30 Linux gate — regroups the canonical rows from `v0.1.30-beta.44-full.md` by app state (the order they're run). Complements (does not replace) the module-organized full doc; advances part of item 46 (beta.48 refresh). Docs-only, `release:none`. 1.2 / 4.2-user / 2.1 already ticked from this session's run.