### PR TITLE
docs: document beta.49 App-section UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ The first-run welcome modal offers to install ws-scrcpy-web as a systemd service
 
 You can also install/uninstall the service later from Settings → Service.
 
+**Settings → App (Linux)** has two further actions. **Install for all users** relocates the app to a machine-wide `/opt` install under a single `pkexec` prompt (the control greys out once it's installed system-wide). **Uninstall…** completely removes ws-scrcpy-web — including any installed user- or system-scope service and a machine-wide `/opt` install — in a single pass, with at most one `pkexec` prompt; a **keep my settings & logs** option preserves your `config.json` and logs (so a later reinstall reuses your saved port) while still removing the program and its bundled dependencies.
+
 #### AppImage placement caveat
 
 For a **user-scope** service the systemd unit's `ExecStart=` points at the AppImage where it lived at install time, so **do not move or rename the AppImage after installing a user-scope service** — it will fail to start on next login. If you need to relocate it, uninstall the service first, move the file, then re-install. A **system-scope** service is unaffected: the installer stages a copy of the AppImage to `/opt/ws-scrcpy-web/` (labelled `bin_t` for SELinux) and points `ExecStart=` there, so moving your home AppImage does not break it.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1592,6 +1592,8 @@ The uninstall flow avoids UAC by deferring privileged work to a `post-stop.bat` 
 | GET | `/api/service/status` | Returns current service state (installed, running, mode). Always 200. |
 | POST | `/api/service/install` | Install the service. Triggers UAC. Returns 501 if not a Velopack install. |
 | POST | `/api/service/uninstall` | Uninstall the service via the operation-server pattern (no UAC). |
+| POST | `/api/service/install-system-wide` | (Linux) Relocate a local install to a machine-wide `/opt` install under one `pkexec` prompt; re-execs from `/opt`. |
+| POST | `/api/service/uninstall-app` `{keep}` | (Linux) Complete app uninstall — cascades through any service + `/opt` in one pass; `keep` preserves `config.json` + logs. |
 
 ### 19.4 Config.json Port Discovery
 
@@ -1620,6 +1622,8 @@ The unit body (`renderUnitFile`) is `Type=simple`, `Restart=on-failure` / `Resta
 
 **Uninstall — out-of-cgroup teardown.** Calling `systemctl stop` from inside the service unit's own cgroup would kill the calling process mid-operation (item 32). So `ServiceApi` launches the launcher helper via `systemd-run` (its own transient unit / separate cgroup) with `--linux-service-teardown --scope <user|system> --unit <name>`; `linux_service.rs` then runs, best-effort: `stop` → `disable` → `reset-failed` → remove the unit file → (system scope) `rm -rf /opt/ws-scrcpy-web` + `semanage fcontext -d` the `bin_t` rule → `daemon-reload` → reap the escaped adb daemon. **User scope** then relaunches the home AppImage in local mode via `systemd-run --user --collect` (path read from the `<dataRoot>/control/local-appimage` marker); **system scope** does not auto-relaunch (the admin relaunches their own AppImage).
 
+**Complete uninstall (beta.49).** Distinct from the service teardown above, `POST /api/service/uninstall-app {keep}` removes the *entire* app — any user/system service, a machine-wide `/opt` install, the user data root, the start-menu `.desktop` + icon, and the SELinux fcontext rules — in a single pass. `app_uninstall_commands` (`launcher/src/linux_app_uninstall.rs`) is a pure builder splitting the teardown into a `privileged` group (root-owned: `/opt`, `/var/opt`, `.desktop`/icon, fcontext) and an unelevated `user_owned` group (stray processes, user-scope unit, the `~/.local` data root). `--linux-app-uninstall` runs `user_owned` directly and elevates `privileged` per uid (mirroring the service-update split): a root system-service runs them directly; a non-root caller re-invokes the launcher under **one** `pkexec` (`--linux-app-uninstall-elevated`), and a declined prompt aborts before anything is removed, relaunching the app so the user is never stranded. `keep=true` deletes only the regenerable `dependencies`/`bin`/`control` subdirs — preserving `config.json` + `logs/` (at the data root's owner, `~/.local` or `/var/opt`) — and resets `installMode` so a later reinstall comes up clean.
+
 ### 19.6 Components
 
 | File | Purpose |
@@ -1633,6 +1637,7 @@ The unit body (`renderUnitFile`) is `Type=simple`, `Restart=on-failure` / `Resta
 | `src/app/client/SettingsModal.ts` | Service install/uninstall controls + scope radios in the Settings panel |
 | `launcher/src/operation_server.rs` | Rust binary that serves the transition page during uninstall/update (Windows) |
 | `launcher/src/elevated_runner.rs` | Generates `post-stop.bat` with uninstall/update-apply logic (Windows) |
+| `launcher/src/linux_app_uninstall.rs` | (Linux, beta.49) Pure `app_uninstall_commands` builder + `--linux-app-uninstall` dispatch for the in-app complete uninstall (getuid-aware `pkexec` elevation) |
 | `launcher/src/linux_service.rs` | Out-of-cgroup systemd teardown + user-scope local relaunch (Linux) |
 
 ---


### PR DESCRIPTION
Documents the beta.49 App-section UX features (shipped in v0.1.30-beta.49) in the user + architecture docs. Docs-only — `release:none` (no version bump).

- **README.md** — Linux install section now covers Settings → App: **install for all users** and the complete **uninstall…** (with **keep my settings & logs**).
- **docs/TECHNICAL_GUIDE.md** — §19.3 adds the `/api/service/install-system-wide` + `/api/service/uninstall-app` endpoints; §19.5 adds the complete-uninstall architecture (the `launcher/src/linux_app_uninstall.rs` builder, privileged/user_owned split, getuid-aware pkexec elevation, keep semantics); §19.6 adds the new launcher component.

Surfaced by the wrap-up doc sweep after the feature shipped.