### PR TITLE
chore: ETXTBSY log to WARN + version-agnostic smoke docs (item 46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux service start no longer logs a spurious `ERROR … text file busy`.** On service start the launcher refreshes its bundled operation-server helper by copying the current binary over it — but in service mode that helper *is* the binary already running, so the copy fails with `ETXTBSY` ("text file busy"). The failure is harmless (the running copy is already the current version; the next start refreshes it while it's free), so it is now logged as a warning instead of an alarming error.
+
 ## [0.1.30-beta.49] - 2026-06-08
 
 ### Added

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -120,6 +120,10 @@ pub fn info(msg: &str) {
     append("INFO", msg);
 }
 
+pub fn warn(msg: &str) {
+    append("WARN", msg);
+}
+
 pub fn error(msg: &str) {
     append("ERROR", msg);
 }

--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -1,28 +1,40 @@
-# ws-scrcpy-web — v0.1.30-beta.48 Smoke Run-Sheet
+# ws-scrcpy-web — Smoke Run-Sheet
+
+> **Smoke target: `v0.1.30-beta.50`** — bump this one line each release; everything below is version-agnostic.
 
 Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
-[`v0.1.30-beta.44-full.md`](./v0.1.30-beta.44-full.md) by **app state** — the order you actually run them; that doc
-stays the module-organized reference. Wherever a row shows a version, expect **`0.1.30-beta.48`** (the doc's "beta.44"
-strings are the item-46 refresh).
+[`smoke-full.md`](./smoke-full.md) by **app state** — the order you actually run them; that doc
+stays the module-organized reference. Wherever a row shows a version, expect the **smoke-target version** (top of this doc),
+which carries the beta.48 port-discovery fix plus the App-section UX (batch #15).
 
 **Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.40 artifact / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot)
 
-Clear the slate before a run with [`clear-install.sh`](./clear-install.sh).
+## Before each run — reset to a clean slate
+
+1. **Wipe prior state** with [`clear-install.sh`](./clear-install.sh) (user + system service, `/opt` + `/var/opt`, dataRoot, autostart, `.desktop`, all fcontext rules, the lock, stray procs → prints `CLEAN SLATE ✓`).
+2. **Re-download the latest** — the `~/Downloads` AppImage is stale; **no `chmod +x`** (GUI double-click of a non-`+x` AppImage is the realistic path):
+   ```bash
+   gh release download --repo bilbospocketses/ws-scrcpy-web --pattern '*linux-beta.AppImage' --dir ~/Downloads
+   ```
+
+Boxes start unticked — this is a fresh pass (prior beta.48 ✅ live in the breadcrumb/todo).
 
 ---
 
-## #6 — Confirmed on beta.48 ✅
+## #6 — First install + the beta.48 port-discovery re-confirm
+
+> Run this batch **first** on the fresh download (breadcrumb step 1). 1.2 + 4.2-user passed on beta.48; the smoke-target leaves that install/service code unchanged, so this is a quick re-confirm on the new binary.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ✅ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = `0.1.30-beta.48`; system `.desktop` present; original `~/Downloads` AppImage **gone** |
-| ✅ **4.2-user** `[L]` Install user service | Settings → service → **user** scope → install (no elevation) | Service active on 8000; stable ExecStart; **no "port discovery timed out"** (the beta.48 fix) |
+| ☐ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = the smoke-target version; system `.desktop` present; original `~/Downloads` AppImage **gone** |
+| ☐ **4.2-user** `[L]` Install user service | Settings → service → **user** scope → install (no elevation) | Service active on 8000; stable ExecStart; **no "port discovery timed out"** (the beta.48 fix) |
 
 ## #7 — Current install checks ▶ active *(machine-wide + user-service in place, no teardown)*
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ✅ **2.1** `[L]` Binary/deps labels | `ls -Z /opt/ws-scrcpy-web` | → **bin_t** — confirmed: `VERSION` + `WsScrcpyWeb.AppImage` both `unconfined_u:object_r:bin_t:s0` |
+| ☐ **2.1** `[L]` Binary/deps labels | `ls -Z /opt/ws-scrcpy-web` | → **bin_t** — `VERSION` + `WsScrcpyWeb.AppImage` both `unconfined_u:object_r:bin_t:s0` |
 | ☐ **2.4** `[L]` Zero AVC | Watch `sudo journalctl -f \| grep -i avc` across the installs | **No** AVC denials |
 | ☐ **4.1** `[L]` System-scope gate | Settings → service → pick **system** scope | Now **enabled** (was greyed before machine-wide); user scope available in both modes |
 | ☐ **4.4** `[L]` Scope-radio legibility | Reopen Settings | Selected dot a **clear blue**; radios non-interactive (`pointer-events:none` + `tabindex=-1`, **not** `disabled`); **user** scope shown selected |
@@ -49,10 +61,10 @@ Clear the slate before a run with [`clear-install.sh`](./clear-install.sh).
 |---|---|---|
 | ☐ **4.2-system** `[L]` Install system service | Settings → service → **system** scope → install (pkexec) | `/opt` ExecStart **as root**; state in `/var/opt`; zero AVC |
 | ☐ **2.2** `[L]` State labels | `ls -Z /var/opt/ws-scrcpy-web` | → **var_lib_t** |
-| ☐ **2.3** `[L]` fcontext rules | `semanage fcontext -l \| grep ws-scrcpy-web` | **Both** the `/opt` bin_t rule and the `/var/opt` var_lib_t rule |
+| ☐ **2.3** `[L]` fcontext rules | `sudo semanage fcontext -l \| grep ws-scrcpy-web` | **Both** the `/opt` bin_t rule and the `/var/opt` var_lib_t rule |
 | ☐ **3.3** `[L]` Service-defer | System service running → launch locally | Defers to the service (opens its URL); no 2nd server |
 | ☐ **5.1** `[L]` Same-user uninstall → relaunch | Uninstall as the active user | App reappears in that session, **same port**, visible "relaunching…" |
-| ☐ **5.4** `[L]` fcontext cleanup | After uninstall: `semanage fcontext -l \| grep ws-scrcpy-web` | **Empty** (both rules gone) |
+| ☐ **5.4** `[L]` fcontext cleanup | After uninstall: `sudo semanage fcontext -l \| grep ws-scrcpy-web` | **Empty** (both rules gone) |
 | ☐ **5.9** `[L]` Uninstall message | After a no-active-session uninstall | **Neutral** info line — not red, no "retry" button |
 
 ## #10 — First-run variants 🧩 *(needs fresh snapshot / 2nd user / 2nd admin)*
@@ -72,8 +84,8 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **6.1** `[B]` Update check | Settings → Updates → Check | beta.40 **offers beta.48**; beta.48 = up-to-date; no log spam |
-| ☐ **6.2** `[L]` Local update apply | beta.40 home (local mode) → Apply | Verifies + swaps + **auto-relaunches** to beta.48; reconnects |
+| ☐ **6.1** `[B]` Update check | Settings → Updates → Check | beta.40 **offers the latest**; the latest = up-to-date; no log spam |
+| ☐ **6.2** `[L]` Local update apply | beta.40 home (local mode) → Apply | Verifies + swaps + **auto-relaunches** to the latest; reconnects |
 | ☐ **6.3** `[L]` No-service /opt update | Machine-wide `/opt`, no service → update | One pkexec; **rename**-swap; relabel bin_t; **no ETXTBSY**; FUSE intact |
 | ☐ **6.4** `[L]` Newer home over /opt | `/opt` beta.40 + newer home AppImage → launch | Offers system-wide update → swap → next launch runs updated `/opt` |
 | ☐ **6.5** `[L]` User-service update | User-service → Apply | Unit stops, home swaps, restarts **same port**, **no prompt** |
@@ -84,7 +96,7 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **11.1** `[L]` No-libfuse2 launch | Run the beta.48 AppImage on a host without `libfuse2` | Launches (type-2 FUSE embedded); no "dlopen libfuse" error |
+| ☐ **11.1** `[L]` No-libfuse2 launch | Run the smoke-target AppImage on a host without `libfuse2` | Launches (type-2 FUSE embedded); no "dlopen libfuse" error |
 | ☐ **11.2** `[L]` No-libfuse2 update | In-app update from that host | Succeeds → **clears item 31 step 3** (then remove the 5 gate files) |
 | ☐ **11.3** `[L]` Locator-fix watch | During 6.3 / 6.4 / 6.6 apply + relaunch | No Velopack locator root-path regression (velopack#921) |
 
@@ -106,7 +118,7 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **1.5** `[W]` Fresh MSI install | Install `WsScrcpyWeb-beta.msi` as Admin | Auto-opens; WelcomeModal; About = beta.48; `C:\Program Files\WsScrcpyWeb\` |
+| ☐ **1.5** `[W]` Fresh MSI install | Install `WsScrcpyWeb-beta.msi` as Admin | Auto-opens; WelcomeModal; About = the smoke-target version; `C:\Program Files\WsScrcpyWeb\` |
 | ☐ **1.6** `[W]` Reinstall reuses config | After 5.7, reinstall the MSI | Existing `config.json` detected + reused; same saved port |
 | ☐ **3.4** `[W]` Per-session tray | Service installed; Fast User Switch Admin→User1→User2 | Exactly **one** tray/session (~2s); "Open" → same backend port |
 | ☐ **3.5** `[W]` 2nd tray rejected | Launch a 2nd `ws-scrcpy-web-tray.exe` | No 2nd tray; spawned proc exits ~100ms |
@@ -121,9 +133,9 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 | ☐ **11.4** `[W]` PerMachine intact | After the MSI install, check the location | `C:\Program Files\WsScrcpyWeb\` (PerMachine) |
 | ☐ **12.3** `[W]` Stop-exit reaps tray | Local mode → stop server & exit | Tray disappears; no lingering launcher/node/tray/adb; **cancel** leaves running |
 
-## #15 — beta.49 App-section UX (Linux)
+## #15 — App-section UX (Linux)
 
-beta.49 App-section additions (no module-doc counterpart): the one-click **install for all users**, the machine-wide start-menu icon, and the in-app **uninstall** flows.
+App-section additions (no module-doc counterpart): the one-click **install for all users**, the machine-wide start-menu icon, and the in-app **uninstall** flows.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
@@ -133,7 +145,7 @@ beta.49 App-section additions (no module-doc counterpart): the one-click **insta
 | ☐ **15.4** `[L]` uninstall — user-service cascade | User-scope service installed (machine-wide `/opt` binary) → Settings → **App** → **uninstall…** → confirm. | **One pkexec** (for the `/opt` removal); the `--user` unit is **gone** AND the app is **removed in one pass**; **no relaunch**. |
 | ☐ **15.5** `[L]` uninstall — system-service cascade | System-scope service installed → **uninstall…** (runs from the root service context). | Runs **as root, NO pkexec**; `/opt/ws-scrcpy-web` + `/var/opt/ws-scrcpy-web` + the systemd unit are **all gone**; **zero AVC**. |
 | ☐ **15.6** `[L]` uninstall — keep settings & logs | Uninstall with **"keep my settings & logs" checked**. | `config.json` + `logs/` **survive** at the data root (`~/.local/share/WsScrcpyWeb` local, or `/var/opt/ws-scrcpy-web` system); `dependencies/` is **gone either way**; a **reinstall reuses the saved port**. |
-| ☐ **15.7** `[L]` uninstall — SELinux clean | After any uninstall, inspect the fcontext rules + the AVC monitor. | `semanage fcontext -l \| grep ws-scrcpy-web` → **empty**; **zero AVC**. |
+| ☐ **15.7** `[L]` uninstall — SELinux clean | After any uninstall, inspect the fcontext rules + the AVC monitor. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` → **empty**; **zero AVC**. |
 
 ---
 
@@ -141,7 +153,7 @@ beta.49 App-section additions (no module-doc counterpart): the one-click **insta
 
 | Criterion | Holds when |
 |---|---|
-| **SELinux clean** `[L]` | Zero AVC all session; `semanage fcontext -l \| grep ws-scrcpy-web` empty after every uninstall |
+| **SELinux clean** `[L]` | Zero AVC all session; `sudo semanage fcontext -l \| grep ws-scrcpy-web` empty after every uninstall |
 | **Single instance** | Never two trays (Win) / two servers (Linux) per user/session |
 | **Relaunch fidelity** | Every uninstall→relaunch lands on the **same port**; no orphaned processes |
 | **Updates apply everywhere** | local, machine-wide `/opt` (no-service), user-service, system-service (headless) all swap + relaunch on the same port; **zero AVC** on the system-service path |

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -1,16 +1,18 @@
-# ws-scrcpy-web — Full Smoke Test · v0.1.30-beta.44
+# ws-scrcpy-web — Full Smoke Test
+
+> **Smoke target: `v0.1.30-beta.50`** — bump this one line each release; everything below is version-agnostic.
 
 All-encompassing manual smoke, grouped by function and tagged by platform (`[Win]` / `[Linux]` / `[Both]`). Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
 
-> **Consolidated 2026-06-06.** This doc absorbs the three former per-feature checklists — Linux service-mode (`beta.37`), stop-server-&-exit (`beta.39`), and the Windows multi-user / MSI pass (`v0.1.25-beta.3`) — so it is the **single gate for `0.1.30` final** (the first true Windows + Linux release). It covers every shipped feature through beta.44: install/first-run, Linux layout & SELinux, multi-user & single-instance, service mode, lifecycle, updates (local / machine-wide / user- & system-service / migration), devices, streaming, adb, logs, Velopack 1.2.0, stop-server-&-exit, and settings prompts.
+> **Consolidated 2026-06-06.** This doc absorbs the three former per-feature checklists — Linux service-mode (`beta.37`), stop-server-&-exit (`beta.39`), and the Windows multi-user / MSI pass (`v0.1.25-beta.3`) — so it is the **single gate for `0.1.30` final** (the first true Windows + Linux release). It covers every shipped feature to date: install/first-run, Linux layout & SELinux, multi-user & single-instance, service mode (incl. the beta.45–48 stable-ExecStart + install hand-off + post-install port-discovery fix), lifecycle, updates (local / machine-wide / user- & system-service / migration), devices, streaming, adb, logs, Velopack 1.2.0, stop-server-&-exit, settings prompts, and the **Linux App-section UX** (install-for-all-users, start-menu icon, in-app complete uninstall — Module 14).
 
 ## Pre-flight
 
-- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `semanage fcontext -l | grep ws-scrcpy-web` empty (or run `clear-install.sh` beside this doc for a one-shot verified clean slate); keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage` from the **`v0.1.30-beta.44`** release, `chmod +x`.
-- **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi` from the **`v0.1.30-beta.44`** release.
+- **Linux:** Fedora VM, `getenforce` → **Enforcing**; a 2nd user account + a 2nd admin login; baseline `sudo semanage fcontext -l | grep ws-scrcpy-web` empty (or run `clear-install.sh` beside this doc for a one-shot verified clean slate); keep `sudo journalctl -f | grep -i avc` running the whole session. Download `WsScrcpyWeb-linux-beta.AppImage` from the **latest** release — **don't `chmod +x`**: GUI double-click of a non-`+x` AppImage is the realistic path (it's what surfaced the F1 service-mode bug).
+- **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi` from the **latest** release.
 - **Devices:** an Android device with **Wireless debugging** enabled (Android 11+) reachable from the VM, plus (Windows) one USB device if available.
 
-**Build-prep — the "update from" build (Modules 6 + the migration row).** The releases page is wiped to beta.44 only, so the update/migration rows need an older build to update *from*. Don't rebuild — download the still-retained **beta.40** CI artifact (the exact published beta.40 AppImage: Velopack 1.1.1, the old `/opt/.../data` system layout the migration row needs):
+**Build-prep — the "update from" build (Modules 6 + the migration row).** The releases page is curated to the latest only, so the update/migration rows need an older build to update *from*. Don't rebuild — download the still-retained **beta.40** CI artifact (the exact published beta.40 AppImage: Velopack 1.1.1, the old `/opt/.../data` system layout the migration row needs):
 
 ```bash
 # Linux — the update/migration "from" build
@@ -19,7 +21,7 @@ chmod +x ./beta40/WsScrcpyWeb-linux-beta.AppImage
 # Windows MSI (row 6.8 / the Windows pass): --name windows-final from the same run
 ```
 
-Artifacts are retained ~90 days from 2026-06-03. **No beta.45 is needed** — beta.44 is feed-latest, so any older install updates *to* it.
+Artifacts are retained ~90 days from 2026-06-03. **the latest release is feed-latest**, so any older install updates *to* it.
 
 - **No-libfuse2 host (Module 11.1/11.2):** a minimal Fedora container/distro **without** `libfuse2`. This is the gate for closing item 31, not a 0.1.30-stable blocker on its own.
 
@@ -42,10 +44,10 @@ sudo systemctl daemon-reload
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | **1.1** `[Linux]` First-run modal | Run the home AppImage on a machine with no prior install/decline marker. | "install for all users?" modal: 3 stacked lines + buttons **yes, all users** / **no, me only**; **no ×**; **Esc** and **click-outside do nothing** (forced choice). |
-| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = `0.1.30-beta.44`; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
+| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = the smoke-target version; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
 | **1.3** `[Linux]` Decline + remember | Fresh state / 2nd user → **no, me only**. | Runs in place from `~/.local`; **next launch does NOT re-prompt**; original AppImage **kept**. |
 | **1.4** `[Linux]` Headless first-run | Launch over SSH / no display. | No hang; graceful fallback, no crash. |
-| **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = `0.1.30-beta.44`; installs to `C:\Program Files\WsScrcpyWeb\`. |
+| **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = the smoke-target version; installs to `C:\Program Files\WsScrcpyWeb\`. |
 | **1.6** `[Win]` Reinstall reuses config *(H.2)* | After 5.7's full uninstall, reinstall `WsScrcpyWeb-beta.msi`. | Installs clean; existing `config.json` under dataRoot is **detected and reused** (no fresh skeleton overwrite); app reachable on the previously-saved port. |
 
 ## Module 2 — Linux layout & SELinux
@@ -54,7 +56,7 @@ sudo systemctl daemon-reload
 |---|---|---|
 | **2.1** `[Linux]` Binary/deps labels | After a machine-wide (and/or system-service) install. | `ls -Z /opt/ws-scrcpy-web` → **bin_t**. |
 | **2.2** `[Linux]` State labels | Inspect the variable-state tree. | `ls -Z /var/opt/ws-scrcpy-web` → **var_lib_t** (config/logs/deps the service writes). |
-| **2.3** `[Linux]` fcontext rules registered | After a system-service install. | `semanage fcontext -l \| grep ws-scrcpy-web` shows **both** the `/opt` bin_t rule and the `/var/opt` var_lib_t rule. |
+| **2.3** `[Linux]` fcontext rules registered | After a system-service install. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` shows **both** the `/opt` bin_t rule and the `/var/opt` var_lib_t rule. |
 | **2.4** `[Linux]` Zero AVC during install | Watch the `journalctl` monitor through 1.2 + a service install. | **No AVC** denials. |
 
 ## Module 3 — Multi-user & single-instance
@@ -85,7 +87,7 @@ sudo systemctl daemon-reload
 | **5.1** `[Linux]` Same-user uninstall → relaunch | System service installed, active user using app → uninstall **as that user**. | App reappears in the active user's session, **same port**, visible "relaunching…" wait. |
 | **5.2** `[Linux]` Different-admin uninstall | Uninstall via **pkexec as a different admin**. | App reappears in the **active desktop user's** session (not the admin's), same port. |
 | **5.3** `[Linux]` Headless uninstall | Uninstall with no active graphical session. | No relaunch; manual fallback; **no orphan**; no `data_root_for_linux` panic. |
-| **5.4** `[Linux]` fcontext cleanup *(fix a)* | After any uninstall. | `semanage fcontext -l \| grep ws-scrcpy-web` → **empty** (both rules gone). |
+| **5.4** `[Linux]` fcontext cleanup *(fix a)* | After any uninstall. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` → **empty** (both rules gone). |
 | **5.5** `[Win]` Uninstall + handoff affordance | Service mode, Settings as `Admin` → "uninstall service" → continue → Yes on UAC. | Button → "uninstalling…"; if handoff >5s → "still waiting for user session…"; ends at local-mode URL. |
 | **5.6** `[Win]` Uninstall handoff-failure guard | Service mode; kill all `ws-scrcpy-web-tray.exe`; then uninstall. | ~5s → "still waiting…"; ~30s → "couldn't reach the user session…"; button freed; **service STILL installed** (no silent direct uninstall). |
 | **5.7** `[Win]` Full uninstall | Add/Remove Programs → ws-scrcpy-web → Uninstall as `Admin`. | Service stops/unregisters; `HKLM\…\Run\WsScrcpyWebTray` removed; `Program Files\WsScrcpyWeb` cleared; **user data under dataRoot preserved**; admin tray disappears. |
@@ -95,17 +97,17 @@ sudo systemctl daemon-reload
 
 ## Module 6 — Updates
 
-Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact). beta.44 is feed-latest, so every row updates *to* beta.44.
+Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact). The latest release is feed-latest, so every row updates *to* it.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **6.1** `[Both]` Update check | Settings → Updates → Check for updates. | A beta.40 install **offers beta.44**; a beta.44 install reports **up-to-date**; no error spam in `server.log` / `launcher.log`. |
-| **6.2** `[Linux]` Local-mode (home) update apply + relaunch *(#27)* | beta.40 home AppImage in **local mode** (no service) → Settings → Updates → Apply. | Downloads + SHA-256 verifies; the "updating…" overlay shows **above** Settings; the AppImage **swaps and auto-relaunches** onto beta.44 unattended; browser reconnects; About = beta.44. **Edge:** also confirm apply on an instance **relaunched right after a user-scope service uninstall** (the `systemd-run --collect` cgroup case) still swaps + relaunches. |
+| **6.1** `[Both]` Update check | Settings → Updates → Check for updates. | A beta.40 install **offers the latest**; the latest reports **up-to-date**; no error spam in `server.log` / `launcher.log`. |
+| **6.2** `[Linux]` Local-mode (home) update apply + relaunch *(#27)* | beta.40 home AppImage in **local mode** (no service) → Settings → Updates → Apply. | Downloads + SHA-256 verifies; the "updating…" overlay shows **above** Settings; the AppImage **swaps and auto-relaunches** onto the latest unattended; browser reconnects; About = the new version. **Edge:** also confirm apply on an instance **relaunched right after a user-scope service uninstall** (the `systemd-run --collect` cgroup case) still swaps + relaunches. |
 | **6.3** `[Linux]` No-service `/opt` update *(one pkexec)* | Machine-wide `/opt`, **no** service → trigger update. | One pkexec; `/opt` swapped by **rename**; relabel bin_t + restorecon; VERSION bumps; relaunches **as the user**; reconnects. No `ETXTBSY`; FUSE intact. |
-| **6.4** `[Linux]` Newer home over `/opt` | `/opt` at beta.40; place a newer (beta.44) home AppImage; launch. | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
+| **6.4** `[Linux]` Newer home over `/opt` | `/opt` at beta.40; place a newer home AppImage; launch. | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
 | **6.5** `[Linux]` User-scope service update apply *(item 39)* | User-scope service installed → Settings → Updates → Apply. | The `--user` unit stops, the home `$APPIMAGE` swaps, the unit restarts on the **same** web port, browser reconnects via the overlay. **No prompt.** |
 | **6.6** `[Linux]` System-scope headless service update apply *(item 39 — the SELinux risk)* | System-scope service installed → Apply. | **No polkit prompt** (root self-update); `/opt` copy swaps; `restorecon` re-applies `bin_t`; unit restarts; **zero AVC**. The `systemd-run` apply helper **survives `systemctl stop`** of the unit it's restarting (out-of-cgroup); the FUSE unmount settles within the helper's ~15s swap-retry window (widen if the VM is slow). If SELinux blocks the `init_t` `/opt` write or relabel → **narrow targeted policy only, never broad `audit2allow`**. |
-| **6.7** `[Linux]` Migrate a legacy beta.40 system install *(Phase 3a)* | *Clean snapshot* → install **beta.40** → install **system-scope** service (old `/opt/ws-scrcpy-web/data` layout) → update to beta.44 **from a local instance, NOT from inside the running service**. | In-app notice *"the system service must be reinstalled for the new layout"* + **[reinstall now]** → uninstall→reinstall at `/var/opt`, **`webPort` + `installMode` carried over**, service active, **zero AVC**, `semanage fcontext -l \| grep ws-scrcpy-web` shows only the new `/var/opt` rule. |
+| **6.7** `[Linux]` Migrate a legacy beta.40 system install *(Phase 3a)* | *Clean snapshot* → install **beta.40** → install **system-scope** service (old `/opt/ws-scrcpy-web/data` layout) → update to the latest **from a local instance, NOT from inside the running service**. | In-app notice *"the system service must be reinstalled for the new layout"* + **[reinstall now]** → uninstall→reinstall at `/var/opt`, **`webPort` + `installMode` carried over**, service active, **zero AVC**, `sudo semanage fcontext -l \| grep ws-scrcpy-web` shows only the new `/var/opt` rule. |
 | **6.8** `[Win]` In-app update apply + tray persists *(SE-2)* | From a prior installed build (beta.40 MSI) → Settings → Updates → Apply. | Applies clean; app reachable post-update; **the tray persists across the update** (the `apply-update-pending` marker gates the reap off; the relaunched launcher keeps it) — **one** tray after settling, no duplicate/orphan. |
 
 ## Module 7 — Devices: scan & connect
@@ -141,13 +143,13 @@ Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact).
 | **10.2** `[Win]` Logs clean | Tail `C:\ProgramData\WsScrcpyWeb\logs\{launcher,server}.log` during normal use. | No `ERR` / `Error:` except known cosmetic node-pty AttachConsole noise. |
 | **10.3** `[Linux]` Logs clean | Tail logs under `~/.local/share/.../logs` (or `/var/opt/.../logs` for system). | No error spam; teardown logs present on stop. |
 
-## Module 11 — Velopack 1.2.0 / item-31 (new for beta.44)
+## Module 11 — Velopack 1.2.0 / item-31
 
-beta.44 bumped Velopack to 1.2.0. These rows close out item 31 (the libfuse2 first-run gate) and guard the 1.2.0 apply path.
+Velopack is at 1.2.0 (bumped in beta.44). These rows close out item 31 (the libfuse2 first-run gate) and guard the 1.2.0 apply path.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **11.1** `[Linux]` No-libfuse2 launch | On a minimal distro/container **without** `libfuse2` installed, run the beta.44 AppImage. | Launches (type-2 runtime has FUSE embedded); **no** `libfuse.so.2` / "dlopen libfuse" error. |
+| **11.1** `[Linux]` No-libfuse2 launch | On a minimal distro/container **without** `libfuse2` installed, run the smoke-target AppImage. | Launches (type-2 runtime has FUSE embedded); **no** `libfuse.so.2` / "dlopen libfuse" error. |
 | **11.2** `[Linux]` No-libfuse2 in-app update | From that no-libfuse2 host, run an in-app update (6.x flow). | Update succeeds → **clears item 31 step 3**; then the 5 libfuse2 gate files can be removed (`SystemdClient.ts`, `UpdatesApi.ts`, `UpdateEvents.ts`, `SettingsModal.ts`, README section). |
 | **11.3** `[Linux]` Locator fix watch (velopack#921) | During **6.3 / 6.4 / 6.6** apply + relaunch on the machine-wide `/opt` install. | Apply + relaunch land correctly; no Velopack locator root-path regression (the 1.2.0 fix targets exactly this path). |
 | **11.4** `[Win]` PerMachine intact | After the 1.5 MSI install, check the install location. | Installed PerMachine to `C:\Program Files\WsScrcpyWeb\` (vpk 1.2.0 `--msi --instLocation PerMachine` unchanged). |
@@ -170,13 +172,27 @@ beta.39 added a "stop server & exit" button (Settings → App) with graceful tea
 | **13.1** `[Both]` Bookmark global-dismiss *(beta.32)* | Reach the bookmark / port-change reminder → check "don't show again — ever, even when the port changes" → confirm. | The confirmation dialog uses the white-outline buttons; checking it **supersedes + disables** the per-port checkbox; persists (`bookmarkDismissedGlobally` in `config.json`). |
 | **13.2** `[Both]` Reset welcome & bookmark prompts *(beta.40 fix)* | Settings → "reset welcome and bookmark prompts". | Re-shows the welcome modal **and** clears the bookmark dismissal — both **per-port** and **global** — so the reminder can re-fire. Regression check: the welcome reset must **not** re-suppress the per-port bookmark (the eager `bookmarkDismissedForPort` re-stamp is gone). |
 
+## Module 14 — Linux App-section UX
+
+The App section adds three Settings → **App** affordances on Linux: a one-click **install for all users**, a machine-wide **start-menu icon**, and an always-available in-app **complete uninstall** — it cascades through any installed service in one pass, runs root-direct under a system service (otherwise self-elevates via **one** pkexec), and offers a **"keep my settings & logs"** option.
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **14.1** `[Linux]` Install-for-all-users button | Local (me-only) install running → Settings → **App** → **install for all users**; authenticate the one prompt. | One pkexec; the binary **relocates to `/opt/ws-scrcpy-web/`**; the button then **greys/disables** reading "already installed for all users (/opt)"; the app keeps serving on the same port. |
+| **14.2** `[Linux]` Start-menu icon | After a machine-wide install (14.1 or 1.2), open the desktop apps menu; also check disk. | The launcher entry shows the **ws-scrcpy-web icon** (not a generic placeholder); `ls /usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png` → exists. |
+| **14.3** `[Linux]` Complete uninstall — local | Local mode → Settings → **App** → **uninstall…** → confirm with **"keep my settings & logs" unchecked**. | App removed; tab shows "uninstalled — close this tab"; `clear-install.sh` verifies a **CLEAN SLATE** (no leftover binary / deps / config / decline marker). |
+| **14.4** `[Linux]` Uninstall — user-service cascade | User-scope service installed (machine-wide `/opt` binary) → **uninstall…** → confirm. | **One pkexec** (for the `/opt` removal); the `--user` unit is **gone** AND the app is **removed in one pass**; no relaunch. |
+| **14.5** `[Linux]` Uninstall — system-service cascade | System-scope service installed → **uninstall…** (from the root service context). | Runs **as root, NO pkexec**; `/opt/ws-scrcpy-web` + `/var/opt/ws-scrcpy-web` + the systemd unit are **all gone**; zero AVC. |
+| **14.6** `[Linux]` Uninstall — keep settings & logs | Uninstall with **"keep my settings & logs" checked**. | `config.json` + `logs/` **survive** at the data root (`~/.local/share/WsScrcpyWeb` local, or `/var/opt/ws-scrcpy-web` system); `dependencies/` is **gone either way**; a reinstall reuses the saved port. |
+| **14.7** `[Linux]` Uninstall — SELinux clean | After any uninstall, inspect fcontext + the AVC monitor. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` → **empty**; zero AVC. |
+
 ---
 
 ## Global pass criteria
 
 | Criterion | Holds when |
 |---|---|
-| **SELinux clean** `[Linux]` | Zero AVC all session; `semanage fcontext -l \| grep ws-scrcpy-web` empty after every uninstall. |
+| **SELinux clean** `[Linux]` | Zero AVC all session; `sudo semanage fcontext -l \| grep ws-scrcpy-web` empty after every uninstall. |
 | **Single instance** | Never two trays (Win) / two servers (Linux) per user/session. |
 | **Relaunch fidelity** | Every uninstall→relaunch lands on the **same port**; no orphaned processes. |
 | **Updates apply everywhere** | local, machine-wide `/opt` (no-service), user-service, and system-service (headless) all swap + relaunch on the same port; **zero AVC** on the system-service path. |
@@ -185,4 +201,4 @@ beta.39 added a "stop server & exit" button (Settings → App) with graceful tea
 | **Data preserved** | User config/deps/logs survive uninstall + reinstall. |
 | **Core flow** | Scan → connect → stream (video + control) → shell works on both platforms. |
 
-**If a `[Linux]` SELinux/lifecycle row (Modules 2, 4, 5, the service-mode update rows 6.5/6.6, or the migration row 6.7) or the core-flow criterion fails:** stop, capture `journalctl`/`ausearch`/logs, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker. **Module 11 (no-libfuse2)** is the gate for closing item 31, not a 0.1.30-stable blocker on its own — a failure there means keep the libfuse2 gate, don't remove it.
+**If a `[Linux]` SELinux/lifecycle row (Modules 2, 4, 5, the service-mode update rows 6.5/6.6, the migration row 6.7, or the Module 14 uninstall-cascade rows 14.4–14.7) or the core-flow criterion fails:** stop, capture `journalctl`/`ausearch`/logs, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker. **Module 11 (no-libfuse2)** is the gate for closing item 31, not a 0.1.30-stable blocker on its own — a failure there means keep the libfuse2 gate, don't remove it.

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -1,8 +1,10 @@
-# ws-scrcpy-web — Smoke Test Runbook (plain-English) · v0.1.30-beta.44
+# ws-scrcpy-web — Smoke Test Runbook (plain-English)
+
+> **Smoke target: `v0.1.30-beta.50`** — bump this one line each release; everything below is version-agnostic.
 
 **What this is.** A step-by-step manual test pass for the **ws-scrcpy-web** app. Completing it is the agreed gate before cutting the **0.1.30 final** release — the "prove it really installs, updates, and streams on Windows + Linux" check. You run it by hand on your test VMs plus a real Android device; it can't be automated from a chat.
 
-**Source of truth.** This is the plain-English twin of `docs/smoke-tests/v0.1.30-beta.44-full.md` in the repo. Same 62 tests, jargon spelled out, laid out as fixed-width tables you can keep open and tick through. If the two ever disagree, **the repo doc wins** — tell me and I'll re-sync this one.
+**Source of truth.** This is the plain-English twin of `docs/smoke-tests/smoke-full.md` in the repo. Same 69 tests, jargon spelled out, laid out as fixed-width tables you can keep open and tick through. If the two ever disagree, **the repo doc wins** — tell me and I'll re-sync this one.
 
 ## How to use this runbook
 
@@ -70,7 +72,7 @@ This is **setup, not tests** — nothing here passes or fails the app; it just g
 2. Create two extra accounts: a **2nd normal user** and a **2nd admin (sudo) user**. (For the multi-user tests and the "different admin uninstalls" test.)
 3. Confirm a clean slate — this must print **nothing**:
    ```bash
-   semanage fcontext -l | grep ws-scrcpy-web
+   sudo semanage fcontext -l | grep ws-scrcpy-web
    ```
    (If it prints rules, an old test left residue — clean it with the recovery block at the bottom before starting.)
 4. In a spare terminal, start the live denial monitor and leave it running all session:
@@ -78,18 +80,15 @@ This is **setup, not tests** — nothing here passes or fails the app; it just g
    sudo journalctl -f | grep -i avc
    ```
    (Ideally nothing ever scrolls by.)
-5. Download `WsScrcpyWeb-linux-beta.AppImage` from the `v0.1.30-beta.44` GitHub release, then make it runnable:
-   ```bash
-   chmod +x WsScrcpyWeb-linux-beta.AppImage
-   ```
+5. Download `WsScrcpyWeb-linux-beta.AppImage` from the latest GitHub release. **Leave it non-executable** — double-clicking a NON-`chmod +x` AppImage straight from the file manager is the realistic path most users take, and it's exactly what surfaced the Linux service-mode bug. (Marking it runnable with `chmod +x WsScrcpyWeb-linux-beta.AppImage` is optional — only needed if you'd rather launch it from a terminal.)
 
 ### B. The older "update-from" build (only for the Module 6 update tests)
-The update tests need an **older** version installed first, then updated *to* beta.44. The releases page only has beta.44 now, so pull the older **beta.40** build from its saved CI artifact:
+The update tests need an **older** version installed first, then updated *to* the latest. The releases page now lists only the latest, so pull the older **beta.40** build from its saved CI artifact:
 ```bash
 gh run download 26859605903 --repo bilbospocketses/ws-scrcpy-web --name linux-final --dir ./beta40
 chmod +x ./beta40/WsScrcpyWeb-linux-beta.AppImage
 ```
-(beta.40 = your "before", beta.44 = your "after". The Windows MSI is in the same run under `--name windows-final`. Artifacts are kept ~90 days from 2026-06-03.)
+(beta.40 = your "before", the smoke-target = your "after". The Windows MSI is in the same run under `--name windows-final`. Artifacts are kept ~90 days from 2026-06-03.)
 
 ### C. Android device
 An Android phone/tablet with **Wireless debugging** on (Settings → Developer options, Android 11+), reachable from the VM. Optionally one **USB**-connected device on Windows (for the single USB test, 7.3).
@@ -132,10 +131,10 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 1.2 Accept ->        │ Lin  │ Click "yes, all users";      │ Exactly one password prompt. App lands in        │ [ ]  │
 │ install + delete     │      │ enter your password at the   │ /opt/ws-scrcpy-web/; the file                    │      │
-│ original             │      │ single prompt.               │ /opt/ws-scrcpy-web/VERSION reads 0.1.30-beta.44; │      │
-│                      │      │                              │ a system menu entry exists; the app runs. NEW:   │      │
-│                      │      │                              │ the AppImage you launched (in Downloads) is      │      │
-│                      │      │                              │ deleted afterward.                               │      │
+│ original             │      │ single prompt.               │ /opt/ws-scrcpy-web/VERSION matches the           │      │
+│                      │      │                              │ smoke-target version; a system menu entry        │      │
+│                      │      │                              │ exists; the app runs. NEW: the AppImage you      │      │
+│                      │      │                              │ launched (in Downloads) is deleted afterward.    │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 1.3 Decline +        │ Lin  │ On a fresh machine, or as a  │ Runs from your home folder (~/.local). The NEXT  │ [ ]  │
 │ remember             │      │ 2nd user, choose "no, me     │ launch does NOT ask again. The downloaded        │      │
@@ -146,8 +145,8 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 1.5 Fresh MSI        │ Win  │ On a clean snapshot as       │ Installs cleanly; a browser opens                │ [ ]  │
 │ install              │      │ Admin, run                   │ http://localhost:<port>; the welcome dialog      │      │
-│                      │      │ WsScrcpyWeb-beta.msi.        │ shows; Settings > About = 0.1.30-beta.44; files  │      │
-│                      │      │                              │ in C:\Program Files\WsScrcpyWeb\.                │      │
+│                      │      │ WsScrcpyWeb-beta.msi.        │ shows; Settings > About = the smoke-target       │      │
+│                      │      │                              │ version; files in C:\Program Files\WsScrcpyWeb\. │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 1.6 Reinstall reuses │ Win  │ After the full uninstall in  │ Installs cleanly and REUSES your old settings    │ [ ]  │
 │ config               │      │ test 5.7, install the MSI    │ file (config.json) instead of overwriting it;    │      │
@@ -268,8 +267,8 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ uninstall            │      │ logged into the desktop.     │ message; nothing left running; no crash.         │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 5.4 Security rules   │ Lin  │ After any uninstall:         │ Returns NOTHING - both SELinux rules were        │ [ ]  │
-│ cleaned up           │      │ semanage fcontext -l | grep  │ removed.                                         │      │
-│                      │      │ ws-scrcpy-web                │                                                  │      │
+│ cleaned up           │      │ sudo semanage fcontext -l    │ removed.                                         │      │
+│                      │      │ | grep ws-scrcpy-web         │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 5.5 Win uninstall +  │ Win  │ Service mode, Settings as    │ Button shows "uninstalling..."; if handoff takes │ [ ]  │
 │ handoff message      │      │ Admin > "uninstall service"  │ >5s you see "still waiting for user session..."; │      │
@@ -305,21 +304,21 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ```
 
 ### Module 6 — Updates
-*beta.44 is the newest, so every row updates **to** it. Get the beta.40 "from" build first (Pre-flight B).*
+*The smoke-target build is the newest, so every row updates **to** it. Get the beta.40 "from" build first (Pre-flight B).*
 
 ```text
 ┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 6.1 Update check     │ Both │ Settings > Updates > "Check  │ A beta.40 install OFFERS beta.44; a beta.44      │ [ ]  │
+│ 6.1 Update check     │ Both │ Settings > Updates > "Check  │ A beta.40 install offers the latest; the latest  │ [ ]  │
 │                      │      │ for updates".                │ install says "up to date". No error spam in the  │      │
 │                      │      │                              │ server/launcher logs.                            │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 6.2 Local (home)     │ Lin  │ Start from the beta.40       │ It downloads, verifies the checksum, shows an    │ [ ]  │
-│ update +             │      │ AppImage in plain local mode │ "updating..." overlay, swaps itself to beta.44   │      │
-│ auto-relaunch        │      │ (no service). Settings >     │ and relaunches on its own; the browser           │      │
-│                      │      │ Updates > Apply.             │ reconnects; About = beta.44. Also confirm on a   │      │
-│                      │      │                              │ copy just relaunched after a user-scope service  │      │
+│ update +             │      │ AppImage in plain local mode │ "updating..." overlay, swaps to the latest and   │      │
+│ auto-relaunch        │      │ (no service). Settings >     │ relaunches on its own; the browser reconnects;   │      │
+│                      │      │ Updates > Apply.             │ About = the new version. Also confirm on a copy  │      │
+│                      │      │                              │ just relaunched after a user-scope service       │      │
 │                      │      │                              │ uninstall.                                       │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 6.3 Machine-wide     │ Lin  │ Machine-wide /opt install    │ One password prompt; the /opt binary is swapped  │ [ ]  │
@@ -328,7 +327,7 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │                              │ relaunches as you and reconnects.                │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 6.4 Newer home copy  │ Lin  │ With /opt at beta.40, drop a │ It runs the home copy, then offers "update the   │ [ ]  │
-│ over /opt            │      │ newer beta.44 AppImage in    │ system-wide install to vX"; accept > it swaps    │      │
+│ over /opt            │      │ newer AppImage in            │ system-wide install to vX"; accept > it swaps    │      │
 │                      │      │ your home folder and launch  │ /opt; the next launch runs the updated /opt.     │      │
 │                      │      │ it.                          │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
@@ -345,7 +344,7 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ 6.7 Migrate an old   │ Lin  │ Fresh snapshot > install     │ A notice "the system service must be reinstalled │ [ ]  │
 │ beta.40 system       │      │ beta.40 > install the system │ for the new layout" + a [reinstall now] button > │      │
 │ install              │      │ service (old layout) >       │ it uninstalls + reinstalls at /var/opt, keeping  │      │
-│                      │      │ update to beta.44 FROM a     │ your port + install settings; the service is     │      │
+│                      │      │ update to the latest FROM a  │ your port + install settings; the service is     │      │
 │                      │      │ normal local copy, NOT from  │ active; zero denials; only the new /var/opt rule │      │
 │                      │      │ inside the running service.  │ remains.                                         │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
@@ -454,8 +453,8 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 11.1 Runs without    │ Lin  │ On a minimal                 │ It launches (the newer AppImage bundles its own  │ [ ]  │
 │ libfuse2             │      │ distro/container with NO     │ FUSE); no "libfuse.so.2"/dlopen error.           │      │
-│                      │      │ libfuse2, run the beta.44    │                                                  │      │
-│                      │      │ AppImage.                    │                                                  │      │
+│                      │      │ libfuse2, run the            │                                                  │      │
+│                      │      │ smoke-target AppImage.       │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 11.2 Updates without │ Lin  │ From that same no-libfuse2   │ The update succeeds. (Passing this lets the old  │ [ ]  │
 │ libfuse2             │      │ machine, run an in-app       │ libfuse2 special-case code be deleted.)          │      │
@@ -522,6 +521,55 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
+### Module 14 — Linux App section UX
+*The App section adds three Settings → App affordances on Linux: a one-click "install for all users" button, a machine-wide start-menu icon, and an always-available in-app "complete uninstall". The uninstall cascades through any installed service in one pass — it runs root-direct under a system service, otherwise self-elevates via ONE pkexec — and offers a "keep my settings & logs" option.*
+
+```text
+┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
+│ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.1 Install for     │ Lin  │ From a local (me-only)       │ Exactly one pkexec prompt. The binary            │ [ ]  │
+│ all users            │      │ install: Settings > App >    │ relocates to /opt/ws-scrcpy-web/; the            │      │
+│                      │      │ click 'install for all       │ button then greys/disables, reading              │      │
+│                      │      │ users'; authenticate the     │ 'already installed for all users                 │      │
+│                      │      │ single prompt.               │ (/opt)'; the app keeps serving on the            │      │
+│                      │      │                              │ same port.                                       │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.2 Start-menu      │ Lin  │ After a machine-wide         │ The ws-scrcpy-web icon shows in the menu         │ [ ]  │
+│ icon                 │      │ install, open the desktop    │ (not a generic placeholder). On disk,            │      │
+│                      │      │ apps menu.                   │ /usr/share/icons/hicolor/256x256/apps            │      │
+│                      │      │                              │ /ws-scrcpy-web.png exists.                       │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.3 Uninstall -     │ Lin  │ Settings > App >             │ App removed; the browser tab shows               │ [ ]  │
+│ local mode           │      │ 'uninstall...' > confirm     │ 'uninstalled - close this tab'. Running          │      │
+│                      │      │ with 'keep my settings &     │ clear-install.sh verifies a CLEAN SLATE:         │      │
+│                      │      │ logs' UNCHECKED.             │ no leftover binary, dependencies,                │      │
+│                      │      │                              │ config, or decline marker.                       │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.4 Uninstall -     │ Lin  │ With a user-scope service    │ Exactly ONE pkexec (for the /opt removal);       │ [ ]  │
+│ user-service         │      │ installed on a machine-wide  │ the per-user systemd unit is gone AND            │      │
+│ cascade              │      │ /opt binary, click           │ the app is removed in one pass; no               │      │
+│                      │      │ uninstall.                   │ relaunch.                                        │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.5 Uninstall -     │ Lin  │ With a system-scope          │ Runs as root with NO pkexec;                     │ [ ]  │
+│ system-service       │      │ service installed, run       │ /opt/ws-scrcpy-web,                              │      │
+│ cascade              │      │ uninstall from the root      │ /var/opt/ws-scrcpy-web, and the                  │      │
+│                      │      │ service context.             │ systemd unit are all gone; zero                  │      │
+│                      │      │                              │ SELinux AVC denials.                             │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.6 Uninstall -     │ Lin  │ Run uninstall with 'keep     │ config.json and logs/ survive at the data        │ [ ]  │
+│ keep settings        │      │ my settings & logs'          │ root: ~/.local/share/WsScrcpyWeb for a           │      │
+│ & logs               │      │ CHECKED.                     │ local install, or /var/opt/ws-scrcpy-web         │      │
+│                      │      │                              │ for a system service); dependencies/ is          │      │
+│                      │      │                              │ removed either way; a later reinstall            │      │
+│                      │      │                              │ reuses the saved port.                           │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 14.7 Uninstall -     │ Lin  │ After any uninstall, run     │ The output is empty - the fcontext list          │ [ ]  │
+│ SELinux clean        │      │ sudo semanage fcontext -l    │ has no ws-scrcpy-web rules - and there           │      │
+│                      │      │ | grep ws-scrcpy-web.        │ are zero AVC denials.                            │      │
+└──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
+```
+
 ---
 
 ## Global pass criteria
@@ -558,4 +606,4 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 
 **If any Linux SELinux/lifecycle test (Modules 2, 4, 5, the service-update rows 6.5/6.6, or migration 6.7) — or the core-flow criterion — fails:** stop, capture `journalctl` / `ausearch` and the app logs, and report it before promoting 0.1.30 to stable. Cosmetic/polish failures: note and triage later. **Module 11 (no-libfuse2)** is optional — a failure there just means keep the libfuse2 code; it doesn't block 0.1.30.
 
-*Plain-English companion to [`v0.1.30-beta.44-full.md`](./v0.1.30-beta.44-full.md), the canonical machine-precise checklist. Same 62 tests with the jargon spelled out; if the two ever diverge, the full doc wins.*
+*Plain-English companion to [`smoke-full.md`](./smoke-full.md), the canonical machine-precise checklist. Same 69 tests with the jargon spelled out; if the two ever diverge, the full doc wins.*

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -44,6 +44,22 @@ pub fn decide_restart(exit_code: i32, marker_exists: bool) -> Option<RestartReas
     }
 }
 
+/// Returns true when a helper-refresh error is the benign "text file busy"
+/// (ETXTBSY) case: the destination helper is currently being executed, so it
+/// can't be overwritten right now — and need not be. This is expected on
+/// service start, where the operation-server helper IS the running launcher
+/// binary; the live copy stays in use until it exits, then the next supervisor
+/// start refreshes it. That path logs at WARN, not ERROR. Any other failure
+/// (permissions, missing source, disk full) is a genuine ERROR.
+fn refresh_error_is_benign_busy(e: &std::io::Error) -> bool {
+    // ETXTBSY is errno 26 on Linux/Unix. Matching the raw errno keeps this on
+    // stable Rust (vs the newer ErrorKind::ExecutableFileBusy) without pulling
+    // in libc/rustix for a single constant. On Windows a running binary
+    // surfaces a different code, so this correctly stays ERROR there — the
+    // ETXTBSY refresh case is Linux service-mode only.
+    e.raw_os_error() == Some(26)
+}
+
 /// Main supervisor entry. Returns the final exit code to bubble to OS.
 pub fn run() -> Result<i32> {
     let paths = Paths::from_env()?;
@@ -123,6 +139,9 @@ pub fn run() -> Result<i32> {
         match crate::operation_server::refresh_helper_binary(&paths.data_root) {
             Ok(p) => log::info(&format!(
                 "supervisor: refreshed operation-server helper at {p:?}"
+            )),
+            Err(e) if refresh_error_is_benign_busy(&e) => log::warn(&format!(
+                "supervisor: operation-server helper is in use (text file busy); keeping the running copy — it refreshes on the next start when free: {e}"
             )),
             Err(e) => log::error(&format!(
                 "supervisor: could not refresh operation-server helper (operation-server spawn will use stale binary or fail): {e}"
@@ -401,6 +420,32 @@ mod tests {
         // If both signals are present, marker wins (matches start.cmd's
         // ordering — marker checked before exit code).
         assert_eq!(decide_restart(75, true), Some(RestartReason::RestartMarker));
+    }
+
+    #[test]
+    fn benign_busy_detects_etxtbsy() {
+        // ETXTBSY (errno 26): the helper binary is currently executing —
+        // benign (the running copy stays in use), so it logs at WARN.
+        let e = std::io::Error::from_raw_os_error(26);
+        assert!(refresh_error_is_benign_busy(&e));
+    }
+
+    #[test]
+    fn benign_busy_rejects_other_os_errors() {
+        // EACCES (13) and ENOENT (2) are genuine refresh failures → ERROR.
+        assert!(!refresh_error_is_benign_busy(
+            &std::io::Error::from_raw_os_error(13)
+        ));
+        assert!(!refresh_error_is_benign_busy(
+            &std::io::Error::from_raw_os_error(2)
+        ));
+    }
+
+    #[test]
+    fn benign_busy_rejects_non_os_error() {
+        // A synthesized error with no raw OS code is not benign.
+        let e = std::io::Error::other("synthetic");
+        assert!(!refresh_error_is_benign_busy(&e));
     }
 
 }


### PR DESCRIPTION
Two bits of owed polish (item 46), no release impact on its own.

## G2 — quieter Linux service start
On service start the launcher refreshes its bundled operation-server helper by copying the current binary over it. In service mode that helper *is* the running binary, so the copy fails with `ETXTBSY` ("text file busy") and logged a scary `ERROR`. It's harmless — the running copy is already current, and the next start refreshes it while it's free — so it now logs at WARN. A small pure classifier (`refresh_error_is_benign_busy`, unit-tested) keeps genuine refresh failures at ERROR. Adds a WARN level to the shared logger.

## Smoke docs — version-agnostic
The smoke docs stamped the build-under-test version into nearly every row, so they needed a sweep every release. Stripped those stamps; the smoke target now lives in one top-of-doc tag you bump once per release. Also:
- Renamed to stable generic names so we stop renaming files per release: `smoke-checklist.md` / `smoke-full.md` / `smoke-runbook.md`.
- Added Module 14 (the Linux App-section UX) to the full + runbook docs.
- Corrected the `semanage fcontext -l` verification commands to use `sudo` (they error as non-root).
- Kept the version-specific bits that matter: the beta.40 "update from" build and historical fix provenance.

Verified locally: launcher + common unit tests pass, clippy `-D warnings` clean. `release:none` — docs plus a cosmetic log change; ships with the next beta.