### PR TITLE
fix(client): shorten App-section install button to "install for all users"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Shortened the Settings → App "install for all users" button.** It now reads **install for all users** instead of "install ws-scrcpy-web for all users" — the App section already makes the app clear, so the name was redundant. (The **uninstall ws-scrcpy-web** action keeps its name.)
+
 ### Fixed
 
 - **Linux service start no longer logs a spurious `ERROR … text file busy`.** On service start the launcher refreshes its bundled operation-server helper by copying the current binary over it — but in service mode that helper *is* the binary already running, so the copy fails with `ETXTBSY` ("text file busy"). The failure is harmless (the running copy is already the current version; the next start refreshes it while it's free), so it is now logged as a warning instead of an alarming error.

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -1680,7 +1680,7 @@ export class SettingsModal extends Modal {
         const install = buildInstallAllUsersControl({ reload: () => window.location.reload() });
         this.installAllUsersButton = install.button;
         this.installAllUsersNote = install.note;
-        const installRow = this.buildRow('install ws-scrcpy-web for all users', install.button);
+        const installRow = this.buildRow('install for all users', install.button);
         installRow.style.display = 'none';
         this.installAllUsersRow = installRow;
         body.appendChild(installRow);


### PR DESCRIPTION
Tiny UX text tweak for the beta.50 cut: the Settings -> App row now reads **install for all users** instead of "install ws-scrcpy-web for all users" (the app name was redundant). The **uninstall ws-scrcpy-web** action is intentionally left as-is.

`release:beta` - this is the change that cuts beta.50, which also carries the G2 log fix from #318.