### PR TITLE
feat: in-app Windows uninstall + App-section reorder/modal + Windows stop-exit reap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Uninstall ws-scrcpy-web from inside the app on Windows.** The Settings → App **uninstall** action — previously Linux-only (on Windows you had to use Add/Remove Programs) — now works on Windows too: it runs the Velopack uninstaller (`Update.exe --uninstall`, which removes the install and stops/removes any installed service and the tray), with the same **keep my settings & logs** option (checked by default; unchecking also deletes config, logs, and dependencies).
+
+### Changed
+
+- **Reordered the Settings → App section and moved the uninstall confirmation to an overlay modal.** The rows are now, top to bottom: reset prompts → install for all users (Linux only) → stop server & exit → uninstall, on both Windows and Linux. The uninstall confirmation is now a top-layer modal (instead of an inline panel) with a **keep my settings & logs** checkbox that defaults to checked, a white **cancel** and a red **uninstall** button.
+
+### Fixed
+
+- **"Stop server & exit" now fully cleans up on Windows.** It previously left the tray (`ws-scrcpy-web-tray.exe`) resident and only ran `adb kill-server`, which can leave stray `adb.exe` processes behind. The tray-supervisor poll thread is now stopped before the tray is reaped (so it can't respawn the tray that was just killed), and the shutdown also runs `taskkill /F /IM adb.exe /T` to catch any stray adb — the same belt-and-braces the in-app update path already uses.
+
 ## [0.1.30-beta.50] - 2026-06-08
 
 ### Changed

--- a/docs/plans/2026-06-08-app-section-redesign-windows-uninstall.md
+++ b/docs/plans/2026-06-08-app-section-redesign-windows-uninstall.md
@@ -1,0 +1,249 @@
+# App-section redesign + in-app Windows uninstall — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorder Settings → App, move the uninstall confirm to an overlay modal, add an in-app Windows uninstall (parity with Linux), and fix the Windows tray reap on "stop server & exit".
+
+**Architecture:** Frontend (TS, `SettingsModal.ts` + a new modal) is one layer; backend (`ServiceApi.ts` win32 branch + a new Rust `windows_app_uninstall.rs` helper) is the other; the tray-reap fix is launcher-only. The contract between them is unchanged: the uninstall button POSTs `/api/service/uninstall-app { keep }` on both OSes; the server branches by platform. Mirror the existing Linux uninstall throughout (`linux_app_uninstall.rs`, `handleAppUninstall`).
+
+**Tech Stack:** TypeScript (vitest, jsdom), Rust (launcher; `cargo`/`cross`), no new deps.
+
+**Spec:** `docs/specs/2026-06-08-app-section-redesign-windows-uninstall-design.md`.
+
+**Parallelization:** Phases A/B (frontend) and C (backend) are independent after this plan; D (tray-reap) is independent of all. Good `/build-with-agent-team` split: one agent on A+B, one on C, one on D.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/app/client/SettingsModal.ts` | App-section assembly + pure state helper + `buildUninstallControl` | modify: reorder appends; `appSectionButtonsState.showUninstall` → both OS; rewire uninstall button to open the modal |
+| `src/app/client/UninstallConfirmModal.ts` | the overlay uninstall modal (checkbox + cancel/uninstall) | **create** |
+| `src/app/client/__tests__/UninstallConfirmModal.test.ts` | modal unit tests | **create** |
+| `src/app/client/__tests__/SettingsModal.test.ts` | state + ordering + rewire tests | modify |
+| `src/style/modal.css` | red-outline "uninstall" button style | modify |
+| `src/server/api/ServiceApi.ts` | `handleAppUninstall` win32 branch | modify (~L980–1060) |
+| `src/server/__tests__/ServiceApi.test.ts` | win32-pinned branch test | modify |
+| `launcher/src/windows_app_uninstall.rs` | pure command builder + parse_args + dispatch + run | **create** |
+| `launcher/src/main.rs` | dispatch `--windows-app-uninstall` | modify (cfg(windows) flag dispatch) |
+| `launcher/src/lib.rs` (or `main.rs` mod block) | declare `mod windows_app_uninstall` (cfg windows) | modify |
+| `launcher/src/tray_supervisor.rs` + `supervisor.rs` + `main.rs` | stop the poll thread before the reap | modify |
+| `docs/smoke-tests/smoke-full.md` + `smoke-checklist.md` | Windows uninstall + tray-reap rows | modify |
+
+---
+
+## Phase A — Frontend: reorder + uninstall-on-both-OS
+
+### Task A1: `appSectionButtonsState` reveals uninstall on Windows too
+
+**Files:** Modify `src/app/client/SettingsModal.ts:172-189`; Test `src/app/client/__tests__/SettingsModal.test.ts`.
+
+- [ ] **Step 1 — failing test.** In `SettingsModal.test.ts`, in the `appSectionButtonsState` describe block, add:
+
+```ts
+it('shows uninstall on win32 (parity with linux), hides install-all-users', () => {
+    const s = appSectionButtonsState({ platform: 'win32', machineWideInstalled: false });
+    expect(s.showUninstall).toBe(true);          // NEW: win32 gets the uninstall row
+    expect(s.showInstallAllUsers).toBe(false);   // install-all-users stays linux-only
+});
+it('shows both rows on linux', () => {
+    const s = appSectionButtonsState({ platform: 'linux', machineWideInstalled: false });
+    expect(s.showUninstall).toBe(true);
+    expect(s.showInstallAllUsers).toBe(true);
+});
+```
+
+- [ ] **Step 2 — run, expect FAIL** (`showUninstall` is `false` on win32 today). `npx vitest run src/app/client/__tests__/SettingsModal.test.ts -t appSectionButtonsState`
+- [ ] **Step 3 — implement.** In `appSectionButtonsState`, compute `const showUninstall = linux || resp.platform === 'win32';` and return `showUninstall` (replace the `showUninstall: linux`). Update the doc-comment ("two Linux-only rows" → "install-all-users is Linux-only; uninstall shows on Linux + Windows").
+- [ ] **Step 4 — run, expect PASS.** Same command.
+- [ ] **Step 5 — commit.** `git add -A && git commit -m "feat(client): reveal App-section uninstall row on Windows"`
+
+### Task A2: Reorder the App-section rows
+
+**Files:** Modify `src/app/client/SettingsModal.ts:buildAppSection` (~1595-1702).
+
+- [ ] **Step 1 — reorder the appends.** The desired DOM order (top→bottom) is: reset → install-all-users (Linux) → stop-server → uninstall. Move the `body.appendChild(...)` calls into that order. Keep each control's construction; only the append sequence changes. Specifically: build `reset` (+ its inline confirm panel) first and append; then `install` row + note; then `stop` row + note; then `uninstall` row. The reset confirm panel stays inline (only the *uninstall* confirm becomes a modal — Phase B). Result, in append order:
+  1. reset row, reset confirm panel
+  2. install-all-users row + note (hidden until Linux)
+  3. stop-server row, stop note
+  4. uninstall row (hidden until A1 reveals it)
+- [ ] **Step 2 — verify ordering test.** Add a test asserting the rendered App-section row labels appear in order. In `SettingsModal.test.ts`, render the section (the test file already constructs a `SettingsModal`; follow its existing pattern for building the App section), collect `.settings-row` label texts, and assert `['reset welcome and bookmark prompts', 'install for all users', 'stop the server and close the app', 'uninstall ws-scrcpy-web']` is a subsequence. Run it; expect PASS after Step 1 (write the test first if the existing harness supports it — if rendering the full section in jsdom is heavy, assert order by reading `body.children` label cells).
+- [ ] **Step 3 — run vitest** for the file; expect PASS.
+- [ ] **Step 4 — commit.** `git commit -am "feat(client): reorder App-section (reset, install, stop, uninstall)"`
+
+---
+
+## Phase B — Frontend: uninstall confirm modal
+
+### Task B1: `UninstallConfirmModal` (top-layer dialog + checkbox + cancel/uninstall)
+
+**Files:** Create `src/app/client/UninstallConfirmModal.ts`; Create `src/app/client/__tests__/UninstallConfirmModal.test.ts`. **Pattern to mirror:** `src/app/client/ConfirmModal.ts` (static `confirm(): Promise<...>`, extends `Modal`, `showModal()` top layer) and `AdminConfirmModal.ts`. **Test pattern:** `src/app/client/__tests__/AdminConfirmModal.test.ts` (stubs `HTMLDialogElement.showModal`).
+
+Contract:
+```ts
+// Resolves on cancel → { confirmed: false }; on uninstall → { confirmed: true, keep: <checkbox> }.
+UninstallConfirmModal.confirm(): Promise<{ confirmed: boolean; keep: boolean }>
+```
+
+- [ ] **Step 1 — failing tests** (`UninstallConfirmModal.test.ts`), mirroring `AdminConfirmModal.test.ts`'s `showModal` stub:
+
+```ts
+it('defaults keep checkbox to checked', async () => {
+    const p = UninstallConfirmModal.confirm();
+    const box = document.querySelector('input[type=checkbox]') as HTMLInputElement;
+    expect(box.checked).toBe(true);                  // SAFETY DEFAULT
+    (document.querySelector('.uninstall-cancel') as HTMLButtonElement).click();
+    expect(await p).toEqual({ confirmed: false, keep: true });
+});
+it('resolves confirmed + keep=false when unchecked then uninstall clicked', async () => {
+    const p = UninstallConfirmModal.confirm();
+    (document.querySelector('input[type=checkbox]') as HTMLInputElement).checked = false;
+    (document.querySelector('.uninstall-confirm') as HTMLButtonElement).click();
+    expect(await p).toEqual({ confirmed: true, keep: false });
+});
+it('renders the body copy and red uninstall button', () => {
+    void UninstallConfirmModal.confirm();
+    expect(document.body.textContent).toContain('this removes the app, its dependencies, and any installed service.');
+    expect(document.querySelector('.uninstall-confirm')?.className).toContain('settings-btn-danger-outline');
+});
+```
+
+- [ ] **Step 2 — run, expect FAIL** (module missing). `npx vitest run src/app/client/__tests__/UninstallConfirmModal.test.ts`
+- [ ] **Step 3 — implement** `UninstallConfirmModal.ts`: a `Modal` subclass building title `uninstall ws-scrcpy-web`, body `<p>this removes the app, its dependencies, and any installed service.</p>`, a `<label>` with a checked-by-default `<input type=checkbox>` + text `keep my settings & logs`, and two buttons: `cancel` (class `settings-btn uninstall-cancel`) and `uninstall` (class `settings-btn settings-btn-danger-outline uninstall-confirm`). `confirm()` opens via `showModal()`, wires cancel→resolve `{confirmed:false, keep:<box>}`, uninstall→resolve `{confirmed:true, keep:<box>}`, closes the dialog on either.
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit.** `git commit -am "feat(client): UninstallConfirmModal (keep-checked default, red uninstall button)"`
+
+### Task B2: red-outline button CSS
+
+**Files:** Modify `src/style/modal.css`.
+
+- [ ] **Step 1 — add the style.** Mirror the existing `settings-btn` / white-outline rule; add `.settings-btn-danger-outline { color: <red token>; border-color: <red token>; background: transparent; }` using the project's red token (grep `#f06c75` / the disconnect-red used elsewhere — the disconnect button color from the project conventions). Cancel reuses the plain `settings-btn` (white outline).
+- [ ] **Step 2 — verify** the class name matches B1's test (`settings-btn-danger-outline`). No unit test for CSS; visual check happens in the smoke. Commit. `git commit -am "style: red-outline danger button for uninstall modal"`
+
+### Task B3: rewire `buildUninstallControl` to the modal
+
+**Files:** Modify `src/app/client/SettingsModal.ts` (`buildUninstallControl` ~L325 + its use in `buildAppSection` ~L1692-1699). Test: `SettingsModal.test.ts`.
+
+- [ ] **Step 1 — failing test.** Replace/extend the existing `buildUninstallControl` test: clicking the uninstall button calls `UninstallConfirmModal.confirm` (mock it), and on `{confirmed:true, keep}` it POSTs `/api/service/uninstall-app` with `{ keep }` (mock `fetch`), then calls `onUninstalled`. On `{confirmed:false}` it does nothing.
+- [ ] **Step 2 — run, expect FAIL.**
+- [ ] **Step 3 — implement.** Change `buildUninstallControl` to return `{ button }` only (drop `confirmPanel`/`keepCheckbox`/`confirmButton`/`cancelButton`). The button's click handler: `const r = await UninstallConfirmModal.confirm(); if (!r.confirmed) return; button.disabled = true; button.textContent = 'uninstalling…'; await fetch('/api/service/uninstall-app', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ keep: r.keep }) }); opts.onUninstalled();`. In `buildAppSection`, remove the `confirmPanel` append (L1699) and the `uninstallConfirmPanel` field usage; update `applyAppSectionButtonsState` (L1740-1752) to drop the confirm-panel-collapse branch (no panel anymore).
+- [ ] **Step 4 — run vitest (full client suite), expect PASS;** fix any references to the removed `uninstallConfirmPanel`/`keepCheckbox` fields (grep them).
+- [ ] **Step 5 — commit.** `git commit -am "feat(client): uninstall confirm via overlay modal (drop inline panel)"`
+
+---
+
+## Phase C — Backend: in-app Windows uninstall
+
+### Task C1: `windows_app_uninstall.rs` — pure builder + dispatch
+
+**Files:** Create `launcher/src/windows_app_uninstall.rs`; Modify `launcher/src/main.rs` (declare `#[cfg(windows)] mod windows_app_uninstall;` near the other mods, and dispatch the flag before normal launch). **Pattern to mirror:** `launcher/src/linux_app_uninstall.rs` (pure builder + `parse_args` + `handle` dispatch + best-effort exec + extensive unit tests).
+
+Pure builder contract:
+```rust
+/// Ordered steps for a complete Windows uninstall. `update_exe` = <installRoot>\Update.exe;
+/// `data_root` = %ProgramData%\WsScrcpyWeb. Step 1 ALWAYS: Velopack uninstaller.
+/// Then dataRoot keep/wipe — deps always removed; config.json + logs kept iff `keep`.
+pub fn windows_app_uninstall_commands(update_exe: &str, data_root: &str, keep: bool) -> Vec<Vec<String>>
+```
+
+- [ ] **Step 1 — failing tests** (in `windows_app_uninstall.rs`, mirror `linux_app_uninstall.rs` test style — string-join argv for order-preserving asserts):
+
+```rust
+#[test]
+fn wipe_removes_whole_data_root_after_update_uninstall() {
+    let c = windows_app_uninstall_commands(r"C:\PF\WsScrcpyWeb\Update.exe", r"C:\PD\WsScrcpyWeb", false);
+    assert_eq!(c[0], vec![r"C:\PF\WsScrcpyWeb\Update.exe".to_string(), "--uninstall".to_string()]); // primary
+    // wipe: a single rmdir/remove of the whole data root.
+    assert!(c.iter().any(|v| v.join(" ").contains(r"C:\PD\WsScrcpyWeb") && !v.join(" ").contains("dependencies")));
+}
+#[test]
+fn keep_removes_deps_only_preserves_config_logs() {
+    let c = windows_app_uninstall_commands(r"C:\PF\WsScrcpyWeb\Update.exe", r"C:\PD\WsScrcpyWeb", true);
+    assert_eq!(c[0][1], "--uninstall");
+    let joined: Vec<String> = c.iter().map(|v| v.join(" ")).collect();
+    assert!(joined.iter().any(|s| s.contains(r"WsScrcpyWeb\dependencies")));   // deps gone
+    assert!(!joined.iter().any(|s| s.contains("config.json")));                 // never named (preserved)
+    // never a bare wipe of the whole root on keep.
+    assert!(!joined.iter().any(|s| s.ends_with(r"\WsScrcpyWeb")));
+}
+```
+Plus `parse_args` tests mirroring `linux_app_uninstall.rs::parse_args_*`: `--windows-app-uninstall --keep|--wipe --data-root <p> --update-exe <p>`; exactly one of keep/wipe; required data-root + update-exe.
+
+- [ ] **Step 2 — run, expect FAIL** (module/fn missing). `cargo test -p ws-scrcpy-web-launcher windows_app_uninstall` (Windows host runs the cfg(windows) module).
+- [ ] **Step 3 — implement** the pure builder + `parse_args` + a `handle(args) -> Option<i32>` dispatcher + a best-effort executor. For the dataRoot removal use a deletion command resolvable without PATH per Local-Dependencies-Only (prefer Rust `std::fs::remove_dir_all` in the executor over shelling to `cmd /c rmdir`; the *pure builder* can model steps as either fs-op descriptors or argv — keep the builder returning argv for `Update.exe`, and have the executor do `std::fs::remove_dir_all` for the data-root steps; OR model both as argv and resolve the system `cmd.exe` via `%SystemRoot%\System32\cmd.exe` absolute path, never bare `cmd`). Decide in implementation; the unit test asserts the *Update.exe* argv + the data-root *targets*, not the deletion mechanism.
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — wire dispatch** in `main.rs`: `#[cfg(windows)] mod windows_app_uninstall;` and, in the early flag-dispatch region (where other `--…` flags are handled), `#[cfg(windows)] if let Some(code) = windows_app_uninstall::handle(&args) { std::process::exit(code); }`. Build: `cargo build -p ws-scrcpy-web-launcher`. Commit. `git commit -am "feat(launcher): windows_app_uninstall helper (Update.exe --uninstall + dataRoot keep/wipe)"`
+
+### Task C2: `ServiceApi.handleAppUninstall` win32 branch
+
+**Files:** Modify `src/server/api/ServiceApi.ts` (`handleAppUninstall` ~L980-1060). Test: `src/server/__tests__/ServiceApi.test.ts`. **Pattern to mirror:** the Linux branch in the same method (resolve `keep`, spawn the detached helper, 200 `{ ok, status:'uninstalling' }`, `scheduleExit`).
+
+- [ ] **Step 1 — failing test** (win32-pinned, per the cross-platform-test discipline — inject `platform:'win32'` into the factory). Assert: POST with `{ keep:false }` spawns the elevated helper with `--windows-app-uninstall --wipe --data-root <pd> --update-exe <installRoot>\Update.exe`, responds 200 `{ ok:true, status:'uninstalling' }`, and schedules exit. (Mock the detached-spawn + elevation seam the same way the Linux test mocks `spawnDetached`.)
+- [ ] **Step 2 — run, expect FAIL** (today win32 returns `{ ok:false, reason:'unsupported' }`).
+- [ ] **Step 3 — implement** the win32 branch: read `keep`; resolve `installRoot` (→ `Update.exe`) + `dataRoot` (ProgramData); build the helper argv (`--windows-app-uninstall` + keep/wipe + `--data-root` + `--update-exe`); spawn it **elevated + detached** via the existing elevated-runner / `ShellExecuteEx "runas"` seam (mirror `install-system-wide` / service uninstall elevation); write 200 `{ ok:true, status:'uninstalling' }`; `scheduleExit`. Keep the Linux branch unchanged; the `unsupported` fallback now only covers non-win32/non-linux.
+- [ ] **Step 4 — run vitest (server suite), expect PASS** (both the new win32 test and the existing linux test).
+- [ ] **Step 5 — commit.** `git commit -am "feat(server): in-app Windows uninstall (ServiceApi win32 branch)"`
+
+---
+
+## Phase D — Tray reap on stop-exit (item 4)
+
+### Task D1: stop the tray-supervisor poll thread before the reap
+
+**Files:** Modify `launcher/src/supervisor.rs` (L117 `let _stop = start_background(...)` — capture + return/expose the `stop_flag`), `launcher/src/tray_supervisor.rs`, `launcher/src/main.rs` (set the flag before `reap_tray_on_terminal_exit`).
+
+- [ ] **Step 1 — failing/define test.** Add a pure ordering guard. The reap decision is already `should_reap_tray_on_exit` (tested). Add a small pure helper if the fix introduces a decision (e.g. none needed if it's pure wiring). If wiring-only, this task has no new unit test — its proof is the VM (Step 4 of Phase E). Record that explicitly here rather than inventing a hollow test.
+- [ ] **Step 2 — implement.** Thread the `Arc<AtomicBool>` `stop_flag` from `tray_supervisor::start_background` up out of `supervisor::run` (return it alongside the exit code, or store it where `main` can reach it), and in `main.rs` **before** the `reap_tray_on_terminal_exit` call, `stop_flag.store(true, Ordering::SeqCst)` so the poll loop (which checks the flag at the top of each iteration) cannot respawn the tray the reap just killed. Keep the marker gating intact.
+- [ ] **Step 3 — build + existing tests.** `cargo test -p ws-scrcpy-web-launcher tray_supervisor` (the `should_reap_tray_on_exit` tests still pass).
+- [ ] **Step 4 — commit.** `git commit -am "fix(launcher): stop tray-supervisor poll before reaping tray on exit"`
+
+### Task D1b: stop-exit must reap stray adb on Windows (mirror the update path)
+
+**Files:** Modify `src/server/index.ts` (`gracefulShutdown` ~L283-291). Test: extend `src/server/__tests__/ServerShutdownApi.test.ts` or add a `gracefulShutdown` test. **Pattern to mirror:** `UpdateService.ts:689-697` preApply hygiene (the exact taskkill it already uses).
+
+- [ ] **Step 1 — failing test** (win32-pinned): after the cleanup runs on win32, `execFileAsync` was called with `C:\Windows\System32\taskkill.exe ['/F','/IM','adb.exe','/T']`. Mock `execFileAsync`; pin `process.platform` to `win32`.
+- [ ] **Step 2 — run, expect FAIL** (gracefulShutdown does `kill-server` only today). `npx vitest run -t "stop-exit reaps stray adb"`
+- [ ] **Step 3 — implement.** In `gracefulShutdown`, after the `scanAdb.killServer()` try/catch, add:
+
+```ts
+if (process.platform === 'win32') {
+    serverLog.info('Stopping stray adb (taskkill) ...');
+    try {
+        await execFileAsync('C:\\Windows\\System32\\taskkill.exe', ['/F', '/IM', 'adb.exe', '/T'], { timeout: 5000 });
+    } catch {
+        // non-zero = no matching adb process = success (mirror UpdateService preApply)
+    }
+}
+```
+Import `execFileAsync` if not already in `index.ts` (it's used via the adb managers; import the same `promisify(execFile)` helper the codebase uses).
+
+- [ ] **Step 4 — run vitest, expect PASS** (win32 test passes; the non-win32 path is unchanged — assert it does NOT taskkill on linux).
+- [ ] **Step 5 — commit.** `git commit -am "fix(server): reap stray adb on Windows stop-exit (taskkill belt-and-braces)"`
+
+### Task D2: VM diagnosis (gated — done during Phase E smoke)
+
+- [ ] On the Win11 VM, stop-exit then read `…\WsScrcpyWeb\logs\launcher.log`: is `tray-supervisor: terminal exit; reaping tray helper` present? a `leaving tray for relaunch` (marker) line? Does `ws-scrcpy-web-tray.exe` die? If D1 alone doesn't fix it, apply the diagnosed fix (stale-marker cleanup, or taskkill targeting). Record the finding in the smoke doc.
+
+---
+
+## Phase E — Integration, smoke, ship
+
+### Task E1: smoke rows
+- [ ] Add to `docs/smoke-tests/smoke-full.md` (Module 14) + `smoke-checklist.md` (batch #15): Windows install-via-MSI → in-app **uninstall** (keep checked → config/logs survive, deps gone, ARP entry gone, one UAC; unchecked → whole dataRoot gone); and a `[W]` **stop-exit reaps tray** row (Task 12.3 already exists — note it's now expected to pass). Version-agnostic phrasing per the existing docs. Commit.
+
+### Task E2: build + PR + beta + VM
+- [ ] Full local verify: `npx tsc --noEmit`, `npx vitest run`, `cargo test -p ws-scrcpy-web-launcher -p ws-scrcpy-web-common`, `cargo clippy --all-targets -- -D warnings`.
+- [ ] CHANGELOG `[Unreleased]` entries (Added: in-app Windows uninstall; Changed: App-section order + uninstall modal; Fixed: tray reap on stop-exit).
+- [ ] PR (`release:beta`) → CI green → squash-merge → bump bot cuts **beta.51**.
+- [ ] **Win11 VM smoke** (the real gate): the Update.exe-vs-msiexec decision (§8) and the tray-reap diagnosis (D2). Fix-forward as needed.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §1 order → A2; §2 modal → B1/B2/B3; §3 Windows uninstall → C1/C2; §4 keep/wipe → C1 (builder) + B1 (checkbox); §5 testable units → A1/B1/C1/C2 tests; §6 verify → E2; §9 tray-reap → D1/D2. All sections mapped.
+
+**Placeholder scan:** the only deferred specifics are the **VM-gated** runtime decisions (Update.exe-vs-msiexec in C/E2; the tray-reap root cause in D2) — these are genuinely VM-dependent and explicitly flagged, not lazy TODOs. The data-root deletion mechanism in C1 is left to implementation with the constraint stated (Local-Dependencies-Only: Rust fs-op or absolute `cmd.exe`), and the unit test asserts targets not mechanism — acceptable.
+
+**Type consistency:** `UninstallConfirmModal.confirm(): Promise<{confirmed, keep}>` used identically in B1 + B3. `windows_app_uninstall_commands(update_exe, data_root, keep)` + the `--windows-app-uninstall --keep|--wipe --data-root --update-exe` flag set are consistent across C1 + C2. `appSectionButtonsState.showUninstall` used in A1 + A2 + B3.

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -186,6 +186,20 @@ The App section adds three Settings → **App** affordances on Linux: a one-clic
 | **14.6** `[Linux]` Uninstall — keep settings & logs | Uninstall with **"keep my settings & logs" checked**. | `config.json` + `logs/` **survive** at the data root (`~/.local/share/WsScrcpyWeb` local, or `/var/opt/ws-scrcpy-web` system); `dependencies/` is **gone either way**; a reinstall reuses the saved port. |
 | **14.7** `[Linux]` Uninstall — SELinux clean | After any uninstall, inspect fcontext + the AVC monitor. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` → **empty**; zero AVC. |
 
+## Module 15 — Windows App-section uninstall + stop-exit cleanup
+
+In-app **uninstall** now works on Windows (parity with Linux), and "stop server & exit" fully reaps the tray + stray adb. The uninstall triggers Velopack's `Update.exe --uninstall`; **the elevation path and the running-helper self-deletion are the things to settle on the VM** (flagged rows).
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **15.1** `[Win]` In-app uninstall — keep | MSI install → Settings → **App** → **uninstall** → modal with **keep checked** (default) → uninstall. | **One UAC prompt** (Update.exe self-elevates); `C:\Program Files\WsScrcpyWeb\` gone; service gone (`sc query WsScrcpyWeb` → not found); **tray gone**; **Add/Remove-Programs entry gone** (no orphan); `config.json` + `logs/` **survive** under `%ProgramData%\WsScrcpyWeb`, `dependencies/` gone; reinstall reuses the saved port. |
+| **15.2** `[Win]` In-app uninstall — wipe | Same, but **uncheck** keep. | As 15.1 but the **whole `%ProgramData%\WsScrcpyWeb` is gone**. ⚠️ **Watch:** the helper runs from `…\control\operation-server\` and Windows can't delete a running exe — confirm the wipe doesn't leave that dir behind (if it does → self-deleting-helper follow-up). |
+| **15.3** `[Win]` Uninstall modal UX | Open the uninstall modal. | Top-layer overlay above Settings; **cancel** white-outline, **uninstall** red text + red border; keep checkbox **checked by default**; cancel / Esc / backdrop = no action. |
+| **15.4** `[Win]` Stop-exit reaps tray + adb *(item 4)* | Local mode, device + stream live → Settings → **App** → **stop server & exit**. | Tab closes / "app stopped"; Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / `adb.exe` — the tray is reaped (poll thread stopped first) **and** stray adb is `taskkill`'d. |
+| **15.5** `[Win]` App-section order | Settings → App. | Order top→bottom: **reset prompts → stop server & exit → uninstall ws-scrcpy-web** (no "install for all users" on Windows). |
+
+> **VM decisions to settle (beta.51):** (a) does `Update.exe --uninstall` self-elevate when launched by the unelevated staged launcher (15.1 UAC)? If it needs an already-elevated caller, route the Node spawn through the launcher's `--request-uac` / `--elevate-and-run` seam with a new `windows-app-uninstall` command. (b) Does the wipe fully clear the dataRoot despite the running helper (15.2)? If it orphans `control\operation-server\`, add a self-deleting step.
+
 ---
 
 ## Global pass criteria

--- a/docs/specs/2026-06-08-app-section-redesign-windows-uninstall-design.md
+++ b/docs/specs/2026-06-08-app-section-redesign-windows-uninstall-design.md
@@ -5,11 +5,12 @@
 
 ## Goal
 
-Three changes to **Settings → App**, bringing the Windows and Linux variants closer:
+Four changes to **Settings → App**, bringing the Windows and Linux variants closer:
 
 1. **Reorder** the App-section rows (per-OS).
 2. Move the **uninstall confirmation** from an inline panel to an **overlay modal**.
 3. Add an **in-app Windows uninstall** — Windows has no in-app uninstall today (only Add/Remove Programs); give it the same "uninstall ws-scrcpy-web" button Linux has.
+4. **Fix the Windows "stop server & exit" teardown** — the tray (`ws-scrcpy-web-tray.exe`) is left resident, and adb is only `kill-server`'d (missing the `taskkill /F /IM adb.exe /T` belt-and-braces the update path uses), so stray adb can linger. node + launcher do exit.
 
 ## Current state
 
@@ -91,3 +92,20 @@ The helper is the win32 analog of `linux_app_uninstall.rs`: a pure command/step 
 ### 8. Open item (VM-gated)
 
 `Update.exe --uninstall` vs `msiexec /x {ProductCode}` — which produces a clean MSI uninstall (hook fires **and** ARP entry removed, no orphan). Resolved on the Win11 VM during the smoke; the helper is structured so the command choice is a one-line swap.
+
+### 9. Windows tray reap on "stop server & exit" (item 4)
+
+**Symptom:** on Windows, "stop server & exit" exits node + launcher + adb cleanly but leaves `ws-scrcpy-web-tray.exe` resident. Smoke 12.3 (SE-1) expected the reap; it was never runtime-verified on Windows.
+
+**What's already there (verified by inspection):** the reap is wired — after `supervisor::run()` returns, `main.rs:391` calls `tray_supervisor::reap_tray_on_terminal_exit(data_root)`, which (gated only by `apply-update-pending` / `uninstall-pending` markers under `<dataRoot>/control/`) runs `taskkill /F /IM ws-scrcpy-web-tray.exe`. `data_root_from_env()` always returns `Some` on Windows (PROGRAMDATA-based), so the call site IS reached. `should_reap_tray_on_exit` is pure + unit-tested.
+
+**Root cause — diagnose on the VM, then fix.** Candidates, in likely order:
+1. **Respawn race (strongest):** the tray-supervisor poll thread (`tray_supervisor_loop`, 10 s) re-spawns a missing tray and is never signalled to stop before the reap. Its `stop_flag` exists but is unused (`let _stop = start_background(...)` in `supervisor.rs`). **Hardening regardless:** thread the `stop_flag` up so the supervisor/`main` sets it BEFORE the reap, so the loop can't respawn the tray the reap just killed.
+2. **Stale marker:** a leftover `apply-update-pending` / `uninstall-pending` under `control/` skips the reap. Confirm none is present on a plain stop-exit.
+3. **taskkill miss:** the kill doesn't reach the tray (image-name/session). Confirm it runs + exits 0.
+
+**Method:** on the Win11 VM, stop-exit then read `…\WsScrcpyWeb\logs\launcher.log` — is the `tray-supervisor: terminal exit; reaping tray helper` line present? is a marker present (the "leaving tray for relaunch" line)? Then fix the identified cause. Keep `should_reap_tray_on_exit` coverage; add a unit test for whatever pure decision the fix introduces (e.g. a `stop_flag`-set-before-reap ordering helper).
+
+**adb — verified code gap (not just a runtime question).** `gracefulShutdown` (`src/server/index.ts:283`, the stop-exit teardown) runs **`adb kill-server` only**. The in-app *update* path (`UpdateService.ts:689-697` preApply hygiene) runs kill-server **plus** a Windows `taskkill /F /IM adb.exe /T` belt-and-braces — added precisely because kill-server alone leaves stray `adb.exe` (stuck transport, in-flight forward; the daemon is spawned `detached` to escape Node's job object). So stop-exit is missing that reap → stray adb survives on Windows. **Fix:** after `killServer()` in `gracefulShutdown`, add a win32-only `execFileAsync('C:\\Windows\\System32\\taskkill.exe', ['/F','/IM','adb.exe','/T'])` (non-zero = no-match = ok), mirroring the update path exactly. Unit-testable: pin win32, mock `execFileAsync`, assert the taskkill is issued.
+
+**Note:** independent of the App-section UI work, but bundled into this pass + beta per the user's request.

--- a/docs/specs/2026-06-08-app-section-redesign-windows-uninstall-design.md
+++ b/docs/specs/2026-06-08-app-section-redesign-windows-uninstall-design.md
@@ -1,0 +1,93 @@
+# App-section redesign + in-app Windows uninstall — design
+
+**Date:** 2026-06-08
+**Status:** approved (brainstorm) — pending spec review
+
+## Goal
+
+Three changes to **Settings → App**, bringing the Windows and Linux variants closer:
+
+1. **Reorder** the App-section rows (per-OS).
+2. Move the **uninstall confirmation** from an inline panel to an **overlay modal**.
+3. Add an **in-app Windows uninstall** — Windows has no in-app uninstall today (only Add/Remove Programs); give it the same "uninstall ws-scrcpy-web" button Linux has.
+
+## Current state
+
+- `src/app/client/SettingsModal.ts` builds the App-section rows in this order via `buildRow(...)` + `appendChild`: **stop-server** (~L1610), **reset prompts** (~L1623), **install-for-all-users** (~L1683, Linux-only), **uninstall** (~L1695, Linux-only). Row visibility/enabled state comes from a pure helper (`appSectionButtonsState`, ~L158–209; applied at ~L1221). The uninstall confirmation is an **inline panel** beneath the button (`buildUninstallControl`, the settings-confirm-panel pattern).
+- **Linux uninstall:** `POST /api/service/uninstall-app` (`ServiceApi.handleAppUninstall`, ~L980) → spawns the detached, out-of-cgroup `--linux-app-uninstall` helper (`launcher/src/linux_app_uninstall.rs`, pure `app_uninstall_commands` split into privileged/user-owned) → cascades through any service + removes `/opt` + deps; `keep` preserves `config.json` + `logs/`, else wipes. App then exits.
+- **Windows uninstall:** only via Add/Remove Programs → the Velopack uninstaller runs the launcher with `--veloapp-uninstall` → `hooks.rs:on_uninstall` (servy stop + uninstall the `WsScrcpyWeb` service, kill the tray, **preserve user data**). No in-app trigger. Each install has `<installRoot>\Update.exe` (Velopack's updater/uninstaller).
+
+## Design
+
+### 1. App-section row order
+
+```
+LINUX                                WINDOWS
+─────────────────────────────        ─────────────────────────────
+reset welcome & bookmark             reset welcome & bookmark
+install for all users                stop the server and close the app
+stop the server and close the app    uninstall ws-scrcpy-web   ← NEW
+uninstall ws-scrcpy-web
+```
+
+Pure reorder of the `appendChild` sequence. `install for all users` stays **Linux-only**; the **uninstall** row now renders on **both** OSes. `reset` moves to the top on both. The `appSectionButtonsState` helper is extended so `showUninstall` is true on win32 too (today it is `linux` only).
+
+### 2. Uninstall confirmation → overlay modal (both OS)
+
+Replaces the inline confirm panel with a **top-layer `<dialog>`** opened via `showModal()` (consistent with the welcome / system-wide-install modals, and avoids the z-index/top-layer trap noted in the Velopack packaging memory).
+
+Contents:
+- Title: **uninstall ws-scrcpy-web**
+- One-line body: *"this removes the app, its dependencies, and any installed service."*
+- Checkbox: **keep my settings & logs** — **defaults to checked** (deleting data is a deliberate uncheck). No extra explanatory line.
+- Two buttons:
+  - **cancel** — white text + white border (the existing white-outline style) → closes the modal, no action.
+  - **uninstall** — **red text + red border** (new red-outline danger style) → `POST /api/service/uninstall-app { keep: <checkbox> }`, then the "uninstalling…" overlay, then the app exits.
+
+The `keep` semantics are identical to Linux's existing toggle; the modal simply moves where it is asked.
+
+### 3. Windows uninstall backend
+
+`ServiceApi.handleAppUninstall` gains a **win32 branch** (today it returns `{ ok:false, reason:'unsupported' }` on non-linux). It mirrors the Linux branch: resolve `keep` from the body, spawn a **detached + elevated** Windows uninstall helper, write a 200 `{ ok:true, status:'uninstalling' }`, and schedule the local instance's exit so the helper can remove the running binary.
+
+New launcher routine **`launcher/src/windows_app_uninstall.rs`** (mirrors `linux_app_uninstall.rs`), dispatched by a new **`--windows-app-uninstall [--keep|--wipe]`** flag in `main.rs`. It:
+
+1. **Triggers the Velopack uninstaller** — `<installRoot>\Update.exe --uninstall` (primary). This removes the Program Files install and fires the existing `--veloapp-uninstall` hook (servy stop + uninstall the service, kill the tray, ARP cleanup).
+   - **VM-verified fallback:** if `Update.exe --uninstall` leaves the MSI's Add/Remove-Programs entry orphaned, switch to `msiexec /x {ProductCode}` (literally what ARP runs). Decided on the Win11 VM (see §6).
+2. **Handles the dataRoot** (`%ProgramData%\WsScrcpyWeb`) for keep/wipe parity with Linux:
+   - always remove `dependencies/`;
+   - remove `config.json` + `logs/` **only if `keep` is false**.
+
+The helper is the win32 analog of `linux_app_uninstall.rs`: a pure command/step builder (`windows_app_uninstall_commands` returning the `Update.exe` invocation + the dataRoot keep/wipe steps) wrapped by a thin best-effort executor.
+
+**Elevation + survival.** The helper runs **elevated** (one UAC prompt) via the existing elevated-runner / `ShellExecuteEx "runas"` pattern, and must **survive the app's exit and job-object teardown** the same way the apply-time `Update.exe` does (it can't delete a running binary otherwise — cf. the Velopack Job-Object `KILL_ON_JOB_CLOSE` gotcha). Spawned out of the app's job, then the app exits.
+
+### 4. Keep/wipe semantics (both OS, unchanged contract)
+
+- **keep (checked — default):** `config.json` + `logs/` survive; `dependencies/` removed; app binary/install removed. A reinstall reuses the saved config (port).
+- **wipe (unchecked):** the whole dataRoot is removed in addition to the app binary/install.
+
+### 5. Pure / testable units
+
+- **`appSectionButtonsState`** — extend + test: `showUninstall` true on win32; ordering reflected where state-driven.
+- **Uninstall modal** — DOM construction, checkbox **defaults checked**, cancel(white)/uninstall(red) button classes, `keep` read from the checkbox.
+- **`windows_app_uninstall_commands`** — Rust unit (like `app_uninstall_commands`): the `Update.exe --uninstall` step is always present; the dataRoot steps include `dependencies/` always and `config.json`+`logs/` only when `!keep`.
+- **`ServiceApi` win32 branch** — vitest, platform pinned to `win32` (per the cross-platform-test discipline): asserts it spawns the helper + schedules exit, doesn't run the Linux path.
+
+### 6. Verification
+
+- **Automated:** vitest (frontend + API) + `cargo`/`cross` (launcher) — the pure pieces. CI is the Rust gate (the win32 helper compiles/tests there; local Windows `cargo test` covers the cross-platform parts).
+- **The real gate — Win11 VM smoke** (you already run it): install via the MSI → in-app **uninstall** →
+  - `Update.exe --uninstall` removes `C:\Program Files\WsScrcpyWeb\`, the service is gone (`sc query WsScrcpyWeb` → not found), the tray is gone, **the Add/Remove-Programs entry is gone** (no orphan), **one** UAC prompt;
+  - **keep checked** → `config.json` + `logs/` survive under `%ProgramData%\WsScrcpyWeb`, `dependencies/` gone, a reinstall reuses the port; **unchecked** → the whole dataRoot is gone;
+  - if the ARP entry orphans → flip to `msiexec /x {ProductCode}` and re-verify.
+- Add Windows uninstall rows to the smoke docs (the Linux App-section rows already exist in Module 14 / batch #15).
+
+### 7. Non-goals
+
+- **No Windows "install for all users."** Velopack's PerMachine MSI already installs machine-wide; an in-app machine-wide install is meaningless on Windows.
+- **No change to the Linux uninstall mechanism** — only its confirmation UX moves to the shared modal, and the checkbox now defaults checked.
+
+### 8. Open item (VM-gated)
+
+`Update.exe --uninstall` vs `msiexec /x {ProductCode}` — which produces a clean MSI uninstall (hook fires **and** ARP entry removed, no orphan). Resolved on the Win11 VM during the smoke; the helper is structured so the command choice is a one-line swap.

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -371,6 +371,9 @@ fn main() {
     let _ = data_root; // keep the load above visible to the compiler; supervisor reads its own env probe
     let _ = install_root;
 
+    // tray_stop_flag is consumed only by the Windows tray-reap block below; on
+    // other platforms it is intentionally unused (allow it so `-D warnings` passes).
+    #[cfg_attr(not(windows), allow(unused_variables))]
     let (exit_code, tray_stop_flag) = match supervisor::run() {
         Ok(pair) => pair,
         Err(e) => {

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -371,11 +371,11 @@ fn main() {
     let _ = data_root; // keep the load above visible to the compiler; supervisor reads its own env probe
     let _ = install_root;
 
-    let exit_code = match supervisor::run() {
-        Ok(code) => code,
+    let (exit_code, tray_stop_flag) = match supervisor::run() {
+        Ok(pair) => pair,
         Err(e) => {
             log::error(&format!("launcher failed: {e:#}"));
-            1
+            (1, None)
         }
     };
 
@@ -400,9 +400,20 @@ fn main() {
     // exit on its own; without this a plain "stop server & exit" (or any clean
     // exit) leaves an orphaned tray pointing at a dead launcher. Marker-gated so
     // update-apply / uninstall handoffs (which relaunch) keep their tray.
+    //
+    // Signal the tray-supervisor poll thread BEFORE the taskkill reap so it
+    // cannot respawn the tray between the signal and the kill (the poll thread
+    // checks stop_flag at the top of each 10s iteration).
     #[cfg(windows)]
-    if let Some(dr) = common::config::data_root_from_env() {
-        tray_supervisor::reap_tray_on_terminal_exit(&dr);
+    {
+        use std::sync::atomic::Ordering;
+        if let Some(flag) = &tray_stop_flag {
+            log::info("tray-supervisor: signalling stop_flag before reap");
+            flag.store(true, Ordering::SeqCst);
+        }
+        if let Some(dr) = common::config::data_root_from_env() {
+            tray_supervisor::reap_tray_on_terminal_exit(&dr);
+        }
     }
 
     log::info(&format!("ws-scrcpy-web-launcher exiting with code {exit_code}"));

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -27,6 +27,8 @@ mod linux_service;
 mod linux_app_uninstall;
 #[cfg(windows)]
 mod user_session_spawn;
+#[cfg(windows)]
+mod windows_app_uninstall;
 
 fn main() {
     // --print-active-session: one-shot Win32 query. Used by the service-Node
@@ -222,6 +224,17 @@ fn main() {
     // (Velopack-untouchable). Part 3's launcher-as-post-stop approach
     // got the launcher process killed mid-sleep when Velopack swapped
     // current/. The new architecture has no in-launcher post-stop code.
+
+    // Windows in-app uninstall helper. Invoked by the Node server when the
+    // user triggers an in-app complete uninstall: runs Update.exe --uninstall
+    // (fires Velopack's --veloapp-uninstall hook → service/tray teardown +
+    // ARP cleanup) then removes dataRoot targets per keep/wipe scope. Must
+    // come BEFORE elevated_runner::handle so it dispatches cleanly.
+    #[cfg(windows)]
+    if let Some(code) = windows_app_uninstall::handle(&args) {
+        log::info(&format!("windows-app-uninstall exiting with code {code}"));
+        std::process::exit(code);
+    }
 
     // Elevate-and-run dispatch comes BEFORE Velopack hooks because the
     // helper is invoked through a UAC prompt and is a single-shot

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -60,8 +60,22 @@ fn refresh_error_is_benign_busy(e: &std::io::Error) -> bool {
     e.raw_os_error() == Some(26)
 }
 
-/// Main supervisor entry. Returns the final exit code to bubble to OS.
-pub fn run() -> Result<i32> {
+/// Main supervisor entry. Returns the final exit code alongside the tray-supervisor
+/// stop_flag (Windows-only; `None` on non-Windows platforms). The caller should
+/// signal the flag BEFORE reaping the tray so the poll thread cannot respawn
+/// the tray between the signal and the `taskkill`.
+pub fn run() -> Result<(i32, Option<Arc<AtomicBool>>)> {
+    // Windows: tray-supervisor stop_flag threaded out so main.rs can signal it
+    // BEFORE calling reap_tray_on_terminal_exit. Declared `mut` on Windows so
+    // the cfg(windows) block below can assign the flag returned by
+    // start_background; the initial None is immediately overwritten, hence the
+    // allow. Non-Windows: immutable None (tray-supervisor does not run there).
+    #[cfg_attr(windows, allow(unused_assignments))]
+    #[cfg(windows)]
+    let mut tray_stop_flag: Option<Arc<AtomicBool>> = None;
+    #[cfg(not(windows))]
+    let tray_stop_flag: Option<Arc<AtomicBool>> = None;
+
     let paths = Paths::from_env()?;
     log::info(&format!(
         "supervisor: install_root={:?} data_root={:?} deps_path={:?}",
@@ -114,14 +128,15 @@ pub fn run() -> Result<i32> {
         #[cfg(windows)]
         {
             let is_service_mode = cfg.is_service_mode() && !local_takeover_override;
-            let _stop = crate::tray_supervisor::start_background(
+            let stop_flag = crate::tray_supervisor::start_background(
                 &paths.install_root,
                 &paths.data_root,
                 is_service_mode,
             );
-            // We intentionally drop `_stop` — the thread runs for the
-            // lifetime of the process. If we ever need clean shutdown,
-            // keep the handle and signal it.
+            // Thread the stop_flag out so main.rs can signal it BEFORE
+            // reap_tray_on_terminal_exit, preventing the poll thread from
+            // respawning the tray between the signal and the taskkill.
+            tray_stop_flag = Some(stop_flag);
             log::info("supervisor: tray-supervisor background thread started");
         }
 
@@ -199,7 +214,7 @@ pub fn run() -> Result<i32> {
 
         if stop.load(Ordering::SeqCst) {
             log::info("supervisor: shutdown signal received; not restarting");
-            return Ok(code);
+            return Ok((code, tray_stop_flag.clone()));
         }
 
         // Launcher-driven service uninstall. When the uninstall-pending marker
@@ -253,7 +268,7 @@ pub fn run() -> Result<i32> {
                     log::error(&format!(
                         "supervisor: failed to write uninstall bat at {bat_path:?}: {e}; exiting (post-stop.bat is fallback)"
                     ));
-                    return Ok(code);
+                    return Ok((code, tray_stop_flag.clone()));
                 }
                 log::info(&format!("supervisor: wrote uninstall bat at {bat_path:?}"));
 
@@ -280,13 +295,13 @@ pub fn run() -> Result<i32> {
                             "supervisor: schtasks /create failed (exit {:?}); exiting (post-stop.bat is fallback)",
                             s.code()
                         ));
-                        return Ok(code);
+                        return Ok((code, tray_stop_flag.clone()));
                     }
                     Err(e) => {
                         log::error(&format!(
                             "supervisor: schtasks spawn failed: {e}; exiting (post-stop.bat is fallback)"
                         ));
-                        return Ok(code);
+                        return Ok((code, tray_stop_flag.clone()));
                     }
                 }
 
@@ -305,20 +320,20 @@ pub fn run() -> Result<i32> {
                             "supervisor: schtasks /run failed (exit {:?}); exiting (post-stop.bat is fallback)",
                             s.code()
                         ));
-                        return Ok(code);
+                        return Ok((code, tray_stop_flag.clone()));
                     }
                     Err(e) => {
                         log::error(&format!(
                             "supervisor: schtasks /run spawn failed: {e}; exiting (post-stop.bat is fallback)"
                         ));
-                        return Ok(code);
+                        return Ok((code, tray_stop_flag.clone()));
                     }
                 }
 
                 loop {
                     if stop.load(Ordering::SeqCst) {
                         log::info("supervisor: stop signal received during uninstall; exiting cleanly");
-                        return Ok(0);
+                        return Ok((0, tray_stop_flag.clone()));
                     }
                     thread::sleep(POLL_INTERVAL);
                 }
@@ -331,7 +346,7 @@ pub fn run() -> Result<i32> {
         match reason {
             None => {
                 log::info("supervisor: clean exit; not restarting");
-                return Ok(code);
+                return Ok((code, tray_stop_flag.clone()));
             }
             Some(RestartReason::RestartMarker) => {
                 let _ = std::fs::remove_file(&paths.restart_marker);

--- a/launcher/src/windows_app_uninstall.rs
+++ b/launcher/src/windows_app_uninstall.rs
@@ -1,0 +1,454 @@
+// Windows in-app uninstall helper (beta.49 parity).
+//
+// `windows_app_uninstall_commands` returns an `UninstallPlan` with:
+//   - `update_exe_step`: the `[update_exe, "--uninstall"]` argv-vector.
+//     Running this triggers Velopack's uninstaller, which removes the
+//     Program Files install AND fires the launcher's `--veloapp-uninstall`
+//     hook → stops/uninstalls the WsScrcpyWeb service + kills the tray +
+//     ARP cleanup.
+//   - `data_root_targets`: the dataRoot (`%ProgramData%\WsScrcpyWeb`) paths
+//     to remove after Update.exe completes:
+//       keep=true  → ["<data_root>\\dependencies", "<data_root>\\bin",
+//                     "<data_root>\\control"] (deps/regenerable only;
+//                     config.json + logs preserved)
+//       keep=false → ["<data_root>"] (the whole root)
+//
+// Dispatch (`handle`): owns `--windows-app-uninstall`. Runs Update.exe via
+// `std::process::Command` (the absolute path supplied by the caller — no
+// PATH, no env-var). Removes each dataRoot target via `std::fs::remove_dir_all`
+// / `std::fs::remove_file`. Best-effort: logs + continues on errors (the
+// app is being uninstalled regardless).
+//
+// Local-Dependencies-Only: Update.exe is the absolute path argument.
+// dataRoot deletion = `std::fs` compiled into the binary. No bare
+// cmd/rmdir/powershell on PATH.
+
+use crate::log;
+
+/// Ordered uninstall plan for the Windows path.
+///
+/// Kept as a named struct (mirroring linux_app_uninstall's `UninstallPlan`)
+/// so callers can inspect the two distinct groups independently — the
+/// Update.exe step and the dataRoot deletion targets — which the tests
+/// assert on separately.
+#[derive(Debug, Clone)]
+pub struct UninstallPlan {
+    /// The single Update.exe invocation: `[update_exe, "--uninstall"]`.
+    /// Always exactly one entry. Run FIRST so Velopack's uninstaller fires
+    /// the `--veloapp-uninstall` hook (service/tray teardown + ARP cleanup)
+    /// before we touch the dataRoot.
+    pub update_exe_step: Vec<String>,
+    /// dataRoot filesystem targets to remove after Update.exe completes.
+    /// `keep=false` → `["<data_root>"]`; `keep=true` →
+    /// `["<data_root>\\dependencies", "<data_root>\\bin", "<data_root>\\control"]`.
+    pub data_root_targets: Vec<String>,
+}
+
+/// Build the uninstall plan. Pure — no I/O, fully unit-testable.
+///
+/// * `update_exe`  — absolute path to `<installRoot>\Update.exe`.
+/// * `data_root`   — absolute path to the app data root
+///   (`%ProgramData%\WsScrcpyWeb`).
+/// * `keep`        — `true` preserves config.json + logs/ (deletes only
+///   deps/bin/control); `false` wipes the whole data root.
+pub fn windows_app_uninstall_commands(
+    update_exe: &str,
+    data_root: &str,
+    keep: bool,
+) -> UninstallPlan {
+    let update_exe_step = vec![update_exe.to_string(), "--uninstall".to_string()];
+
+    let data_root_targets = if keep {
+        ["dependencies", "bin", "control"]
+            .iter()
+            .map(|sub| format!("{}\\{}", data_root, sub))
+            .collect()
+    } else {
+        vec![data_root.to_string()]
+    };
+
+    UninstallPlan { update_exe_step, data_root_targets }
+}
+
+// ─── Dispatch + execution ──────────────────────────────────────────────────
+
+/// Parsed `--windows-app-uninstall` invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UninstallArgs {
+    pub update_exe: String,
+    pub data_root: String,
+    pub keep: bool,
+}
+
+/// Parse `--windows-app-uninstall` flags.
+///
+/// Flags:
+///   `--windows-app-uninstall`   — presence marker (required in caller's argv)
+///   `--update-exe <abs path>`   — absolute path to Update.exe (required)
+///   `--data-root  <abs path>`   — absolute path to the data root (required)
+///   exactly one of `--keep` / `--wipe`   — scope selector (required)
+///
+/// Returns `None` on any missing/invalid input (mirrors linux's parse_args
+/// validation contract). Returning `None` signals the caller to log an error
+/// and return exit code 2.
+pub fn parse_args(args: &[String]) -> Option<UninstallArgs> {
+    // --keep XOR --wipe (exactly one required)
+    let keep = match (
+        args.iter().any(|a| a == "--keep"),
+        args.iter().any(|a| a == "--wipe"),
+    ) {
+        (true, false) => true,
+        (false, true) => false,
+        _ => return None,
+    };
+
+    // --data-root <abs path> (required)
+    let data_root = args
+        .iter()
+        .position(|a| a == "--data-root")
+        .and_then(|i| args.get(i + 1))
+        .cloned()?;
+
+    // --update-exe <abs path> (required)
+    let update_exe = args
+        .iter()
+        .position(|a| a == "--update-exe")
+        .and_then(|i| args.get(i + 1))
+        .cloned()?;
+
+    Some(UninstallArgs { update_exe, data_root, keep })
+}
+
+/// Dispatch `--windows-app-uninstall`. Returns `Some(exit_code)` when it
+/// owns the invocation, `None` to let the next dispatcher try.
+pub fn handle(args: &[String]) -> Option<i32> {
+    if !args.iter().any(|a| a == "--windows-app-uninstall") {
+        return None;
+    }
+    let a = match parse_args(args) {
+        Some(v) => v,
+        None => {
+            log::error("windows-app-uninstall: missing/invalid args");
+            return Some(2);
+        }
+    };
+    Some(run_uninstall(&a))
+}
+
+/// Execute the uninstall plan. Best-effort: log + continue on errors.
+fn run_uninstall(a: &UninstallArgs) -> i32 {
+    log::info(&format!(
+        "windows-app-uninstall: update_exe={:?} data_root={:?} keep={}",
+        a.update_exe, a.data_root, a.keep
+    ));
+    let plan = windows_app_uninstall_commands(&a.update_exe, &a.data_root, a.keep);
+
+    // 1. Run Update.exe --uninstall FIRST. This fires Velopack's uninstaller
+    //    which triggers --veloapp-uninstall → service/tray teardown + ARP
+    //    cleanup. Local-Dependencies-Only: absolute path, no PATH resolution.
+    let argv = &plan.update_exe_step;
+    let (cmd, rest) = argv.split_first().expect("update_exe_step is always non-empty");
+    match std::process::Command::new(cmd).args(rest).status() {
+        Ok(s) if s.success() => {
+            log::info(&format!("windows-app-uninstall: Update.exe ok ({})", argv.join(" ")))
+        }
+        Ok(s) => log::error(&format!(
+            "windows-app-uninstall: Update.exe non-zero ({:?}): {}",
+            s.code(),
+            argv.join(" ")
+        )),
+        Err(e) => log::error(&format!(
+            "windows-app-uninstall: Update.exe spawn failed: {} ({e})",
+            argv.join(" ")
+        )),
+    }
+
+    // 2. Remove dataRoot targets via std::fs (compiled-in; no PATH tools).
+    for target in &plan.data_root_targets {
+        let path = std::path::Path::new(target);
+        if !path.exists() {
+            log::info(&format!("windows-app-uninstall: target absent, skipping: {target}"));
+            continue;
+        }
+        let result = if path.is_dir() {
+            std::fs::remove_dir_all(path)
+        } else {
+            std::fs::remove_file(path)
+        };
+        match result {
+            Ok(()) => log::info(&format!("windows-app-uninstall: removed {target}")),
+            Err(e) => log::error(&format!(
+                "windows-app-uninstall: could not remove {target}: {e}"
+            )),
+        }
+    }
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Space-join each argv-vector for readable, order-preserving assertions.
+    /// Mirrors the helper in linux_app_uninstall tests.
+    fn joined(cmds: &[Vec<String>]) -> Vec<String> {
+        cmds.iter().map(|c| c.join(" ")).collect()
+    }
+
+    const UPDATE_EXE: &str = r"C:\Program Files\WsScrcpyWeb\Update.exe";
+    const DATA_ROOT: &str = r"C:\ProgramData\WsScrcpyWeb";
+
+    // ── Pure builder tests ────────────────────────────────────────────────
+
+    #[test]
+    fn update_exe_step_is_always_first_and_correct() {
+        // Both keep and wipe: the Update.exe step is the first (and only)
+        // step in update_exe_step, always [update_exe, "--uninstall"].
+        for keep in [true, false] {
+            let plan = windows_app_uninstall_commands(UPDATE_EXE, DATA_ROOT, keep);
+            assert_eq!(
+                plan.update_exe_step,
+                vec![UPDATE_EXE.to_string(), "--uninstall".to_string()],
+                "update_exe_step mismatch for keep={keep}"
+            );
+        }
+    }
+
+    #[test]
+    fn wipe_targets_whole_data_root() {
+        // keep=false → data_root_targets = ["<data_root>"] — single entry,
+        // the whole root. No subdirectory carve-out.
+        let plan = windows_app_uninstall_commands(UPDATE_EXE, DATA_ROOT, false);
+        assert_eq!(
+            plan.data_root_targets,
+            vec![DATA_ROOT.to_string()],
+            "wipe must target the whole data root"
+        );
+    }
+
+    #[test]
+    fn keep_targets_deps_bin_control_only() {
+        // keep=true → data_root_targets contains exactly dependencies, bin,
+        // control (subdirs); does NOT contain a bare wipe and never names
+        // config.json or logs.
+        let plan = windows_app_uninstall_commands(UPDATE_EXE, DATA_ROOT, true);
+        let targets = &plan.data_root_targets;
+
+        // Exactly the three regenerable subdirs.
+        assert!(
+            targets.contains(&format!(r"{DATA_ROOT}\dependencies")),
+            "keep must target dependencies"
+        );
+        assert!(
+            targets.contains(&format!(r"{DATA_ROOT}\bin")),
+            "keep must target bin"
+        );
+        assert!(
+            targets.contains(&format!(r"{DATA_ROOT}\control")),
+            "keep must target control"
+        );
+
+        // NOT a bare wipe of the data root itself.
+        assert!(
+            !targets.contains(&DATA_ROOT.to_string()),
+            "keep must NOT target the whole data root"
+        );
+
+        // Preserved paths are never referenced.
+        assert!(
+            !targets.iter().any(|t| t.contains("config.json")),
+            "keep must not reference config.json"
+        );
+        assert!(
+            !targets.iter().any(|t| t.contains("logs")),
+            "keep must not reference logs"
+        );
+    }
+
+    #[test]
+    fn update_exe_step_is_distinct_from_data_root_targets() {
+        // The struct keeps the two groups separate so callers (and tests) can
+        // assert each independently. Verify the split is never collapsed.
+        let plan = windows_app_uninstall_commands(UPDATE_EXE, DATA_ROOT, false);
+        // update_exe_step has exactly the Update.exe invocation.
+        assert_eq!(plan.update_exe_step.len(), 2);
+        assert_eq!(plan.update_exe_step[1], "--uninstall");
+        // data_root_targets has no Update.exe entry.
+        assert!(!plan.data_root_targets.iter().any(|t| t.contains("Update.exe")));
+    }
+
+    #[test]
+    fn keep_has_exactly_three_targets() {
+        let plan = windows_app_uninstall_commands(UPDATE_EXE, DATA_ROOT, true);
+        assert_eq!(
+            plan.data_root_targets.len(),
+            3,
+            "keep must produce exactly 3 targets (dependencies, bin, control)"
+        );
+    }
+
+    #[test]
+    fn wipe_has_exactly_one_target() {
+        let plan = windows_app_uninstall_commands(UPDATE_EXE, DATA_ROOT, false);
+        assert_eq!(
+            plan.data_root_targets.len(),
+            1,
+            "wipe must produce exactly 1 target (the whole data root)"
+        );
+    }
+
+    #[test]
+    fn update_exe_path_is_preserved_verbatim() {
+        // The absolute path passed in must appear unchanged — no normalization,
+        // no quoting, no PATH lookup.
+        let exotic = r"C:\Program Files (x86)\WsScrcpyWeb\Update.exe";
+        let plan = windows_app_uninstall_commands(exotic, DATA_ROOT, false);
+        assert_eq!(plan.update_exe_step[0], exotic);
+    }
+
+    // Smoke-check the joined() helper (mirrors linux tests).
+    #[test]
+    fn joined_helper_formats_correctly() {
+        let cmds: Vec<Vec<String>> = vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c".to_string()],
+        ];
+        assert_eq!(joined(&cmds), vec!["a b".to_string(), "c".to_string()]);
+    }
+
+    // ── parse_args tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_args_round_trips_keep() {
+        let args: Vec<String> = [
+            "--windows-app-uninstall",
+            "--keep",
+            "--data-root",
+            DATA_ROOT,
+            "--update-exe",
+            UPDATE_EXE,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            parse_args(&args),
+            Some(UninstallArgs {
+                update_exe: UPDATE_EXE.to_string(),
+                data_root: DATA_ROOT.to_string(),
+                keep: true,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_args_round_trips_wipe() {
+        let args: Vec<String> = [
+            "--windows-app-uninstall",
+            "--wipe",
+            "--data-root",
+            DATA_ROOT,
+            "--update-exe",
+            UPDATE_EXE,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            parse_args(&args),
+            Some(UninstallArgs {
+                update_exe: UPDATE_EXE.to_string(),
+                data_root: DATA_ROOT.to_string(),
+                keep: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_both_keep_and_wipe() {
+        let args: Vec<String> = [
+            "--windows-app-uninstall",
+            "--keep",
+            "--wipe",
+            "--data-root",
+            DATA_ROOT,
+            "--update-exe",
+            UPDATE_EXE,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(parse_args(&args), None);
+    }
+
+    #[test]
+    fn parse_args_rejects_neither_keep_nor_wipe() {
+        let args: Vec<String> = [
+            "--windows-app-uninstall",
+            "--data-root",
+            DATA_ROOT,
+            "--update-exe",
+            UPDATE_EXE,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(parse_args(&args), None);
+    }
+
+    #[test]
+    fn parse_args_rejects_missing_data_root() {
+        let args: Vec<String> =
+            ["--windows-app-uninstall", "--keep", "--update-exe", UPDATE_EXE]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+        assert_eq!(parse_args(&args), None);
+    }
+
+    #[test]
+    fn parse_args_rejects_missing_update_exe() {
+        let args: Vec<String> =
+            ["--windows-app-uninstall", "--keep", "--data-root", DATA_ROOT]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+        assert_eq!(parse_args(&args), None);
+    }
+
+    #[test]
+    fn parse_args_rejects_data_root_without_value() {
+        // --data-root present but no value following it → parse error.
+        let args: Vec<String> =
+            ["--windows-app-uninstall", "--keep", "--data-root", "--update-exe", UPDATE_EXE]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+        // --data-root's "value" would be "--update-exe" (the next flag), and
+        // --update-exe would then have no value. parse_args returns None for
+        // missing --update-exe value.
+        // (We don't validate that values aren't flags; the contract matches linux.)
+        // Either way: no panic.
+        let _ = parse_args(&args);
+    }
+
+    #[test]
+    fn handle_returns_none_when_flag_absent() {
+        let args: Vec<String> = ["--some-other-flag", "--keep"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(handle(&args), None);
+    }
+
+    #[test]
+    fn handle_returns_error_code_on_invalid_args() {
+        // Flag present but missing required --data-root and --update-exe.
+        let args: Vec<String> = ["--windows-app-uninstall", "--keep"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(handle(&args), Some(2));
+    }
+}

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -1,6 +1,7 @@
 import { Modal } from '../ui/Modal';
 import { AdminConfirmModal, type AdminConfirmOptions } from './AdminConfirmModal';
 import { ConfirmModal } from './ConfirmModal';
+import { UninstallConfirmModal } from './UninstallConfirmModal';
 import { ServiceOperationModal } from './ServiceOperationModal';
 import { runUpgradingHandoff } from './UpgradingOverlay';
 import type { AppConfigEnvelope, AppConfigPatchResponse, UpdateChannel } from '../../common/ConfigEvents';
@@ -313,100 +314,36 @@ export function buildInstallAllUsersControl(opts: { reload: () => void }): {
 }
 
 /**
- * Build the Linux-only "uninstall ws-scrcpy-web" control: a danger trigger
- * button plus an inline confirm panel (the same settings-confirm-panel pattern
- * the reset-prompts row uses). The trigger toggles the panel; the panel holds a
- * warning line, a "keep my settings & logs" checkbox (unchecked by default), and
- * confirm/cancel buttons. Confirm POSTs /api/service/uninstall-app with
- * `{ keep: <checkbox> }`; on success it invokes `onUninstalled` (the terminal
- * "uninstalled — close this tab" message, since the server tears itself down);
- * on failure it surfaces an inline error inside the panel. Self-contained DOM +
- * wiring (no network until confirm is clicked) so it is unit-testable.
+ * Build the "uninstall ws-scrcpy-web" trigger button. When clicked, opens
+ * UninstallConfirmModal (a top-layer <dialog>) instead of an inline panel.
+ * On confirmation, POSTs /api/service/uninstall-app with { keep } and calls
+ * opts.onUninstalled on success. Self-contained DOM + wiring; no network call
+ * until the modal is confirmed.
  */
 export function buildUninstallControl(opts: { onUninstalled: () => void }): {
     button: HTMLButtonElement;
-    confirmPanel: HTMLElement;
-    keepCheckbox: HTMLInputElement;
-    confirmButton: HTMLButtonElement;
-    cancelButton: HTMLButtonElement;
 } {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'settings-btn settings-btn-danger';
     button.textContent = 'uninstall…';
 
-    const confirmPanel = document.createElement('div');
-    confirmPanel.className = 'settings-confirm-panel';
-
-    const warning = document.createElement('p');
-    warning.textContent = 'this completely removes ws-scrcpy-web, including any installed service.';
-    confirmPanel.appendChild(warning);
-
-    const keepLabel = document.createElement('label');
-    keepLabel.className = 'settings-radio-label';
-    const keepCheckbox = document.createElement('input');
-    keepCheckbox.type = 'checkbox';
-    keepLabel.appendChild(keepCheckbox);
-    keepLabel.appendChild(document.createTextNode('keep my settings & logs'));
-    confirmPanel.appendChild(keepLabel);
-
-    const errorNote = document.createElement('p');
-    errorNote.className = 'settings-status settings-status-error';
-    errorNote.hidden = true;
-    confirmPanel.appendChild(errorNote);
-
-    const confirmButtons = document.createElement('div');
-    confirmButtons.className = 'settings-confirm-buttons';
-
-    const cancelButton = document.createElement('button');
-    cancelButton.type = 'button';
-    cancelButton.className = 'settings-btn';
-    cancelButton.textContent = 'cancel';
-    cancelButton.addEventListener('click', () => {
-        confirmPanel.classList.remove('expanded');
-    });
-    confirmButtons.appendChild(cancelButton);
-
-    const confirmButton = document.createElement('button');
-    confirmButton.type = 'button';
-    confirmButton.className = 'settings-btn settings-btn-primary';
-    confirmButton.textContent = 'uninstall';
-    confirmButton.addEventListener('click', () => {
-        const keep = keepCheckbox.checked;
-        confirmButton.disabled = true;
-        cancelButton.disabled = true;
-        confirmButton.textContent = 'uninstalling…';
-        errorNote.hidden = true;
+    button.addEventListener('click', () => {
         void (async () => {
-            try {
-                const res = await fetch('/api/service/uninstall-app', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ keep }),
-                });
-                if (res.ok) {
-                    opts.onUninstalled();
-                    return;
-                }
-                errorNote.textContent = 'uninstall failed — see the server logs and try again.';
-            } catch {
-                errorNote.textContent = 'uninstall failed — could not reach the server.';
-            }
-            errorNote.hidden = false;
-            confirmButton.disabled = false;
-            cancelButton.disabled = false;
-            confirmButton.textContent = 'uninstall';
+            const r = await UninstallConfirmModal.confirm();
+            if (!r.confirmed) return;
+            button.disabled = true;
+            button.textContent = 'uninstalling…';
+            await fetch('/api/service/uninstall-app', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ keep: r.keep }),
+            });
+            opts.onUninstalled();
         })();
     });
-    confirmButtons.appendChild(confirmButton);
 
-    confirmPanel.appendChild(confirmButtons);
-
-    button.addEventListener('click', () => {
-        confirmPanel.classList.toggle('expanded');
-    });
-
-    return { button, confirmPanel, keepCheckbox, confirmButton, cancelButton };
+    return { button };
 }
 
 /**
@@ -449,7 +386,6 @@ export class SettingsModal extends Modal {
     private installAllUsersNote: HTMLElement | null = null;
     private uninstallRow: HTMLElement | null = null;
     private uninstallButton: HTMLButtonElement | null = null;
-    private uninstallConfirmPanel: HTMLElement | null = null;
 
     // ── Updates section state ─────────────────────────────────────────────
     private updatesBody!: HTMLElement;
@@ -1683,11 +1619,10 @@ export class SettingsModal extends Modal {
 
         // ── uninstall ws-scrcpy-web (Linux + win32) ──────────────────────
         // Always enabled when shown (NOT gated on service mode — uninstalling is how you
-        // remove a service). Reuses the confirm-panel pattern; confirm POSTs
+        // remove a service). Opens UninstallConfirmModal on click; confirm POSTs
         // /api/service/uninstall-app { keep }.
         const uninstall = buildUninstallControl({ onUninstalled: () => this.showUninstalledOverlay() });
         this.uninstallButton = uninstall.button;
-        this.uninstallConfirmPanel = uninstall.confirmPanel;
         const uninstallRow = this.buildRow('uninstall ws-scrcpy-web', uninstall.button);
         uninstallRow.style.display = 'none';
         this.uninstallRow = uninstallRow;
@@ -1702,9 +1637,8 @@ export class SettingsModal extends Modal {
         // 3. stop the server and close the app + note
         body.appendChild(this.buildRow('stop the server and close the app', stopBtn));
         body.appendChild(stopNote);
-        // 4. uninstall ws-scrcpy-web + confirm panel (Linux + win32, hidden until revealed)
+        // 4. uninstall ws-scrcpy-web (Linux + win32, hidden until revealed)
         body.appendChild(uninstallRow);
-        body.appendChild(uninstall.confirmPanel);
 
         return section;
     }
@@ -1753,10 +1687,6 @@ export class SettingsModal extends Modal {
             // (unlike "stop server & exit"); uninstalling is how you tear a service
             // down. Asserting it here documents and enforces that invariant.
             this.uninstallButton.disabled = false;
-        }
-        // Collapse a left-open confirm panel if the row is being hidden (non-Linux).
-        if (!state.showUninstall && this.uninstallConfirmPanel) {
-            this.uninstallConfirmPanel.classList.remove('expanded');
         }
     }
 

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -160,11 +160,12 @@ export function stopServerButtonState(resp: ScopeRadioInputs): {
  * unit-testable; mirrors stopServerButtonState's shape and is driven from
  * renderServiceState once /api/service/status resolves.
  *
- * - Both rows are Linux-only (hidden on win32/other).
+ * - "install for all users" is Linux-only (hidden on win32/other).
+ * - "uninstall" shows on Linux AND win32 (hidden on other platforms).
  * - "install for all users" is disabled once the shared /opt machine-wide
  *   install already exists (the root service execs that binary; re-installing it
  *   is a no-op), with an explanatory note in that state.
- * - "uninstall" is ALWAYS enabled on Linux (unlike "stop server & exit" it is
+ * - "uninstall" is ALWAYS enabled when shown (unlike "stop server & exit" it is
  *   NOT gated on service mode — uninstalling is exactly how you tear a service
  *   down). Fields admit `undefined` so the full ServiceStatusResponse is
  *   assignable under exactOptionalPropertyTypes.
@@ -184,7 +185,7 @@ export function appSectionButtonsState(resp: {
         showInstallAllUsers: linux,
         installAllUsersDisabled: linux && machineWide,
         installAllUsersNote: linux && machineWide ? 'already installed for all users (/opt)' : null,
-        showUninstall: linux,
+        showUninstall: linux || resp.platform === 'win32',
     };
 }
 
@@ -1595,32 +1596,11 @@ export class SettingsModal extends Modal {
     private buildAppSection(): HTMLElement {
         const { section, body } = this.buildSection('App');
 
-        // §27 — stop the server and exit the app. Backs the existing
-        // /api/server/shutdown endpoint (which now runs graceful teardown
-        // before exiting 0 — a clean exit the launcher supervisor will NOT
-        // restart). Gated off in service mode (the OS service manager owns the
-        // lifecycle) by applyStopServerButtonState, driven from
-        // renderServiceState once /api/service/status resolves.
-        const stopBtn = document.createElement('button');
-        stopBtn.type = 'button';
-        stopBtn.className = 'settings-btn settings-btn-primary';
-        stopBtn.textContent = 'stop server & exit';
-        stopBtn.addEventListener('click', () => void this.onStopServerExit(stopBtn));
-        this.stopServerButton = stopBtn;
-        body.appendChild(this.buildRow('stop the server and close the app', stopBtn));
-
-        const stopNote = document.createElement('p');
-        stopNote.className = 'settings-status';
-        stopNote.style.gridColumn = '1 / -1';
-        stopNote.hidden = true;
-        this.stopServerNote = stopNote;
-        body.appendChild(stopNote);
-
+        // ── reset welcome & bookmark prompts ─────────────────────────────
         const resetBtn = document.createElement('button');
         resetBtn.type = 'button';
         resetBtn.className = 'settings-btn settings-btn-primary';
         resetBtn.textContent = 'reset';
-        body.appendChild(this.buildRow('reset welcome and bookmark prompts', resetBtn));
 
         // Confirm panel — hidden by default, expands inside the grid below
         // the reset row when the button is clicked. Spans both columns.
@@ -1663,38 +1643,66 @@ export class SettingsModal extends Modal {
         confirmButtons.appendChild(confirmBtn);
 
         confirmPanel.appendChild(confirmButtons);
-        body.appendChild(confirmPanel);
 
         resetBtn.addEventListener('click', () => {
             confirmPanel.classList.toggle('expanded');
         });
 
-        // §beta.49 — two Linux-only rows. Built hidden (display:none overrides the
-        // .settings-row { display: contents } rule via inline style) and revealed
-        // only on Linux by applyAppSectionButtonsState once /api/service/status
-        // resolves, so they never flash on Windows.
-
-        // "install for all users": POST /api/service/install-system-wide (pkexec
-        // → relocate to /opt → re-exec). The OS pkexec dialog is the confirmation,
-        // so no extra modal — just reload onto the re-execed instance on success.
+        // ── install for all users (Linux-only) ───────────────────────────
+        // §beta.49 — hidden (display:none overrides the .settings-row { display: contents }
+        // rule via inline style) and revealed only on Linux by applyAppSectionButtonsState
+        // once /api/service/status resolves, so it never flashes on Windows.
+        // POST /api/service/install-system-wide (pkexec → relocate to /opt → re-exec).
+        // The OS pkexec dialog is the confirmation, so no extra modal — just reload onto
+        // the re-execed instance on success.
         const install = buildInstallAllUsersControl({ reload: () => window.location.reload() });
         this.installAllUsersButton = install.button;
         this.installAllUsersNote = install.note;
         const installRow = this.buildRow('install for all users', install.button);
         installRow.style.display = 'none';
         this.installAllUsersRow = installRow;
-        body.appendChild(installRow);
-        body.appendChild(install.note);
 
-        // "uninstall ws-scrcpy-web": always enabled on Linux (NOT gated on service
-        // mode — uninstalling is how you remove a service). Reuses the confirm-panel
-        // pattern; confirm POSTs /api/service/uninstall-app { keep }.
+        // ── stop the server and exit the app ─────────────────────────────
+        // §27 — backs the /api/server/shutdown endpoint (which now runs graceful teardown
+        // before exiting 0 — a clean exit the launcher supervisor will NOT restart).
+        // Gated off in service mode (the OS service manager owns the lifecycle) by
+        // applyStopServerButtonState, driven from renderServiceState once
+        // /api/service/status resolves.
+        const stopBtn = document.createElement('button');
+        stopBtn.type = 'button';
+        stopBtn.className = 'settings-btn settings-btn-primary';
+        stopBtn.textContent = 'stop server & exit';
+        stopBtn.addEventListener('click', () => void this.onStopServerExit(stopBtn));
+        this.stopServerButton = stopBtn;
+
+        const stopNote = document.createElement('p');
+        stopNote.className = 'settings-status';
+        stopNote.style.gridColumn = '1 / -1';
+        stopNote.hidden = true;
+        this.stopServerNote = stopNote;
+
+        // ── uninstall ws-scrcpy-web (Linux + win32) ──────────────────────
+        // Always enabled when shown (NOT gated on service mode — uninstalling is how you
+        // remove a service). Reuses the confirm-panel pattern; confirm POSTs
+        // /api/service/uninstall-app { keep }.
         const uninstall = buildUninstallControl({ onUninstalled: () => this.showUninstalledOverlay() });
         this.uninstallButton = uninstall.button;
         this.uninstallConfirmPanel = uninstall.confirmPanel;
         const uninstallRow = this.buildRow('uninstall ws-scrcpy-web', uninstall.button);
         uninstallRow.style.display = 'none';
         this.uninstallRow = uninstallRow;
+
+        // ── DOM order (top → bottom) ──────────────────────────────────────
+        // 1. reset welcome & bookmark (+ inline confirm panel)
+        body.appendChild(this.buildRow('reset welcome and bookmark prompts', resetBtn));
+        body.appendChild(confirmPanel);
+        // 2. install for all users + note (Linux-only, hidden until revealed)
+        body.appendChild(installRow);
+        body.appendChild(install.note);
+        // 3. stop the server and close the app + note
+        body.appendChild(this.buildRow('stop the server and close the app', stopBtn));
+        body.appendChild(stopNote);
+        // 4. uninstall ws-scrcpy-web + confirm panel (Linux + win32, hidden until revealed)
         body.appendChild(uninstallRow);
         body.appendChild(uninstall.confirmPanel);
 

--- a/src/app/client/UninstallConfirmModal.ts
+++ b/src/app/client/UninstallConfirmModal.ts
@@ -1,0 +1,103 @@
+import { Modal } from '../ui/Modal';
+
+export interface UninstallConfirmResult {
+    confirmed: boolean;
+    keep: boolean;
+}
+
+/**
+ * Overlay modal shown when the user clicks "uninstall…" in the App section.
+ * Replaces the inline confirm-panel pattern so the destructive action is
+ * presented in a top-layer dialog that demands deliberate interaction.
+ *
+ * `UninstallConfirmModal.confirm()` is the only public API.
+ * - cancel button → { confirmed: false, keep: <checkbox> }
+ * - uninstall button → { confirmed: true, keep: <checkbox> }
+ * - Esc / backdrop / close-X → { confirmed: false, keep: <checkbox> }
+ *
+ * The "keep my settings & logs" checkbox defaults to CHECKED so the
+ * safer option (preserve data) is the default path.
+ */
+export class UninstallConfirmModal extends Modal {
+    private resolveFn: ((value: UninstallConfirmResult) => void) | null = null;
+    private resolved = false;
+    private keepCheckboxEl!: HTMLInputElement;
+
+    public static confirm(): Promise<UninstallConfirmResult> {
+        return new Promise((resolve) => {
+            new UninstallConfirmModal(resolve);
+        });
+    }
+
+    private constructor(resolve: (value: UninstallConfirmResult) => void) {
+        super({ title: 'uninstall ws-scrcpy-web' });
+        this.resolveFn = resolve;
+        this.dialog.classList.add('uninstall-confirm-modal');
+        queueMicrotask(() => this.fillBody(this.bodyEl));
+    }
+
+    protected buildBody(_container: HTMLElement): void {
+        // Body content rendered by fillBody() via queueMicrotask (fields not yet set).
+    }
+
+    private fillBody(container: HTMLElement): void {
+        const description = document.createElement('p');
+        description.textContent =
+            'this removes the app, its dependencies, and any installed service.';
+        container.appendChild(description);
+
+        const keepLabel = document.createElement('label');
+        keepLabel.style.cssText =
+            'display: flex; align-items: center; gap: 0.5rem; margin-top: 0.75rem; cursor: pointer;';
+
+        this.keepCheckboxEl = document.createElement('input');
+        this.keepCheckboxEl.type = 'checkbox';
+        this.keepCheckboxEl.checked = true; // default: keep data
+
+        keepLabel.appendChild(this.keepCheckboxEl);
+        keepLabel.appendChild(document.createTextNode('keep my settings & logs'));
+        container.appendChild(keepLabel);
+    }
+
+    protected override buildFooter(): HTMLElement | null {
+        const footer = document.createElement('div');
+        footer.style.cssText = 'display: flex; gap: 8px; justify-content: flex-end;';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'settings-btn uninstall-cancel';
+        cancelBtn.textContent = 'cancel';
+        cancelBtn.addEventListener('click', () => this.resolveAndClose(false));
+        footer.appendChild(cancelBtn);
+
+        const uninstallBtn = document.createElement('button');
+        uninstallBtn.type = 'button';
+        uninstallBtn.className = 'settings-btn settings-btn-danger-outline uninstall-confirm';
+        uninstallBtn.textContent = 'uninstall';
+        uninstallBtn.addEventListener('click', () => this.resolveAndClose(true));
+        footer.appendChild(uninstallBtn);
+
+        return footer;
+    }
+
+    protected override onEscapeKey(_event: Event): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onBackdropClick(_event: MouseEvent): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onCloseButtonClick(): void {
+        this.resolveAndClose(false);
+    }
+
+    private resolveAndClose(confirmed: boolean): void {
+        if (this.resolved) return;
+        this.resolved = true;
+        const keep = this.keepCheckboxEl?.checked ?? true;
+        this.resolveFn?.({ confirmed, keep });
+        this.resolveFn = null;
+        this.close({ confirmed, keep });
+    }
+}

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -15,6 +15,7 @@ import {
     appSectionButtonsState,
     buildInstallAllUsersControl,
     buildUninstallControl,
+    SettingsModal,
 } from '../SettingsModal';
 
 /** Flush microtasks + a macrotask so the awaited fetch handlers settle. */
@@ -250,13 +251,26 @@ describe('appSectionButtonsState', () => {
         expect(s.showUninstall).toBe(true);
     });
 
-    it('non-linux (win32) -> both rows hidden, nothing disabled, no note', () => {
+    it('win32 -> install-all-users hidden, uninstall shown, nothing disabled, no note', () => {
         expect(appSectionButtonsState({ platform: 'win32', machineWideInstalled: false })).toEqual({
             showInstallAllUsers: false,
             installAllUsersDisabled: false,
             installAllUsersNote: null,
-            showUninstall: false,
+            showUninstall: true,
         });
+    });
+
+    // Part A: win32 should show uninstall but NOT install-all-users
+    it('win32 -> showUninstall=true, showInstallAllUsers=false', () => {
+        const s = appSectionButtonsState({ platform: 'win32', machineWideInstalled: false });
+        expect(s.showUninstall).toBe(true);
+        expect(s.showInstallAllUsers).toBe(false);
+    });
+
+    it('linux -> showUninstall=true AND showInstallAllUsers=true', () => {
+        const s = appSectionButtonsState({ platform: 'linux', machineWideInstalled: false });
+        expect(s.showUninstall).toBe(true);
+        expect(s.showInstallAllUsers).toBe(true);
     });
 });
 
@@ -341,5 +355,45 @@ describe('buildUninstallControl', () => {
         await flush();
 
         expect(onUninstalled).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('App section row order (Part B)', () => {
+    /** Flush microtasks so SettingsModal.fillBody() runs (it is queued via queueMicrotask). */
+    const flushMicrotasks = (): Promise<void> => new Promise((resolve) => queueMicrotask(resolve));
+
+    it('App section rows appear in order: reset, install-for-all-users, stop-server, uninstall', async () => {
+        // Stub fetch so the refresh* calls inside the constructor never settle
+        // (we only need the base DOM structure, not service-status overlays).
+        vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => undefined)));
+        // jsdom does not implement <dialog>.showModal(); polyfill it so Modal constructor
+        // does not throw. The polyfill is a no-op — we only need the DOM tree, not the
+        // native dialog open state.
+        HTMLDialogElement.prototype.showModal = vi.fn();
+
+        new SettingsModal();
+        // Modal constructor appends to document.body already; wait for
+        // queueMicrotask(() => fillBody(...)) to run.
+        await flushMicrotasks();
+
+        const labels = Array.from(
+            document.body.querySelectorAll<HTMLElement>('.settings-row .settings-label'),
+        ).map((el) => el.textContent ?? '');
+
+        const resetIdx = labels.indexOf('reset welcome and bookmark prompts');
+        const installIdx = labels.indexOf('install for all users');
+        const stopIdx = labels.indexOf('stop the server and close the app');
+        const uninstallIdx = labels.indexOf('uninstall ws-scrcpy-web');
+
+        // All four rows must exist
+        expect(resetIdx, 'reset row missing').toBeGreaterThanOrEqual(0);
+        expect(installIdx, 'install-for-all-users row missing').toBeGreaterThanOrEqual(0);
+        expect(stopIdx, 'stop-server row missing').toBeGreaterThanOrEqual(0);
+        expect(uninstallIdx, 'uninstall row missing').toBeGreaterThanOrEqual(0);
+
+        // Order: reset < install-for-all-users < stop < uninstall
+        expect(resetIdx, 'reset must come before install-for-all-users').toBeLessThan(installIdx);
+        expect(installIdx, 'install-for-all-users must come before stop').toBeLessThan(stopIdx);
+        expect(stopIdx, 'stop must come before uninstall').toBeLessThan(uninstallIdx);
     });
 });

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -17,6 +17,7 @@ import {
     buildUninstallControl,
     SettingsModal,
 } from '../SettingsModal';
+import * as UninstallConfirmModalModule from '../UninstallConfirmModal';
 
 /** Flush microtasks + a macrotask so the awaited fetch handlers settle. */
 const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -306,55 +307,72 @@ describe('buildInstallAllUsersControl', () => {
 });
 
 describe('buildUninstallControl', () => {
-    it('clicking the trigger expands the inline confirm panel', () => {
-        const { button, confirmPanel } = buildUninstallControl({ onUninstalled: vi.fn() });
-        expect(confirmPanel.classList.contains('settings-confirm-panel')).toBe(true);
-        expect(confirmPanel.classList.contains('expanded')).toBe(false);
-        button.click();
-        expect(confirmPanel.classList.contains('expanded')).toBe(true);
+    it('returns only { button } — no confirmPanel, keepCheckbox, confirmButton, cancelButton', () => {
+        const result = buildUninstallControl({ onUninstalled: vi.fn() });
+        expect(result).toHaveProperty('button');
+        expect(result).not.toHaveProperty('confirmPanel');
+        expect(result).not.toHaveProperty('keepCheckbox');
+        expect(result).not.toHaveProperty('confirmButton');
+        expect(result).not.toHaveProperty('cancelButton');
     });
 
-    it('confirm with "keep" checked POSTs /api/service/uninstall-app with {keep:true}', async () => {
+    it('button click opens UninstallConfirmModal (calls confirm)', async () => {
+        const confirmSpy = vi.spyOn(UninstallConfirmModalModule.UninstallConfirmModal, 'confirm')
+            .mockResolvedValue({ confirmed: false, keep: true });
+        const { button } = buildUninstallControl({ onUninstalled: vi.fn() });
+        button.click();
+        await flush();
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('on confirmed=true,keep=true POSTs /api/service/uninstall-app with {keep:true} and calls onUninstalled', async () => {
         const fetchMock = vi.fn().mockResolvedValue({ ok: true });
         vi.stubGlobal('fetch', fetchMock);
+        const onUninstalled = vi.fn();
+        vi.spyOn(UninstallConfirmModalModule.UninstallConfirmModal, 'confirm')
+            .mockResolvedValue({ confirmed: true, keep: true });
 
-        const { button, keepCheckbox, confirmButton } = buildUninstallControl({ onUninstalled: vi.fn() });
+        const { button } = buildUninstallControl({ onUninstalled });
         button.click();
-        keepCheckbox.checked = true;
-        confirmButton.click();
+        await flush();
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
         expect(url).toBe('/api/service/uninstall-app');
         expect(init.method).toBe('POST');
         expect(JSON.parse(init.body as string)).toEqual({ keep: true });
-        await flush();
+        expect(onUninstalled).toHaveBeenCalledTimes(1);
     });
 
-    it('confirm with "keep" unchecked POSTs {keep:false}', async () => {
-        const fetchMock = vi.fn().mockResolvedValue({ ok: true });
-        vi.stubGlobal('fetch', fetchMock);
-
-        const { button, confirmButton } = buildUninstallControl({ onUninstalled: vi.fn() });
-        button.click();
-        confirmButton.click();
-
-        const [, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
-        expect(JSON.parse(init.body as string)).toEqual({ keep: false });
-        await flush();
-    });
-
-    it('invokes onUninstalled (the terminal message) after a successful uninstall', async () => {
+    it('on confirmed=true,keep=false POSTs {keep:false} and calls onUninstalled', async () => {
         const fetchMock = vi.fn().mockResolvedValue({ ok: true });
         vi.stubGlobal('fetch', fetchMock);
         const onUninstalled = vi.fn();
+        vi.spyOn(UninstallConfirmModalModule.UninstallConfirmModal, 'confirm')
+            .mockResolvedValue({ confirmed: true, keep: false });
 
-        const { button, confirmButton } = buildUninstallControl({ onUninstalled });
+        const { button } = buildUninstallControl({ onUninstalled });
         button.click();
-        confirmButton.click();
         await flush();
 
+        const [, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+        expect(JSON.parse(init.body as string)).toEqual({ keep: false });
         expect(onUninstalled).toHaveBeenCalledTimes(1);
+    });
+
+    it('on confirmed=false does NOT POST and does NOT call onUninstalled', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const onUninstalled = vi.fn();
+        vi.spyOn(UninstallConfirmModalModule.UninstallConfirmModal, 'confirm')
+            .mockResolvedValue({ confirmed: false, keep: true });
+
+        const { button } = buildUninstallControl({ onUninstalled });
+        button.click();
+        await flush();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(onUninstalled).not.toHaveBeenCalled();
     });
 });
 

--- a/src/app/client/__tests__/UninstallConfirmModal.test.ts
+++ b/src/app/client/__tests__/UninstallConfirmModal.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { UninstallConfirmModal } from '../UninstallConfirmModal';
+
+// Mirror the AdminConfirmModal test stub: showModal throws InvalidStateError
+// if the dialog already has the 'open' attribute (spec-realistic).
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        if (this.hasAttribute('open')) {
+            throw new DOMException(
+                "Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.",
+                'InvalidStateError',
+            );
+        }
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+});
+
+function getDialog(): HTMLDialogElement {
+    const dialog = document.querySelector('dialog.uninstall-confirm-modal');
+    expect(dialog, 'modal dialog should be in the DOM').toBeTruthy();
+    return dialog as HTMLDialogElement;
+}
+
+function getButton(label: string): HTMLButtonElement {
+    const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+    const btn = btns.find((b) => b.textContent?.trim().toLowerCase() === label.toLowerCase());
+    expect(btn, `button labeled "${label}" should be in the DOM`).toBeTruthy();
+    return btn!;
+}
+
+function getCheckbox(): HTMLInputElement {
+    const dialog = getDialog();
+    const cb = dialog.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(cb, 'keep checkbox should be in the DOM').toBeTruthy();
+    return cb!;
+}
+
+describe('UninstallConfirmModal.confirm', () => {
+    it('checkbox defaults to checked', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const cb = getCheckbox();
+        expect(cb.checked).toBe(true);
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('cancel resolves { confirmed: false, keep: true } when checkbox is still checked', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        // checkbox is checked by default
+        getButton('cancel').click();
+        await expect(promise).resolves.toEqual({ confirmed: false, keep: true });
+    });
+
+    it('uncheck then uninstall resolves { confirmed: true, keep: false }', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const cb = getCheckbox();
+        cb.checked = false;
+        getButton('uninstall').click();
+        await expect(promise).resolves.toEqual({ confirmed: true, keep: false });
+    });
+
+    it('uninstall with keep still checked resolves { confirmed: true, keep: true }', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        // checkbox is checked by default
+        getButton('uninstall').click();
+        await expect(promise).resolves.toEqual({ confirmed: true, keep: true });
+    });
+
+    it('body contains the expected copy', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const body = document.querySelector('.modal-body');
+        expect(body?.textContent?.toLowerCase()).toContain('removes the app');
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('uninstall button has class settings-btn-danger-outline', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('uninstall');
+        expect(btn.classList.contains('settings-btn-danger-outline')).toBe(true);
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('uninstall button also has class settings-btn', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('uninstall');
+        expect(btn.classList.contains('settings-btn')).toBe(true);
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('cancel button has class settings-btn (white outline, no danger)', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('cancel');
+        expect(btn.classList.contains('settings-btn')).toBe(true);
+        expect(btn.classList.contains('settings-btn-danger-outline')).toBe(false);
+        btn.click();
+        await promise;
+    });
+
+    it('cancel button has class uninstall-cancel', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('cancel');
+        expect(btn.classList.contains('uninstall-cancel')).toBe(true);
+        btn.click();
+        await promise;
+    });
+
+    it('uninstall button has class uninstall-confirm', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('uninstall');
+        expect(btn.classList.contains('uninstall-confirm')).toBe(true);
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('calls showModal exactly once', async () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        expect(spy).toHaveBeenCalledTimes(1);
+        getButton('cancel').click();
+        await promise;
+        spy.mockRestore();
+    });
+
+    it('resolves only once even if multiple close paths fire', async () => {
+        const promise = UninstallConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('uninstall').click();
+        getButton('cancel').click();
+        await expect(promise).resolves.toEqual({ confirmed: true, keep: true });
+    });
+});

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1696,12 +1696,101 @@ describe('ServiceApi', () => {
             expect(spawnMock).not.toHaveBeenCalled();
         });
 
-        it('POST /uninstall-app on non-linux → 200 unsupported, does NOT spawn', async () => {
+        // ── win32 branch (mirrors the linux structure: spawn the detached Rust
+        //    helper, 200 uninstalling, scheduleExit). The staged launcher carries
+        //    raw `--windows-app-uninstall` argv; elevation is delegated to
+        //    Update.exe (PerMachine UAC manifest) at runtime, the same
+        //    "elevation lives in the launcher" model as the §30 --request-uac
+        //    path and the linux helper's pkexec self-elevation.
+
+        it('POST /uninstall-app {keep:false} on win32 → 200 uninstalling, spawns the staged launcher with --windows-app-uninstall --wipe + Update.exe', async () => {
             const client = fakeClient();
             const factoryResult: ServiceClientFactoryResult = {
                 client,
                 supported: true,
                 platform: 'win32',
+            };
+            let spawnedCmd = '';
+            let spawnedArgs: string[] = [];
+            const spawnMock = vi.fn((cmd: string, args: string[]) => { spawnedCmd = cmd; spawnedArgs = args; });
+            const scheduleExit = vi.fn();
+            // existsCheck → staged helper present.
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnMock, scheduleExit);
+            const { req, res } = makeReqRes('/api/service/uninstall-app', 'POST', JSON.stringify({ keep: false }));
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body).toEqual({ ok: true, status: 'uninstalling' });
+
+            // Local instance sacrifices itself to the detached teardown.
+            expect(scheduleExit).toHaveBeenCalledTimes(1);
+
+            expect(spawnMock).toHaveBeenCalledTimes(1);
+            // Spawns the operation-server staged launcher copy (survives Program
+            // Files removal) — same path the win32 service-uninstall handoff uses.
+            expect(spawnedCmd).toMatch(/ws-scrcpy-web-launcher\.exe$/);
+            expect(spawnedCmd).toContain('operation-server');
+            // Raw argv carries the windows-app-uninstall flags.
+            expect(spawnedArgs).toContain('--windows-app-uninstall');
+            expect(spawnedArgs).toContain('--wipe');
+            expect(spawnedArgs).not.toContain('--keep');
+            // --data-root <dataRoot> (same accessor the rest of ServiceApi uses).
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            expect(spawnedArgs[spawnedArgs.indexOf('--data-root') + 1]).toBe(dataRoot);
+            // --update-exe <installRoot>\Update.exe (Velopack root = parent of current/).
+            const updateExe = spawnedArgs[spawnedArgs.indexOf('--update-exe') + 1];
+            expect(updateExe).toMatch(/Update\.exe$/);
+        });
+
+        it('POST /uninstall-app {keep:true} on win32 → spawns with --keep (preserves config + logs)', async () => {
+            const client = fakeClient();
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            let spawnedArgs: string[] = [];
+            const spawnMock = vi.fn((_cmd: string, args: string[]) => { spawnedArgs = args; });
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnMock, () => {});
+            const { req, res } = makeReqRes('/api/service/uninstall-app', 'POST', JSON.stringify({ keep: true }));
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(200);
+            const body = JSON.parse((res as any).getBody());
+            expect(body).toEqual({ ok: true, status: 'uninstalling' });
+            expect(spawnedArgs).toContain('--keep');
+            expect(spawnedArgs).not.toContain('--wipe');
+        });
+
+        it('POST /uninstall-app on win32 returns 500 when the staged launcher is missing, does NOT spawn', async () => {
+            const client = fakeClient();
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: true,
+                platform: 'win32',
+            };
+            const spawnMock = vi.fn();
+            // existsCheck → false: the staged helper is absent (dev/from-source run).
+            const api = new ServiceApi(() => factoryResult, () => 'user', () => false, spawnMock, () => {});
+            const { req, res } = makeReqRes('/api/service/uninstall-app', 'POST', JSON.stringify({ keep: false }));
+            await api.handle(req, res);
+
+            expect((res as any).getStatus()).toBe(500);
+            const body = JSON.parse((res as any).getBody());
+            expect(body.ok).toBe(false);
+            expect(body.error).toMatch(/ws-scrcpy-web-launcher\.exe/);
+            expect(spawnMock).not.toHaveBeenCalled();
+        });
+
+        it('POST /uninstall-app on an unsupported platform (darwin) → 200 unsupported, does NOT spawn', async () => {
+            const client = fakeClient();
+            const factoryResult: ServiceClientFactoryResult = {
+                client,
+                supported: false,
+                platform: 'darwin',
+                unsupportedReason: 'macOS service mode unsupported',
             };
             const spawnMock = vi.fn();
             const api = new ServiceApi(() => factoryResult, () => 'user', () => true, spawnMock, () => {});

--- a/src/server/__tests__/gracefulShutdown.adb.test.ts
+++ b/src/server/__tests__/gracefulShutdown.adb.test.ts
@@ -1,0 +1,71 @@
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import * as child_process from 'child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reapStrayAdbOnWindows } from '../shutdownHelpers';
+
+// Mock child_process so execFileAsync (promisify(execFile)) never touches the
+// real system; we only care which arguments were passed.
+vi.mock('child_process', async (importOriginal) => {
+    const real = await importOriginal<typeof child_process>();
+    return {
+        ...real,
+        execFile: vi.fn(
+            (
+                _file: string,
+                _args: string[],
+                _opts: unknown,
+                cb: (err: Error | null) => void,
+            ) => {
+                cb(null);
+            },
+        ),
+    };
+});
+
+describe('reapStrayAdbOnWindows', () => {
+    let execFileMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        execFileMock = vi.mocked(child_process.execFile);
+        execFileMock.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('issues taskkill /F /IM adb.exe /T on win32', async () => {
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+        await reapStrayAdbOnWindows();
+
+        expect(execFileMock).toHaveBeenCalledTimes(1);
+        const [file, args] = execFileMock.mock.calls[0]!;
+        expect(file).toBe('C:\\Windows\\System32\\taskkill.exe');
+        expect(args).toEqual(['/F', '/IM', 'adb.exe', '/T']);
+    });
+
+    it('does NOT call taskkill on non-win32 platforms', async () => {
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+        await reapStrayAdbOnWindows();
+
+        expect(execFileMock).not.toHaveBeenCalled();
+    });
+
+    it('swallows a non-zero exit (no-match) without throwing', async () => {
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+        execFileMock.mockImplementation(
+            (
+                _file: string,
+                _args: string[],
+                _opts: unknown,
+                cb: (err: Error | null) => void,
+            ) => {
+                const err = Object.assign(new Error('no matching process'), { code: 1 });
+                cb(err);
+            },
+        );
+
+        // Must not throw.
+        await expect(reapStrayAdbOnWindows()).resolves.toBeUndefined();
+    });
+});

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -977,28 +977,98 @@ export class ServiceApi {
     }
 
     /**
-     * POST /api/service/uninstall-app — Linux-only. Spawn the detached Rust
-     * uninstall helper (`--linux-app-uninstall`) and exit the local instance so
-     * the out-of-cgroup helper can tear the app down from underneath us.
+     * POST /api/service/uninstall-app — Linux + win32. Spawn the detached Rust
+     * uninstall helper and sacrifice the local instance so the out-of-process
+     * helper can tear the app down from underneath us.
+     *
+     * Linux (`--linux-app-uninstall`, via systemd-run): forwards scope /
+     * machine-wide / relaunch so the helper tears down the right pieces; the
+     * helper self-elevates (root → direct; non-root → pkexec; declined →
+     * relaunch local), so this spawn stays unelevated.
+     *
+     * win32 (`--windows-app-uninstall`): the helper runs
+     * `<installRoot>\Update.exe --uninstall` (fires Velopack's --veloapp-uninstall
+     * hook → service/tray teardown + ARP cleanup) then removes the dataRoot
+     * targets. Elevation is delegated to Update.exe (a PerMachine install's
+     * Update.exe self-elevates via UAC) — the same "elevation lives in the
+     * launcher binary" model as the §30 --request-uac path; this spawn itself
+     * stays unelevated. Both branches mirror the detached teardown handoff in
+     * handleUninstall.
      *
      * `keep` (request body) preserves config.json + logs/ (`--keep`) vs. wiping
      * all state (`--wipe`). On keep we ALSO reset installMode to null up front so
      * the preserved config.json boots in local mode next time rather than a
      * phantom service mode with no backing service.
-     *
-     * Scope/machine-wide context is resolved here and forwarded so the helper
-     * tears down the right pieces:
-     *   - scope: the installed systemd unit scope (user/system) or 'none'.
-     *   - machineWide: whether the shared /opt machine-wide AppImage exists.
-     * The helper self-elevates (root → direct; non-root → pkexec; declined →
-     * relaunch local), so this spawn stays unelevated. Mirrors the systemd-run
-     * teardown handoff in handleUninstall.
      */
     private async handleAppUninstall(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
         const result = this.factory();
+
+        // win32: spawn the detached Rust uninstall helper (--windows-app-uninstall)
+        // and sacrifice the local instance so it can remove the running install.
+        if (result.platform === 'win32') {
+            const winBody = await readJsonBody(req);
+            const keep = Boolean((winBody as Partial<AppUninstallRequest>).keep);
+
+            const cfg = Config.getInstance();
+            const dataRoot = cfg.dataRoot ?? path.dirname(cfg.dependenciesPath);
+            // Staged operation-server launcher copy: lives under dataRoot
+            // (Velopack-untouchable) so it survives the Program Files removal —
+            // the same copy the win32 service-uninstall handoff + UpdateService
+            // spawn. The current/ launcher would be deleted mid-uninstall.
+            const helper = path.join(dataRoot, 'control', 'operation-server', 'ws-scrcpy-web-launcher.exe');
+            if (!this.existsCheck(helper)) {
+                const failure: ServiceActionFailure = {
+                    ok: false,
+                    error: `uninstall helper not found at ${helper}`,
+                    reason: 'unknown',
+                };
+                res.writeHead(500);
+                res.end(JSON.stringify(failure));
+                return true;
+            }
+
+            // Velopack install root = parent of current/ (where Update.exe lives).
+            // Resolved the same way UpdateService anchors installRoot: at the
+            // webpack bundle location (__dirname = <installRoot>/current/dist), NOT
+            // process.cwd()/execPath (which point inside current/ or the deps tree).
+            const installRoot = path.resolve(__dirname, '..', '..');
+            const updateExe = path.join(installRoot, 'Update.exe');
+
+            // keep=true: reset installMode to null BEFORE spawning so the preserved
+            // config.json comes back up in local mode, not a phantom service mode.
+            // Best-effort — log and proceed; the teardown still goes ahead.
+            if (keep) {
+                try {
+                    cfg.updateAppConfig({ installMode: null });
+                } catch (err) {
+                    log.warn(`app-uninstall(win32): installMode reset failed (continuing): ${(err as Error).message}`);
+                }
+            }
+
+            // Detached spawn of the staged launcher with the raw uninstall argv
+            // (absolute paths only — Local-Dependencies-Only: no PATH/env binary
+            // resolution). Elevation is delegated to Update.exe; this spawn stays
+            // unelevated, mirroring the linux helper's pkexec self-elevation, and
+            // reuses the same spawnDetached seam the linux teardown uses.
+            this.spawnDetached(helper, [
+                '--windows-app-uninstall',
+                keep ? '--keep' : '--wipe',
+                '--data-root', dataRoot,
+                '--update-exe', updateExe,
+            ]);
+            this.scheduleExit(() => {
+                log.info('app-uninstall(win32): local instance exiting → detached teardown');
+                process.exit(0);
+            }, 1_500);
+
+            res.writeHead(200);
+            res.end(JSON.stringify({ ok: true, status: 'uninstalling' }));
+            return true;
+        }
+
         if (result.platform !== 'linux') {
             res.writeHead(200);
-            res.end(JSON.stringify({ ok: false, reason: 'unsupported', error: 'app uninstall is linux-only' }));
+            res.end(JSON.stringify({ ok: false, reason: 'unsupported', error: 'app uninstall is not supported on this platform' }));
             return true;
         }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,6 +30,7 @@ import { ScrcpyConnection } from './ScrcpyConnection';
 import { HttpServer } from './services/HttpServer';
 import type { Service, ServiceClass } from './services/Service';
 import { WebSocketServer } from './services/WebSocketServer';
+import { reapStrayAdbOnWindows } from './shutdownHelpers';
 
 // Velopack JS SDK init must run before any other side-effecting startup logic.
 // In dev mode (no install layout) this returns gracefully without altering state.
@@ -289,6 +290,8 @@ async function gracefulShutdown(): Promise<void> {
     } catch (err) {
         serverLog.warn(`adb kill-server during exit failed: ${(err as Error).message}`);
     }
+    serverLog.info('Stopping stray adb (taskkill) ...');
+    await reapStrayAdbOnWindows();
     runningServices.forEach((service: Service) => {
         const serviceName = service.getName();
         serverLog.info(`Stopping ${serviceName} ...`);

--- a/src/server/shutdownHelpers.ts
+++ b/src/server/shutdownHelpers.ts
@@ -1,0 +1,27 @@
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { execFile } from 'child_process';
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Reap any stray adb.exe processes on Windows via taskkill.
+ *
+ * `adb kill-server` alone leaves stray adb processes when the daemon was
+ * spawned detached (escaping the Node job object) or had stuck transports /
+ * in-flight forwards. This belt-and-braces taskkill catches those. Non-zero
+ * exit (no matching processes) is not an error — swallowed silently.
+ *
+ * No-op on non-Windows platforms.
+ */
+export async function reapStrayAdbOnWindows(): Promise<void> {
+    if (process.platform !== 'win32') {
+        return;
+    }
+    try {
+        await execFileAsync('C:\\Windows\\System32\\taskkill.exe', ['/F', '/IM', 'adb.exe', '/T'], { timeout: 5_000 });
+    } catch {
+        // taskkill exits non-zero when no matching process; treat as success.
+    }
+}

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -701,6 +701,12 @@ dialog.settings-modal .settings-btn-danger {
     border-color: #ff6b6b;
 }
 
+dialog.settings-modal .settings-btn-danger-outline {
+    color: #f06c75;
+    border-color: #f06c75;
+    background: transparent;
+}
+
 dialog.settings-modal .settings-status {
     margin: 0.25rem 0 0;
     color: var(--text-color-light, #888);


### PR DESCRIPTION
Implements the App-section redesign + in-app Windows uninstall (spec/plan: `docs/{specs,plans}/2026-06-08-app-section-redesign-windows-uninstall*`). Built TDD via subagent-driven development, each unit independently verified.

## 1. App-section reorder (both OS)
reset prompts -> install for all users (Linux) -> stop server & exit -> uninstall. install-for-all-users stays Linux-only; **uninstall now shows on both** OSes.

## 2. Uninstall confirm -> overlay modal (both OS)
Inline panel -> top-layer `<dialog>` (`UninstallConfirmModal`) with a **keep my settings & logs** checkbox (defaults to **checked** — the safe option) + white **cancel** / red **uninstall** buttons.

## 3. In-app Windows uninstall (NEW — parity with Linux)
The uninstall button now works on Windows: `ServiceApi` win32 branch -> a new `launcher/src/windows_app_uninstall.rs` helper (mirror of `linux_app_uninstall.rs`) -> `Update.exe --uninstall` (fires the existing `--veloapp-uninstall` hook: service + tray + ARP cleanup) + dataRoot keep/wipe (deps always gone; config + logs per the checkbox).

## 4. Fix Windows "stop server & exit" cleanup
- The tray-supervisor poll thread is now **stopped before the tray reap** (it could otherwise respawn the tray the reap just killed).
- `gracefulShutdown` now also runs `taskkill /F /IM adb.exe /T` to catch stray adb, mirroring the in-app update path.

## Verification (unit-green)
`tsc --noEmit` exit 0; `vitest` **932 passed**; launcher `cargo test` **108+1**, `clippy -D warnings` clean.

## VM-gated — settled on the Win11 smoke (Module 15 in `smoke-full.md`)
- Does `Update.exe --uninstall` self-elevate when launched by the unelevated staged launcher (one UAC)? If not, route the Node spawn through the launcher's `--request-uac` seam (a new `windows-app-uninstall` command).
- On **wipe**, does the dataRoot fully clear despite the running helper in `control\operation-server\` (Windows can't delete a running exe)? If it orphans that dir, add a self-deleting step.
- `Update.exe --uninstall` vs `msiexec /x` for a clean Add/Remove-Programs removal.

`release:beta` -> cuts beta.51 for the VM smoke.