### PR TITLE
fix: system-service install self-copy + smoke-found UI polish (beta.52 smoke)

### DIFF
--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -30,11 +30,12 @@ Boxes start unticked — this is a fresh pass.
 
 ## #6 — First install + the beta.48 port-discovery re-confirm
 
-> Run this batch **first** on the fresh download (breadcrumb step 1). 1.2 + 4.2-user passed on beta.48; the smoke-target leaves that install/service code unchanged, so this is a quick re-confirm on the new binary.
+> Run this batch **first** on the fresh download (breadcrumb step 1). **Order matters — check 4.1 in the no-service window (after 1.2, before 4.2-user): installing any service flips `scopeRadioState.locked`, locking the scope radios read-only, so "system becomes selectable" is only observable before any service exists.** 1.2 + 4.2-user passed on beta.48; the smoke-target leaves that install/service code unchanged, so this is a quick re-confirm.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | ☐ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = the smoke-target version; system `.desktop` present; original `~/Downloads` AppImage **gone** |
+| ☐ **4.1** `[L]` System-scope gate un-greys | **Before installing any service** (a service install flips `scopeRadioState.locked` → radios go read-only; see 4.4): Settings → service → select **system** scope | Now **selectable** + its install **un-greyed** now that you're machine-wide; was gated *"requires installing system-wide for all users first"* before 1.2 |
 | ☐ **4.2-user** `[L]` Install user service | Settings → service → **user** scope → install (no elevation) | Service active on 8000; stable ExecStart; **no "port discovery timed out"** (the beta.48 fix) |
 
 ## #7 — Current install checks ▶ active *(machine-wide + user-service in place, no teardown)*
@@ -43,8 +44,7 @@ Boxes start unticked — this is a fresh pass.
 |---|---|---|
 | ☐ **2.1** `[L]` Binary/deps labels | `ls -Z /opt/ws-scrcpy-web` | → **bin_t** — `VERSION` + `WsScrcpyWeb.AppImage` both `unconfined_u:object_r:bin_t:s0` |
 | ☐ **2.4** `[L]` Zero AVC | Watch `sudo journalctl -f \| grep -i avc` across the installs | **No** AVC denials |
-| ☐ **4.1** `[L]` System-scope gate | Settings → service → pick **system** scope | Now **enabled** (was greyed before machine-wide); user scope available in both modes |
-| ☐ **4.4** `[L]` Scope-radio legibility | Reopen Settings | Selected dot a **clear blue**; radios non-interactive (`pointer-events:none` + `tabindex=-1`, **not** `disabled`); **user** scope shown selected |
+| ☐ **4.4** `[L]` Scope-radio legibility *(locked-radios state — counterpart to 4.1)* | Reopen Settings | Selected dot a **clear blue**; radios non-interactive (`pointer-events:none` + `tabindex=-1`, **not** `disabled`); **user** scope shown selected |
 | ☐ **4.5** `[B]` Confirm-dialog buttons | Open the install/uninstall "privileges required" confirm | Cancel/confirm are **white-outline + white-text** |
 | ☐ **4.6** `[L]` Unit hygiene | `journalctl --user -u WsScrcpyWeb`; `pgrep -fa WsScrcpyWeb` | **No** `Unknown key 'StartLimitIntervalSec'`; **only the service** runs (no leftover home instance); no false timeout toast |
 | ☐ **3.2** `[L]` Single-instance flock | Launch a 2nd copy from `/opt` **and** from `~/Downloads` | 2nd launch **blocked** (flock on `$XDG_RUNTIME_DIR`); no 2nd server; existing URL opens |

--- a/launcher/src/linux_app_uninstall.rs
+++ b/launcher/src/linux_app_uninstall.rs
@@ -335,14 +335,7 @@ fn run_unelevated(a: &UninstallArgs) -> i32 {
             // DIRECTLY, best-effort (mirrors linux_service::run / the user_owned
             // loop). No relaunch — a complete uninstall never relaunches.
             log::info("uninstall: already root (system-service) — running privileged group directly");
-            for argv in &plan.privileged {
-                let (cmd, rest) = argv.split_first().expect("non-empty argv");
-                match std::process::Command::new(cmd).args(rest).status() {
-                    Ok(s) if s.success() => log::info(&format!("uninstall (root) ok: {}", argv.join(" "))),
-                    Ok(s) => log::error(&format!("uninstall (root) non-zero ({:?}): {}", s.code(), argv.join(" "))),
-                    Err(e) => log::error(&format!("uninstall (root) spawn failed: {} ({e})", argv.join(" "))),
-                }
-            }
+            run_best_effort(&plan.privileged, "uninstall (root)");
         }
         PrivMode::Pkexec => {
             let pkexec = format!("{}/pkexec", tool_dir("pkexec"));
@@ -406,14 +399,7 @@ fn run_unelevated(a: &UninstallArgs) -> i32 {
 
     // 2. Unelevated group (kills our own processes + tears down the user data
     //    root). Best-effort: log non-zero, KEEP GOING (mirrors linux_service::run).
-    for argv in plan.user_owned {
-        let (cmd, rest) = argv.split_first().expect("non-empty argv");
-        match std::process::Command::new(cmd).args(rest).status() {
-            Ok(s) if s.success() => log::info(&format!("uninstall ok: {}", argv.join(" "))),
-            Ok(s) => log::error(&format!("uninstall non-zero ({:?}): {}", s.code(), argv.join(" "))),
-            Err(e) => log::error(&format!("uninstall spawn failed: {} ({e})", argv.join(" "))),
-        }
-    }
+    run_best_effort(&plan.user_owned, "uninstall");
     0
 }
 
@@ -426,15 +412,22 @@ fn run_elevated(a: &UninstallArgs) -> i32 {
         a.svc_scope, a.machine_wide, a.keep
     ));
     let plan = plan_for(a);
-    for argv in plan.privileged {
+    run_best_effort(&plan.privileged, "uninstall (root)");
+    0
+}
+
+/// Run a best-effort command group: log each step's outcome and KEEP GOING on
+/// failure (never aborts the teardown). `label` distinguishes the privileged
+/// (root) group from the user-owned group in the log lines.
+fn run_best_effort(group: &[Vec<String>], label: &str) {
+    for argv in group {
         let (cmd, rest) = argv.split_first().expect("non-empty argv");
         match std::process::Command::new(cmd).args(rest).status() {
-            Ok(s) if s.success() => log::info(&format!("uninstall (root) ok: {}", argv.join(" "))),
-            Ok(s) => log::error(&format!("uninstall (root) non-zero ({:?}): {}", s.code(), argv.join(" "))),
-            Err(e) => log::error(&format!("uninstall (root) spawn failed: {} ({e})", argv.join(" "))),
+            Ok(s) if s.success() => log::info(&format!("{label} ok: {}", argv.join(" "))),
+            Ok(s) => log::error(&format!("{label} non-zero ({:?}): {}", s.code(), argv.join(" "))),
+            Err(e) => log::error(&format!("{label} spawn failed: {} ({e})", argv.join(" "))),
         }
     }
-    0
 }
 
 /// How `run_unelevated` runs the privileged teardown group — the

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -255,6 +255,15 @@ fn home_for_uid(uid: u32) -> Option<String> {
     String::from_utf8_lossy(&out.stdout).lines().next()?.split(':').nth(5).map(str::to_string)
 }
 
+/// A non-zero exit from a teardown step is benign — WARN, not ERROR — only for
+/// `reset-failed`: systemctl returns non-zero there when the unit isn't in a
+/// failed state, which is the normal case after a clean stop+disable. Every
+/// other step's non-zero is a genuine teardown error. (Mirrors the
+/// benign-error pattern in supervisor.rs's helper-refresh ETXTBSY handling.)
+fn teardown_failure_is_benign(argv: &[String]) -> bool {
+    argv.iter().any(|a| a == "reset-failed")
+}
+
 fn run(scope: Scope, unit: &str) -> i32 {
     let bd = tool_dir("systemctl");
     log::info(&format!("linux-service-teardown: scope={scope:?} unit={unit}"));
@@ -264,6 +273,13 @@ fn run(scope: Scope, unit: &str) -> i32 {
         let (cmd, rest) = argv.split_first().expect("non-empty argv");
         match std::process::Command::new(cmd).args(rest).status() {
             Ok(s) if s.success() => log::info(&format!("teardown ok: {}", argv.join(" "))),
+            // `reset-failed` exits non-zero when the unit isn't in a failed state
+            // (the normal case after a clean stop+disable) — benign, log at WARN.
+            Ok(s) if teardown_failure_is_benign(&argv) => log::warn(&format!(
+                "teardown: {} exited {:?} (benign — unit was not in a failed state)",
+                argv.join(" "),
+                s.code()
+            )),
             Ok(s) => log::error(&format!("teardown non-zero ({:?}): {}", s.code(), argv.join(" "))),
             Err(e) => log::error(&format!("teardown spawn failed: {} ({e})", argv.join(" "))),
         }
@@ -482,6 +498,29 @@ fn read_local_appimage_marker() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reset_failed_nonzero_is_benign() {
+        // systemctl reset-failed exits non-zero when the unit isn't failed —
+        // the normal case after a clean stop+disable; must NOT log as ERROR.
+        let argv = ["/usr/bin/systemctl", "--user", "reset-failed", "WsScrcpyWeb.service"]
+            .map(String::from)
+            .to_vec();
+        assert!(teardown_failure_is_benign(&argv));
+    }
+
+    #[test]
+    fn other_teardown_steps_nonzero_are_real_errors() {
+        for step in ["stop", "disable", "daemon-reload"] {
+            let argv = ["/usr/bin/systemctl", "--user", step, "WsScrcpyWeb.service"]
+                .map(String::from)
+                .to_vec();
+            assert!(
+                !teardown_failure_is_benign(&argv),
+                "{step} non-zero should be a real error, not benign"
+            );
+        }
+    }
 
     #[test]
     fn user_scope_teardown_sequence() {

--- a/launcher/src/windows_app_uninstall.rs
+++ b/launcher/src/windows_app_uninstall.rs
@@ -92,31 +92,33 @@ pub struct UninstallArgs {
 /// validation contract). Returning `None` signals the caller to log an error
 /// and return exit code 2.
 pub fn parse_args(args: &[String]) -> Option<UninstallArgs> {
-    // --keep XOR --wipe (exactly one required)
-    let keep = match (
+    let keep = parse_keep_flag(args)?;
+    let data_root = flag_value(args, "--data-root")?;
+    let update_exe = flag_value(args, "--update-exe")?;
+
+    Some(UninstallArgs { update_exe, data_root, keep })
+}
+
+/// Exactly one of `--keep` / `--wipe`. `Some(true)` = keep, `Some(false)` =
+/// wipe, `None` if neither or both are present (invalid).
+fn parse_keep_flag(args: &[String]) -> Option<bool> {
+    match (
         args.iter().any(|a| a == "--keep"),
         args.iter().any(|a| a == "--wipe"),
     ) {
-        (true, false) => true,
-        (false, true) => false,
-        _ => return None,
-    };
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        _ => None,
+    }
+}
 
-    // --data-root <abs path> (required)
-    let data_root = args
-        .iter()
-        .position(|a| a == "--data-root")
+/// Value following `flag` in `args` (e.g. the path after `--data-root`).
+/// `None` if the flag is absent or has no following value.
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
         .and_then(|i| args.get(i + 1))
-        .cloned()?;
-
-    // --update-exe <abs path> (required)
-    let update_exe = args
-        .iter()
-        .position(|a| a == "--update-exe")
-        .and_then(|i| args.get(i + 1))
-        .cloned()?;
-
-    Some(UninstallArgs { update_exe, data_root, keep })
+        .cloned()
 }
 
 /// Parsed `--windows-app-uninstall-run` invocation (the Phase-2 cleaner).
@@ -152,29 +154,10 @@ pub fn parse_run_args(args: &[String]) -> Option<RunArgs> {
     if !args.iter().any(|a| a == "--windows-app-uninstall-run") {
         return None;
     }
-    let keep = match (
-        args.iter().any(|a| a == "--keep"),
-        args.iter().any(|a| a == "--wipe"),
-    ) {
-        (true, false) => true,
-        (false, true) => false,
-        _ => return None,
-    };
-    let wait_pid = args
-        .iter()
-        .position(|a| a == "--wait-pid")
-        .and_then(|i| args.get(i + 1))
-        .and_then(|s| s.parse::<u32>().ok())?;
-    let data_root = args
-        .iter()
-        .position(|a| a == "--data-root")
-        .and_then(|i| args.get(i + 1))
-        .cloned()?;
-    let update_exe = args
-        .iter()
-        .position(|a| a == "--update-exe")
-        .and_then(|i| args.get(i + 1))
-        .cloned()?;
+    let keep = parse_keep_flag(args)?;
+    let wait_pid = flag_value(args, "--wait-pid").and_then(|s| s.parse::<u32>().ok())?;
+    let data_root = flag_value(args, "--data-root")?;
+    let update_exe = flag_value(args, "--update-exe")?;
     Some(RunArgs { wait_pid, update_exe, data_root, keep })
 }
 
@@ -234,10 +217,11 @@ fn remove_targets(targets: &[String], attempts: u32) {
     let attempts = attempts.max(1);
     for target in targets {
         let path = std::path::Path::new(target);
-        let mut last_err: Option<std::io::Error> = None;
+        // Ok(true) = we removed it; Ok(false) = it was already absent; Err = failed.
+        let mut outcome: Result<bool, std::io::Error> = Ok(false);
         for attempt in 0..attempts {
             if !path.exists() {
-                last_err = None;
+                outcome = Ok(false);
                 break;
             }
             let result = if path.is_dir() {
@@ -247,20 +231,23 @@ fn remove_targets(targets: &[String], attempts: u32) {
             };
             match result {
                 Ok(()) => {
-                    last_err = None;
+                    outcome = Ok(true);
                     break;
                 }
                 Err(e) => {
-                    last_err = Some(e);
+                    outcome = Err(e);
                     if attempt + 1 < attempts {
                         std::thread::sleep(std::time::Duration::from_millis(500));
                     }
                 }
             }
         }
-        match last_err {
-            None => log::info(&format!("windows-app-uninstall: removed {target}")),
-            Some(e) => log::error(&format!(
+        match outcome {
+            Ok(true) => log::info(&format!("windows-app-uninstall: removed {target}")),
+            Ok(false) => log::info(&format!(
+                "windows-app-uninstall: {target} already absent — nothing to remove"
+            )),
+            Err(e) => log::error(&format!(
                 "windows-app-uninstall: could not remove {target}: {e}"
             )),
         }

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -33,7 +33,6 @@ describe('system-scope staging', () => {
 
 describe('buildSystemInstallScript', () => {
     const args = {
-        sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
         unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
         unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
         name: 'WsScrcpyWeb',
@@ -41,7 +40,6 @@ describe('buildSystemInstallScript', () => {
 
     it('stages the launcher helper into /opt alongside the AppImage (bin_t via the fcontext rule)', () => {
         const script = buildSystemInstallScript({
-            sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
             sourceHelper: '/home/u/.local/share/WsScrcpyWeb/control/operation-server/ws-scrcpy-web-launcher.exe',
             unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
             unitPath: '/etc/systemd/system/WsScrcpyWeb.service',
@@ -56,15 +54,15 @@ describe('buildSystemInstallScript', () => {
 
     it('omits the helper cp when no sourceHelper is provided (from-source / unavailable)', () => {
         const script = buildSystemInstallScript({
-            sourceAppImage: '/a.AppImage', unitTmpPath: '/t', unitPath: '/u', name: 'WsScrcpyWeb',
+            unitTmpPath: '/t', unitPath: '/u', name: 'WsScrcpyWeb',
         });
         expect(script).not.toContain('ws-scrcpy-web-launcher.exe');
     });
 
-    it('stages the AppImage to /opt, chmods, labels bin_t, then installs the unit', () => {
+    it('prepares /opt, chmods the (already-staged) binary, labels bin_t, then installs the unit', () => {
         const script = buildSystemInstallScript(args);
         expect(script).toContain('mkdir -p /opt/ws-scrcpy-web');
-        expect(script).toContain('cp "/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        // the AppImage is NOT re-copied (machine-wide precondition) — only chmod'd
         expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
         expect(script).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
         expect(script).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
@@ -96,7 +94,6 @@ describe('buildSystemInstallScript', () => {
 
     it('copies the user deps into /opt and seeds the data config (#36)', () => {
         const script = buildSystemInstallScript({
-            sourceAppImage: '/home/u/Apps/WsScrcpyWeb-linux-beta.AppImage',
             sourceDeps: '/home/u/.local/share/WsScrcpyWeb/dependencies',
             seedConfigTmpPath: '/tmp/WsScrcpyWeb.seed.json',
             unitTmpPath: '/tmp/WsScrcpyWeb.service.tmp',
@@ -123,6 +120,17 @@ describe('buildSystemInstallScript', () => {
         expect(script).not.toContain('cp -a');
         expect(script).not.toContain('config.json');
     });
+
+    it('does NOT stage/copy the AppImage into /opt (machine-wide is a precondition — the binary is already there, so copying self-copies)', () => {
+        // The system-service install is gated behind a machine-wide install, so
+        // /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage already exists AND is the
+        // running binary ($APPIMAGE). Re-staging it is a `cp X X` self-copy that
+        // GNU cp refuses ("are the same file"), aborting the pkexec script. The
+        // install must not copy the AppImage — the unit's ExecStart already
+        // points at the existing /opt binary.
+        const script = buildSystemInstallScript(args);
+        expect(script).not.toMatch(/cp\s+"[^"]*"\s+"\/opt\/ws-scrcpy-web\/WsScrcpyWeb\.AppImage"/);
+    });
 });
 
 describe('SYSTEM_STATE_DIR — FHS /var/opt retargeting', () => {
@@ -143,7 +151,7 @@ describe('SYSTEM_STATE_DIR — FHS /var/opt retargeting', () => {
 
     it('system install seeds config + labels state under /var/opt (var_lib_t)', () => {
         const script = buildSystemInstallScript(
-            { sourceAppImage: '/home/u/App.AppImage', seedConfigTmpPath: '/tmp/seed.json',
+            { seedConfigTmpPath: '/tmp/seed.json',
               unitTmpPath: '/tmp/u.service', unitPath: '/etc/systemd/system/WsScrcpyWeb.service', name: 'WsScrcpyWeb' },
             (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
         );

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -288,7 +288,6 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
  */
 export function buildSystemInstallScript(
     args: {
-        sourceAppImage: string;
         sourceHelper?: string;
         sourceDeps?: string;
         seedConfigTmpPath?: string;
@@ -316,7 +315,12 @@ export function buildSystemInstallScript(
         //    The deps dir is added below only when we have deps to copy.
         `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
         `${mkdir} -p ${SYSTEM_STATE_DIR}`,
-        `${cp} "${args.sourceAppImage}" "${staged}"`,
+        // The AppImage is intentionally NOT staged here. A system-service install
+        // is gated on a prior machine-wide install (systemServiceInstallGate), so
+        // /opt/ws-scrcpy-web/WsScrcpyWeb.AppImage already exists AND is the running
+        // binary — copying it onto itself is a `cp X X` self-copy that GNU cp
+        // refuses ("are the same file"), aborting the pkexec script. We only ensure
+        // it's executable; the unit's ExecStart points at this existing /opt binary.
         `${chmod} 0755 "${staged}"`,
     ];
     // 1b. optionally stage the teardown helper alongside the AppImage so the
@@ -705,7 +709,6 @@ export class SystemdClient implements ServiceClient {
             }
             try {
                 const cmd = buildSystemInstallScript({
-                    sourceAppImage: opts.binPath,
                     ...(opts.linuxHelperSource ? { sourceHelper: opts.linuxHelperSource } : {}),
                     ...(opts.sourceDeps ? { sourceDeps: opts.sourceDeps } : {}),
                     ...(seedTmpFile ? { seedConfigTmpPath: seedTmpFile } : {}),

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -575,6 +575,22 @@ dialog.settings-modal .settings-row {
     display: contents;
 }
 
+/*
+ * Error rows stretch out. The error message is rendered on the row's label,
+ * which normally lives in the fixed 20rem [labels] column — too narrow for the
+ * longer service/update errors. When a row's label carries .settings-status-error,
+ * lift the whole row out of `display: contents` into a full-width block spanning
+ * both columns so the error wraps across the full width; the retry/save button
+ * drops beneath it. (Status notes already span via grid-column:1/-1 on a <p>.)
+ */
+dialog.settings-modal .settings-row:has(.settings-status-error) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    grid-column: 1 / -1;
+}
+
 dialog.settings-modal .settings-label {
     grid-column: labels;
     color: var(--text-color-light, #888);

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -645,12 +645,12 @@ dialog.settings-modal .settings-control .settings-radio-label.settings-radio-loc
  * than .settings-btn-primary so it overrides when both classes are
  * present (used in the Updates section's dual-purpose button).
  */
-dialog.settings-modal .settings-btn.settings-btn-ready {
+dialog.modal .settings-btn.settings-btn-ready {
     color: #4caf50;
     border-color: #4caf50;
 }
 
-dialog.settings-modal .settings-btn.settings-btn-ready:hover {
+dialog.modal .settings-btn.settings-btn-ready:hover {
     background: rgba(76, 175, 80, 0.08);
 }
 
@@ -676,7 +676,7 @@ dialog.settings-modal .settings-input:focus {
     border-color: rgba(0, 0, 0, 0.15);
 }
 
-dialog.settings-modal .settings-btn {
+dialog.modal .settings-btn {
     border: 0.5px solid var(--text-color, #ddd);
     border-radius: 6px;
     background: transparent;
@@ -686,22 +686,22 @@ dialog.settings-modal .settings-btn {
     font: inherit;
 }
 
-dialog.settings-modal .settings-btn:disabled {
+dialog.modal .settings-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
 
-dialog.settings-modal .settings-btn-primary {
+dialog.modal .settings-btn-primary {
     color: #5b9aff;
     border-color: #5b9aff;
 }
 
-dialog.settings-modal .settings-btn-danger {
+dialog.modal .settings-btn-danger {
     color: #ff6b6b;
     border-color: #ff6b6b;
 }
 
-dialog.settings-modal .settings-btn-danger-outline {
+dialog.modal .settings-btn-danger-outline {
     color: #f06c75;
     border-color: #f06c75;
     background: transparent;

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -709,9 +709,15 @@ dialog.modal .settings-btn-danger-outline {
 
 dialog.settings-modal .settings-status {
     margin: 0.25rem 0 0;
+    /* Notes + status read as sub-text of the setting they annotate: indented +
+       bold-italic to set them apart. Errors add red via .settings-status-error
+       (layered on top, so they inherit this indent/weight/style). */
+    padding-left: 1.25rem;
     color: var(--text-color-light, #888);
     font-size: 13px;
     min-height: 1em;
+    font-style: italic;
+    font-weight: 600;
 }
 
 dialog.settings-modal .settings-status-error {
@@ -730,9 +736,11 @@ dialog.settings-modal .settings-status-ready {
 
 dialog.settings-modal .settings-stub-note {
     margin: 0;
+    padding-left: 1.25rem;
     color: var(--text-color-light, #888);
     font-size: 13px;
     font-style: italic;
+    font-weight: 600;
 }
 
 /*


### PR DESCRIPTION
Fixes found during the beta.52 Linux smoke (Fedora VM). The headline is a P0 that blocked system-service install entirely; the rest is smoke-found polish folded into the same beta.

## P0 — system-service install was unconditionally broken
System-service install is gated on a prior machine-wide install, so the running binary is always the `/opt` copy. `buildSystemInstallScript` then `cp`'d that binary onto itself — `cp X X`, which GNU cp refuses ("are the same file") — aborting the pkexec script every time. It no longer stages the AppImage (the unit `ExecStart` already points at the existing `/opt` binary); the now-unused `sourceAppImage` param is dropped. Regression test added.

## Polish
- **49** — Linux service teardown logged `reset-failed`'s benign non-zero as ERROR (it returns non-zero when the unit isn't failed — the normal case after stop+disable). Now WARN, with a tested classifier.
- **46** — dedup the uninstall best-effort exec loop (`run_best_effort`) and the windows arg parsing (`parse_keep_flag`/`flag_value`); `remove_targets` distinguishes already-absent vs removed.
- **47** — settings contextual notes + status/error text render indented + bold-italic (white for status, red for errors).
- **48** — the shared `.settings-btn` styles were scoped to the settings modal, so `UninstallConfirmModal`'s buttons rendered as unstyled UA defaults; broadened to `dialog.modal`.
- **error layout** — settings errors render on the row label (stuck in the fixed 20rem labels column) and cramped; error rows now span full-width.
- **docs** — smoke run-sheet 4.1 reorder (it was sequenced after the service install, but installing locks the scope radios).

## Verification
`tsc` 0 · `vitest` 933 · `cross clippy -D warnings` 0 (linux) · `cargo test` + `clippy` 0 (windows). The CSS items visual-confirm on the beta.53 re-smoke.