### PR TITLE
fix(linux): menu icon + shortcut relaunch-reopen (beta.53 re-smoke)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Linux app-menu shortcut now shows the app icon** instead of a blank placeholder. The machine-wide install resolved the menu icon from a `$APPDIR/.DirIcon` path that vpk's AppImage doesn't actually provide, so it never installed; the icon now ships bundled (`tray-icon.png`, resolved next to `package.json` like the version file) and installs reliably into the hicolor theme.
+- **Clicking the Linux app-menu shortcut while the app is already running now reopens it** — it opens the running instance's URL in the browser instead of doing nothing. Previously only an active *system* service reopened; a user-scope service or a running local instance silently no-op'd.
+
 ## [0.1.30-beta.53] - 2026-06-09
 
 ### Fixed

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -324,6 +324,26 @@ fn main() {
         Ok(Some(guard)) => Some(guard),
         Ok(None) => {
             log::info("another ws-scrcpy-web-launcher instance is already running; exiting");
+            // §item50: reopen the running instance in the browser rather than a
+            // silent no-op — clicking the .desktop shortcut (or any second launch)
+            // should bring the app back up, not do nothing. Linux only: the running
+            // instance wrote its port to the per-user dataRoot config, so we open
+            // http://localhost:<port>. An active *system* service is handled by the
+            // defer block earlier in main(); this covers user-service + local-instance
+            // launches. (Windows keeps the no-op — the hidden-console launcher has no
+            // window/IPC channel to the original instance.)
+            #[cfg(target_os = "linux")]
+            {
+                if let Some(dr) = common::config::data_root_from_env() {
+                    let cfg = common::config::AppConfig::load(&dr);
+                    if let Some(port) = cfg.web_port {
+                        let url = format!("http://localhost:{port}");
+                        log::info(&format!("reopening already-running instance at {url}"));
+                        let xdg = format!("{}/xdg-open", linux_service::tool_dir("xdg-open"));
+                        let _ = std::process::Command::new(&xdg).arg(&url).status();
+                    }
+                }
+            }
             std::process::exit(0);
         }
         Err(e) => {

--- a/scripts/stage-publish.mjs
+++ b/scripts/stage-publish.mjs
@@ -123,6 +123,20 @@ function main() {
         copyFileSync(pkgLock, join(PUBLISH, 'package-lock.json')),
     );
 
+    // 5b. Linux menu icon — bundle the 256x256 tray-icon.png alongside
+    // package.json so the machine-wide install can copy it into the hicolor theme
+    // for the system .desktop entry (Icon=ws-scrcpy-web). Resolved at runtime via
+    // path.resolve(__dirname, '..', 'tray-icon.png') — the same bundled-file pattern
+    // getAppVersion() uses for package.json. (vpk's --icon embeds the icon in the
+    // AppImage too, but that copy is NOT reliably reachable as $APPDIR/.DirIcon —
+    // the prior approach, which left the menu icon blank.)
+    const trayIcon = join(REPO_ROOT, 'assets', 'tray-icon.png');
+    if (existsSync(trayIcon)) {
+        step('Copy tray-icon.png', () => copyFileSync(trayIcon, join(PUBLISH, 'tray-icon.png')));
+    } else {
+        console.log('  tray-icon.png skip (assets/tray-icon.png not present)');
+    }
+
     // 6. Install production deps into publish/.
     // execFileSync with explicit args array — no user input, no injection
     // surface. cmd.exe wrapper avoids the .cmd-execFile restriction

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -840,16 +840,17 @@ export class ServiceApi {
             return true;
         }
         const version = getAppVersion();
-        // Resolve the launcher icon from the mounted AppImage so the machine-wide
-        // install can drop it into the hicolor theme (the system .desktop entry
-        // references `Icon=ws-scrcpy-web`). vpk embeds the icon as the AppImage's
-        // `.DirIcon` (built from `--icon assets/tray-icon.png`); `$APPDIR` is the
-        // FUSE-mount root of the running AppImage. This in-AppImage path is a
-        // runtime assumption (vpk's AppDir layout) verified in the smoke; the
-        // script's cp is best-effort, so a miss never fails the install. Gated on
-        // `$APPDIR` being set — when absent the icon step is skipped entirely.
-        const appDir = process.env['APPDIR'];
-        const iconSource = appDir ? path.join(appDir, '.DirIcon') : undefined;
+        // Resolve the launcher icon for the system .desktop entry (Icon=ws-scrcpy-web)
+        // so the machine-wide install can copy it into the hicolor theme. The icon is
+        // BUNDLED next to package.json (stage-publish.mjs copies assets/tray-icon.png →
+        // publish/tray-icon.png), resolved the same way getAppVersion() finds
+        // package.json: `path.resolve(__dirname, '..')` is the app root in both the
+        // packaged (<installRoot>/current/) and dev layouts. This replaces the prior
+        // `$APPDIR/.DirIcon` approach, which assumed a vpk AppDir layout that doesn't
+        // hold — the icon never installed and the menu entry stayed blank (item 51).
+        // The install script's cp is still best-effort, so a miss never fails install.
+        const bundledIcon = path.resolve(__dirname, '..', 'tray-icon.png');
+        const iconSource = fs.existsSync(bundledIcon) ? bundledIcon : undefined;
         const script = buildMachineWideInstallScript({ sourceAppImage: appImage, version, iconSource });
         try {
             await this.runPkexecFn(script, 'install-system-wide');

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -410,9 +410,9 @@ export function buildMachineWideInstallScript(
     ];
     // Install the launcher icon into the hicolor theme so the .desktop's
     // `Icon=ws-scrcpy-web` resolves to a real icon instead of a generic
-    // placeholder. The icon ships embedded in the AppImage (vpk `--icon
-    // assets/tray-icon.png` → the AppImage's `.DirIcon`); the caller passes its
-    // mounted path. Omitted (graceful skip) when no `iconSource` is supplied.
+    // placeholder. The caller (ServiceApi) passes `iconSource` = the bundled
+    // tray-icon.png (publish/tray-icon.png, resolved via __dirname — same pattern
+    // as getAppVersion's package.json). Omitted (graceful skip) when absent.
     // Wrapped in ONE best-effort group (trailing `|| true`, like the SELinux line
     // above): POSIX sh gives `&&`/`||` EQUAL left-assoc precedence, so a missing
     // `.DirIcon` (cp fails) must not break the outer `&&` chain and skip the


### PR DESCRIPTION
Two Linux shortcut bugs found in the beta.53 re-smoke (test 1.2).

**Blank menu icon (item 51).** The machine-wide install resolved the menu icon from `$APPDIR/.DirIcon` — a vpk AppDir-layout assumption that doesn't hold, so the best-effort `cp` failed and `/usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png` never existed; `Icon=ws-scrcpy-web` rendered blank. Now `tray-icon.png` (the 256x256 PNG vpk already uses) ships bundled in `publish/`, resolved via `path.resolve(__dirname, '..')` — the same pattern `getAppVersion()` uses for `package.json` — so the install has a guaranteed-present source.

**Shortcut does nothing when already running (item 50).** Clicking the `.desktop` while the app was up silently `exit(0)`'d: browser-reopen only fired for an active *system* service (`service_defer_url` matches `"system-service"`, config from `/var/opt`), so a user-scope service or a running local instance fell through to the single-instance `None` branch with no reopen. `main.rs` now reads the running port from the per-user config on lock-held and `xdg-open`s its URL.

Gates: `tsc` 0 · `vitest` 933 · `cross clippy -D warnings` 0 (linux) · `cargo check` 0 (windows). Runtime behavior confirms on the beta.54 re-smoke.