### PR TITLE
fix(linux): stage menu icon to a root-readable temp (item 51, take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Linux app-menu icon now actually renders** (completing the beta.54 fix). beta.54 bundled the icon correctly, but the machine-wide install runs as root (`pkexec`) and can't read it from the *per-user FUSE-mounted* AppImage — the privileged `cp` failed silently and the menu entry stayed blank. The icon is now staged to a root-readable temp (`os.tmpdir()`) before the install copies it into the hicolor theme.
+
 ## [0.1.30-beta.54] - 2026-06-09
 
 ### Fixed

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -840,17 +840,29 @@ export class ServiceApi {
             return true;
         }
         const version = getAppVersion();
-        // Resolve the launcher icon for the system .desktop entry (Icon=ws-scrcpy-web)
-        // so the machine-wide install can copy it into the hicolor theme. The icon is
-        // BUNDLED next to package.json (stage-publish.mjs copies assets/tray-icon.png →
-        // publish/tray-icon.png), resolved the same way getAppVersion() finds
-        // package.json: `path.resolve(__dirname, '..')` is the app root in both the
-        // packaged (<installRoot>/current/) and dev layouts. This replaces the prior
-        // `$APPDIR/.DirIcon` approach, which assumed a vpk AppDir layout that doesn't
-        // hold — the icon never installed and the menu entry stayed blank (item 51).
-        // The install script's cp is still best-effort, so a miss never fails install.
+        // Launcher icon for the system .desktop entry (Icon=ws-scrcpy-web). It ships
+        // BUNDLED next to package.json (stage-publish.mjs → publish/tray-icon.png),
+        // resolved like getAppVersion() finds package.json: path.resolve(__dirname, '..').
+        //
+        // CRITICAL: the install runs as ROOT (pkexec), but we run from a per-user
+        // FUSE-mounted AppImage — and root CANNOT read that mount (mounts are private
+        // to the mounting user; no allow_other/allow_root). Handing root a mount-path
+        // iconSource makes the privileged `cp` fail silently → blank menu icon (item 51,
+        // confirmed in the smoke: `sudo test -r <mount>/usr/bin/tray-icon.png` → cannot
+        // read). Fix: WE (the mounting user) copy the icon to a root-readable temp in
+        // os.tmpdir() first; the install script copies from there into the hicolor theme.
+        // Removed in `finally`. Best-effort throughout — a miss never fails the install.
         const bundledIcon = path.resolve(__dirname, '..', 'tray-icon.png');
-        const iconSource = fs.existsSync(bundledIcon) ? bundledIcon : undefined;
+        let iconSource: string | undefined;
+        if (fs.existsSync(bundledIcon)) {
+            try {
+                const stagedIcon = path.join(os.tmpdir(), `ws-scrcpy-web-menu-icon-${process.pid}.png`);
+                fs.copyFileSync(bundledIcon, stagedIcon);
+                iconSource = stagedIcon;
+            } catch {
+                iconSource = undefined;
+            }
+        }
         const script = buildMachineWideInstallScript({ sourceAppImage: appImage, version, iconSource });
         try {
             await this.runPkexecFn(script, 'install-system-wide');
@@ -884,6 +896,12 @@ export class ServiceApi {
             const declined = /dismissed/i.test(msg);
             res.writeHead(declined ? 403 : 500);
             res.end(JSON.stringify({ ok: false, error: msg, reason: declined ? 'uac-declined' : 'unknown' }));
+        } finally {
+            // Remove the root-readable temp icon (best-effort; the privileged install
+            // script has already copied it into the hicolor theme by now).
+            if (iconSource) {
+                try { fs.rmSync(iconSource, { force: true }); } catch { /* best-effort */ }
+            }
         }
         return true;
     }

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -410,9 +410,10 @@ export function buildMachineWideInstallScript(
     ];
     // Install the launcher icon into the hicolor theme so the .desktop's
     // `Icon=ws-scrcpy-web` resolves to a real icon instead of a generic
-    // placeholder. The caller (ServiceApi) passes `iconSource` = the bundled
-    // tray-icon.png (publish/tray-icon.png, resolved via __dirname — same pattern
-    // as getAppVersion's package.json). Omitted (graceful skip) when absent.
+    // placeholder. The caller (ServiceApi) stages the bundled tray-icon.png to a
+    // root-readable temp (os.tmpdir()) and passes THAT as `iconSource` — the pkexec
+    // cp runs as root, which can't read the user's FUSE-mounted AppImage. Omitted
+    // (graceful skip) when absent.
     // Wrapped in ONE best-effort group (trailing `|| true`, like the SELinux line
     // above): POSIX sh gives `&&`/`||` EQUAL left-assoc precedence, so a missing
     // `.DirIcon` (cp fails) must not break the outer `&&` chain and skip the


### PR DESCRIPTION
Take 2 on the blank Linux menu icon (item 51) — root cause nailed in the beta.54 re-smoke.

beta.54 correctly bundled `tray-icon.png` into the AppImage (`usr/bin/tray-icon.png` in the mount) and resolved it via `path.resolve(__dirname, '..')`. But the machine-wide install runs as **root** (`pkexec`), and the AppImage is mounted on a **per-user FUSE mount root can't read** (mounts are private to the mounting user — no `allow_other`/`allow_root`). Confirmed on the VM: `sudo test -r <mount>/usr/bin/tray-icon.png` -> cannot read. So the privileged `cp` failed silently and the icon never landed in the hicolor theme — same failure mode as the original `.DirIcon` approach.

Fix: `ServiceApi.handleInstallSystemWide` runs **as the user** (it can read the mount), so it copies the bundled icon to a **root-readable temp** (`os.tmpdir()`) before building the pkexec script; the install copies from there. Removed in `finally`.

TS-only. Gates: `tsc` 0 · `vitest` 933. Confirms at re-smoke test 1.2 (menu icon renders).