### PR TITLE
feat(ui): browser-tab favicon + KDE menu-icon cache refresh (beta.56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The browser tab now shows the app's favicon** (derived from the app icon). The page had no favicon before, so the tab showed a generic/blank icon.
+
+### Fixed
+
+- **The Linux app-menu icon now appears immediately after a machine-wide install on KDE.** beta.55 installed the icon correctly, but KDE's launcher keeps a per-user icon cache that doesn't refresh on its own — so the install now rebuilds it (`kbuildsycoca` + clears the stale per-user icon cache) as your user, with no manual cache-clear or re-login needed. (No-op on GNOME/others, where the system icon-cache refresh already covers it.)
+
 ## [0.1.30-beta.55] - 2026-06-09
 
 ### Fixed

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Android Power Tools</title>
+    <link rel="icon" type="image/png" href="favicon.png">
     <link rel="stylesheet" href="bundle.css">
 </head>
 <body>

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1394,8 +1394,10 @@ describe('ServiceApi', () => {
                 const scheduleExit = vi.fn();
                 let spawnedArgs: string[] = [];
                 const spawnDetached = vi.fn((_cmd: string, args: string[]) => { spawnedArgs = args; });
-                // existsCheck → relaunch helper present, so F5 hands off + exits.
-                const api = new ServiceApi(undefined, undefined, () => true, spawnDetached, scheduleExit, fakePkexec);
+                // existsCheck → true for the relaunch helper (F5 hands off + exits) but FALSE for
+                // kbuildsycoca, so refreshDesktopCaches no-ops (treated as non-KDE) and spawnDetached
+                // stays at exactly 1 (the relaunch helper) for the assertion below.
+                const api = new ServiceApi(undefined, undefined, (p: string) => !p.includes('kbuildsycoca'), spawnDetached, scheduleExit, fakePkexec);
                 const { req, res } = makeReqRes('/api/service/install-system-wide', 'POST');
                 await api.handle(req, res);
 

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -866,6 +866,7 @@ export class ServiceApi {
         const script = buildMachineWideInstallScript({ sourceAppImage: appImage, version, iconSource });
         try {
             await this.runPkexecFn(script, 'install-system-wide');
+            this.refreshDesktopCaches();
             // F5: the running instance launched from the home AppImage (now
             // deleted by the install) and never re-execs to /opt — it lingers on
             // the deleted FUSE mount and holds the per-user lock. Hand off to the
@@ -904,6 +905,35 @@ export class ServiceApi {
             }
         }
         return true;
+    }
+
+    /**
+     * Best-effort: refresh KDE's per-user desktop caches after a machine-wide install
+     * so the new menu entry + icon appear immediately. The root install already
+     * refreshed the SYSTEM icon-theme cache (gtk-update-icon-cache) + the .desktop db,
+     * but KDE's launcher keeps a stale PER-USER icon cache (~/.cache/icon-cache.kcache)
+     * that survives reinstalls — clearing it + rebuilding ksycoca is what makes the
+     * icon show without a re-login (item 51, confirmed in the beta.55 smoke). Runs as
+     * us (the Node server is the user's process). KDE-only (gated on kbuildsycoca); a
+     * no-op on GNOME/others, where the system gtk-update-icon-cache already covers it.
+     */
+    private refreshDesktopCaches(): void {
+        if (process.platform !== 'linux') return;
+        const kbuildsycoca = ['kbuildsycoca6', 'kbuildsycoca5']
+            .map((t) => `/usr/bin/${t}`)
+            .find((p) => this.existsCheck(p));
+        if (!kbuildsycoca) return; // not KDE — the system icon-cache refresh covers it
+        try {
+            const iconCache = path.join(os.homedir(), '.cache', 'icon-cache.kcache');
+            if (this.existsCheck(iconCache)) fs.rmSync(iconCache, { force: true });
+        } catch {
+            /* best-effort */
+        }
+        try {
+            this.spawnDetached(kbuildsycoca, []);
+        } catch {
+            /* best-effort */
+        }
     }
 
     private async handleDeclineSystemWide(res: ServerResponse): Promise<boolean> {

--- a/webpack/ws-scrcpy-web.common.ts
+++ b/webpack/ws-scrcpy-web.common.ts
@@ -49,11 +49,11 @@ class GenerateDistPackageJsonPlugin {
     }
 }
 
-// Inline plugin: copies public/index.html into dist/public/
-class CopyIndexHtmlPlugin {
+// Inline plugin: copies a single file into dist/public/ (index.html, favicon, ...)
+class CopyFilePlugin {
     constructor(private src: string, private dest: string) {}
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.afterEmit.tapAsync('CopyIndexHtmlPlugin', (_: webpack.Compilation, callback: () => void) => {
+        compiler.hooks.afterEmit.tapAsync(`CopyFilePlugin:${this.dest}`, (_: webpack.Compilation, callback: () => void) => {
             const fs = require('fs') as typeof import('fs');
             const destDir = path.dirname(this.dest);
             fs.mkdirSync(destDir, { recursive: true });
@@ -120,9 +120,16 @@ const front: webpack.Configuration = {
     externals: ['fs'],
     plugins: [
         new MiniCssExtractPlugin({ filename: 'bundle.css' }),
-        new CopyIndexHtmlPlugin(
+        new CopyFilePlugin(
             path.resolve(PROJECT_ROOT, 'public/index.html'),
             path.resolve(CLIENT_DIST_PATH, 'index.html'),
+        ),
+        // Favicon — derive it from the app icon (assets/tray-icon.png) so the
+        // browser tab shows our icon. Served from dist/public/favicon.png and
+        // referenced in public/index.html's <head>.
+        new CopyFilePlugin(
+            path.resolve(PROJECT_ROOT, 'assets/tray-icon.png'),
+            path.resolve(CLIENT_DIST_PATH, 'favicon.png'),
         ),
         new CopyHelpDirPlugin(),
     ],


### PR DESCRIPTION
Two smoke-found icon items, batched.

**Browser-tab favicon (new).** The web UI had no favicon, so the tab showed a generic icon. A webpack `CopyFilePlugin` copies `assets/tray-icon.png` -> `dist/public/favicon.png`, and `public/index.html` references it via `<link rel="icon">`.

**KDE menu-icon cache refresh (item 51 follow-up).** As of beta.55 the menu icon installs correctly, but KDE's launcher keeps a *per-user* icon cache (`~/.cache/icon-cache.kcache`) that doesn't refresh on reinstall — confirmed in the smoke (a manual `rm icon-cache.kcache && kbuildsycoca6` fixed it instantly). The machine-wide install now does that refresh itself (best-effort, as the user, KDE-gated via `kbuildsycoca`); no-op on GNOME/others.

Gates: `tsc` 0 · `vitest` 933 · `npm run build` 0 (favicon confirmed in `dist/public/`).