### PR TITLE
docs(smoke): bump smoke target to v0.1.30-beta.56

### DIFF
--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Smoke Run-Sheet
 
-> **Smoke target: `v0.1.30-beta.52`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.56`** — bump this one line each release; everything below is version-agnostic.
 
 Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
 [`smoke-full.md`](./smoke-full.md) by **app state** — the order you actually run them; that doc


### PR DESCRIPTION
Bump the smoke run-sheet target line to the current release (beta.56). Everything below the target line is version-agnostic; only that one line changes.