### PR TITLE
fix(linux): SELinux fcontext idempotency - system-service install now labels /var/opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installing the Linux *system-wide* service now labels its data folder correctly under SELinux.** On SELinux systems (e.g. Fedora) the install registers two file-context rules — `bin_t` for the program under `/opt`, `var_lib_t` for the writable data under `/var/opt` — then relabels both. But a system-wide service install requires a machine-wide install first, which had *already* registered the `/opt` rule; re-adding it errored "already defined", and because the steps were chained with `&&`, that error skipped the `/var/opt` rule and both relabel steps — leaving `/var/opt` mislabelled `usr_t`. (The service still ran and served, because the unit is unconfined, so nothing was actually blocked.) Each file-context registration is now idempotent — add, or modify if it already exists — so a pre-existing rule can no longer short-circuit the rest. The machine-wide install and the legacy-layout migration were hardened the same way.
+
 ## [0.1.30-beta.57] - 2026-06-10
 
 ### Fixed

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -148,6 +148,20 @@ describe('buildSystemInstallScript', () => {
             '"/opt/ws-scrcpy-web/ws-scrcpy-web-launcher.exe" --linux-service-install-handoff --scope system --unit WsScrcpyWeb'
         );
     });
+
+    it('makes the SELinux fcontext adds idempotent (-a || -m) so a pre-existing /opt bin_t rule cannot short-circuit the var_lib_t add + restorecons (beta.57 #9 2.2/2.3)', () => {
+        const script = buildSystemInstallScript(args);
+        // A system-service install is gated on machine-wide-first, so the /opt bin_t
+        // fcontext rule ALWAYS pre-exists. A bare `semanage fcontext -a` then errors
+        // "already defined" and the `&&` chain skips the /var/opt var_lib_t add + both
+        // restorecons -> /var/opt mislabelled usr_t (smoke 2.2/2.3). Each add must be
+        // `-a || -m` (add, or modify-if-already-defined) so it can't fail-and-cascade.
+        expect(script).toContain("semanage fcontext -m -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain("semanage fcontext -m -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        // the var_lib_t add + the /var/opt restorecon still happen (not skipped):
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+    });
 });
 
 describe('SYSTEM_STATE_DIR — FHS /var/opt retargeting', () => {
@@ -266,6 +280,17 @@ describe('buildMachineWideInstallScript', () => {
         expect(s).not.toContain('/usr/share/icons/hicolor');
         expect(s).not.toContain('gtk-update-icon-cache');
     });
+
+    it('makes the /opt bin_t fcontext add idempotent (-a || -m) so a re-install over an existing rule still restorecons (no &&-cascade)', () => {
+        const s = buildMachineWideInstallScript(
+            { sourceAppImage: '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage', version: '0.1.31-beta.1' },
+            (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+        );
+        // a re-install (or any path hitting a pre-existing /opt rule) makes a bare
+        // `semanage -a` error "already defined" and the `&&` skips restorecon. The
+        // `-a || -m` form keeps it idempotent. (Sibling of the #9 2.2/2.3 bug.)
+        expect(s).toContain("semanage fcontext -m -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+    });
 });
 
 describe('buildMachineWideUpdateScript', () => {
@@ -359,6 +384,11 @@ describe('buildSystemMigrationScript', () => {
         expect(script).toContain('cp "/tmp/WsScrcpyWeb.service.tmp" "/etc/systemd/system/WsScrcpyWeb.service"');
         expect(script).toContain('systemctl daemon-reload');
         expect(script).toContain('systemctl enable --now WsScrcpyWeb.service');
+    });
+
+    it('makes the var_lib_t fcontext add idempotent (-a || -m) — consistent with the install scripts, robust to a re-run over an existing rule', () => {
+        const script = buildSystemMigrationScript(args);
+        expect(script).toContain("semanage fcontext -m -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
     });
 
     it('carries the seeded webPort into /var/opt/.../config.json', () => {

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -356,7 +356,13 @@ export function buildSystemInstallScript(
         //    erroring on a non-SELinux fs) would break the outer `&&` chain and
         //    silently skip the unit cp + enable below.
         //    restorecon covers the whole dir — labels the helper bin_t too when present.
-        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        //    Each `semanage fcontext -a` is paired with `|| …-m` (add, or modify-if-
+        //    already-defined): a system install is GATED on machine-wide-first, so the
+        //    /opt bin_t rule ALWAYS pre-exists — a bare `-a` errors "already defined",
+        //    and because the inner steps are `&&`-chained that failure would skip the
+        //    /var/opt var_lib_t add + both restorecons, leaving /var/opt mislabelled
+        //    usr_t (the beta.57 #9 2.2/2.3 bug). `-a || -m` makes each add idempotent.
+        `( ( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' || ${semanage} fcontext -m -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' ) && ( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ) && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         // 3. install the unit (ExecStart already points at ${staged}).
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
         `${systemctl} daemon-reload`,
@@ -425,7 +431,7 @@ export function buildMachineWideInstallScript(
         `${cp} "${args.sourceAppImage}" "${staged}"`,
         `${chmod} 0755 "${staged}"`,
         `${printf} '%s' '${args.version}' > ${SYSTEM_OPT_VERSION_FILE}`,
-        `( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        `( ( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' || ${semanage} fcontext -m -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' ) && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
         `( ${printf} '${desktop}\\n' > ${SYSTEM_DESKTOP_FILE} || true )`,
         `( ${updateDesktopDb} /usr/share/applications || true )`,
     ];
@@ -584,7 +590,7 @@ export function buildSystemMigrationScript(
         // label the state dir var_lib_t + restorecon. Best-effort subshell with a
         // chcon transient fallback + trailing `|| true` so a non-SELinux host still
         // proceeds to install the unit — mirrors buildSystemInstallScript.
-        `( ( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t var_lib_t "${SYSTEM_STATE_DIR}" || true )`,
+        `( ( ( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ) && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t var_lib_t "${SYSTEM_STATE_DIR}" || true )`,
         // reinstall the unit (ExecStart still points at the in-place /opt AppImage;
         // env now carries DATA_ROOT=/var/opt) + reload + enable.
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,


### PR DESCRIPTION
The beta.57 re-smoke finally got the system service to stay up (the self-defer P0 is dead), which let smoke #9 reach the SELinux label checks (2.2/2.3) for the first time — and they failed: `/var/opt/ws-scrcpy-web` came out `usr_t` with no `var_lib_t` fcontext rule.

## Root cause
`buildSystemInstallScript` runs the label step as `( A && B && C && D ) || chcon || true`, where A registers the `/opt` bin_t rule and B registers the `/var/opt` var_lib_t rule. Since a system-scope install is gated on a machine-wide install first, the `/opt` rule **always** already exists — so `semanage fcontext -a` errors *"already defined"*, the `&&` short-circuits, and B plus both `restorecon`s never run. The trailing `|| true` (there so a non-SELinux host doesn''t abort the unit install) then hides it. The service still served because the unit is unconfined, so this stayed invisible until the smoke could actually reach #9.

## Fix
Make each `semanage fcontext -a` idempotent: `-a || -m` (add, or modify if already defined). A pre-existing rule now no-ops through `-m` instead of failing the chain. Applied to all three builders that register fcontext rules:
- `buildSystemInstallScript` — the reported bug
- `buildMachineWideInstallScript` — same bare `-a`, latent on re-install
- `buildSystemMigrationScript` — same, robust to a re-run

## Testing
New unit tests assert the `-m` fallback for each builder (red before the fix, green after). Full suite: **vitest 938 green, tsc 0**. Runtime re-verify is the beta.58 smoke #9 (2.2 → `var_lib_t`, 2.3 → both rules).