### PR TITLE
feat(ui): reset-prompts confirm overlay + taller settings modal (item 53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The "reset welcome and bookmark prompts" confirmation is now a dialog instead of an inline panel.** Clicking "reset" in Settings → App opens a small overlay that explains what reset does and asks you to confirm — matching the uninstall confirmation in the same section. What reset actually does is unchanged.
+- **The Settings panel is taller**, giving the App, Updates, and Service sections more room before an inner scrollbar appears on shorter screens.
+
 ## [0.1.30-beta.59] - 2026-06-10
 
 ### Changed

--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Smoke Run-Sheet
 
-> **Smoke target: `v0.1.30-beta.57`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.60`** — bump this one line each release; everything below is version-agnostic.
 
 Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
 [`smoke-full.md`](./smoke-full.md) by **app state** — the order you actually run them; that doc

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Full Smoke Test
 
-> **Smoke target: `v0.1.30-beta.57`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.60`** — bump this one line each release; everything below is version-agnostic.
 
 All-encompassing manual smoke, grouped by function and tagged by platform (`[Win]` / `[Linux]` / `[Both]`). Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
 

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Smoke Test Runbook (plain-English)
 
-> **Smoke target: `v0.1.30-beta.57`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.60`** — bump this one line each release; everything below is version-agnostic.
 
 **What this is.** A step-by-step manual test pass for the **ws-scrcpy-web** app. Completing it is the agreed gate before cutting the **0.1.30 final** release — the "prove it really installs, updates, and streams on Windows + Linux" check. You run it by hand on your test VMs plus a real Android device; it can't be automated from a chat.
 

--- a/src/app/client/ResetConfirmModal.ts
+++ b/src/app/client/ResetConfirmModal.ts
@@ -1,0 +1,86 @@
+import { Modal } from '../ui/Modal';
+
+/**
+ * Overlay modal shown when the user clicks "reset" in the App section's
+ * "reset welcome and bookmark prompts" row. Replaces the former inline
+ * settings-confirm-panel so the action is presented in a top-layer dialog,
+ * matching the UninstallConfirmModal pattern used by the sibling uninstall
+ * action in the same section.
+ *
+ * `ResetConfirmModal.confirm()` is the only public API.
+ * - confirm reset button → resolves true
+ * - cancel button → resolves false
+ * - Esc / backdrop / close-X → resolves false
+ *
+ * Reset is non-destructive (it clears the first-run / bookmark flags and
+ * reloads the page), so the confirm button uses the primary/accent colour
+ * (settings-btn-primary, #5b9aff) — NOT the danger-outline red the uninstall
+ * modal uses for its genuinely destructive action.
+ */
+export class ResetConfirmModal extends Modal {
+    private resolveFn: ((value: boolean) => void) | null = null;
+    private resolved = false;
+
+    public static confirm(): Promise<boolean> {
+        return new Promise((resolve) => {
+            new ResetConfirmModal(resolve);
+        });
+    }
+
+    private constructor(resolve: (value: boolean) => void) {
+        super({ title: 'reset prompts' });
+        this.resolveFn = resolve;
+        this.dialog.classList.add('reset-confirm-modal');
+    }
+
+    protected buildBody(container: HTMLElement): void {
+        const description = document.createElement('p');
+        description.textContent =
+            'this resets the welcome modal, service-mode modal, the per-port bookmark ' +
+            'reminder, and the global bookmark dismissal. the page will reload so the ' +
+            'appropriate modal can re-fire. it does not affect install mode, audio ' +
+            'preferences, or scan history.';
+        container.appendChild(description);
+    }
+
+    protected override buildFooter(): HTMLElement | null {
+        const footer = document.createElement('div');
+        footer.style.cssText = 'display: flex; gap: 8px; justify-content: flex-end;';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'settings-btn reset-cancel';
+        cancelBtn.textContent = 'cancel';
+        cancelBtn.addEventListener('click', () => this.resolveAndClose(false));
+        footer.appendChild(cancelBtn);
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.type = 'button';
+        confirmBtn.className = 'settings-btn settings-btn-primary reset-confirm';
+        confirmBtn.textContent = 'confirm reset';
+        confirmBtn.addEventListener('click', () => this.resolveAndClose(true));
+        footer.appendChild(confirmBtn);
+
+        return footer;
+    }
+
+    protected override onEscapeKey(_event: Event): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onBackdropClick(_event: MouseEvent): void {
+        this.resolveAndClose(false);
+    }
+
+    protected override onCloseButtonClick(): void {
+        this.resolveAndClose(false);
+    }
+
+    private resolveAndClose(confirmed: boolean): void {
+        if (this.resolved) return;
+        this.resolved = true;
+        this.resolveFn?.(confirmed);
+        this.resolveFn = null;
+        this.close(confirmed);
+    }
+}

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -2,6 +2,7 @@ import { Modal } from '../ui/Modal';
 import { AdminConfirmModal, type AdminConfirmOptions } from './AdminConfirmModal';
 import { ConfirmModal } from './ConfirmModal';
 import { UninstallConfirmModal } from './UninstallConfirmModal';
+import { ResetConfirmModal } from './ResetConfirmModal';
 import { ServiceOperationModal } from './ServiceOperationModal';
 import { runUpgradingHandoff } from './UpgradingOverlay';
 import type { AppConfigEnvelope, AppConfigPatchResponse, UpdateChannel } from '../../common/ConfigEvents';
@@ -340,6 +341,42 @@ export function buildUninstallControl(opts: { onUninstalled: () => void }): {
                 body: JSON.stringify({ keep: r.keep }),
             });
             opts.onUninstalled();
+        })();
+    });
+
+    return { button };
+}
+
+/**
+ * Build the "reset welcome and bookmark prompts" trigger button. When clicked,
+ * opens ResetConfirmModal (a top-layer <dialog>) instead of expanding an inline
+ * panel — mirroring buildUninstallControl. On confirmation, PATCHes /api/config
+ * with resetPromptsPayload() (clearing the first-run / bookmark flags) and calls
+ * opts.reload so the appropriate modal re-fires. The reload runs regardless of
+ * the PATCH outcome (the page reload re-reads config either way). Self-contained
+ * DOM + wiring; no network call until the modal is confirmed.
+ */
+export function buildResetControl(opts: { reload: () => void }): {
+    button: HTMLButtonElement;
+} {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'settings-btn settings-btn-primary';
+    button.textContent = 'reset';
+
+    button.addEventListener('click', () => {
+        void (async () => {
+            const confirmed = await ResetConfirmModal.confirm();
+            if (!confirmed) return;
+            // Reset reloads regardless of the PATCH outcome; swallow any network
+            // error so it does not surface as an unhandled rejection (the page
+            // reload re-reads config either way).
+            await fetch('/api/config', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(resetPromptsPayload()),
+            }).catch(() => undefined);
+            opts.reload();
         })();
     });
 
@@ -1533,56 +1570,11 @@ export class SettingsModal extends Modal {
         const { section, body } = this.buildSection('App');
 
         // ── reset welcome & bookmark prompts ─────────────────────────────
-        const resetBtn = document.createElement('button');
-        resetBtn.type = 'button';
-        resetBtn.className = 'settings-btn settings-btn-primary';
-        resetBtn.textContent = 'reset';
-
-        // Confirm panel — hidden by default, expands inside the grid below
-        // the reset row when the button is clicked. Spans both columns.
-        const confirmPanel = document.createElement('div');
-        confirmPanel.className = 'settings-confirm-panel';
-
-        const confirmText = document.createElement('p');
-        confirmText.textContent =
-            'this resets the welcome modal, service-mode modal, the per-port bookmark ' +
-            'reminder, and the global bookmark dismissal. the page will reload so the ' +
-            'appropriate modal can re-fire. it does not affect install mode, audio ' +
-            'preferences, or scan history.';
-        confirmPanel.appendChild(confirmText);
-
-        const confirmButtons = document.createElement('div');
-        confirmButtons.className = 'settings-confirm-buttons';
-
-        const cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'settings-btn';
-        cancelBtn.textContent = 'cancel';
-        cancelBtn.addEventListener('click', () => {
-            confirmPanel.classList.remove('expanded');
-        });
-        confirmButtons.appendChild(cancelBtn);
-
-        const confirmBtn = document.createElement('button');
-        confirmBtn.type = 'button';
-        confirmBtn.className = 'settings-btn settings-btn-primary';
-        confirmBtn.textContent = 'confirm reset';
-        confirmBtn.addEventListener('click', () => {
-            fetch('/api/config', {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(resetPromptsPayload()),
-            }).finally(() => {
-                window.location.reload();
-            });
-        });
-        confirmButtons.appendChild(confirmBtn);
-
-        confirmPanel.appendChild(confirmButtons);
-
-        resetBtn.addEventListener('click', () => {
-            confirmPanel.classList.toggle('expanded');
-        });
+        // Extracted builder (mirrors buildUninstallControl): the reset button
+        // opens ResetConfirmModal and, on confirm, clears the first-run /
+        // bookmark flags and reloads so the appropriate modal re-fires.
+        const reset = buildResetControl({ reload: () => window.location.reload() });
+        const resetBtn = reset.button;
 
         // ── install for all users (Linux-only) ───────────────────────────
         // §beta.49 — hidden (display:none overrides the .settings-row { display: contents }
@@ -1628,9 +1620,8 @@ export class SettingsModal extends Modal {
         this.uninstallRow = uninstallRow;
 
         // ── DOM order (top → bottom) ──────────────────────────────────────
-        // 1. reset welcome & bookmark (+ inline confirm panel)
+        // 1. reset welcome & bookmark (confirm now lives in ResetConfirmModal)
         body.appendChild(this.buildRow('reset welcome and bookmark prompts', resetBtn));
-        body.appendChild(confirmPanel);
         // 2. install for all users + note (Linux-only, hidden until revealed)
         body.appendChild(installRow);
         body.appendChild(install.note);

--- a/src/app/client/__tests__/ResetConfirmModal.test.ts
+++ b/src/app/client/__tests__/ResetConfirmModal.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ResetConfirmModal } from '../ResetConfirmModal';
+
+// Mirror the UninstallConfirmModal test stub: showModal throws InvalidStateError
+// if the dialog already has the 'open' attribute (spec-realistic).
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        if (this.hasAttribute('open')) {
+            throw new DOMException(
+                "Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.",
+                'InvalidStateError',
+            );
+        }
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+});
+
+function getDialog(): HTMLDialogElement {
+    const dialog = document.querySelector('dialog.reset-confirm-modal');
+    expect(dialog, 'modal dialog should be in the DOM').toBeTruthy();
+    return dialog as HTMLDialogElement;
+}
+
+function getButton(label: string): HTMLButtonElement {
+    const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+    const btn = btns.find((b) => b.textContent?.trim().toLowerCase() === label.toLowerCase());
+    expect(btn, `button labeled "${label}" should be in the DOM`).toBeTruthy();
+    return btn!;
+}
+
+describe('ResetConfirmModal.confirm', () => {
+    it('confirm reset resolves true', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('confirm reset').click();
+        await expect(promise).resolves.toBe(true);
+    });
+
+    it('cancel resolves false', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('cancel').click();
+        await expect(promise).resolves.toBe(false);
+    });
+
+    it('close (×) resolves false', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        const closeBtn = getDialog().querySelector<HTMLButtonElement>('.modal-close:last-child');
+        expect(closeBtn, 'close button should exist').toBeTruthy();
+        closeBtn!.click();
+        await expect(promise).resolves.toBe(false);
+    });
+
+    it('body contains the verbatim reset copy', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        const body = document.querySelector('.modal-body');
+        const text = body?.textContent?.toLowerCase() ?? '';
+        expect(text).toContain('this resets the welcome modal');
+        expect(text).toContain('the page will reload');
+        expect(text).toContain('does not affect install mode, audio preferences, or scan history');
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('confirm button is primary blue (settings-btn-primary, NOT danger)', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('confirm reset');
+        expect(btn.classList.contains('settings-btn')).toBe(true);
+        expect(btn.classList.contains('settings-btn-primary')).toBe(true);
+        expect(btn.classList.contains('settings-btn-danger-outline')).toBe(false);
+        getButton('cancel').click();
+        await promise;
+    });
+
+    it('cancel button is neutral (settings-btn, no primary/danger)', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        const btn = getButton('cancel');
+        expect(btn.classList.contains('settings-btn')).toBe(true);
+        expect(btn.classList.contains('settings-btn-primary')).toBe(false);
+        expect(btn.classList.contains('settings-btn-danger-outline')).toBe(false);
+        btn.click();
+        await promise;
+    });
+
+    it('calls showModal exactly once', async () => {
+        const spy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        expect(spy).toHaveBeenCalledTimes(1);
+        getButton('cancel').click();
+        await promise;
+        spy.mockRestore();
+    });
+
+    it('resolves only once even if multiple close paths fire', async () => {
+        const promise = ResetConfirmModal.confirm();
+        await Promise.resolve();
+        getButton('confirm reset').click();
+        getButton('cancel').click();
+        await expect(promise).resolves.toBe(true);
+    });
+});

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -15,9 +15,11 @@ import {
     appSectionButtonsState,
     buildInstallAllUsersControl,
     buildUninstallControl,
+    buildResetControl,
     SettingsModal,
 } from '../SettingsModal';
 import * as UninstallConfirmModalModule from '../UninstallConfirmModal';
+import * as ResetConfirmModalModule from '../ResetConfirmModal';
 
 /** Flush microtasks + a macrotask so the awaited fetch handlers settle. */
 const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -373,6 +375,77 @@ describe('buildUninstallControl', () => {
 
         expect(fetchMock).not.toHaveBeenCalled();
         expect(onUninstalled).not.toHaveBeenCalled();
+    });
+});
+
+describe('buildResetControl', () => {
+    it('returns only { button } — no inline confirmPanel/note', () => {
+        const result = buildResetControl({ reload: vi.fn() });
+        expect(result).toHaveProperty('button');
+        expect(result).not.toHaveProperty('confirmPanel');
+        expect(result).not.toHaveProperty('note');
+    });
+
+    it('button is the primary "reset" button', () => {
+        const { button } = buildResetControl({ reload: vi.fn() });
+        expect(button.textContent).toBe('reset');
+        expect(button.classList.contains('settings-btn')).toBe(true);
+        expect(button.classList.contains('settings-btn-primary')).toBe(true);
+    });
+
+    it('button click opens ResetConfirmModal (calls confirm)', async () => {
+        const confirmSpy = vi
+            .spyOn(ResetConfirmModalModule.ResetConfirmModal, 'confirm')
+            .mockResolvedValue(false);
+        const { button } = buildResetControl({ reload: vi.fn() });
+        button.click();
+        await flush();
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('on confirm=true PATCHes /api/config with resetPromptsPayload and reloads', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+        vi.stubGlobal('fetch', fetchMock);
+        const reload = vi.fn();
+        vi.spyOn(ResetConfirmModalModule.ResetConfirmModal, 'confirm').mockResolvedValue(true);
+
+        const { button } = buildResetControl({ reload });
+        button.click();
+        await flush();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+        expect(url).toBe('/api/config');
+        expect(init.method).toBe('PATCH');
+        expect(JSON.parse(init.body as string)).toEqual(resetPromptsPayload());
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('on confirm=false does NOT PATCH and does NOT reload', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const reload = vi.fn();
+        vi.spyOn(ResetConfirmModalModule.ResetConfirmModal, 'confirm').mockResolvedValue(false);
+
+        const { button } = buildResetControl({ reload });
+        button.click();
+        await flush();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads even when the PATCH rejects (reset always reloads)', async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+        vi.stubGlobal('fetch', fetchMock);
+        const reload = vi.fn();
+        vi.spyOn(ResetConfirmModalModule.ResetConfirmModal, 'confirm').mockResolvedValue(true);
+
+        const { button } = buildResetControl({ reload });
+        button.click();
+        await flush();
+
+        expect(reload).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -530,7 +530,11 @@ dialog.list-files-modal .modal-body {
    modals (AdminConfirmModal etc.) stay narrow. */
 dialog.settings-modal .modal-frame {
     width: clamp(460px, 66vw, 820px);
-    max-height: 85vh;
+    /* 95vh (not the base 80vh / prior 85vh): the App + Updates + Service
+       sections together are tall enough that 85vh forced an inner scrollbar on
+       smaller viewports. 95vh leaves a ~2.5% margin top/bottom so the frame
+       doesn't kiss the screen edges; long sections still scroll inside. */
+    max-height: 95vh;
 }
 
 dialog.settings-modal .settings-section {
@@ -771,36 +775,6 @@ dialog.settings-modal .settings-stub-note {
  * Section-specific input widths handled inline (max-width on the
  * .settings-input itself).
  */
-
-/* App section: reset-prompts confirm panel (collapsed by default). */
-dialog.settings-modal .settings-confirm-panel {
-    grid-column: 1 / -1;
-    display: none;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 0.75rem;
-    border-radius: 6px;
-    background: rgba(91, 154, 255, 0.08);
-    border-left: 3px solid #5b9aff;
-    margin-top: 0.5rem;
-}
-
-dialog.settings-modal .settings-confirm-panel.expanded {
-    display: flex;
-}
-
-dialog.settings-modal .settings-confirm-panel p {
-    margin: 0;
-    color: var(--text-color-light, #888);
-    font-size: 13px;
-    line-height: 1.5;
-}
-
-dialog.settings-modal .settings-confirm-panel .settings-confirm-buttons {
-    display: flex;
-    gap: 0.75rem;
-    justify-content: flex-end;
-}
 
 /* --- Service operation modal (Phase 3) --- */
 


### PR DESCRIPTION
## What

Item 53 settings UI polish, plus the beta.60 smoke-doc target bump.

### Reset confirmation → overlay modal
The "reset welcome and bookmark prompts" action in **Settings → App** used an inline expanding panel for its confirm step. It now opens a top-layer overlay (`ResetConfirmModal`), matching the uninstall confirmation in the same section. The reset button is wired through an extracted `buildResetControl` helper (mirroring `buildUninstallControl` / `buildInstallAllUsersControl`); on confirm it clears the first-run / bookmark flags and reloads. **Reset behaviour is unchanged** (smoke 13.1 / 13.2 still apply).

The confirm button stays primary/blue (`settings-btn-primary`), not the uninstall modal's danger red — reset is reversible, so red would mis-signal. Cancel is the neutral outline either way.

### Taller settings modal
`dialog.settings-modal .modal-frame` max-height 85vh → 95vh, so the App / Updates / Service sections have more headroom before an inner scrollbar appears on shorter screens. Removed the now-dead `settings-confirm-panel` CSS.

### Smoke docs
Bumped the smoke target line to `v0.1.30-beta.60` (the build this PR cuts) across all three smoke docs.

## Tests
- New `ResetConfirmModal.test.ts` (8 cases, written test-first) + a new `buildResetControl` suite in `SettingsModal.test.ts` (6 cases), including the reload-even-when-PATCH-rejects path.
- `tsc --noEmit` 0 · vitest **957** · webpack build clean.

## Release
`release:beta` — no version bump in this PR; the auto-release bump PR promotes `[Unreleased]` → `[0.1.30-beta.60]`.