### PR TITLE
docs: correct VERSION marker path to /opt/ws-scrcpy-web/VERSION

### DIFF
--- a/docs/plans/2026-06-05-machine-wide-opt-install-phases2-3.md
+++ b/docs/plans/2026-06-05-machine-wide-opt-install-phases2-3.md
@@ -234,7 +234,7 @@ fn bootstrap_decides_by_version() {
 pub enum BootstrapAction { ExecOpt(PathBuf), RunHomeOfferUpdate, RunHome }
 
 /// `self_version` = the running (home) AppImage's version; `opt_version` = parsed
-/// /opt/VERSION (None if absent/unreadable). Pure.
+/// /opt/ws-scrcpy-web/VERSION (None if absent/unreadable). Pure.
 pub fn bootstrap_decision(opt_exists: bool, appimage_env: Option<&str>, self_version: &str, opt_version: Option<&str>) -> BootstrapAction {
     let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
     let is_self_opt = appimage_env.map(|p| p == opt.to_string_lossy()).unwrap_or(false);

--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -34,7 +34,7 @@ Boxes start unticked — this is a fresh pass.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = the smoke-target version; system `.desktop` present; original `~/Downloads` AppImage **gone** |
+| ☐ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/ws-scrcpy-web/VERSION` = the smoke-target version; system `.desktop` present; original `~/Downloads` AppImage **gone** |
 | ☐ **4.1** `[L]` System-scope gate un-greys | **Before installing any service** (a service install flips `scopeRadioState.locked` → radios go read-only; see 4.4): Settings → service → select **system** scope | Now **selectable** + its install **un-greyed** now that you're machine-wide; was gated *"requires installing system-wide for all users first"* before 1.2 |
 | ☐ **4.2-user** `[L]` Install user service | Settings → service → **user** scope → install (no elevation) | Service active on 8000; stable ExecStart; **no "port discovery timed out"** (the beta.48 fix) |
 

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -46,7 +46,7 @@ sudo systemctl daemon-reload
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | **1.1** `[Linux]` First-run modal | Run the home AppImage on a machine with no prior install/decline marker. | "install for all users?" modal: 3 stacked lines + buttons **yes, all users** / **no, me only**; **no ×**; **Esc** and **click-outside do nothing** (forced choice). |
-| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/VERSION` = the smoke-target version; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
+| **1.2** `[Linux]` Accept → install + **delete original** | Click **yes, all users**; authenticate the one prompt. | One pkexec; binary at `/opt/ws-scrcpy-web/`; `/opt/ws-scrcpy-web/VERSION` = the smoke-target version; system `.desktop` present; app runs. **NEW:** the original home AppImage (the file you launched) is **gone** — `ls ~/Downloads/WsScrcpyWeb*.AppImage` → not found. |
 | **1.3** `[Linux]` Decline + remember | Fresh state / 2nd user → **no, me only**. | Runs in place from `~/.local`; **next launch does NOT re-prompt**; original AppImage **kept**. |
 | **1.4** `[Linux]` Headless first-run | Launch over SSH / no display. | No hang; graceful fallback, no crash. |
 | **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = the smoke-target version; installs to `C:\Program Files\WsScrcpyWeb\`. |

--- a/docs/specs/2026-06-05-machine-wide-opt-install-phases2-3-design.md
+++ b/docs/specs/2026-06-05-machine-wide-opt-install-phases2-3-design.md
@@ -62,13 +62,13 @@ System service installed → uninstall **(a) as the same user** and **(b) via pk
 
 ### 3b — Machine-wide-no-service app update (`pkexec` the swap only)
 The user runs `/opt` locally (no service); a Velopack update must write the root-owned `/opt`.
-- **`pkexec` *only* the file swap** — reuse Phase 1's machine-wide-install elevated step: `cp` staged AppImage → `/opt/.../WsScrcpyWeb.AppImage`, re-label `bin_t` + `restorecon`, bump `/opt/VERSION`. **One prompt.**
+- **`pkexec` *only* the file swap** — reuse Phase 1's machine-wide-install elevated step: `cp` staged AppImage → `/opt/.../WsScrcpyWeb.AppImage`, re-label `bin_t` + `restorecon`, bump `/opt/ws-scrcpy-web/VERSION`. **One prompt.**
 - **Relaunch in the user's context** — the `pkexec` covers *only* the swap; after it, the user-context process re-execs the new `/opt` (as the user, **never root**). Browser reconnects (same port, local config).
 - **Unchanged:** run-in-place home installs update with zero elevation (existing `linux_apply`); system-service installs self-update prompt-free (item 39).
 
 ### 3c — Bootstrapper version-compare + offer-update
 Phase 1's bootstrapper just execs `/opt` if present. Phase 3 makes it version-aware so a manually-downloaded newer AppImage isn't silently ignored:
-- The launcher reads `/opt/VERSION` and its own `CARGO_PKG_VERSION`, semver-compares.
+- The launcher reads `/opt/ws-scrcpy-web/VERSION` and its own `CARGO_PKG_VERSION`, semver-compares.
 - **home ≤ /opt** → exec `/opt` (normal).
 - **home > /opt** → run the **home** AppImage in place (the newer one) and flag it for the app, which **offers** *"update the system-wide install to vX? [update]"* → POST → the **3b** `pkexec` swap using the home AppImage as source. Next launch execs the updated `/opt`.
 - Reuses 3b's swap; the offer lives in the frontend (the launcher can't draw UI).
@@ -86,7 +86,7 @@ Machine-wide-no-service `/opt` install → in-app update → **one** pkexec → 
 
 ## Cross-cutting
 - **Linux-only** (Windows is already PerMachine).
-- Phase 2 depends only on Phase 1's `/opt` layout (shipped). Phase 3's update + version-compare depend on Phase 1's `buildMachineWideInstallScript` + `/opt/VERSION` (shipped).
+- Phase 2 depends only on Phase 1's `/opt` layout (shipped). Phase 3's update + version-compare depend on Phase 1's `buildMachineWideInstallScript` + `/opt/ws-scrcpy-web/VERSION` (shipped).
 - Build order for the plan: **Phase 2** (relaunch) is independent and smaller → first; **Phase 3** (migration + update + version-compare) second.
 
 ## Open risks (carry into the plan)

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -121,7 +121,7 @@ fn version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
 }
 
 /// `self_version` = the running (home) AppImage's version; `opt_version` = parsed
-/// /opt/VERSION (None if absent/unreadable). Pure.
+/// /opt/ws-scrcpy-web/VERSION (None if absent/unreadable). Pure.
 pub fn bootstrap_decision(opt_exists: bool, appimage_env: Option<&str>, self_version: &str, opt_version: Option<&str>) -> BootstrapAction {
     let opt = PathBuf::from("/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage");
     let is_self_opt = appimage_env.map(|p| p == opt.to_string_lossy()).unwrap_or(false);


### PR DESCRIPTION
Found during the beta.60 Fedora smoke: row 1.2 told the tester to check `/opt/VERSION`, which doesn''t exist. The machine-wide install writes the version marker to `/opt/ws-scrcpy-web/VERSION` (inside the app dir) — `SystemdClient.ts` `SYSTEM_OPT_VERSION_FILE` writes it and the launcher (`main.rs:197`) reads it from there, so the code is correct and consistent. Only the docs and one stale doc-comment were wrong.

Swept the repo; fixed all 7 occurrences:
- `docs/smoke-tests/smoke-checklist.md` (row 1.2)
- `docs/smoke-tests/smoke-full.md` (row 1.2)
- `docs/specs/2026-06-05-machine-wide-opt-install-phases2-3-design.md` (3x)
- `docs/plans/2026-06-05-machine-wide-opt-install-phases2-3.md` (1x)
- `launcher/src/linux_service.rs` (`bootstrap_decision` doc-comment — comment only, no logic)

Repo-wide grep for `/opt/VERSION` now returns zero. `release:none` (docs + comment only).