### PR TITLE
fix(linux): system-service install fcontext + uninstall teardown (beta.61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux system-wide service install now labels its state directory correctly under SELinux.** A flaw in the install script's SELinux labeling could leave `/var/opt/ws-scrcpy-web` mislabeled on enforcing systems like Fedora; the labeling steps are now independent, so one failing step can no longer skip the rest (and the bundled dependencies get relabeled too).
+- **Linux system-wide service uninstall now actually removes the service.** The uninstall spawned a helper that crashed on startup — before tearing anything down — so the service kept running while the UI reported it removed. The helper now starts correctly, and the in-app uninstall verifies the service is really gone before reporting success (and tells you if it isn't).
+
 ## [0.1.30-beta.60] - 2026-06-11
 
 ### Changed

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -73,6 +73,38 @@ pub fn data_root_from_env() -> Option<PathBuf> {
     }
 }
 
+/// Non-panicking sibling of `data_root_for_linux` for BEST-EFFORT callers (e.g. the
+/// launcher's startup `service.log` rotation, which a teardown transient unit hits
+/// without any `DATA_ROOT`/`HOME`/`XDG_DATA_HOME`). Returns `None` instead of
+/// panicking when none is set — the hard panic stays in `data_root_for_linux` for the
+/// supervisor path, where a persistent data root is genuinely mandatory.
+pub fn try_data_root_for_linux(
+    data_root: Option<&str>,
+    xdg_data_home: Option<&str>,
+    home: Option<&str>,
+) -> Option<PathBuf> {
+    if data_root.filter(|s| !s.is_empty()).is_none()
+        && xdg_data_home.filter(|s| !s.is_empty()).is_none()
+        && home.filter(|s| !s.is_empty()).is_none()
+    {
+        return None;
+    }
+    Some(data_root_for_linux(data_root, xdg_data_home, home))
+}
+
+/// Non-panicking env wrapper. `Some` when a data root is resolvable, `None` when
+/// nothing is set (best-effort callers skip rather than crash). On Windows it always
+/// resolves (PROGRAMDATA has a default), so this delegates to `data_root_from_env`.
+pub fn try_data_root_from_env() -> Option<PathBuf> {
+    if cfg!(windows) {
+        return data_root_from_env();
+    }
+    let data_root = std::env::var("DATA_ROOT").ok();
+    let xdg = std::env::var("XDG_DATA_HOME").ok();
+    let home = std::env::var("HOME").ok();
+    try_data_root_for_linux(data_root.as_deref(), xdg.as_deref(), home.as_deref())
+}
+
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]
 #[serde(default)]
 pub struct AppConfig {
@@ -305,6 +337,26 @@ mod tests {
         // #36 defense: the old `None => /tmp/WsScrcpyWeb` silently landed a
         // no-HOME root service in ephemeral /tmp. It now fails loudly instead.
         let _ = data_root_for_linux(None, None, None);
+    }
+
+    #[test]
+    fn try_data_root_for_linux_is_none_when_nothing_set() {
+        // Non-panicking sibling for best-effort callers (e.g. the service.log rotation
+        // in a teardown transient unit with no DATA_ROOT/HOME/XDG — beta.60 #9 5.1).
+        assert_eq!(try_data_root_for_linux(None, None, None), None);
+    }
+
+    #[test]
+    fn try_data_root_for_linux_is_some_when_data_root_set() {
+        assert_eq!(
+            try_data_root_for_linux(Some("/explicit/root"), None, None),
+            Some(PathBuf::from("/explicit/root")),
+        );
+    }
+
+    #[test]
+    fn try_data_root_for_linux_ignores_empty_strings() {
+        assert_eq!(try_data_root_for_linux(Some(""), Some(""), Some("")), None);
     }
 
     #[test]

--- a/docs/plans/2026-06-11-beta61-system-service-fixes.md
+++ b/docs/plans/2026-06-11-beta61-system-service-fixes.md
@@ -1,0 +1,380 @@
+# beta.61 — Linux system-service fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`; branch `beta61-linux-service-fixes`; no push until all gates green. Each Rust task: `cross test`/`cross clippy -D warnings` (Docker; plain cargo has no Linux linker). Each TS task: `npm test -- <file>` AND `npx tsc --noEmit` (0 errors — vitest does NOT type-check). Verify each task's on-disk diff + the gate yourself; IDE mid-edit diagnostics are often stale.
+
+**Goal:** Fix the two runtime-confirmed Linux system-service bugs from the beta.60 #9 smoke — `/var/opt` never gets `var_lib_t` (the SELinux gate), and the uninstall teardown helper core-dumps — plus the two robustness gaps they exposed.
+
+**Architecture:** The SELinux labeling is reworked from a fragile `&&` chain (where one `semanage` failure short-circuits the rest) into independent `;`-separated steps that can't short-circuit, across all three builders. The teardown spawn gains the `--setenv=DATA_ROOT` the install handoff already has. The launcher gains a non-panicking data-root resolver for best-effort callers. The uninstall UI verifies completion instead of assuming it.
+
+**Tech Stack:** TypeScript server (`src/server`, vitest), Rust launcher + common crate (`launcher`/`common`, `cross`), frontend (`src/app`).
+
+**Spec:** `docs/specs/2026-06-11-beta61-system-service-fixes-design.md`.
+
+---
+
+## File structure
+
+- `src/server/service/SystemdClient.ts` — rework the fcontext labeling in `buildSystemInstallScript` (:365), `buildMachineWideInstallScript` (:434), `buildSystemMigrationScript` (:593). One responsibility: build the privileged install/migration shell scripts.
+- `src/server/service/SystemdClient.test.ts` — update the existing `buildSystemInstallScript` fcontext assertions (drop bin_t-add + chcon; add var_lib_t + restorecon-/var/opt + independence); add equivalents for the other two builders.
+- `src/server/api/ServiceApi.ts` — add `--setenv=DATA_ROOT` to the system-scope teardown spawn in `handleUninstall` (:687-690).
+- `src/server/__tests__/ServiceApi.test.ts` — assert the teardown spawn arg-vector carries `--setenv=DATA_ROOT=/var/opt/ws-scrcpy-web`.
+- `common/src/config.rs` — add `try_data_root_from_env() -> Option<PathBuf>` (non-panicking sibling of `data_root_from_env`).
+- `launcher/src/main.rs:76` — use `try_data_root_from_env()` for the best-effort `service.log` rotation.
+- `src/app/...` (frontend) — uninstall-completion verification (surface a timeout failure instead of assuming "removed").
+
+---
+
+## Task 1: fcontext rework — `buildSystemInstallScript`
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts:349-365` (the `steps.push( … fcontext element … )`)
+- Test: `src/server/service/SystemdClient.test.ts` (the `describe('buildSystemInstallScript')` block, ~:62-73)
+
+- [ ] **Step 1: Update the failing test.** In `SystemdClient.test.ts`, replace the body of the `it('prepares /opt, chmods the (already-staged) binary, labels bin_t, then installs the unit', …)` test (~:62) with assertions for the new behavior, and add a dedicated independence test:
+
+```ts
+it('labels /var/opt var_lib_t + restorecons both trees as independent steps (no && chain, no chcon)', () => {
+    const script = buildSystemInstallScript(args);
+    // var_lib_t add for the FHS state dir (the beta.60 gate that never ran)
+    expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+    // BOTH restorecons present
+    expect(script).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
+    expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+    // the redundant /opt bin_t re-add is GONE (it short-circuited the chain on this Fedora)
+    expect(script).not.toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+    // the chcon fallback is GONE (it masked the failure + only touched one file)
+    expect(script).not.toContain('chcon -t bin_t');
+    // var_lib_t add is NOT gated behind a bin_t step via && (independence)
+    expect(script).not.toMatch(/bin_t[^;]*&&[^;]*var_lib_t/);
+});
+```
+
+Also update the older `it('prepares /opt … labels bin_t …')` test: remove its `expect(script).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'")` and `expect(script).toContain('chcon -t bin_t "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"')` lines (those behaviors are intentionally removed); keep the `restorecon -Rv "/opt/ws-scrcpy-web"`, unit-cp, and daemon-reload assertions.
+
+- [ ] **Step 2: Run the test, verify it FAILS.**
+
+Run: `npm test -- SystemdClient.test.ts`
+Expected: FAIL — current script still contains the bin_t add + chcon and lacks the var_lib_t-`-a`/restorecon-/var/opt independence the new test asserts.
+
+- [ ] **Step 3: Implement.** In `SystemdClient.ts`, replace the fcontext element pushed at :365 (and its leading comment block :350-364) with:
+
+```ts
+        // 2. SELinux labels — INDEPENDENT steps (`;`-separated, whole thing `|| true`)
+        //    so no single `semanage` failure can short-circuit the rest (the beta.58/60
+        //    #9 2.2/2.3 gate failure: the redundant `/opt` bin_t re-add's `-a` failed
+        //    "already defined" AND `-m`-to-unchanged-type also failed, breaking the old
+        //    `&&` chain before the var_lib_t add + both restorecons ever ran).
+        //    `/opt` is ALREADY bin_t (machine-wide-first gate created the rule + ran
+        //    restorecon at install) — so we do NOT re-add it; restorecon -Rv /opt below
+        //    just relabels the freshly-copied deps (cp -a preserved data_home_t) using
+        //    the existing rule. No chcon fallback (it masked failures + only relabeled
+        //    one file).
+        `( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ; ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ; ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || true`,
+```
+
+(The `chcon` local at :308 may now be unused in this function — if `buildSystemInstallScript` no longer references it, remove the `const chcon = binTool('chcon');` line to keep tsc/biome clean. Check: it is only used in this fcontext element.)
+
+- [ ] **Step 4: Run the test + type-check, verify PASS.**
+
+Run: `npm test -- SystemdClient.test.ts` → Expected: PASS
+Run: `npx tsc --noEmit` → Expected: 0 errors
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): var_lib_t labeling can no longer be short-circuited (system install)"
+```
+
+---
+
+## Task 2: fcontext rework — machine-wide + migration builders
+
+**Files:**
+- Modify: `src/server/service/SystemdClient.ts:434` (`buildMachineWideInstallScript`) and `:593` (`buildSystemMigrationScript`)
+- Test: `src/server/service/SystemdClient.test.ts`
+
+- [ ] **Step 1: Write failing tests.** Add to `SystemdClient.test.ts`:
+
+```ts
+describe('fcontext independence (machine-wide + migration)', () => {
+    it('buildMachineWideInstallScript: restorecon /opt runs independently, no chcon, no && chain', () => {
+        const script = buildMachineWideInstallScript(
+            { sourceAppImage: '/home/u/Downloads/App.AppImage', version: '0.1.30-beta.61' },
+        );
+        expect(script).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
+        expect(script).not.toContain('chcon -t bin_t');
+        expect(script).not.toMatch(/-a -t bin_t[^;]*&&[^;]*restorecon/);
+    });
+    it('buildSystemMigrationScript: var_lib_t add + restorecon independent, no chcon', () => {
+        const script = buildSystemMigrationScript(
+            { unitTmpPath: '/t', unitPath: '/u', name: 'WsScrcpyWeb', seedConfigJson: '{}' },
+        );
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+        expect(script).not.toContain('chcon -t var_lib_t');
+        expect(script).not.toMatch(/var_lib_t[^;]*&&[^;]*restorecon/);
+    });
+});
+```
+
+(Check the exact required args for both builders by reading their signatures at the top of each function; adjust the test arg objects to match. `buildMachineWideInstallScript` takes `{ sourceAppImage, version, iconSource? }`; `buildSystemMigrationScript` takes `{ unitTmpPath, unitPath, name, seedConfigJson }`.)
+
+- [ ] **Step 2: Run, verify FAIL.** `npm test -- SystemdClient.test.ts` → FAIL (both still use the `&&`-chain + chcon).
+
+- [ ] **Step 3: Implement.**
+
+In `buildMachineWideInstallScript` (:434), replace the fcontext element with (keep the bin_t add — this is the FIRST install that creates the `/opt` rule — but `;`-separate restorecon and drop chcon):
+
+```ts
+        `( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' || ${semanage} fcontext -m -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' ; ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || true`,
+```
+
+In `buildSystemMigrationScript` (:593), replace the fcontext element with:
+
+```ts
+        `( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ; ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || true`,
+```
+
+Remove any now-unused `const chcon = …` in `buildSystemMigrationScript` (:563) if it's no longer referenced.
+
+- [ ] **Step 4: Run + type-check, verify PASS.** `npm test -- SystemdClient.test.ts` → PASS; `npx tsc --noEmit` → 0.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/service/SystemdClient.ts src/server/service/SystemdClient.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): same fcontext independence fix for machine-wide + migration builders"
+```
+
+---
+
+## Task 3: teardown spawn passes `--setenv=DATA_ROOT`
+
+**Files:**
+- Modify: `src/server/api/ServiceApi.ts:687-690` (system-scope `runArgs`) + the `SYSTEM_STATE_DIR` import
+- Test: `src/server/__tests__/ServiceApi.test.ts`
+
+- [ ] **Step 1: Write the failing test.** In `ServiceApi.test.ts`, add a test that drives `handleUninstall` for a system-scope install with an injected `spawnDetached` spy + a service client whose `getInstalledScope` resolves `'system'`, running as root (`process.getuid` stubbed to return 0), and asserts the captured args:
+
+```ts
+it('system-scope uninstall teardown spawn sets DATA_ROOT (else the helper panics in data_root_for_linux)', async () => {
+    const spawned: { cmd: string; args: string[] }[] = [];
+    const api = new ServiceApi(
+        () => ({
+            supported: true,
+            platform: 'linux',
+            client: { getInstalledScope: async () => 'system' } as any,
+        }),
+        () => 'system',
+        () => true,
+        (cmd, args) => { spawned.push({ cmd, args }); },
+    );
+    const origGetuid = process.getuid;
+    (process as any).getuid = () => 0;
+    try {
+        const { req, res } = makeReqRes('POST', '/api/service/uninstall'); // use the file's existing req/res helper
+        await (api as any).handleUninstall(req, res);
+    } finally {
+        (process as any).getuid = origGetuid;
+    }
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0]!.args).toContain('--setenv=DATA_ROOT=/var/opt/ws-scrcpy-web');
+    // sanity: still the teardown helper invocation
+    expect(spawned[0]!.args).toContain('--linux-service-teardown');
+});
+```
+
+(Read the top of `ServiceApi.test.ts` for the existing request/response construction helper and the `ServiceApi` constructor signature — mirror them rather than the placeholder `makeReqRes` above.)
+
+- [ ] **Step 2: Run, verify FAIL.** `npm test -- ServiceApi.test.ts` → FAIL — current `runArgs` has no `--setenv=DATA_ROOT`.
+
+- [ ] **Step 3: Implement.** In `ServiceApi.ts`, ensure `SYSTEM_STATE_DIR` is imported from `../service/SystemdClient` (add to the existing import if absent). In `handleUninstall`'s system-scope branch (:687-690), change `runArgs` to insert the setenv right after `teardownUnit`:
+
+```ts
+                const optHelper = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_HELPER}`;
+                const runArgs = [
+                    '--system', '--collect', teardownUnit,
+                    // DATA_ROOT is MANDATORY: a `systemd-run --system` transient unit has no
+                    // HOME/XDG either, so without it the launcher panics in
+                    // data_root_for_linux (config.rs) at startup — before running any
+                    // teardown command (beta.60 #9 5.1 core-dump). Mirrors the install handoff.
+                    `--setenv=DATA_ROOT=${SYSTEM_STATE_DIR}`,
+                    optHelper, '--linux-service-teardown', '--scope', 'system', '--unit', WS_SCRCPY_SERVICE_NAME,
+                ];
+```
+
+- [ ] **Step 4: Run + type-check, verify PASS.** `npm test -- ServiceApi.test.ts` → PASS; `npx tsc --noEmit` → 0.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/server/api/ServiceApi.ts src/server/__tests__/ServiceApi.test.ts
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): system-service uninstall teardown sets DATA_ROOT (no more launcher panic)"
+```
+
+---
+
+## Task 4: non-panicking `try_data_root_from_env`
+
+**Files:**
+- Modify: `common/src/config.rs` (add the fn + tests near `data_root_from_env` :64)
+
+- [ ] **Step 1: Write the failing tests.** Add to the `#[cfg(test)] mod tests` in `config.rs`:
+
+```rust
+    #[test]
+    fn try_data_root_from_env_is_none_when_nothing_set() {
+        // Non-panicking sibling for best-effort callers (e.g. service.log rotation
+        // in a teardown transient unit that has no DATA_ROOT/HOME/XDG).
+        assert_eq!(try_data_root_for_linux(None, None, None), None);
+    }
+    #[test]
+    fn try_data_root_from_env_is_some_when_data_root_set() {
+        assert_eq!(try_data_root_for_linux(Some("/explicit/root"), None, None), Some(PathBuf::from("/explicit/root")));
+    }
+```
+
+- [ ] **Step 2: Run, verify FAIL.** `cross test -p ws-scrcpy-web-common --target x86_64-unknown-linux-gnu try_data_root` (adjust crate name if the common crate is named differently — check `common/Cargo.toml`). Expected: FAIL — `try_data_root_for_linux` not defined.
+
+- [ ] **Step 3: Implement.** In `config.rs`, add a pure non-panicking resolver + the env wrapper (place after `data_root_for_linux`, ~:59):
+
+```rust
+/// Non-panicking sibling of `data_root_for_linux` for BEST-EFFORT callers (e.g.
+/// the service.log rotation at launcher startup, which a teardown transient unit
+/// hits without any DATA_ROOT/HOME/XDG). Returns `None` instead of panicking when
+/// none is set — the hard panic stays in `data_root_for_linux` for the supervisor
+/// path, where a persistent data root is genuinely mandatory.
+pub fn try_data_root_for_linux(
+    data_root: Option<&str>,
+    xdg_data_home: Option<&str>,
+    home: Option<&str>,
+) -> Option<PathBuf> {
+    if data_root.filter(|s| !s.is_empty()).is_none()
+        && xdg_data_home.filter(|s| !s.is_empty()).is_none()
+        && home.filter(|s| !s.is_empty()).is_none()
+    {
+        return None;
+    }
+    Some(data_root_for_linux(data_root, xdg_data_home, home))
+}
+
+/// Non-panicking env wrapper. `Some` when a data root is resolvable, `None` when
+/// nothing is set (best-effort callers skip rather than crash).
+pub fn try_data_root_from_env() -> Option<PathBuf> {
+    if cfg!(windows) {
+        return data_root_from_env();
+    }
+    let data_root = std::env::var("DATA_ROOT").ok();
+    let xdg = std::env::var("XDG_DATA_HOME").ok();
+    let home = std::env::var("HOME").ok();
+    try_data_root_for_linux(data_root.as_deref(), xdg.as_deref(), home.as_deref())
+}
+```
+
+- [ ] **Step 4: Run + clippy, verify PASS.** `cross test -p <common-crate> --target x86_64-unknown-linux-gnu try_data_root` → PASS; `cross clippy -p <common-crate> --target x86_64-unknown-linux-gnu -- -D warnings` → clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add common/src/config.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "feat(common): try_data_root_from_env — non-panicking resolver for best-effort callers"
+```
+
+---
+
+## Task 5: launcher startup uses `try_data_root_from_env`
+
+**Files:**
+- Modify: `launcher/src/main.rs:75-81` (the `service.log` rotation block)
+
+- [ ] **Step 1: Read** `launcher/src/main.rs:75-81` to confirm the exact current block (the `if let Some(data_root) = common::config::data_root_from_env() { copy_truncate_if_large(... service.log ...) }`).
+
+- [ ] **Step 2: Implement.** Change the call from the panicking `data_root_from_env()` to the new `try_data_root_from_env()`:
+
+```rust
+    // Best-effort service.log rotation — MUST NOT panic. A teardown helper spawned
+    // via `systemd-run --system` has no DATA_ROOT/HOME/XDG; the panicking
+    // data_root_from_env() would abort it here (beta.60 #9 5.1) before it reached
+    // the teardown dispatch below. try_ returns None → we simply skip the rotation.
+    #[cfg(target_os = "linux")]
+    if let Some(data_root) = common::config::try_data_root_from_env() {
+        common::log::copy_truncate_if_large(
+            &data_root.join("logs").join("service.log"),
+            10 * 1024 * 1024,
+        );
+    }
+```
+
+- [ ] **Step 3: Build + clippy, verify.** `cross build -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu` → compiles; `cross clippy -p ws-scrcpy-web-launcher --target x86_64-unknown-linux-gnu -- -D warnings` → clean. (main() itself isn't unit-tested; the behavior is covered by Task 4's resolver test + the #9 re-smoke.)
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add launcher/src/main.rs
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(linux): launcher startup log-rotation no longer panics without DATA_ROOT"
+```
+
+---
+
+## Task 6: UI honesty — uninstall verifies completion
+
+**Files:**
+- Read first: the frontend service-uninstall flow + the existing install/reconnect poll. Grep `src/app` for `service/uninstall`, `shutting-down`, `classifyInstallPoll`, `reconnect`, and the Settings service-section uninstall handler.
+- Modify: the frontend uninstall handler (found above) + its test.
+
+- [ ] **Step 1: Read + map** the current flow: where the frontend POSTs `/api/service/uninstall`, what it does with the `status: 'shutting-down'` response, and the existing post-action reconnect/relaunch poll (the spec notes user-scope already shows "this page will reconnect shortly"). Identify the smallest extension point that adds a **timeout-surfacing** completion check for the system-scope case.
+
+- [ ] **Step 2: Write the failing test** for the completion classifier — model it on the existing install-poll test. Assert: a `/api/service/status` response showing the service gone (`status` not running / `getInstalledScope` null) → resolves "done"; still-present after the timeout budget → resolves a surfaced failure (not a silent success).
+
+- [ ] **Step 3: Run, verify FAIL.** `npm test -- <that test file>` → FAIL.
+
+- [ ] **Step 4: Implement** the completion poll/classifier, reusing the install-poll affordance rather than duplicating it. Keep the backend `shutting-down` response as-is.
+
+- [ ] **Step 5: Run + type-check, verify PASS.** `npm test -- <that test file>` → PASS; `npx tsc --noEmit` → 0.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add src/app/...  # the touched files
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "fix(ui): system-service uninstall verifies completion instead of assuming success"
+```
+
+---
+
+## Task 7: full gate + CHANGELOG
+
+- [ ] **Step 1: Full gates.**
+
+```bash
+npx tsc --noEmit                 # 0 errors
+npm test                         # full vitest suite green
+cross test --target x86_64-unknown-linux-gnu          # launcher + common green
+cross clippy --target x86_64-unknown-linux-gnu -- -D warnings   # clean
+npm run build                    # webpack clean
+```
+
+Paste each result. Do NOT proceed to push/release until all are green.
+
+- [ ] **Step 2: CHANGELOG.** Add entries under `## [Unreleased]` in `CHANGELOG.md` (NEVER a pre-written `## [0.1.30-beta.61]` heading — `bump-version.mjs` promotes Unreleased and aborts if the version heading already exists):
+
+```markdown
+### Fixed
+- Linux system-service install now reliably labels `/var/opt` `var_lib_t` — the SELinux labeling steps are independent so one `semanage` quirk can no longer short-circuit the rest (the `/opt` bin_t re-add that failed "already defined" on a pre-existing rule). Also relabels the copied dependencies `bin_t`.
+- Linux system-service uninstall now actually tears the service down — the teardown helper spawn was missing `DATA_ROOT`, so it core-dumped at startup before running. The launcher's best-effort startup log-rotation no longer panics when `DATA_ROOT`/`HOME`/`XDG_DATA_HOME` are unset.
+- The in-app uninstall reports success only once the service is actually gone.
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add CHANGELOG.md
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "docs(changelog): beta.61 system-service fixes"
+```
+
+---
+
+## After implementation
+
+- Open a `release:beta` PR (the auto-release Mode 1 cuts the bump PR — do NOT manually bump). Squash-merge.
+- **The real gate is the Fedora #9 re-smoke on the published beta.61** (exit criteria in the spec): 2.2 `var_lib_t`, 2.3 both rules, deps `bin_t`, zero AVC; 5.1 uninstall actually removes + relaunches local; 5.4 fcontext empty. Then resume the smoke past #9.

--- a/docs/specs/2026-06-11-beta61-system-service-fixes-design.md
+++ b/docs/specs/2026-06-11-beta61-system-service-fixes-design.md
@@ -1,0 +1,94 @@
+# beta.61 — Linux system-service fixes (fcontext + uninstall teardown) design
+
+**Status:** approved (brainstorm) 2026-06-11. **Linux-only.** Two independent, runtime-confirmed bugs found during the beta.60 Fedora smoke (#9 system-scope pass), plus the two robustness gaps they exposed.
+
+**Scope (user pick, 2026-06-11): Complete** — both root-cause fixes + launcher-resilience + UI-honesty.
+
+**Tech:** TS server (vitest + `tsc`), Rust launcher (`cross`), frontend. `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`; branch `beta61-linux-service-fixes`; no push until gates green.
+
+---
+
+## Evidence (beta.60, Fedora VM, captured `D:\OneDrive\20260611-144431-9-2.2-selinux-usr_t\` + live journal)
+
+- **2.2:** `/var/opt/ws-scrcpy-web` dir + config.json + control + logs all `usr_t` (expected `var_lib_t`). **2.3:** only the `/opt` bin_t fcontext rule exists; the `/var/opt` var_lib_t rule is **absent**. `/opt/ws-scrcpy-web/dependencies` is **`data_home_t`** (not bin_t). **10-avc:** no denials.
+- **Uninstall journal:** `wsscrcpy-teardown-*.service` (the `systemd-run --system` transient unit) **core-dumps** — `ws-scrcpy-web-launcher.exe panicked at common/src/config.rs:53: data_root_for_linux: none of DATA_ROOT, XDG_DATA_HOME, or HOME is set` → `status=6/ABRT`. The **install** handoff in the same journal spawns with `--setenv=DATA_ROOT=/var/opt/ws-scrcpy-web`; the teardown spawn does not.
+
+---
+
+## Bug 1 — fcontext labeling never applies `var_lib_t` (the gate, #9 2.2/2.3)
+
+### Root cause
+`buildSystemInstallScript` (`src/server/service/SystemdClient.ts:365`) labels via a single fragile chain:
+
+```
+( ( (semanage -a bin_t /opt || semanage -m bin_t /opt) && (semanage -a var_lib_t /var/opt || semanage -m var_lib_t /var/opt) && restorecon -Rv /opt && restorecon -Rv /var/opt ) || chcon -t bin_t <AppImage> || true )
+```
+
+A system install is gated machine-wide-first, so the `/opt` bin_t rule **always pre-exists** → `semanage fcontext -a` fails "already defined", and `semanage fcontext -m -t bin_t` **also fails** on the unchanged rule. The leading `( -a || -m )` therefore returns non-zero, the `&&` chain short-circuits, and the var_lib_t add + **both** restorecons never run. Proof: deps stayed `data_home_t` (would be bin_t if `restorecon /opt` had run), the var_lib_t rule is absent, and `/var/opt` is `usr_t`. beta.58's `-a || -m` "fix" was insufficient because `-m`-to-an-unchanged-type also fails.
+
+### Fix — robust by construction (no chain to short-circuit)
+The `/opt` bin_t labeling is **not this script's job** — the machine-wide install already created the rule and ran restorecon. So:
+
+- **Drop the bin_t `-a || -m` re-add step entirely.**
+- Emit the labeling as **independent, individually non-fatal** steps (not an `&&` chain):
+  1. `semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?' || semanage fcontext -m -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?' || true`
+  2. `restorecon -Rv /opt/ws-scrcpy-web || true`  *(relabels the freshly-copied deps `data_home_t → bin_t` — fixes that mislabel)*
+  3. `restorecon -Rv /var/opt/ws-scrcpy-web || true`  *(applies var_lib_t)*
+- **Remove the `chcon` fallback** — it masked the failure and only ever relabeled one file.
+
+On a clean install the var_lib_t `-a` succeeds (rule absent → added); on a re-install the `-m` covers it; `|| true` guarantees no step can short-circuit the others. The seed config (`/var/opt/.../config.json`) is still written *before* the restorecons, so it picks up `var_lib_t`.
+
+### Same pattern elsewhere (migration-audit)
+`buildMachineWideInstallScript` (~:434) and `buildSystemMigrationScript` (~:587) carry the same `-a || -m`-in-an-`&&`-chain shape. Apply the same independence fix (grep `semanage fcontext` across `SystemdClient.ts` during impl to confirm the full set).
+
+---
+
+## Bug 2 — system-service uninstall is a no-op (#9 5.1), three parts
+
+### 2a — the crash (makes uninstall actually work)
+`handleUninstall` (`src/server/api/ServiceApi.ts:687-690`), system-scope path, builds the teardown spawn **without** `--setenv=DATA_ROOT`:
+
+```
+systemd-run --system --collect --unit=wsscrcpy-teardown-<ts> /opt/.../ws-scrcpy-web-launcher.exe --linux-service-teardown --scope system --unit WsScrcpyWeb
+```
+
+A `systemd-run --system` transient unit inherits no HOME/XDG either, so the launcher panics at startup. **Fix:** add `--setenv=DATA_ROOT=${SYSTEM_STATE_DIR}` (`/var/opt/ws-scrcpy-web`) to the system-scope `runArgs`, mirroring the install handoff.
+
+### 2b — launcher resilience (defense-in-depth)
+`launcher/src/main.rs:76` calls the panicking `common::config::data_root_from_env()` solely to copy-truncate-rotate `service.log` (a best-effort convenience, from the beta.59 10 MB rotation). That makes *any* subcommand spawned without DATA_ROOT (e.g. the teardown) crash before its real work. **Fix:** add `common::config::try_data_root_from_env() -> Option<PathBuf>` (the non-panicking sibling that returns `None` instead of hitting the `data_root_for_linux` panic) and use it for the best-effort rotation at main.rs:76. The hard panic in `data_root_for_linux` stays for the supervisor path, where a persistent data root is genuinely mandatory.
+
+### 2c — UI honesty
+`ServiceApi` returns `{ok:true, status:'shutting-down'}` immediately after spawning the teardown (fire-and-forget), so the UI shows "service removed, restart for local mode" even when the teardown core-dumps. **Fix:** mirror the existing install-poll pattern — keep returning `shutting-down`, but the frontend polls `/api/service/status` until the service is actually gone (`getInstalledScope` → null / `status` not running), with a timeout that surfaces a real failure instead of the false "removed."
+
+---
+
+## Testing strategy (why beta.58 shipped green-but-broken)
+
+beta.58's test only asserted the generated script *string* contained `-a || -m` — it never exercised the runtime, so it could not catch `-m` failing on an unchanged rule. beta.61 tests target **behavior**, not strings:
+
+- **fcontext (vitest):** assert the builder emits the var_lib_t add **and both** restorecons as **independent steps** with **no `&&` chain and no `chcon` fallback** — so a single `semanage` failure is structurally unable to skip the rest. Repeat the assertion for all three builders. *(Stretch, if cheap on Linux CI: execute the generated step list against injected stub `semanage`/`restorecon` tools that simulate "already defined", and assert the var_lib_t rule + restorecons still ran.)*
+- **teardown DATA_ROOT (vitest):** assert the system-scope teardown spawn arg-vector contains `--setenv=DATA_ROOT=/var/opt/ws-scrcpy-web` (mirror the existing install-handoff spawn test).
+- **launcher resilience (cross test):** `try_data_root_from_env()` returns `None` (does not panic) when DATA_ROOT/XDG_DATA_HOME/HOME are all unset; still returns `Some` when any is set. The existing `data_root_for_linux_panics_…` test stays (the hard-fail contract is unchanged where it matters).
+- **UI honesty (vitest):** the uninstall-poll classifier resolves "service gone" → success and "still present after timeout" → surfaced failure.
+
+All TDD (RED → GREEN). Full gates: `tsc --noEmit` 0 · vitest · `cross test` · `cross clippy -D warnings` · webpack.
+
+---
+
+## Components / files
+
+- `src/server/service/SystemdClient.ts` — fcontext rework in `buildSystemInstallScript` (+ `buildMachineWideInstallScript`, `buildSystemMigrationScript`).
+- `src/server/api/ServiceApi.ts` — `--setenv=DATA_ROOT` in the system-scope teardown spawn; the uninstall success path waits-on / signals poll instead of immediate success (coordinate with frontend).
+- `common/src/config.rs` — new `try_data_root_from_env()`.
+- `launcher/src/main.rs` — use `try_data_root_from_env()` for the service.log rotation at :76.
+- `src/app/...` (frontend) — uninstall reconnect/verify poll (reuse the install-poll affordance).
+
+## Exit criteria (Fedora, runtime — the re-smoke)
+
+Re-run #9 on beta.61 from a clean slate: system-service install → **2.2** `/var/opt` = `var_lib_t`, **2.3** both the `/opt` bin_t and `/var/opt` var_lib_t rules present, deps now `bin_t`, **zero AVC**; **5.1** uninstall **actually removes** the service (unit gone, `/opt`+`/var/opt` gone, app relaunches local same-port) and the UI only reports success once it's truly gone; **5.4** fcontext rules empty after uninstall. Then continue #9 → the rest of the smoke.
+
+## Out of scope (tracked in `todo_ws_scrcpy_web.md`, fix later)
+
+- **Cold-start-via-`.desktop` opens no browser tab** until a 2nd click — auto-open-browser is gated `firstRunComplete === false` (`openBrowser.ts`), so a cold start past first-run boots the server without a tab; the 2nd click opens it via the defer path.
+- **Smoke-doc nit:** row 5.8 "pgrep clean" wording is misleading (a relaunch leaves the local instance + its pre-warmed adb daemon; the adb daemon is reaped at 12.1).
+- **`capture-logs.sh` polish:** grabs whole-history journal instead of `-b` (so old crash-loop noise leaks in) and omits the system service's complete `ws-scrcpy-web.log`.

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -72,8 +72,13 @@ fn main() {
     // copy-truncate (a rename would orphan that fd). No-op off-Linux, when the
     // file is absent/small, or when not service-run (harmless on a stale file).
     // Windows service.log is rotated by servy natively (see elevated_runner).
+    // try_ (NON-panicking): a teardown helper spawned via `systemd-run --system`
+    // (uninstall) has no DATA_ROOT/HOME/XDG, and the panicking data_root_from_env()
+    // would abort the process HERE — before reaching the teardown dispatch below
+    // (the beta.60 #9 5.1 core-dump that made uninstall a no-op). None → just skip
+    // the best-effort rotation.
     #[cfg(target_os = "linux")]
-    if let Some(data_root) = common::config::data_root_from_env() {
+    if let Some(data_root) = common::config::try_data_root_from_env() {
         common::log::copy_truncate_if_large(
             &data_root.join("logs").join("service.log"),
             10 * 1024 * 1024,

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -5,6 +5,7 @@ import { UninstallConfirmModal } from './UninstallConfirmModal';
 import { ResetConfirmModal } from './ResetConfirmModal';
 import { ServiceOperationModal } from './ServiceOperationModal';
 import { runUpgradingHandoff } from './UpgradingOverlay';
+import { pollServiceUninstalled } from './pollServiceUninstalled';
 import type { AppConfigEnvelope, AppConfigPatchResponse, UpdateChannel } from '../../common/ConfigEvents';
 import type {
     ServiceStatusResponse,
@@ -1472,12 +1473,25 @@ export class SettingsModal extends Modal {
                 const isSystemUninstall =
                     data.installMode === 'system' || data.installMode === 'system-service';
                 if (isLinux && isSystemUninstall) {
-                    // System scope on Linux: teardown helper stops the unit but
-                    // does NOT relaunch a local instance. Nothing to poll for.
+                    // System scope on Linux: the out-of-cgroup teardown helper runs
+                    // ASYNCHRONOUSLY. Do NOT claim success blindly — beta.60 #9 5.1: the
+                    // helper could core-dump (missing DATA_ROOT) while ServiceApi already
+                    // returned `shutting-down`, leaving the service running but the UI
+                    // saying "removed". Poll /api/service/status until the service is
+                    // actually gone, and surface a failure if it never does.
                     modal.close();
+                    this.renderServiceInfo('removing the system service…');
+                    const outcome = await pollServiceUninstalled();
                     btn.disabled = false;
                     btn.textContent = prevText;
-                    this.renderServiceInfo(uninstallFollowupMessage('system'));
+                    if (outcome === 'uninstalled') {
+                        this.renderServiceInfo(uninstallFollowupMessage('system'));
+                    } else {
+                        this.renderServiceError(
+                            'the system service is still running — uninstall may not have completed. check the service logs and try again.',
+                            () => void this.refreshService(),
+                        );
+                    }
                     return;
                 }
                 // User scope on Linux (or Windows): a fresh local instance is

--- a/src/app/client/__tests__/pollServiceUninstalled.test.ts
+++ b/src/app/client/__tests__/pollServiceUninstalled.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pollServiceUninstalled } from '../pollServiceUninstalled';
+
+function statusResponse(status: string) {
+    return { ok: true, json: async () => ({ status }) } as unknown as Response;
+}
+
+describe('pollServiceUninstalled', () => {
+    it('resolves "uninstalled" once /status reports not-installed (swallows the teardown down-window)', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('down')) // teardown stops the serving unit
+            .mockResolvedValueOnce(statusResponse('running')) // still up briefly
+            .mockResolvedValueOnce(statusResponse('not-installed')); // gone
+        const result = await pollServiceUninstalled({
+            fetchFn: fetchMock as unknown as typeof fetch,
+            intervalMs: 0,
+            deadlineMs: 10_000,
+            now: (() => { let t = 0; return () => (t += 1); })(),
+        });
+        expect(result).toBe('uninstalled');
+        expect(fetchMock).toHaveBeenCalledWith('/api/service/status', { cache: 'no-store' });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('resolves "still-present" when the service never goes away — surfaces a failed teardown (beta.60 #9 5.1)', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(statusResponse('running'));
+        const result = await pollServiceUninstalled({
+            fetchFn: fetchMock as unknown as typeof fetch,
+            intervalMs: 0,
+            deadlineMs: 5,
+            now: (() => { let t = 0; return () => (t += 2); })(),
+        });
+        expect(result).toBe('still-present');
+    });
+});

--- a/src/app/client/pollServiceUninstalled.ts
+++ b/src/app/client/pollServiceUninstalled.ts
@@ -1,0 +1,50 @@
+import type { ServiceStatusResponse } from '../../common/ServiceEvents';
+
+export interface PollUninstalledOptions {
+    /** Injectable for tests. Defaults to the global fetch. */
+    fetchFn?: typeof fetch;
+    /** Poll interval (ms). Default 1000. */
+    intervalMs?: number;
+    /** Give up after this long (ms). Default 30000. */
+    deadlineMs?: number;
+    /** Injectable clock for tests. Default Date.now. */
+    now?: () => number;
+}
+
+/**
+ * Poll GET /api/service/status until it reports the service is gone
+ * (`status === 'not-installed'` → 'uninstalled'), or the deadline elapses
+ * (→ 'still-present'). Fetch errors are EXPECTED while a system-scope teardown
+ * stops the serving unit (the page's server dies, then a local instance
+ * relaunches) and are swallowed — keep polling. No DOM here; the caller owns the UI.
+ *
+ * This is the honesty check: the UI must CONFIRM the teardown happened before
+ * claiming "service removed". beta.60 #9 5.1 — the system teardown helper used to
+ * core-dump (missing DATA_ROOT) while ServiceApi optimistically returned
+ * `shutting-down`, so the UI reported success while the service kept running.
+ */
+export async function pollServiceUninstalled(
+    opts: PollUninstalledOptions = {},
+): Promise<'uninstalled' | 'still-present'> {
+    const fetchFn = opts.fetchFn ?? fetch;
+    const intervalMs = opts.intervalMs ?? 1000;
+    const deadlineMs = opts.deadlineMs ?? 30_000;
+    const now = opts.now ?? (() => Date.now());
+    const start = now();
+    for (;;) {
+        try {
+            const r = await fetchFn('/api/service/status', { cache: 'no-store' });
+            if (r.ok) {
+                const s = (await r.json()) as ServiceStatusResponse;
+                if (s.status === 'not-installed') {
+                    return 'uninstalled';
+                }
+            }
+        } catch {
+            // server down while the teardown stops the unit (+ a local instance
+            // relaunches) — expected; keep polling.
+        }
+        if (now() - start >= deadlineMs) return 'still-present';
+        if (intervalMs > 0) await new Promise((res) => setTimeout(res, intervalMs));
+    }
+}

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -143,6 +143,23 @@ describe('ServiceApi', () => {
         expect(await api.handle(req, res)).toBe(false);
     });
 
+    it('system-scope uninstall: teardown spawn sets DATA_ROOT (else the helper panics in data_root_for_linux at startup — beta.60 #9 5.1)', async () => {
+        const spawned: { cmd: string; args: string[] }[] = [];
+        const api = new ServiceApi(
+            () => ({ supported: true, platform: 'linux', client: { getInstalledScope: async () => 'system' } } as any),
+            () => 'system',
+            () => true,
+            (cmd, args) => { spawned.push({ cmd, args }); },
+        );
+        const { req, res } = makeReqRes('/api/service/uninstall', 'POST');
+        await api.handle(req, res);
+        expect(spawned).toHaveLength(1);
+        // a `systemd-run --system` transient unit has no HOME/XDG either, so without
+        // DATA_ROOT the launcher panics before running any teardown command.
+        expect(spawned[0]!.args).toContain('--setenv=DATA_ROOT=/var/opt/ws-scrcpy-web');
+        expect(spawned[0]!.args).toContain('--linux-service-teardown');
+    });
+
     it('GET /status returns supported=false envelope on unsupported platforms', async () => {
         const factoryResult: ServiceClientFactoryResult = {
             client: fakeClient(),

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -686,6 +686,12 @@ export class ServiceApi {
                 const optHelper = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_HELPER}`;
                 const runArgs = [
                     '--system', '--collect', teardownUnit,
+                    // DATA_ROOT is MANDATORY: a `systemd-run --system` transient unit has no
+                    // HOME/XDG either, so without it the launcher panics in data_root_for_linux
+                    // (config.rs) at startup — before running ANY teardown command (the beta.60
+                    // #9 5.1 core-dump that made uninstall a silent no-op). Mirrors the install
+                    // handoff's --setenv.
+                    `--setenv=DATA_ROOT=${SYSTEM_STATE_DIR}`,
                     optHelper, '--linux-service-teardown', '--scope', 'system', '--unit', WS_SCRCPY_SERVICE_NAME,
                 ];
                 if (process.getuid?.() === 0) {

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -59,17 +59,32 @@ describe('buildSystemInstallScript', () => {
         expect(script).not.toContain('ws-scrcpy-web-launcher.exe');
     });
 
-    it('prepares /opt, chmods the (already-staged) binary, labels bin_t, then installs the unit', () => {
+    it('prepares /opt, chmods the (already-staged) binary, then installs the unit', () => {
         const script = buildSystemInstallScript(args);
         expect(script).toContain('mkdir -p /opt/ws-scrcpy-web');
         // the AppImage is NOT re-copied (machine-wide precondition) — only chmod'd
         expect(script).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
-        expect(script).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
         expect(script).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
-        expect(script).toContain('chcon -t bin_t "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
         expect(script).toContain('cp "/tmp/WsScrcpyWeb.service.tmp" "/etc/systemd/system/WsScrcpyWeb.service"');
         expect(script).toContain('systemctl daemon-reload');
         expect(script).toContain('systemctl enable --now WsScrcpyWeb.service');
+    });
+
+    it('labels /var/opt var_lib_t + restorecons both trees as independent steps (no && chain, no chcon)', () => {
+        // beta.60 #9 2.2/2.3 gate: the old `&&` chain short-circuited at the redundant
+        // /opt bin_t re-add (`-a` "already defined" + `-m`-to-unchanged both fail on this
+        // Fedora's semanage), so the var_lib_t add + both restorecons never ran and
+        // /var/opt came out usr_t. The labeling steps must be independent.
+        const script = buildSystemInstallScript(args);
+        expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        expect(script).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
+        expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+        // the redundant /opt bin_t re-add is gone (it poisoned the chain)
+        expect(script).not.toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
+        // the chcon fallback is gone (masked failures, only relabeled one file)
+        expect(script).not.toContain('chcon -t bin_t');
+        // var_lib_t labeling is NOT gated behind a bin_t step via && (independence)
+        expect(script).not.toMatch(/bin_t[^;]*&&[^;]*var_lib_t/);
     });
 
     it('staging precedes the unit copy (so ExecStart target exists before enable)', () => {
@@ -149,18 +164,21 @@ describe('buildSystemInstallScript', () => {
         );
     });
 
-    it('makes the SELinux fcontext adds idempotent (-a || -m) so a pre-existing /opt bin_t rule cannot short-circuit the var_lib_t add + restorecons (beta.57 #9 2.2/2.3)', () => {
+    it('var_lib_t labeling cannot be short-circuited — independent steps, no /opt bin_t re-add (beta.58/60 #9 2.2/2.3)', () => {
         const script = buildSystemInstallScript(args);
-        // A system-service install is gated on machine-wide-first, so the /opt bin_t
-        // fcontext rule ALWAYS pre-exists. A bare `semanage fcontext -a` then errors
-        // "already defined" and the `&&` chain skips the /var/opt var_lib_t add + both
-        // restorecons -> /var/opt mislabelled usr_t (smoke 2.2/2.3). Each add must be
-        // `-a || -m` (add, or modify-if-already-defined) so it can't fail-and-cascade.
-        expect(script).toContain("semanage fcontext -m -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
-        expect(script).toContain("semanage fcontext -m -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
-        // the var_lib_t add + the /var/opt restorecon still happen (not skipped):
+        // The OLD `&&` chain led with a redundant /opt bin_t re-add whose `-a` errored
+        // "already defined" (machine-wide-first gate => the rule always pre-exists) AND
+        // `-m`-to-unchanged ALSO failed on Fedora's semanage — short-circuiting the
+        // var_lib_t add + both restorecons, so /var/opt came out usr_t (the beta.58 fix
+        // that this test used to "verify" was string-only and never caught it). /opt is
+        // already bin_t (machine-wide install), so the re-add is GONE and the labeling
+        // steps are `;`-separated — structurally un-short-circuitable.
         expect(script).toContain("semanage fcontext -a -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+        // `-m` fallback keeps re-installs idempotent:
+        expect(script).toContain("semanage fcontext -m -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
         expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+        // the /opt bin_t re-add (and the chcon fallback) that poisoned the chain are gone:
+        expect(script).not.toContain('-t bin_t');
     });
 });
 

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -309,6 +309,16 @@ describe('buildMachineWideInstallScript', () => {
         // `-a || -m` form keeps it idempotent. (Sibling of the #9 2.2/2.3 bug.)
         expect(s).toContain("semanage fcontext -m -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
     });
+
+    it('restorecon runs independently of the bin_t add (;-separated), no chcon fallback (beta.61)', () => {
+        const s = buildMachineWideInstallScript(
+            { sourceAppImage: '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage', version: '0.1.31-beta.1' },
+        );
+        expect(s).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
+        expect(s).not.toContain('chcon -t bin_t');
+        // bin_t add + restorecon are `;`-separated, not `&&`-chained (can't short-circuit)
+        expect(s).not.toMatch(/-a -t bin_t[^;]*&&[^;]*restorecon/);
+    });
 });
 
 describe('buildMachineWideUpdateScript', () => {
@@ -407,6 +417,13 @@ describe('buildSystemMigrationScript', () => {
     it('makes the var_lib_t fcontext add idempotent (-a || -m) — consistent with the install scripts, robust to a re-run over an existing rule', () => {
         const script = buildSystemMigrationScript(args);
         expect(script).toContain("semanage fcontext -m -t var_lib_t '/var/opt/ws-scrcpy-web(/.*)?'");
+    });
+
+    it('restorecon runs independently of the var_lib_t add (;-separated), no chcon fallback (beta.61)', () => {
+        const script = buildSystemMigrationScript(args);
+        expect(script).toContain('restorecon -Rv "/var/opt/ws-scrcpy-web"');
+        expect(script).not.toContain('chcon -t var_lib_t');
+        expect(script).not.toMatch(/var_lib_t[^;]*&&[^;]*restorecon/);
     });
 
     it('carries the seeded webPort into /var/opt/.../config.json', () => {

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -305,7 +305,6 @@ export function buildSystemInstallScript(
     const mkdir = binTool('mkdir');
     const cp = binTool('cp');
     const chmod = binTool('chmod');
-    const chcon = binTool('chcon');
     const systemctl = binTool('systemctl');
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
@@ -347,22 +346,18 @@ export function buildSystemInstallScript(
         steps.push(`${cp} "${args.seedConfigTmpPath}" "${SYSTEM_STATE_DIR}/config.json"`);
     }
     steps.push(
-        // 2. label bin_t so init_t can exec it. Persistent rule (semanage) when
-        //    available; restorecon applies it; chcon is the transient fallback
-        //    for minimal images without policycoreutils-python-utils. The whole
-        //    step is a best-effort subshell with a trailing `|| true`: POSIX sh
-        //    gives `&&`/`||` EQUAL precedence (left-assoc), so without isolation
-        //    a label failure on a non-SELinux host (semanage absent + chcon
-        //    erroring on a non-SELinux fs) would break the outer `&&` chain and
-        //    silently skip the unit cp + enable below.
-        //    restorecon covers the whole dir — labels the helper bin_t too when present.
-        //    Each `semanage fcontext -a` is paired with `|| …-m` (add, or modify-if-
-        //    already-defined): a system install is GATED on machine-wide-first, so the
-        //    /opt bin_t rule ALWAYS pre-exists — a bare `-a` errors "already defined",
-        //    and because the inner steps are `&&`-chained that failure would skip the
-        //    /var/opt var_lib_t add + both restorecons, leaving /var/opt mislabelled
-        //    usr_t (the beta.57 #9 2.2/2.3 bug). `-a || -m` makes each add idempotent.
-        `( ( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' || ${semanage} fcontext -m -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' ) && ( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ) && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        // 2. SELinux labels — INDEPENDENT steps (`;`-separated, whole subshell `|| true`)
+        //    so no single `semanage` call can short-circuit the rest. The beta.58/60 #9
+        //    2.2/2.3 gate failure: the old `&&` chain LED with a redundant `/opt` bin_t
+        //    re-add whose `-a` errored "already defined" (machine-wide-first gate means
+        //    the rule ALWAYS pre-exists) AND `-m`-to-unchanged-type ALSO failed on
+        //    Fedora's semanage — breaking the chain before the var_lib_t add + both
+        //    restorecons ever ran, so /var/opt came out usr_t. `/opt` is already bin_t
+        //    (the machine-wide install created the rule + ran restorecon), so we do NOT
+        //    re-add it; `restorecon -Rv /opt` below just relabels the freshly-copied deps
+        //    (`cp -a` preserved their data_home_t) using the existing rule. No `chcon`
+        //    fallback — it masked failures and only ever relabeled one file.
+        `( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ; ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ; ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || true`,
         // 3. install the unit (ExecStart already points at ${staged}).
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,
         `${systemctl} daemon-reload`,

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -407,7 +407,6 @@ export function buildMachineWideInstallScript(
     const mkdir = binTool('mkdir');
     const cp = binTool('cp');
     const chmod = binTool('chmod');
-    const chcon = binTool('chcon');
     const printf = binTool('printf');
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
@@ -426,7 +425,10 @@ export function buildMachineWideInstallScript(
         `${cp} "${args.sourceAppImage}" "${staged}"`,
         `${chmod} 0755 "${staged}"`,
         `${printf} '%s' '${args.version}' > ${SYSTEM_OPT_VERSION_FILE}`,
-        `( ( ( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' || ${semanage} fcontext -m -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' ) && ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || ${chcon} -t bin_t "${staged}" || true )`,
+        // bin_t add + restorecon as INDEPENDENT `;`-separated steps (whole subshell
+        // `|| true`) so neither a re-install's "already defined" nor the `-m`-to-
+        // unchanged failure can short-circuit the restorecon (beta.61 #9 fix). No chcon.
+        `( ${semanage} fcontext -a -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' || ${semanage} fcontext -m -t bin_t '${STAGED_SYSTEM_DIR}(/.*)?' ; ${restorecon} -Rv "${STAGED_SYSTEM_DIR}" ) || true`,
         `( ${printf} '${desktop}\\n' > ${SYSTEM_DESKTOP_FILE} || true )`,
         `( ${updateDesktopDb} /usr/share/applications || true )`,
     ];
@@ -555,7 +557,6 @@ export function buildSystemMigrationScript(
     const cp = binTool('cp');
     const rm = binTool('rm');
     const printf = binTool('printf');
-    const chcon = binTool('chcon');
     const systemctl = binTool('systemctl');
     const semanage = sbinTool('semanage');
     const restorecon = sbinTool('restorecon');
@@ -582,10 +583,11 @@ export function buildSystemMigrationScript(
         // webPort is auditable in the script). Written BEFORE the relabel so
         // restorecon labels it var_lib_t.
         `${printf} '%s' '${args.seedConfigJson}' > ${SYSTEM_STATE_DIR}/config.json`,
-        // label the state dir var_lib_t + restorecon. Best-effort subshell with a
-        // chcon transient fallback + trailing `|| true` so a non-SELinux host still
-        // proceeds to install the unit — mirrors buildSystemInstallScript.
-        `( ( ( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ) && ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || ${chcon} -t var_lib_t "${SYSTEM_STATE_DIR}" || true )`,
+        // label the state dir var_lib_t + restorecon as INDEPENDENT `;`-separated steps
+        // (whole subshell `|| true`) so no semanage quirk can short-circuit the
+        // restorecon — mirrors buildSystemInstallScript (beta.61 #9 2.2/2.3 fix). No
+        // chcon fallback (it masked failures).
+        `( ${semanage} fcontext -a -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' || ${semanage} fcontext -m -t var_lib_t '${SYSTEM_STATE_DIR}(/.*)?' ; ${restorecon} -Rv "${SYSTEM_STATE_DIR}" ) || true`,
         // reinstall the unit (ExecStart still points at the in-place /opt AppImage;
         // env now carries DATA_ROOT=/var/opt) + reload + enable.
         `${cp} "${args.unitTmpPath}" "${args.unitPath}"`,


### PR DESCRIPTION
Two runtime-confirmed Linux system-service bugs from the beta.60 Fedora smoke (#9), plus the two robustness gaps they exposed. Spec + plan committed (`docs/specs/2026-06-11-beta61-system-service-fixes-design.md`, `docs/plans/2026-06-11-beta61-system-service-fixes.md`).

## The bugs

**1. SELinux labeling never applied `var_lib_t` to `/var/opt` (the gate).** The system-install labeling was one big `&&` chain that led with a redundant `/opt` bin_t re-add. System installs are gated machine-wide-first, so that rule always pre-exists: `-a` errors "already defined", and `-m`-to-unchanged-type ALSO fails on Fedora''s semanage. The chain short-circuited before the `var_lib_t` add + both restorecons ever ran, so `/var/opt` came out `usr_t`. (beta.58''s `-a || -m` fix was string-only — the test asserted the script CONTAINED `-a || -m` but never exercised the runtime, so it stayed green while broken.)

**2. System-service uninstall was a silent no-op.** The teardown helper (spawned via `systemd-run --system`) core-dumped at startup: `data_root_for_linux` panics when DATA_ROOT/HOME/XDG are all unset, and the teardown spawn was missing the `--setenv=DATA_ROOT` the install handoff already had. It crashed before running any teardown command, while ServiceApi optimistically returned `shutting-down` and the UI claimed success.

## The fixes (6 commits)

- **fcontext labeling** is now independent `;`-separated steps (no `&&` short-circuit, no redundant bin_t re-add, no chcon fallback) across all three builders (system-install, machine-wide, migration). Also relabels the copied deps `bin_t`.
- **teardown spawn** passes `--setenv=DATA_ROOT=/var/opt/ws-scrcpy-web` (mirrors the install handoff).
- **launcher startup** uses a new non-panicking `try_data_root_from_env()` for the best-effort `service.log` rotation, so a teardown helper with no DATA_ROOT can''t crash there.
- **in-app uninstall** polls `/api/service/status` and reports success only once the service is actually gone (surfaces a failure otherwise).
- Tests target behavior, not script strings — the gap that let beta.58 ship green-but-broken.

## Verification

- tsc 0 · vitest 963 · webpack clean · `cargo` test + clippy clean (common crate, host).
- The launcher''s Linux-only change is verified by this PR''s CI Rust gate.
- The real gate is the Fedora #9 re-smoke on the published beta.61 (exit criteria in the spec): `/var/opt` = `var_lib_t`, both fcontext rules present, deps `bin_t`, zero AVC; uninstall actually removes + relaunches local.

`release:beta`.