### PR TITLE
beta.63: Windows tab-on-launch (D4) + cosmetics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Launching the app on Windows now opens a browser tab too — not only on the very first run.** This matches the same fix on Linux: starting the app fresh from its shortcut now opens your browser to the app every time. A duplicate tab is still avoided when the app relaunches itself to apply an update.
+
 ## [0.1.30-beta.62] - 2026-06-11
 
 ### Changed

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -293,10 +293,10 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │                              │ tray disappears.                                 │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 5.8 User-scope       │ Lin  │ User-scope service installed │ The user service is stopped/disabled/removed     │ [ ]  │
-│ uninstall -> back to │      │ and in use - uninstall AS    │ (unit file gone); nothing left running (no stray │      │
-│ local                │      │ that user.                   │ adb/scrcpy/app); the app relaunches in plain     │      │
-│                      │      │                              │ local mode and reconnects; Settings shows "not   │      │
-│                      │      │                              │ installed".                                      │      │
+│ uninstall -> back to │      │ and in use - uninstall AS    │ (unit file gone); after relaunch only the local  │      │
+│ local                │      │ that user.                   │ instance runs (launcher+node+pre-warmed adb)     │      │
+│                      │      │                              │ - no service procs, no 2nd instance, no scrcpy;  │      │
+│                      │      │                              │ reconnects; Settings shows "not installed".      │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 5.9 System uninstall │ Lin  │ After a system-scope         │ The "service removed - relaunch manually"        │ [ ]  │
 │ message is neutral   │      │ uninstall with nobody at the │ message is a plain neutral line - not red, no    │      │

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -113,7 +113,7 @@ fn open_server_log(data_root: &Path) -> Option<std::fs::File> {
 ///
 /// Returns the child handle so the caller (supervisor) can wait on it.
 #[cfg(windows)]
-pub fn spawn_server(deps_path: &Path, data_root: &Path, _open_browser: bool) -> Result<Child> {
+pub fn spawn_server(deps_path: &Path, data_root: &Path, open_browser: bool) -> Result<Child> {
     use std::os::windows::process::CommandExt;
 
     let exe = std::env::current_exe()?;
@@ -128,6 +128,15 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path, _open_browser: bool) -> 
         .env("DEPS_PATH", deps_path)
         .env("DATA_ROOT", data_root)
         .creation_flags(CREATE_NO_WINDOW);
+
+    // D4: like the non-Windows path, the launcher's FIRST Node spawn of a fresh
+    // user launch tells Node to open a browser tab. A Velopack update-relaunch is
+    // suppressed Node-side (the post-update suppress-browser-open marker), since
+    // Velopack owns that relaunch and we can't set WS_SCRCPY_NO_BROWSER on it the
+    // way linux_apply does.
+    if open_browser {
+        cmd.env("WS_SCRCPY_OPEN_BROWSER", "1");
+    }
 
     // Plumb the child's stdout AND stderr into server.log (thin crash-catcher).
     // Logger no longer echoes normal lines here, so this only fills on raw

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -414,7 +414,7 @@ export class SettingsModal extends Modal {
     private serviceScopeSystemRadio: HTMLInputElement | null = null;
     private servicePlatform: 'win32' | 'linux' | null = null;
 
-    // ── App section state ─────────────────────────────────────────────────
+    // ── Server section (folded App) state ────────────────────────────────
     private stopServerButton: HTMLButtonElement | null = null;
     private stopServerNote: HTMLElement | null = null;
     // Linux-only rows (hidden on win32). Shown/disabled via appSectionButtonsState
@@ -1632,10 +1632,8 @@ export class SettingsModal extends Modal {
         }
     }
 
-    // ── App section ────────────────────────────────────────────────────────
     // The former "App" section (reset, install-for-all-users, stop & exit,
-    // uninstall) was folded into the Server section — see buildServerSection
-    // (beta.62).
+    // uninstall) was folded into the Server section — see buildServerSection (beta.62).
 
     /**
      * Reflect the (unit-tested) stopServerButtonState decision onto the App

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -573,6 +573,23 @@ export class Config {
         return path.join(base, 'control', 'apply-update-pending');
     }
 
+    /**
+     * Canonical path for the consume-once `suppress-browser-open` marker.
+     * UpdateService.applyUpdate writes it before the app goes down to apply an
+     * update; the relaunched server already carries the user's tab (reconnect /
+     * redirect / reload), so it must NOT auto-open a new one. Node consumes
+     * (deletes) it at startup and honors it only when fresh. Lives under
+     * `control/` alongside the apply-update-pending marker. (D4 — needed on
+     * Windows local mode, where Velopack owns the relaunch and we can't set
+     * WS_SCRCPY_NO_BROWSER on it the way Linux's linux_apply does.)
+     */
+    public get suppressBrowserOpenMarkerPath(): string {
+        const base = this._dataRoot !== null
+            ? this._dataRoot
+            : path.dirname(this._dependenciesPath);
+        return path.join(base, 'control', 'suppress-browser-open');
+    }
+
     public get operationServerPortFilePath(): string {
         const base = this._dataRoot !== null
             ? this._dataRoot

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -453,6 +453,12 @@ export class UpdateService {
         const isServiceMode = installMode === 'user-service' || installMode === 'system-service';
 
         await this.writeApplyUpdatePendingMarker();
+        // D4: every applyUpdate brings the app down and the user's EXISTING tab is
+        // carried through (reconnect / redirect / reload), so the relaunched server
+        // must not auto-open a new tab. This consume-once marker tells it to skip
+        // the open — needed on Windows local mode (no WS_SCRCPY_NO_BROWSER on the
+        // Velopack relaunch); harmless elsewhere (Linux/service already suppress).
+        await this.writeSuppressBrowserOpenMarker();
 
         // Windows service mode keeps Velopack's apply (the operation-server
         // handoff below). Linux service mode falls through to the download-based
@@ -640,6 +646,22 @@ export class UpdateService {
                 `applyUpdate: failed to write apply-update-pending marker at ${markerPath}: ${(err as Error).message} ` +
                     `— service will not auto-restart after Velopack swap; user must restart manually.`,
             );
+        }
+    }
+
+    /**
+     * Write the consume-once `suppress-browser-open` marker (see
+     * Config.suppressBrowserOpenMarkerPath). Best-effort: a failure at worst
+     * yields one redundant browser tab on the post-update relaunch.
+     */
+    private async writeSuppressBrowserOpenMarker(): Promise<void> {
+        const markerPath = Config.getInstance().suppressBrowserOpenMarkerPath;
+        try {
+            await fs.promises.mkdir(path.dirname(markerPath), { recursive: true });
+            await fs.promises.writeFile(markerPath, '', 'utf8');
+            log.info(`applyUpdate: wrote suppress-browser-open marker at ${markerPath}`);
+        } catch (err) {
+            log.warn(`applyUpdate: failed to write suppress-browser-open marker at ${markerPath}: ${(err as Error).message}`);
         }
     }
 

--- a/src/server/__tests__/openBrowser.test.ts
+++ b/src/server/__tests__/openBrowser.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { shouldAutoOpenBrowser } from '../openBrowser';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// biome-ignore lint/style/useNodejsImportProtocol: match the non-prefixed app-code import style
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+// biome-ignore lint/style/useNodejsImportProtocol: match the non-prefixed app-code import style
+import { tmpdir } from 'os';
+// biome-ignore lint/style/useNodejsImportProtocol: match the non-prefixed app-code import style
+import { join } from 'path';
+import { consumeSuppressBrowserMarker, shouldAutoOpenBrowser } from '../openBrowser';
 
 /**
  * D1: a cold start PAST first-run must still open a browser tab. The native
@@ -47,5 +53,41 @@ describe('shouldAutoOpenBrowser', () => {
 
     it('treats undefined firstRunComplete as "not first run" (no spurious open)', () => {
         expect(shouldAutoOpenBrowser({ ...base, firstRunComplete: undefined })).toBe(false);
+    });
+});
+
+/**
+ * D4: a post-update relaunch (esp. Windows local mode, where Velopack owns the
+ * relaunch and carries no WS_SCRCPY_NO_BROWSER) must not pop a 2nd tab on top of
+ * the user's reconnecting one. applyUpdate leaves a consume-once marker; the
+ * relaunched server consumes it (always deletes; honored only when fresh).
+ */
+describe('consumeSuppressBrowserMarker', () => {
+    let dir: string;
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'wssw-suppress-'));
+    });
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('returns false when the marker is absent', () => {
+        expect(consumeSuppressBrowserMarker(join(dir, 'suppress-browser-open'))).toBe(false);
+    });
+
+    it('returns true and deletes the marker when fresh', () => {
+        const p = join(dir, 'suppress-browser-open');
+        writeFileSync(p, '');
+        expect(consumeSuppressBrowserMarker(p)).toBe(true);
+        expect(existsSync(p), 'marker consumed (deleted)').toBe(false);
+    });
+
+    it('returns false but still deletes the marker when stale', () => {
+        const p = join(dir, 'suppress-browser-open');
+        writeFileSync(p, '');
+        // Evaluate "now" an hour ahead so the just-written mtime reads as stale.
+        const future = Date.now() + 60 * 60_000;
+        expect(consumeSuppressBrowserMarker(p, { now: future })).toBe(false);
+        expect(existsSync(p), 'stale marker still cleaned up').toBe(false);
     });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,7 +18,7 @@ import { findAvailablePort, webPortOverride } from './PortPicker';
 import { DeviceLabelStore } from './DeviceLabelStore';
 import { DeviceProbe } from './DeviceProbe';
 import { Logger } from './Logger';
-import { openBrowser, shouldAutoOpenBrowser } from './openBrowser';
+import { consumeSuppressBrowserMarker, openBrowser, shouldAutoOpenBrowser } from './openBrowser';
 import { HostTracker } from './mw/HostTracker';
 import type { MwFactory } from './mw/Mw';
 import { ScanMw } from './mw/ScanMw';
@@ -224,7 +224,15 @@ reconcileWebPort()
             // G1: a relaunch (the post-machine-wide-install /opt re-exec, or an
             // in-app update relaunch) sets WS_SCRCPY_NO_BROWSER=1 — the user
             // already has a tab that reconnects, so don't pop a redundant one.
-            const suppressBrowser = process.env['WS_SCRCPY_NO_BROWSER'] === '1';
+            const noBrowserEnv = process.env['WS_SCRCPY_NO_BROWSER'] === '1';
+            // D4: a Velopack update-relaunch (Windows local mode) carries no
+            // WS_SCRCPY_NO_BROWSER, so applyUpdate left a consume-once marker —
+            // honor + delete it so the post-update relaunch doesn't pop a 2nd tab
+            // on top of the user's reconnecting one.
+            const postUpdateRelaunch = consumeSuppressBrowserMarker(
+                config.suppressBrowserOpenMarkerPath,
+            );
+            const suppressBrowser = noBrowserEnv || postUpdateRelaunch;
             // D1: the native launcher's supervisor sets WS_SCRCPY_OPEN_BROWSER=1
             // on its FIRST Node spawn (a fresh user launch), so a cold start past
             // first-run still opens a tab — not only on first run. Supervisor

--- a/src/server/openBrowser.ts
+++ b/src/server/openBrowser.ts
@@ -1,5 +1,7 @@
 // biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { spawn } from 'child_process';
+// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
+import { rmSync, statSync } from 'fs';
 import { Logger } from './Logger';
 
 const log = Logger.for('OpenBrowser');
@@ -89,4 +91,36 @@ export function shouldAutoOpenBrowser(opts: {
     }
     const isFirstRun = opts.firstRunComplete === false;
     return opts.launcherFreshLaunch || isFirstRun;
+}
+
+/**
+ * Consume the post-update "suppress browser open" marker (see
+ * Config.suppressBrowserOpenMarkerPath). UpdateService.applyUpdate writes it
+ * before the app goes down to apply an update; the relaunched server already
+ * carries the user's tab (reconnect / redirect / reload), so it must not pop a
+ * NEW one — this is the Windows-local-mode equivalent of Linux's
+ * WS_SCRCPY_NO_BROWSER (Velopack owns that relaunch, so we can't set an env on
+ * it). Consume-once: the marker is ALWAYS deleted when present, and only honored
+ * when FRESH (a stale marker from a failed/abandoned update that never
+ * relaunched must not suppress a much-later manual launch). Returns true iff a
+ * fresh marker was present. Pure aside from fs; unit-tested with a real temp file.
+ */
+export function consumeSuppressBrowserMarker(
+    markerPath: string,
+    opts: { maxAgeMs?: number; now?: number } = {},
+): boolean {
+    const maxAgeMs = opts.maxAgeMs ?? 5 * 60_000;
+    let mtimeMs: number;
+    try {
+        mtimeMs = statSync(markerPath).mtimeMs;
+    } catch {
+        return false; // absent — nothing to consume
+    }
+    try {
+        rmSync(markerPath, { force: true });
+    } catch {
+        /* best-effort cleanup */
+    }
+    const now = opts.now ?? Date.now();
+    return now - mtimeMs <= maxAgeMs;
 }


### PR DESCRIPTION
beta.63 — the Windows half of the cold-start tab fix (D4) that beta.62 shipped for Linux, plus two cosmetics.

**Windows tab-on-launch (D4)** (`fix(launcher)`). A fresh Windows launch (shortcut, app not running) now opens a browser tab, matching Linux. The Windows `spawn_server` honors the supervisor''s first-spawn `WS_SCRCPY_OPEN_BROWSER` signal. The wrinkle: a Velopack update-relaunch (Windows local mode) carries no `WS_SCRCPY_NO_BROWSER` (Velopack owns that relaunch, unlike Linux''s `linux_apply`), so `applyUpdate` writes a consume-once `suppress-browser-open` marker that the relaunched Node honors (fresh-only) and deletes - no 2nd tab on top of the user''s reconnecting one. Service mode + supervisor restarts stay gated.

**Cosmetics** (`chore`). Reflowed smoke-runbook.md 5.8 to match the checklist/full reword; dropped the orphan `// App section` comment left when `buildAppSection` was deleted in beta.62.

## Verification
tsc 0, vitest 976, webpack clean, launcher clippy 0 + cargo test 117/1. The Windows `spawn_server` change is host-compiled here; the Linux/runtime side is unchanged from beta.62.

Smoke owed on beta.63 (the standing Fedora re-smoke; fold the Windows tab eyeball into the Windows pass).