### PR TITLE
docs(smoke): retarget smoke docs to v0.1.30-beta.63 (App->Server, 15.5 order, cold-start + restructure rows)

### DIFF
--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -1,11 +1,11 @@
 # ws-scrcpy-web — Smoke Run-Sheet
 
-> **Smoke target: `v0.1.30-beta.62`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.63`** — bump this one line each release; everything below is version-agnostic.
 
 Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
 [`smoke-full.md`](./smoke-full.md) by **app state** — the order you actually run them; that doc
 stays the module-organized reference. Wherever a row shows a version, expect the **smoke-target version** (top of this doc),
-which carries the beta.48 port-discovery fix plus the App-section UX (batch #15).
+which carries the beta.48 port-discovery fix plus the Server-section UX (batch #15).
 
 **Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.40 artifact / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot)
 
@@ -36,6 +36,7 @@ Boxes start unticked — this is a fresh pass.
 |---|---|---|
 | ☐ **1.2** `[L]` Accept "all users" | GUI double-click the non-`+x` AppImage → **yes, all users** → one pkexec | Binary at `/opt/ws-scrcpy-web/`; `/opt/ws-scrcpy-web/VERSION` = the smoke-target version; system `.desktop` present; original `~/Downloads` AppImage **gone** |
 | ☐ **4.1** `[L]` System-scope gate un-greys | **Before installing any service** (a service install flips `scopeRadioState.locked` → radios go read-only; see 4.4): Settings → service → select **system** scope | Now **selectable** + its install **un-greyed** now that you're machine-wide; was gated *"requires installing system-wide for all users first"* before 1.2 |
+| ☐ **1.7** `[L]` Cold-start opens one tab *(D1)* | After 1.2, fully quit, then GUI-launch the menu entry / AppImage again (still **no service**) | Server boots **and exactly one** browser tab opens (beta.62 D1 — previously took a 2nd click); a web-port-change **restart** adds **no** 2nd tab |
 | ☐ **4.2-user** `[L]` Install user service | Settings → service → **user** scope → install (no elevation) | Service active on 8000; stable ExecStart; **no "port discovery timed out"** (the beta.48 fix) |
 
 ## #7 — Current install checks ▶ active *(machine-wide + user-service in place, no teardown)*
@@ -45,18 +46,19 @@ Boxes start unticked — this is a fresh pass.
 | ☐ **2.1** `[L]` Binary/deps labels | `ls -Z /opt/ws-scrcpy-web` | → **bin_t** — `VERSION` + `WsScrcpyWeb.AppImage` both `unconfined_u:object_r:bin_t:s0` |
 | ☐ **2.4** `[L]` Zero AVC | Watch `sudo journalctl -f \| grep -i avc` across the installs | **No** AVC denials |
 | ☐ **4.4** `[L]` Scope-radio legibility *(locked-radios state — counterpart to 4.1)* | Reopen Settings | Selected dot a **clear blue**; radios non-interactive (`pointer-events:none` + `tabindex=-1`, **not** `disabled`); **user** scope shown selected |
+| ☐ **13.3** `[B]` Server-section layout + web-port save | Reopen Settings → inspect the **Server** section (3rd, after Updates + Service) | Rows top→bottom: **reset prompts → web port → [L-only] install for all users → stop server & exit → uninstall**; **web port** has an inline **save** button; status below **empty at rest** (only `saving…`/`saved.`/error after save); change port → save → persists + restarts |
 | ☐ **4.6** `[L]` Unit hygiene | `cat ~/.config/systemd/user/WsScrcpyWeb.service` (StartLimit* under **[Unit]**); `journalctl --user -u WsScrcpyWeb -b` (**current boot only**); `pgrep -fa WsScrcpyWeb` | **No** `Unknown key 'StartLimitIntervalSec'` — must use **`-b`**: the persisted journal keeps stale pre-fix warnings from old installs that false-fail a whole-history grep; **only the service** runs (no leftover home instance); no false timeout toast |
 | ☐ **3.2** `[L]` Single-instance flock | Launch a 2nd copy from `/opt` **and** from `~/Downloads` | 2nd launch **blocked** (flock on `$XDG_RUNTIME_DIR`); no 2nd server; existing URL opens |
 | ☐ **10.1** `[B]` Status API | Browse `/api/service/status` | JSON with correct `platform`, `supported`, `status` |
 | ☐ **10.3** `[L]` Logs clean | Tail `~/.local/share/WsScrcpyWeb/logs` | No error spam; teardown logs on stop |
-| ☐ **12.2** `[B]` Stop-exit gating | Settings → App (service installed) | Button **greyed** + neutral note; clicking fires **no** shutdown POST; re-enables after uninstall |
+| ☐ **12.2** `[B]` Stop-exit gating | Settings → Server (service installed) | Button **greyed** + neutral note; clicking fires **no** shutdown POST; re-enables after uninstall |
 
 ## #8 — User-service uninstall → local mode
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | ☐ **5.8** `[L]` Uninstall → relaunch local | Uninstall the user service **as that user** | Unit file gone (`~/.config/systemd/user/WsScrcpyWeb.service`); after relaunch **only the single local instance** runs (launcher + node + its pre-warmed adb daemon) — **no service procs, no 2nd instance, no `scrcpy-server`** (`pgrep -fa "adb\|scrcpy-server\|WsScrcpyWeb"`); relaunches **local mode**; Settings shows not-installed |
-| ☐ **12.1** `[L]` Clean exit + adb teardown | Local mode, device + stream → Settings → App → "stop server & exit" | Tab self-closes/"app stopped"; process tree exits clean; log shows "Stopping adb daemon"; launcher **exit 0** (no 75 restart) |
+| ☐ **12.1** `[L]` Clean exit + adb teardown | Local mode, device + stream → Settings → Server → "stop server & exit" | Tab self-closes/"app stopped"; process tree exits clean; log shows "Stopping adb daemon"; launcher **exit 0** (no 75 restart) |
 | ☐ **12.4** `[L]` DATA_ROOT override | Launch with `DATA_ROOT=/tmp/wssw-dataroot` exported | Config/deps/logs land there (Node **and** launcher agree) |
 | ☐ **13.1** `[B]` Bookmark global-dismiss | Bookmark/port-change reminder → check "don't show again — ever" | Supersedes + disables the per-port checkbox; persists `bookmarkDismissedGlobally` |
 | ☐ **13.2** `[B]` Reset prompts | Settings → "reset welcome and bookmark prompts" | Re-shows welcome **and** clears bookmark (per-port + global); welcome reset must **not** re-suppress the per-port bookmark |
@@ -127,6 +129,7 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 |---|---|---|
 | ☐ **1.5** `[W]` Fresh MSI install | Install `WsScrcpyWeb-beta.msi` as Admin | Auto-opens; WelcomeModal; About = the smoke-target version; `C:\Program Files\WsScrcpyWeb\` |
 | ☐ **1.6** `[W]` Reinstall reuses config | After 5.7, reinstall the MSI | Existing `config.json` detected + reused; same saved port |
+| ☐ **1.8** `[W]` Cold-start opens one tab *(D4)* | Fully quit, then relaunch (Start-menu / exe), **no service** | Exactly **one** browser tab opens (beta.63 D4); a web-port-change **restart** and an in-app **update relaunch** do **not** double-tab |
 | ☐ **3.4** `[W]` Per-session tray | Service installed; Fast User Switch Admin→User1→User2 | Exactly **one** tray/session (~2s); "Open" → same backend port |
 | ☐ **3.5** `[W]` 2nd tray rejected | Launch a 2nd `ws-scrcpy-web-tray.exe` | No 2nd tray; spawned proc exits ~100ms |
 | ☐ **4.3** `[W]` Install confirm UX | Settings → install service → test cancel/Esc/backdrop, then continue | Cancel/Esc/backdrop = **no** UAC/no fetch; continue → UAC → installs, no WelcomeModal |
@@ -140,31 +143,31 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 | ☐ **11.4** `[W]` PerMachine intact | After the MSI install, check the location | `C:\Program Files\WsScrcpyWeb\` (PerMachine) |
 | ☐ **12.3** `[W]` Stop-exit reaps tray | Local mode → stop server & exit | Tray disappears; no lingering launcher/node/tray/adb; **cancel** leaves running |
 
-## #15 — App-section UX (Linux)
+## #15 — Server-section UX (Linux)
 
-App-section additions (no module-doc counterpart): the one-click **install for all users**, the machine-wide start-menu icon, and the in-app **uninstall** flows.
+Server-section additions (no module-doc counterpart): the one-click **install for all users**, the machine-wide start-menu icon, and the in-app **uninstall** flows.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **15.1** `[L]` install-for-all-users button | Local (me-only) install running → Settings → **App** → click **install for all users**; authenticate the one prompt. | One pkexec; binary **relocates to `/opt/ws-scrcpy-web/`**; the button then goes **greyed/disabled** reading **"already installed for all users (/opt)"**; app keeps serving on the same port. |
+| ☐ **15.1** `[L]` install-for-all-users button | Local (me-only) install running → Settings → **Server** → click **install for all users**; authenticate the one prompt. | One pkexec; binary **relocates to `/opt/ws-scrcpy-web/`**; the button then goes **greyed/disabled** reading **"already installed for all users (/opt)"**; app keeps serving on the same port. |
 | ☐ **15.2** `[L]` start-menu icon | After a machine-wide install (15.1 or 1.2), open the desktop apps menu and find the **ws-scrcpy-web** entry; also check the icon on disk. | The launcher entry shows the **ws-scrcpy-web icon** (not a generic placeholder); `ls /usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png` → **exists**. |
-| ☐ **15.3** `[L]` uninstall — local | Local mode → Settings → **App** → **uninstall…** → confirm (leave **"keep my settings & logs" unchecked**). | App removed; tab shows **"uninstalled — close this tab"**; `docs/smoke-tests/clear-install.sh` verify → **CLEAN SLATE** (no leftover binary / deps / config / decline marker). |
-| ☐ **15.4** `[L]` uninstall — user-service cascade | User-scope service installed (machine-wide `/opt` binary) → Settings → **App** → **uninstall…** → confirm. | **One pkexec** (for the `/opt` removal); the `--user` unit is **gone** AND the app is **removed in one pass**; **no relaunch**. |
+| ☐ **15.3** `[L]` uninstall — local | Local mode → Settings → **Server** → **uninstall…** → confirm (leave **"keep my settings & logs" unchecked**). | App removed; tab shows **"uninstalled — close this tab"**; `docs/smoke-tests/clear-install.sh` verify → **CLEAN SLATE** (no leftover binary / deps / config / decline marker). |
+| ☐ **15.4** `[L]` uninstall — user-service cascade | User-scope service installed (machine-wide `/opt` binary) → Settings → **Server** → **uninstall…** → confirm. | **One pkexec** (for the `/opt` removal); the `--user` unit is **gone** AND the app is **removed in one pass**; **no relaunch**. |
 | ☐ **15.5** `[L]` uninstall — system-service cascade | System-scope service installed → **uninstall…** (runs from the root service context). | Runs **as root, NO pkexec**; `/opt/ws-scrcpy-web` + `/var/opt/ws-scrcpy-web` + the systemd unit are **all gone**; **zero AVC**. |
 | ☐ **15.6** `[L]` uninstall — keep settings & logs | Uninstall with **"keep my settings & logs" checked**. | `config.json` + `logs/` **survive** at the data root (`~/.local/share/WsScrcpyWeb` local, or `/var/opt/ws-scrcpy-web` system); `dependencies/` is **gone either way**; a **reinstall reuses the saved port**. |
 | ☐ **15.7** `[L]` uninstall — SELinux clean | After any uninstall, inspect the fcontext rules + the AVC monitor. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` → **empty**; **zero AVC**. |
 
-## #16 — Windows App-section: in-app uninstall + stop-exit 🪟 *(drive from smoke-full Module 15)*
+## #16 — Windows Server-section: in-app uninstall + stop-exit 🪟 *(drive from smoke-full Module 15)*
 
 New in beta.51, the wipe self-deletion fixed in beta.52. Run on the clean Win11 snapshot after the MSI install. The `[W]` tag distinguishes these from the Linux `15.x` rows in #15.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **15.1** `[W]` In-app uninstall — keep | MSI install → Settings → **App** → **uninstall** → keep **checked** (default) → uninstall | **One UAC** (Update.exe self-elevates — VM decision #1); `C:\Program Files\WsScrcpyWeb\` gone; service gone (`sc query WsScrcpyWeb` → not found); tray gone; **ARP entry gone**; `config.json` + `logs\` **survive** under `%ProgramData%\WsScrcpyWeb`, `dependencies\` gone; reinstall reuses the saved port |
+| ☐ **15.1** `[W]` In-app uninstall — keep | MSI install → Settings → **Server** → **uninstall** → keep **checked** (default) → uninstall | **One UAC** (Update.exe self-elevates — VM decision #1); `C:\Program Files\WsScrcpyWeb\` gone; service gone (`sc query WsScrcpyWeb` → not found); tray gone; **ARP entry gone**; `config.json` + `logs\` **survive** under `%ProgramData%\WsScrcpyWeb`, `dependencies\` gone; reinstall reuses the saved port |
 | ☐ **15.2** `[W]` In-app uninstall — wipe | Same but **uncheck** keep | As 15.1, **and the whole `%ProgramData%\WsScrcpyWeb` is gone** — incl. `control\operation-server\` (the beta.52 fix: the temp-copy cleaner removes it after the original exits). Confirm **no** leftover dir — `capture-logs.ps1 15.2-wipe`, then check `31-dataroot` |
 | ☐ **15.3** `[W]` Uninstall modal UX | Open the uninstall modal | Top-layer overlay above Settings; **cancel** white-outline, **uninstall** red text + border; keep checkbox **checked by default**; cancel / Esc / backdrop = no action |
-| ☐ **15.4** `[W]` Stop-exit reaps tray + adb | Local mode, device + stream live → Settings → **App** → **stop server & exit** | Tab closes / "app stopped"; Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / `adb.exe` |
-| ☐ **15.5** `[W]` App-section order | Settings → App | Order top→bottom: **reset prompts → stop server & exit → uninstall ws-scrcpy-web** (no "install for all users" on Windows) |
+| ☐ **15.4** `[W]` Stop-exit reaps tray + adb | Local mode, device + stream live → Settings → **Server** → **stop server & exit** | Tab closes / "app stopped"; Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / `adb.exe` |
+| ☐ **15.5** `[W]` Server-section order | Settings → Server | Order top→bottom: **reset prompts → web port → stop server & exit → uninstall ws-scrcpy-web** (no "install for all users" on Windows) |
 
 ---
 

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -1,10 +1,10 @@
 # ws-scrcpy-web — Full Smoke Test
 
-> **Smoke target: `v0.1.30-beta.62`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.63`** — bump this one line each release; everything below is version-agnostic.
 
 All-encompassing manual smoke, grouped by function and tagged by platform (`[Win]` / `[Linux]` / `[Both]`). Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
 
-> **Consolidated 2026-06-06.** This doc absorbs the three former per-feature checklists — Linux service-mode (`beta.37`), stop-server-&-exit (`beta.39`), and the Windows multi-user / MSI pass (`v0.1.25-beta.3`) — so it is the **single gate for `0.1.30` final** (the first true Windows + Linux release). It covers every shipped feature to date: install/first-run, Linux layout & SELinux, multi-user & single-instance, service mode (incl. the beta.45–48 stable-ExecStart + install hand-off + post-install port-discovery fix), lifecycle, updates (local / machine-wide / user- & system-service / migration), devices, streaming, adb, logs, Velopack 1.2.0, stop-server-&-exit, settings prompts, and the **Linux App-section UX** (install-for-all-users, start-menu icon, in-app complete uninstall — Module 14).
+> **Consolidated 2026-06-06.** This doc absorbs the three former per-feature checklists — Linux service-mode (`beta.37`), stop-server-&-exit (`beta.39`), and the Windows multi-user / MSI pass (`v0.1.25-beta.3`) — so it is the **single gate for `0.1.30` final** (the first true Windows + Linux release). It covers every shipped feature to date: install/first-run, Linux layout & SELinux, multi-user & single-instance, service mode (incl. the beta.45–48 stable-ExecStart + install hand-off + post-install port-discovery fix), lifecycle, updates (local / machine-wide / user- & system-service / migration), devices, streaming, adb, logs, Velopack 1.2.0, stop-server-&-exit, settings prompts, and the **Linux Server-section UX** (install-for-all-users, start-menu icon, in-app complete uninstall — Module 14).
 
 ## Pre-flight
 
@@ -51,6 +51,8 @@ sudo systemctl daemon-reload
 | **1.4** `[Linux]` Headless first-run | Launch over SSH / no display. | No hang; graceful fallback, no crash. |
 | **1.5** `[Win]` Fresh MSI install | Clean snapshot, log in `Admin`; install `WsScrcpyWeb-beta.msi`. | Installs clean; browser auto-opens `http://localhost:<port>`; WelcomeModal shows; Settings → About = the smoke-target version; installs to `C:\Program Files\WsScrcpyWeb\`. |
 | **1.6** `[Win]` Reinstall reuses config *(H.2)* | After 5.7's full uninstall, reinstall `WsScrcpyWeb-beta.msi`. | Installs clean; existing `config.json` under dataRoot is **detected and reused** (no fresh skeleton overwrite); app reachable on the previously-saved port. |
+| **1.7** `[Linux]` Cold-start opens one tab *(D1, beta.62)* | App fully stopped (past first-run) → GUI-launch the `.desktop` / AppImage, still **no service**. | The server boots **and exactly one** browser tab opens (the beta.62 D1 fix — it previously took a 2nd click); a later web-port-change **restart** does **not** open a second tab. |
+| **1.8** `[Win]` Cold-start opens one tab *(D4, beta.63)* | App fully stopped → launch (Start-menu / exe), **no service**. | Exactly **one** browser tab opens (the beta.63 D4 fix); a web-port-change **restart** **and** an in-app **update relaunch** do **not** double-tab (the `suppress-browser-open` marker covers Velopack's relaunch). |
 
 ## Module 2 — Linux layout & SELinux
 
@@ -158,13 +160,13 @@ Velopack is at 1.2.0 (bumped in beta.44). These rows close out item 31 (the libf
 
 ## Module 12 — Stop server & exit (item 27)
 
-beta.39 added a "stop server & exit" button (Settings → App) with graceful teardown, service-mode gating, and (Windows) a tray reap.
+beta.39 added a "stop server & exit" button (Settings → Server) with graceful teardown, service-mode gating, and (Windows) a tray reap.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **12.1** `[Linux]` Local-mode clean exit + adb teardown *(SE-3)* | Local mode, a device connected + a stream running → Settings → App → "stop server & exit" → confirm. | Browser tab self-closes or blanks to **"app stopped — you can close this tab"**; process tree exits clean (`pgrep -fa WsScrcpyWeb` / `pgrep -fa adb` show nothing from this instance); the log shows `Stopping adb daemon (kill-server)` (graceful teardown ran); the launcher does **not** restart (clean `exit 0`, not the 75 restart sentinel). |
-| **12.2** `[Both]` Service-mode gating *(SE-4)* | With a service installed (Win system; Linux user- or system-scope) → Settings → App. | The button is **disabled (greyed)** with a neutral note ("managed by the system service — stop it via your service manager, or uninstall the service"); clicking fires **no** shutdown POST. After **uninstalling** the service it becomes **enabled again** (re-gates on status refresh, no reload). |
-| **12.3** `[Win]` Local-mode reaps everything *(SE-1)* | Local mode, device + stream live, tray present → Settings → App → "stop server & exit" → ok. | Confirm dialog (title "stop server & exit", modal-styled ok/cancel); server exits (tab self-closes or "app stopped" page); **the tray icon disappears** (launcher reaped it); Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / bundled `adb.exe` from this instance; **cancel** leaves everything running. |
+| **12.1** `[Linux]` Local-mode clean exit + adb teardown *(SE-3)* | Local mode, a device connected + a stream running → Settings → Server → "stop server & exit" → confirm. | Browser tab self-closes or blanks to **"app stopped — you can close this tab"**; process tree exits clean (`pgrep -fa WsScrcpyWeb` / `pgrep -fa adb` show nothing from this instance); the log shows `Stopping adb daemon (kill-server)` (graceful teardown ran); the launcher does **not** restart (clean `exit 0`, not the 75 restart sentinel). |
+| **12.2** `[Both]` Service-mode gating *(SE-4)* | With a service installed (Win system; Linux user- or system-scope) → Settings → Server. | The button is **disabled (greyed)** with a neutral note ("managed by the system service — stop it via your service manager, or uninstall the service"); clicking fires **no** shutdown POST. After **uninstalling** the service it becomes **enabled again** (re-gates on status refresh, no reload). |
+| **12.3** `[Win]` Local-mode reaps everything *(SE-1)* | Local mode, device + stream live, tray present → Settings → Server → "stop server & exit" → ok. | Confirm dialog (title "stop server & exit", modal-styled ok/cancel); server exits (tab self-closes or "app stopped" page); **the tray icon disappears** (launcher reaped it); Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / bundled `adb.exe` from this instance; **cancel** leaves everything running. |
 | **12.4** `[Linux]` DATA_ROOT override honored *(optional, item 40a)* | Launch with `DATA_ROOT=/tmp/wssw-dataroot` exported. | Config/deps/logs land under `/tmp/wssw-dataroot` (Node side **and** launcher agree — same root for spawn and for adb-reap/tray paths). Mostly unit-covered; confirms the env wiring end-to-end. |
 
 ## Module 13 — Settings: bookmark & reset prompts
@@ -173,32 +175,33 @@ beta.39 added a "stop server & exit" button (Settings → App) with graceful tea
 |---|---|---|
 | **13.1** `[Both]` Bookmark global-dismiss *(beta.32)* | Reach the bookmark / port-change reminder → check "don't show again — ever, even when the port changes" → confirm. | The confirmation dialog uses the white-outline buttons; checking it **supersedes + disables** the per-port checkbox; persists (`bookmarkDismissedGlobally` in `config.json`). |
 | **13.2** `[Both]` Reset welcome & bookmark prompts *(beta.40 fix)* | Settings → "reset welcome and bookmark prompts". | Re-shows the welcome modal **and** clears the bookmark dismissal — both **per-port** and **global** — so the reminder can re-fire. Regression check: the welcome reset must **not** re-suppress the per-port bookmark (the eager `bookmarkDismissedForPort` re-stamp is gone). |
+| **13.3** `[Both]` Server-section layout + web-port inline save *(beta.62 restructure)* | Open Settings; inspect the **Server** section (3rd, after Updates + Service). | Top→bottom: **reset welcome & bookmark prompts → web port → [Linux-only] install for all users → stop server & exit → uninstall ws-scrcpy-web**. The **web port** row has an inline **save** button to its right; the status line below it is **empty at rest** (shows `saving…` / `saved.` / an error only after you click save). Change the port → **save** → it persists and the server restarts on the new port. |
 
-## Module 14 — Linux App-section UX
+## Module 14 — Linux Server-section UX
 
-The App section adds three Settings → **App** affordances on Linux: a one-click **install for all users**, a machine-wide **start-menu icon**, and an always-available in-app **complete uninstall** — it cascades through any installed service in one pass, runs root-direct under a system service (otherwise self-elevates via **one** pkexec), and offers a **"keep my settings & logs"** option.
+The Server section adds three Settings → **Server** affordances on Linux: a one-click **install for all users**, a machine-wide **start-menu icon**, and an always-available in-app **complete uninstall** — it cascades through any installed service in one pass, runs root-direct under a system service (otherwise self-elevates via **one** pkexec), and offers a **"keep my settings & logs"** option.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **14.1** `[Linux]` Install-for-all-users button | Local (me-only) install running → Settings → **App** → **install for all users**; authenticate the one prompt. | One pkexec; the binary **relocates to `/opt/ws-scrcpy-web/`**; the button then **greys/disables** reading "already installed for all users (/opt)"; the app keeps serving on the same port. |
+| **14.1** `[Linux]` Install-for-all-users button | Local (me-only) install running → Settings → **Server** → **install for all users**; authenticate the one prompt. | One pkexec; the binary **relocates to `/opt/ws-scrcpy-web/`**; the button then **greys/disables** reading "already installed for all users (/opt)"; the app keeps serving on the same port. |
 | **14.2** `[Linux]` Start-menu icon | After a machine-wide install (14.1 or 1.2), open the desktop apps menu; also check disk. | The launcher entry shows the **ws-scrcpy-web icon** (not a generic placeholder); `ls /usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png` → exists. |
-| **14.3** `[Linux]` Complete uninstall — local | Local mode → Settings → **App** → **uninstall…** → confirm with **"keep my settings & logs" unchecked**. | App removed; tab shows "uninstalled — close this tab"; `clear-install.sh` verifies a **CLEAN SLATE** (no leftover binary / deps / config / decline marker). |
+| **14.3** `[Linux]` Complete uninstall — local | Local mode → Settings → **Server** → **uninstall…** → confirm with **"keep my settings & logs" unchecked**. | App removed; tab shows "uninstalled — close this tab"; `clear-install.sh` verifies a **CLEAN SLATE** (no leftover binary / deps / config / decline marker). |
 | **14.4** `[Linux]` Uninstall — user-service cascade | User-scope service installed (machine-wide `/opt` binary) → **uninstall…** → confirm. | **One pkexec** (for the `/opt` removal); the `--user` unit is **gone** AND the app is **removed in one pass**; no relaunch. |
 | **14.5** `[Linux]` Uninstall — system-service cascade | System-scope service installed → **uninstall…** (from the root service context). | Runs **as root, NO pkexec**; `/opt/ws-scrcpy-web` + `/var/opt/ws-scrcpy-web` + the systemd unit are **all gone**; zero AVC. |
 | **14.6** `[Linux]` Uninstall — keep settings & logs | Uninstall with **"keep my settings & logs" checked**. | `config.json` + `logs/` **survive** at the data root (`~/.local/share/WsScrcpyWeb` local, or `/var/opt/ws-scrcpy-web` system); `dependencies/` is **gone either way**; a reinstall reuses the saved port. |
 | **14.7** `[Linux]` Uninstall — SELinux clean | After any uninstall, inspect fcontext + the AVC monitor. | `sudo semanage fcontext -l \| grep ws-scrcpy-web` → **empty**; zero AVC. |
 
-## Module 15 — Windows App-section uninstall + stop-exit cleanup
+## Module 15 — Windows Server-section uninstall + stop-exit cleanup
 
 In-app **uninstall** now works on Windows (parity with Linux), and "stop server & exit" fully reaps the tray + stray adb. The uninstall triggers Velopack's `Update.exe --uninstall`; **the elevation path and the running-helper self-deletion are the things to settle on the VM** (flagged rows).
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **15.1** `[Win]` In-app uninstall — keep | MSI install → Settings → **App** → **uninstall** → modal with **keep checked** (default) → uninstall. | **One UAC prompt** (Update.exe self-elevates); `C:\Program Files\WsScrcpyWeb\` gone; service gone (`sc query WsScrcpyWeb` → not found); **tray gone**; **Add/Remove-Programs entry gone** (no orphan); `config.json` + `logs/` **survive** under `%ProgramData%\WsScrcpyWeb`, `dependencies/` gone; reinstall reuses the saved port. |
+| **15.1** `[Win]` In-app uninstall — keep | MSI install → Settings → **Server** → **uninstall** → modal with **keep checked** (default) → uninstall. | **One UAC prompt** (Update.exe self-elevates); `C:\Program Files\WsScrcpyWeb\` gone; service gone (`sc query WsScrcpyWeb` → not found); **tray gone**; **Add/Remove-Programs entry gone** (no orphan); `config.json` + `logs/` **survive** under `%ProgramData%\WsScrcpyWeb`, `dependencies/` gone; reinstall reuses the saved port. |
 | **15.2** `[Win]` In-app uninstall — wipe | Same, but **uncheck** keep. | As 15.1 but the **whole `%ProgramData%\WsScrcpyWeb` is gone** — including `control\operation-server\` (the **beta.52** temp-copy-cleaner fix: the deleter runs from a temp copy after the original exits). Capture `capture-logs.ps1 15.2-wipe` and confirm `31-dataroot` shows it absent. |
 | **15.3** `[Win]` Uninstall modal UX | Open the uninstall modal. | Top-layer overlay above Settings; **cancel** white-outline, **uninstall** red text + red border; keep checkbox **checked by default**; cancel / Esc / backdrop = no action. |
-| **15.4** `[Win]` Stop-exit reaps tray + adb *(item 4)* | Local mode, device + stream live → Settings → **App** → **stop server & exit**. | Tab closes / "app stopped"; Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / `adb.exe` — the tray is reaped (poll thread stopped first) **and** stray adb is `taskkill`'d. |
-| **15.5** `[Win]` App-section order | Settings → App. | Order top→bottom: **reset prompts → stop server & exit → uninstall ws-scrcpy-web** (no "install for all users" on Windows). |
+| **15.4** `[Win]` Stop-exit reaps tray + adb *(item 4)* | Local mode, device + stream live → Settings → **Server** → **stop server & exit**. | Tab closes / "app stopped"; Task Manager shows **no** lingering `ws-scrcpy-web-launcher.exe` / `node.exe` / `ws-scrcpy-web-tray.exe` / `adb.exe` — the tray is reaped (poll thread stopped first) **and** stray adb is `taskkill`'d. |
+| **15.5** `[Win]` Server-section order | Settings → Server. | Order top→bottom: **reset prompts → web port → stop server & exit → uninstall ws-scrcpy-web** (no "install for all users" on Windows). |
 
 > **VM decision to settle (beta.51):** does `Update.exe --uninstall` self-elevate when launched by the unelevated staged launcher (15.1 UAC)? If it needs an already-elevated caller, route the Node spawn through the launcher's `--request-uac` / `--elevate-and-run` seam with a new `windows-app-uninstall` command. *(The earlier wipe-self-deletion concern — the helper orphaning `control\operation-server\` — is **fixed in beta.52**: the cleaner runs from a temp copy after the original exits; 15.2 confirms it.)*
 

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -1,10 +1,10 @@
 # ws-scrcpy-web — Smoke Test Runbook (plain-English)
 
-> **Smoke target: `v0.1.30-beta.62`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.63`** — bump this one line each release; everything below is version-agnostic.
 
 **What this is.** A step-by-step manual test pass for the **ws-scrcpy-web** app. Completing it is the agreed gate before cutting the **0.1.30 final** release — the "prove it really installs, updates, and streams on Windows + Linux" check. You run it by hand on your test VMs plus a real Android device; it can't be automated from a chat.
 
-**Source of truth.** This is the plain-English twin of `docs/smoke-tests/smoke-full.md` in the repo. Same 74 tests, jargon spelled out, laid out as fixed-width tables you can keep open and tick through. If the two ever disagree, **the repo doc wins** — tell me and I'll re-sync this one.
+**Source of truth.** This is the plain-English twin of `docs/smoke-tests/smoke-full.md` in the repo. Same 77 tests, jargon spelled out, laid out as fixed-width tables you can keep open and tick through. If the two ever disagree, **the repo doc wins** — tell me and I'll re-sync this one.
 
 ## How to use this runbook
 
@@ -158,6 +158,15 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ 1.6 Reinstall reuses │ Win  │ After the full uninstall in  │ Installs cleanly and REUSES your old settings    │ [ ]  │
 │ config               │      │ test 5.7, install the MSI    │ file (config.json) instead of overwriting it;    │      │
 │                      │      │ again.                       │ the app returns on the port you had before.      │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 1.7 Cold-start tab   │ Lin  │ Fully quit (past first-run); │ The server boots AND exactly one browser tab     │ [ ]  │
+│ (D1)                 │      │ relaunch the menu entry /    │ opens (the beta.62 D1 fix - it took a 2nd click  │      │
+│                      │      │ AppImage, no service yet.    │ before); a later web-port-change restart adds no │      │
+│                      │      │                              │ second tab.                                      │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 1.8 Cold-start tab   │ Win  │ Fully quit, then relaunch    │ Exactly one browser tab opens (the beta.63 D4    │ [ ]  │
+│ (D4)                 │      │ (Start-menu / exe), no       │ fix); a web-port-change restart AND an in-app    │      │
+│                      │      │ service.                     │ update relaunch do NOT double-tab.               │      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
@@ -479,7 +488,7 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ```
 
 ### Module 12 — Stop server & exit
-*The "stop server & exit" button in Settings → App.*
+*The "stop server & exit" button in Settings → Server.*
 
 ```text
 ┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
@@ -487,19 +496,19 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 12.1 Clean exit +    │ Lin  │ Local mode, a device         │ The tab self-closes or shows "app stopped - you  │ [ ]  │
 │ adb shutdown (Linux) │      │ connected + a stream running │ can close this tab"; everything shuts down (no   │      │
-│                      │      │ > Settings > App > "stop     │ leftover app or adb processes); the log shows    │      │
+│                      │      │ > Settings > Server > "stop  │ leftover app or adb processes); the log shows    │      │
 │                      │      │ server & exit" > confirm.    │ "Stopping adb daemon (kill-server)"; the         │      │
 │                      │      │                              │ launcher does NOT restart (clean exit, not the   │      │
 │                      │      │                              │ restart code).                                   │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 12.2 Disabled in     │ Both │ With a service installed     │ The button is greyed with a note ("managed by    │ [ ]  │
 │ service mode         │      │ (Windows system; Linux user  │ the system service..."); clicking does nothing.  │      │
-│                      │      │ or system) > Settings > App. │ After you UNINSTALL the service it becomes       │      │
-│                      │      │                              │ usable again (no page reload).                   │      │
+│                      │      │ or system) > Settings >      │ After you UNINSTALL the service it becomes       │      │
+│                      │      │ Server.                      │ usable again (no page reload).                   │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 12.3 Windows reaps   │ Win  │ Local mode, device + stream  │ A confirm dialog; the server exits (tab closes / │ [ ]  │
 │ everything           │      │ live, tray present >         │ "app stopped" page); the TRAY ICON disappears;   │      │
-│                      │      │ Settings > App > "stop       │ Task Manager shows no leftover                   │      │
+│                      │      │ Settings > Server > "stop    │ Task Manager shows no leftover                   │      │
 │                      │      │ server & exit" > ok.         │ launcher/node/tray/adb; Cancel leaves everything │      │
 │                      │      │                              │ running.                                         │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
@@ -526,18 +535,25 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ prompts              │      │ and bookmark prompts".       │ reminder is cleared (both per-port and "ever"),  │      │
 │                      │      │                              │ so it can re-appear. Check it does NOT           │      │
 │                      │      │                              │ immediately re-suppress the per-port reminder.   │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 13.3 Server-section  │ Both │ Open Settings; look at the   │ Top to bottom: reset prompts > web port > [Linux │ [ ]  │
+│ layout               │      │ Server section (3rd, after   │ only] install for all users > stop server & exit │      │
+│                      │      │ Updates + Service).          │ > uninstall. The web port row has an inline      │      │
+│                      │      │                              │ 'save' button; the status line below it is empty │      │
+│                      │      │                              │ at rest (only saving... / saved. / an error after│      │
+│                      │      │                              │ you click save).                                 │      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
-### Module 14 — Linux App section UX
-*The App section adds three Settings → App affordances on Linux: a one-click "install for all users" button, a machine-wide start-menu icon, and an always-available in-app "complete uninstall". The uninstall cascades through any installed service in one pass — it runs root-direct under a system service, otherwise self-elevates via ONE pkexec — and offers a "keep my settings & logs" option.*
+### Module 14 — Linux Server section UX
+*The Server section adds three Settings → Server affordances on Linux: a one-click "install for all users" button, a machine-wide start-menu icon, and an always-available in-app "complete uninstall". The uninstall cascades through any installed service in one pass — it runs root-direct under a system service, otherwise self-elevates via ONE pkexec — and offers a "keep my settings & logs" option.*
 
 ```text
 ┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 14.1 Install for     │ Lin  │ From a local (me-only)       │ Exactly one pkexec prompt. The binary            │ [ ]  │
-│ all users            │      │ install: Settings > App >    │ relocates to /opt/ws-scrcpy-web/; the            │      │
+│ all users            │      │ install: Settings > Server > │ relocates to /opt/ws-scrcpy-web/; the            │      │
 │                      │      │ click 'install for all       │ button then greys/disables, reading              │      │
 │                      │      │ users'; authenticate the     │ 'already installed for all users                 │      │
 │                      │      │ single prompt.               │ (/opt)'; the app keeps serving on the            │      │
@@ -548,7 +564,7 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │ apps menu.                   │ /usr/share/icons/hicolor/256x256/apps            │      │
 │                      │      │                              │ /ws-scrcpy-web.png exists.                       │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 14.3 Uninstall -     │ Lin  │ Settings > App >             │ App removed; the browser tab shows               │ [ ]  │
+│ 14.3 Uninstall -     │ Lin  │ Settings > Server >          │ App removed; the browser tab shows               │ [ ]  │
 │ local mode           │      │ 'uninstall...' > confirm     │ 'uninstalled - close this tab'. Running          │      │
 │                      │      │ with 'keep my settings &     │ clear-install.sh verifies a CLEAN SLATE:         │      │
 │                      │      │ logs' UNCHECKED.             │ no leftover binary, dependencies,                │      │
@@ -578,18 +594,18 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
-### Module 15 — Windows App section: uninstall + stop-exit
+### Module 15 — Windows Server section: uninstall + stop-exit
 *New on Windows in beta.51 (in-app uninstall), with the **wipe** fully fixed in beta.52. The uninstall cleaner runs with logging OFF by design, so the evidence is filesystem / registry / temp state — capture it with `capture-logs.ps1 <label>` (see Pre-flight) at each row, especially 15.2.*
 
 ```text
 ┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 15.1 Uninstall -     │ Win  │ MSI install > Settings > App │ One UAC prompt (Update.exe self-elevates).       │ [ ]  │
-│ keep                 │      │ > "uninstall" > leave "keep  │ Program Files\WsScrcpyWeb gone; service gone (sc │      │
-│                      │      │ my settings & logs" CHECKED  │ query = not found); tray gone; the Add/Remove    │      │
-│                      │      │ (default) > uninstall.       │ Programs entry is gone. config.json + logs       │      │
-│                      │      │                              │ survive under ProgramData\WsScrcpyWeb;           │      │
+│ 15.1 Uninstall -     │ Win  │ MSI install > Settings >     │ One UAC prompt (Update.exe self-elevates).       │ [ ]  │
+│ keep                 │      │ Server > "uninstall" > leave │ Program Files\WsScrcpyWeb gone; service gone (sc │      │
+│                      │      │ "keep my settings & logs"    │ query = not found); tray gone; the Add/Remove    │      │
+│                      │      │ CHECKED (default) >          │ Programs entry is gone. config.json + logs       │      │
+│                      │      │ uninstall.                   │ survive under ProgramData\WsScrcpyWeb;           │      │
 │                      │      │                              │ dependencies gone. A later reinstall reuses the  │      │
 │                      │      │                              │ saved port.                                      │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
@@ -606,13 +622,13 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │                              │ settings & logs" box is checked by default;      │      │
 │                      │      │                              │ Cancel / Esc / clicking outside all do nothing.  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 15.4 Stop-exit reaps │ Win  │ Local mode, a device +       │ The tab closes / shows "app stopped"; Task       │ [ ]  │
-│ all                  │      │ stream live > Settings > App │ Manager shows NO leftover launcher, node, tray,  │      │
-│                      │      │ > "stop server & exit".      │ or adb processes.                                │      │
+│ 15.4 Stop-exit reaps │ Win  │ Local mode, a device + stream│ The tab closes / shows "app stopped"; Task       │ [ ]  │
+│ all                  │      │ live > Settings > Server >   │ Manager shows NO leftover launcher, node, tray,  │      │
+│                      │      │ "stop server & exit".        │ or adb processes.                                │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 15.5 App section     │ Win  │ Open Settings > App.         │ Top to bottom: reset prompts > stop server &     │ [ ]  │
-│ order                │      │                              │ exit > uninstall ws-scrcpy-web. (No "install for │      │
-│                      │      │                              │ all users" on Windows.)                          │      │
+│ 15.5 Server section  │ Win  │ Open Settings > Server.      │ Top to bottom: reset prompts > web port > stop   │ [ ]  │
+│ order                │      │                              │ server & exit > uninstall ws-scrcpy-web. (No     │      │
+│                      │      │                              │ "install for all users" on Windows.)             │      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
@@ -652,4 +668,4 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 
 **If any Linux SELinux/lifecycle test (Modules 2, 4, 5, the service-update rows 6.5/6.6, or migration 6.7) — or the core-flow criterion — fails:** stop, **run `capture-logs.sh <id>` (Pre-flight F; `.ps1` on Windows)** for the evidence bundle, and report it before promoting 0.1.30 to stable. Cosmetic/polish failures: note and triage later. **Module 11 (no-libfuse2)** is optional — a failure there just means keep the libfuse2 code; it doesn't block 0.1.30.
 
-*Plain-English companion to [`smoke-full.md`](./smoke-full.md), the canonical machine-precise checklist. Same 74 tests with the jargon spelled out; if the two ever diverge, the full doc wins.*
+*Plain-English companion to [`smoke-full.md`](./smoke-full.md), the canonical machine-precise checklist. Same 77 tests with the jargon spelled out; if the two ever diverge, the full doc wins.*


### PR DESCRIPTION
Prep for the upcoming **beta.63** Fedora re-smoke — all changes are in `docs/smoke-tests/`.

**1. Smoke target → beta.63.** Bumped the single `> Smoke target:` line in all three docs.

**2. Settings "App" → "Server".** beta.62 folded the old Settings **App** section into the consolidated **Server** section (order Updates → Service → Server), so every `Settings → App` reference in the smoke docs was stale. Renamed them all (plus the "App-section" module headings/captions). Cross-checked against `SettingsModal.ts` — `buildSection('Server')`, rows: reset prompts → web port → install-for-all-users (Linux-only) → stop server & exit → uninstall.

**3. 15.5 Windows order fix.** The Windows Server-section order now includes the web-port row: **reset prompts → web port → stop server & exit → uninstall** (install-for-all-users stays Linux-only).

**4. New eyeball rows** for behavior that shipped (beta.62/63) but hasn't been smoked at runtime yet:
- **1.7 (Linux, D1)** + **1.8 (Windows, D4)** — a fresh cold-start opens exactly one browser tab; a web-port-change restart / update-relaunch don't double-tab.
- **13.3** — the consolidated Server-section layout + the inline web-port **save** button (status line empty at rest).

The runbook's fixed-width box-tables were re-flowed column-aware, so alignment holds (verified every block is uniform width). Test count 74 → 77.

`release:none` — test docs only, no code change.
