### PR TITLE
chore: remove dead migrationNotice helper and its tests

### DIFF
--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -193,17 +193,6 @@ export function appSectionButtonsState(resp: {
 }
 
 export interface SystemServiceInstallGate { enabled: boolean; note: string | null; }
-/**
- * Derive whether the migration reinstall notice should be shown. Pure (no DOM)
- * so it is unit-testable; mirrors systemServiceInstallGate's shape. When true,
- * the caller should render the notice text and a [reinstall now] action button
- * that POSTs /api/service/migrate-system.
- */
-export function migrationNotice(input: { serviceMigrationNeeded?: boolean }): { show: boolean; text: string } {
-    return input.serviceMigrationNeeded
-        ? { show: true, text: 'this service uses the old layout. reinstall it to update to the new layout.' }
-        : { show: false, text: '' };
-}
 
 /** System-scope service install requires a machine-wide /opt install first
  *  (the root service execs the /opt binary; it can't exist without it). */

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -11,7 +11,6 @@ import {
     buildServiceInfoRow,
     systemServiceInstallGate,
     applySystemInstallGate,
-    migrationNotice,
     appSectionButtonsState,
     buildInstallAllUsersControl,
     buildUninstallControl,
@@ -219,20 +218,6 @@ describe('buildServiceInfoRow', () => {
         expect(row.className).toContain('settings-status');
         expect(row.className).not.toContain('settings-status-error');
         expect(row.querySelector('button')).toBeNull();
-    });
-});
-
-describe('migrationNotice', () => {
-    it('show=true with reinstall text when serviceMigrationNeeded=true', () => {
-        const result = migrationNotice({ serviceMigrationNeeded: true });
-        expect(result.show).toBe(true);
-        expect(result.text).toMatch(/old layout|reinstall|new layout/i);
-    });
-    it('show=false with empty text when serviceMigrationNeeded=false', () => {
-        expect(migrationNotice({ serviceMigrationNeeded: false })).toEqual({ show: false, text: '' });
-    });
-    it('show=false with empty text when serviceMigrationNeeded is undefined', () => {
-        expect(migrationNotice({})).toEqual({ show: false, text: '' });
     });
 });
 


### PR DESCRIPTION
Removes the orphaned `migrationNotice()` helper and its 3 tests from SettingsModal.

beta.64's forward-only `/var/opt`->`/var/lib` change deleted the migration subsystem (the `migrate-system` endpoint, `buildSystemMigrationScript`, `systemServiceNeedsMigration`) but left this frontend helper behind. The server no longer emits `serviceMigrationNeeded`, so it was dead -- always returned `{show:false}` -- and its doc-comment still pointed at the deleted `/api/service/migrate-system`.

Drops the function, its export, the test import, and the 3-case `describe` block. No user-facing change (`release:none`).

Verified: `tsc --noEmit` 0, vitest 954 passed (was 957 -- the 3 removed tests).