### PR TITLE
Security hardening: HTTP/WS auth, adb/device-shell, supply-chain, binary bounds, DOM-XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The HTTP API and WebSocket endpoints now enforce an Origin and Host allowlist.** Requests from another web origin, and requests whose `Host` header is not `localhost` or an IP literal (DNS-rebinding), are rejected — closing a cross-site path by which a malicious page could reach device control, file deletion, and service management.
+- **A per-instance token is now required on the sensitive API surface and on every WebSocket connection.** It is handed to the browser as a `SameSite=Strict`, `HttpOnly` cookie when the page loads, so normal use is unchanged; a non-browser caller that never loaded the page is rejected. (A server restart mints a new token, so an already-open page must reload to reconnect.)
+- **Values that reach `adb` and the device shell are now escaped and validated.** Device file paths and process names are single-quote-escaped before they reach `adb shell`, device serials are validated (blocking adb option injection), the `videoEncoder` stream option is allowlisted, and file-push destinations are checked — preventing command and argument injection against a connected device.
+- **The bundled AppImage runtime is verified against a pinned SHA-256 before it is embedded in the Linux build** (previously only its ELF magic bytes were checked), protecting the build from a tampered or substituted runtime.
+- **The binary stream parsers now bounds-check untrusted input.** The control-message reader and the AV1 sequence-header reader reject out-of-range lengths instead of reading past the buffer or fabricating values.
+- **Untrusted strings are escaped before being rendered into the page.** Dependency names and messages, device identifiers, and file names are HTML-escaped (or assigned as text), and file rows are tracked internally instead of by an attacker-influenced element id — closing DOM-based XSS and DOM-clobbering vectors.
+
 ## [0.1.30-beta.65] - 2026-06-12
 
 ### Added

--- a/scripts/swap-appimage-runtime.mjs
+++ b/scripts/swap-appimage-runtime.mjs
@@ -28,6 +28,7 @@
 //   node scripts/swap-appimage-runtime.mjs Releases/WsScrcpyWeb-linux.AppImage
 
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
     chmodSync,
     createReadStream,
@@ -39,12 +40,38 @@ import { open, rename, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
+import { pathToFileURL } from 'node:url';
 
 // Pin to a known-good URL. The continuous channel is built from main and
 // updates frequently. If reproducibility ever matters, swap to a tagged
 // release URL.
 const RUNTIME_URL =
     'https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64';
+
+// SHA-256 of the known-good runtime, verified before it is embedded into the
+// shipped .AppImage — this binary is the first code that runs on launch. The
+// continuous channel is rebuilt from main; when intentionally adopting a newer
+// runtime, download it from a trusted source, verify it, and update this
+// digest. The build refuses any runtime whose hash does not match.
+const RUNTIME_SHA256 =
+    'a2419dce47568395ae79c01ffa9a5a341dd339581352ff104d073527543177e5';
+
+/**
+ * Verify downloaded runtime bytes against an expected SHA-256, throwing on
+ * mismatch. Returns the buffer unchanged on success.
+ */
+export function verifyRuntimeBytes(buf, expectedSha = RUNTIME_SHA256) {
+    const actual = createHash('sha256').update(buf).digest('hex');
+    if (actual !== expectedSha) {
+        throw new Error(
+            `runtime SHA-256 mismatch: expected ${expectedSha}, got ${actual}. ` +
+                'Refusing to embed an unverified runtime. If the upstream runtime ' +
+                'was intentionally updated, re-pin RUNTIME_SHA256 after verifying ' +
+                'the new binary from a trusted source.',
+        );
+    }
+    return buf;
+}
 
 const SKIP = process.env.SKIP_APPIMAGE_RUNTIME_SWAP === '1';
 
@@ -125,6 +152,10 @@ async function downloadRuntime(url, destPath) {
     }
     const ab = await res.arrayBuffer();
     const buf = Buffer.from(ab);
+    // Supply-chain integrity: verify the pinned SHA-256 before trusting the
+    // runtime. The ELF magic check below is only a secondary sanity check —
+    // any attacker-supplied binary would satisfy the magic bytes.
+    verifyRuntimeBytes(buf);
     // Sanity check: verify ELF magic (0x7F 'E' 'L' 'F').
     if (
         buf.length < 4 ||
@@ -226,9 +257,12 @@ async function main() {
     }
 }
 
-try {
-    await main();
-} catch (e) {
-    err(`unexpected error: ${e.message}`);
-    process.exit(1);
+// Only run when invoked directly, so the module can be imported in tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        await main();
+    } catch (e) {
+        err(`unexpected error: ${e.message}`);
+        process.exit(1);
+    }
 }

--- a/scripts/swap-appimage-runtime.test.mjs
+++ b/scripts/swap-appimage-runtime.test.mjs
@@ -1,0 +1,16 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { verifyRuntimeBytes } from './swap-appimage-runtime.mjs';
+
+describe('swap-appimage-runtime verifyRuntimeBytes', () => {
+    it('returns the buffer when the SHA-256 matches', () => {
+        const buf = Buffer.from('a fake runtime');
+        const sha = createHash('sha256').update(buf).digest('hex');
+        expect(verifyRuntimeBytes(buf, sha)).toBe(buf);
+    });
+
+    it('throws when the SHA-256 does not match (tampered or changed runtime)', () => {
+        const buf = Buffer.from('a fake runtime');
+        expect(() => verifyRuntimeBytes(buf, 'deadbeef')).toThrow(/mismatch/i);
+    });
+});

--- a/src/app/BinaryReader.test.ts
+++ b/src/app/BinaryReader.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { BinaryReader } from './BinaryReader';
+
+describe('BinaryReader', () => {
+    it('reads in-bounds values correctly', () => {
+        const r = new BinaryReader(new Uint8Array([0x00, 0x00, 0x00, 0x2a]));
+        expect(r.readUInt32BE()).toBe(42);
+    });
+
+    it('returns exactly the requested in-bounds slice from readBytes', () => {
+        const r = new BinaryReader(new Uint8Array([10, 20, 30, 40]));
+        expect(Array.from(r.readBytes(2))).toEqual([10, 20]);
+        expect(r.remaining).toBe(2);
+    });
+
+    it('readBytes must not read past the logical view into the backing buffer', () => {
+        // The logical message is only the first 4 bytes, but the backing
+        // ArrayBuffer has 8. readBytes(8) must throw, not alias bytes 5-8.
+        const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+        const view = backing.subarray(0, 4);
+        const r = new BinaryReader(view);
+        expect(() => r.readBytes(8)).toThrow(RangeError);
+    });
+
+    it('throws when a fixed-width read runs past the end', () => {
+        const r = new BinaryReader(new Uint8Array([1, 2]));
+        expect(() => r.readUInt32BE()).toThrow(RangeError);
+    });
+
+    it('throws when readUInt8 runs past the end', () => {
+        const r = new BinaryReader(new Uint8Array([1]));
+        expect(r.readUInt8()).toBe(1);
+        expect(() => r.readUInt8()).toThrow(RangeError);
+    });
+
+    it('rejects a negative or non-finite length', () => {
+        const r = new BinaryReader(new Uint8Array([1, 2, 3, 4]));
+        expect(() => r.readBytes(-1)).toThrow(RangeError);
+    });
+});

--- a/src/app/BinaryReader.ts
+++ b/src/app/BinaryReader.ts
@@ -9,55 +9,78 @@ export class BinaryReader {
         this.pos = offset;
     }
 
+    /**
+     * Bounds-check a read of `n` bytes at the current position against the
+     * logical view length. Throws rather than reading past the message — which,
+     * for readBytes(), would otherwise alias unrelated bytes of the backing
+     * ArrayBuffer (an out-of-message information leak on untrusted input).
+     */
+    private check(n: number): void {
+        if (!Number.isInteger(n) || n < 0 || this.pos + n > this.view.byteLength) {
+            throw new RangeError(
+                `BinaryReader out of bounds: need ${n} byte(s) at offset ${this.pos}, have ${this.remaining}`,
+            );
+        }
+    }
+
     readUInt8(): number {
+        this.check(1);
         const v = this.view.getUint8(this.pos);
         this.pos += 1;
         return v;
     }
 
     readInt8(): number {
+        this.check(1);
         const v = this.view.getInt8(this.pos);
         this.pos += 1;
         return v;
     }
 
     readUInt16BE(): number {
+        this.check(2);
         const v = this.view.getUint16(this.pos);
         this.pos += 2;
         return v;
     }
 
     readInt16BE(): number {
+        this.check(2);
         const v = this.view.getInt16(this.pos);
         this.pos += 2;
         return v;
     }
 
     readUInt32BE(): number {
+        this.check(4);
         const v = this.view.getUint32(this.pos);
         this.pos += 4;
         return v;
     }
 
     readInt32BE(): number {
+        this.check(4);
         const v = this.view.getInt32(this.pos);
         this.pos += 4;
         return v;
     }
 
     readUInt32LE(): number {
+        this.check(4);
         const v = this.view.getUint32(this.pos, true);
         this.pos += 4;
         return v;
     }
 
     readBigUInt64BE(): bigint {
+        this.check(8);
         const v = this.view.getBigUint64(this.pos);
         this.pos += 8;
         return v;
     }
 
     readBytes(length: number): Uint8Array {
+        this.check(length);
         const data = new Uint8Array(this.view.buffer, this.view.byteOffset + this.pos, length);
         this.pos += length;
         return data;

--- a/src/app/Util.escapeUdid.test.ts
+++ b/src/app/Util.escapeUdid.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import Util from './Util';
+
+describe('Util.escapeUdid', () => {
+    it('preserves the output for real USB and network udids', () => {
+        // Behaviour unchanged for normal device serials so DOM ids/lookups
+        // built from escapeUdid stay consistent.
+        expect(Util.escapeUdid('emulator-5554')).toBe('udid_emulator-5554');
+        expect(Util.escapeUdid('192.168.1.5:5555')).toBe('udid_192_168_1_5_5555');
+    });
+
+    it('neutralises HTML-dangerous characters (defence in depth for derived ids)', () => {
+        const out = Util.escapeUdid('x"><img src=x onerror=alert(1)>');
+        expect(out).not.toMatch(/[<>"'&]/);
+        // Only safe id characters remain.
+        expect(out).toMatch(/^udid_[A-Za-z0-9_-]*$/);
+    });
+});

--- a/src/app/Util.ts
+++ b/src/app/Util.ts
@@ -26,7 +26,12 @@ export default class Util {
     }
 
     public static escapeUdid(udid: string): string {
-        return 'udid_' + udid.replace(/[. :]/g, '_');
+        // Replace everything that isn't a safe id character. This preserves the
+        // output for real udids (USB serials keep their '-', host:port becomes
+        // host_port as before) while neutralising HTML-dangerous characters in
+        // any id/name derived from the udid (defence in depth alongside the
+        // html`` quote-escaping).
+        return 'udid_' + udid.replace(/[^A-Za-z0-9_-]/g, '_');
     }
 
     public static parse(params: URLSearchParams, name: string, required?: boolean): string | null {

--- a/src/app/client/DependencyPanel.test.ts
+++ b/src/app/client/DependencyPanel.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { type DependencyInfo, DependencyStatus } from '../../common/DependencyTypes';
+import { DependencyPanel } from './DependencyPanel';
+
+const dep = (o: Partial<DependencyInfo>): DependencyInfo => ({
+    name: 'adb',
+    displayName: 'ADB',
+    installedVersion: null,
+    latestVersion: null,
+    status: DependencyStatus.Error,
+    description: 'desc',
+    requiresRestart: false,
+    canUpdate: false,
+    ...o,
+});
+
+describe('DependencyPanel XSS', () => {
+    it('escapes a malicious displayName/description instead of injecting markup', () => {
+        const panel = new DependencyPanel();
+        (panel as any).render([
+            dep({ displayName: '<img src=x onerror=alert(1)>', description: '<svg onload=alert(2)>' }),
+        ]);
+        const body = panel.getElement().querySelector('tbody');
+        expect(body?.querySelector('img')).toBeNull();
+        expect(body?.querySelector('svg')).toBeNull();
+        expect(body?.textContent).toContain('<img src=x onerror=alert(1)>');
+    });
+
+    it('escapes a malicious errorMessage in the status title attribute', () => {
+        const panel = new DependencyPanel();
+        (panel as any).render([
+            dep({ status: DependencyStatus.Error, errorMessage: 'x"><img src=y onerror=alert(1)>' }),
+        ]);
+        const body = panel.getElement().querySelector('tbody');
+        expect(body?.querySelector('img')).toBeNull();
+    });
+});

--- a/src/app/client/DependencyPanel.ts
+++ b/src/app/client/DependencyPanel.ts
@@ -1,4 +1,5 @@
 import type { DependencyInfo, UpdateResult } from '../../common/DependencyTypes';
+import { escapeHtml } from '../htmlEscape';
 
 const POLL_INTERVAL_MS = 15_000;
 
@@ -187,12 +188,12 @@ export class DependencyPanel {
             row.className = `dep-row dep-status-${dep.status}`;
             row.innerHTML = `
                 <td>
-                    <strong>${dep.displayName}</strong>
-                    ${dep.pairedWith ? `<span class="dep-paired">+ ${dep.pairedWith}</span>` : ''}
-                    <div class="dep-description">${dep.description}</div>
+                    <strong>${escapeHtml(dep.displayName)}</strong>
+                    ${dep.pairedWith ? `<span class="dep-paired">+ ${escapeHtml(dep.pairedWith)}</span>` : ''}
+                    <div class="dep-description">${escapeHtml(dep.description)}</div>
                 </td>
-                <td class="dep-version">${dep.installedVersion || 'Not installed'}</td>
-                <td class="dep-version">${dep.latestVersion || '\u2014'}</td>
+                <td class="dep-version">${escapeHtml(dep.installedVersion || 'Not installed')}</td>
+                <td class="dep-version">${escapeHtml(dep.latestVersion || '\u2014')}</td>
                 <td class="dep-status">${this.statusLabel(dep)}</td>
                 <td class="dep-action">${this.actionButton(dep)}</td>
             `;
@@ -210,7 +211,7 @@ export class DependencyPanel {
             case 'update-available': return '<span class="dep-badge dep-warn">Update available</span>';
             case 'checking': return '<span class="dep-badge dep-info">Checking...</span>';
             case 'updating': return '<span class="dep-badge dep-info">Updating...</span>';
-            case 'error': return `<span class="dep-badge dep-error" title="${dep.errorMessage || ''}">Error</span>`;
+            case 'error': return `<span class="dep-badge dep-error" title="${escapeHtml(dep.errorMessage || '')}">Error</span>`;
             default: return '<span class="dep-badge dep-unknown">Unknown</span>';
         }
     }
@@ -223,7 +224,7 @@ export class DependencyPanel {
                 return `<button class="dep-btn dep-update" disabled title="${tooltip}">` +
                     `update (dev)</button>`;
             }
-            return `<button class="dep-btn dep-update" data-update="${dep.name}">update</button>`;
+            return `<button class="dep-btn dep-update" data-update="${escapeHtml(dep.name)}">update</button>`;
         }
         if (dep.status === 'updating') {
             return '<button class="dep-btn" disabled>updating...</button>';

--- a/src/app/client/FirstRunBanner.test.ts
+++ b/src/app/client/FirstRunBanner.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { type DependencyInfo, DependencyStatus } from '../../common/DependencyTypes';
+import { FirstRunBanner } from './FirstRunBanner';
+
+const dep = (displayName: string): DependencyInfo => ({
+    name: 'x',
+    displayName,
+    installedVersion: null,
+    latestVersion: null,
+    status: DependencyStatus.Error,
+    description: '',
+    requiresRestart: false,
+    canUpdate: false,
+});
+
+describe('FirstRunBanner XSS', () => {
+    it('escapes a malicious dependency displayName instead of injecting markup', () => {
+        const banner = new FirstRunBanner();
+        (banner as any).render([dep('<img src=x onerror=alert(1)>')]);
+        const el = banner.getElement();
+        expect(el.querySelector('img')).toBeNull();
+        expect(el.textContent).toContain('<img src=x onerror=alert(1)>');
+    });
+});

--- a/src/app/client/FirstRunBanner.ts
+++ b/src/app/client/FirstRunBanner.ts
@@ -68,12 +68,15 @@ export class FirstRunBanner {
         this.container.innerHTML = `
             <div class="first-run-banner-inner">
                 <span class="first-run-banner-icon">⚠</span>
-                <span class="first-run-banner-text">
-                    Setup incomplete — ${names} failed to download. Check your network connection.
-                </span>
+                <span class="first-run-banner-text"></span>
                 <button class="first-run-banner-retry" type="button">Retry</button>
             </div>
         `;
+        // Inject the (server-supplied) dependency names as text, never as markup.
+        const textEl = this.container.querySelector('.first-run-banner-text');
+        if (textEl) {
+            textEl.textContent = `Setup incomplete — ${names} failed to download. Check your network connection.`;
+        }
         this.retryButton = this.container.querySelector('.first-run-banner-retry');
         this.retryButton?.addEventListener('click', () => this.onRetry());
         this.container.style.display = 'block';

--- a/src/app/googDevice/client/FileListingClient.ts
+++ b/src/app/googDevice/client/FileListingClient.ts
@@ -97,6 +97,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
     private requestedPath = '';
     private downloads: Map<Multiplexer, Download> = new Map();
     private uploads: Map<string, Upload> = new Map();
+    private rowsByName: Map<string, HTMLElement> = new Map();
     private tableBody: HTMLElement;
     private channels: Set<Multiplexer> = new Set();
     constructor(params: ParamsFileListing) {
@@ -206,9 +207,9 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
     }
 
     private findOrCreateEntryRow(fileName: string): HTMLElement {
-        const row = document.getElementById(`entry-${fileName}`);
-        if (row) {
-            return row;
+        const existing = this.rowsByName.get(fileName);
+        if (existing && existing.isConnected) {
+            return existing;
         }
         return this.addRow(true, fileName, 'file');
     }
@@ -216,12 +217,9 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
     public onFilePushUpdate(data: PushUpdateParams): void {
         const { fileName, progress, error, message, finished } = data;
         let upload = this.uploads.get(fileName);
-        if (!upload || document.getElementById(upload.anchor.id) !== upload.anchor) {
+        if (!upload || !upload.anchor.isConnected) {
             const row = this.findOrCreateEntryRow(fileName);
             const anchor = row.getElementsByTagName('a')[0]!;
-            if (!anchor.id) {
-                anchor.id = `upload_${fileName}`;
-            }
             const progressEl = this.appendProgressElement(anchor);
             upload = { row, progressEl, anchor, timeout: null };
             this.uploads.set(fileName, upload);
@@ -358,6 +356,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
 
     protected clean(): void {
         this.tableBody.innerHTML = '';
+        this.rowsByName.clear();
         const header = document.getElementById('header');
         if (header) {
             header.innerText = `Content ${this.path}`;
@@ -515,8 +514,13 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
 
     protected addRow(push: boolean, name: string, typeClass: string, size = '', date = '', entryId = ''): HTMLElement {
         const row = document.createElement('tr');
-        row.id = `entry-${name}`;
+        // Track rows by name in a Map rather than encoding the untrusted file
+        // name into an element id, which enabled DOM clobbering and selector
+        // breakage. The name is stored as a data-* attribute (set safely, not
+        // parsed as HTML) for any styling/debugging hooks.
         row.classList.add('entry-row');
+        row.setAttribute('data-entry-name', name);
+        this.rowsByName.set(name, row);
         const nameTd = document.createElement('td');
         nameTd.classList.add('entry-name');
         const link = document.createElement('a');

--- a/src/app/htmlEscape.test.ts
+++ b/src/app/htmlEscape.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from './htmlEscape';
+
+describe('escapeHtml', () => {
+    it('escapes angle brackets and ampersands (text-context XSS)', () => {
+        expect(escapeHtml('<img src=x onerror=alert(1)>')).toBe(
+            '&lt;img src=x onerror=alert(1)&gt;',
+        );
+        expect(escapeHtml('a&b')).toBe('a&amp;b');
+    });
+
+    it('escapes quotes so attribute interpolation cannot break out', () => {
+        expect(escapeHtml('x" onmouseover="alert(1)')).toBe('x&quot; onmouseover=&quot;alert(1)');
+        expect(escapeHtml("a'b")).toBe('a&#039;b');
+    });
+
+    it('leaves safe text unchanged', () => {
+        expect(escapeHtml('OMX.qcom.video.encoder.avc')).toBe('OMX.qcom.video.encoder.avc');
+    });
+});

--- a/src/app/htmlEscape.ts
+++ b/src/app/htmlEscape.ts
@@ -1,0 +1,14 @@
+/**
+ * Escape a string for safe interpolation into HTML — both text content and
+ * (because the quotes are escaped) attribute values. Use this anywhere
+ * untrusted data (device names, file names, server-supplied strings) is built
+ * into an HTML string before being assigned to innerHTML.
+ */
+export function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}

--- a/src/app/player/av1-utils.test.ts
+++ b/src/app/player/av1-utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { parseAv1SequenceHeader } from './av1-utils';
+
+describe('av1-utils parseAv1SequenceHeader bounds checking', () => {
+    it('throws on an empty buffer instead of reading undefined', () => {
+        expect(() => parseAv1SequenceHeader(new Uint8Array([]))).toThrow();
+    });
+
+    it('throws on a truncated sequence header rather than fabricating bits', () => {
+        // Far too short for a full sequence header: the bit reader must run out
+        // of bounds and throw, not silently read 0 bits past the buffer and
+        // return a bogus codec/dimensions to VideoDecoder.configure().
+        expect(() => parseAv1SequenceHeader(new Uint8Array([0x00, 0x00]))).toThrow(RangeError);
+    });
+});

--- a/src/app/player/av1-utils.ts
+++ b/src/app/player/av1-utils.ts
@@ -50,6 +50,9 @@ export function parseAv1ConfigRecord(data: Uint8Array): { codec: string } | null
 }
 
 export function parseAv1SequenceHeader(data: Uint8Array): Av1CodecInfo {
+    if (data.length < 1) {
+        throw new RangeError('AV1 sequence header: empty buffer');
+    }
     let pos = 0;
 
     // OBU header
@@ -173,6 +176,9 @@ function readLeb128(data: Uint8Array, pos: number): { value: number; newPos: num
     let i = 0;
     let byte: number;
     do {
+        if (pos >= data.length) {
+            throw new RangeError('AV1 leb128: out of bounds');
+        }
         byte = data[pos++]!;
         value |= (byte & 0x7f) << (i * 7);
         i++;
@@ -193,6 +199,9 @@ class Av1BitReader {
         let value = 0;
         for (let i = 0; i < n; i++) {
             const byteIdx = this.bitPos >> 3;
+            if (byteIdx >= this.data.length) {
+                throw new RangeError('Av1BitReader: out of bounds');
+            }
             const bitIdx = 7 - (this.bitPos & 7);
             value = (value << 1) | ((this.data[byteIdx]! >> bitIdx) & 1);
             this.bitPos++;

--- a/src/app/ui/HtmlTag.test.ts
+++ b/src/app/ui/HtmlTag.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { html } from './HtmlTag';
+
+describe('html tag', () => {
+    it('escapes a value interpolated into an attribute so it cannot break out', () => {
+        const udid = 'x" onmouseover="alert(1)';
+        const tpl = html`<button data-udid="${udid}">go</button>`;
+        const btn = tpl.content.querySelector('button');
+        expect(btn).not.toBeNull();
+        // The attribute holds the literal value; no event-handler attribute injected.
+        expect(btn?.getAttribute('data-udid')).toBe(udid);
+        expect(btn?.hasAttribute('onmouseover')).toBe(false);
+    });
+
+    it('escapes a value interpolated into text content', () => {
+        const name = '<img src=x onerror=alert(1)>';
+        const tpl = html`<div>${name}</div>`;
+        const div = tpl.content.querySelector('div');
+        expect(div?.textContent).toBe(name);
+        expect(div?.querySelector('img')).toBeNull();
+    });
+});

--- a/src/app/ui/HtmlTag.ts
+++ b/src/app/ui/HtmlTag.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from '../htmlEscape';
+
 type Value = any;
 
 function htmlValue(value: Value): string {
@@ -10,9 +12,11 @@ function htmlValue(value: Value): string {
     if (value === null) {
         return 'null';
     }
-    const e = document.createElement('dummy');
-    e.innerText = value.toString();
-    return e.innerHTML;
+    // Escape for both text and attribute context (quotes included) so an
+    // interpolated value cannot break out of an attribute and inject markup or
+    // an event handler. (The previous innerText round-trip did not escape
+    // quotes, leaving attribute interpolation injectable.)
+    return escapeHtml(value.toString());
 }
 
 export const html = function html(strings: TemplateStringsArray, ...values: ReadonlyArray<Value>): HTMLTemplateElement {

--- a/src/server/AdbClient.ts
+++ b/src/server/AdbClient.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, execFile, spawn } from 'child_process';
 import * as path from 'path';
 import { promisify } from 'util';
 import { AdbDaemonManager } from './AdbDaemonManager';
+import { assertSerial } from './security/deviceInput';
 
 const execFileAsync = promisify(execFile);
 
@@ -119,6 +120,11 @@ export class AdbClient {
     }
 
     private async exec(args: string[], opts: AdbExecOptions = {}): Promise<string> {
+        // Validate the target serial (argument injection: a leading "-" would be
+        // parsed by adb as an option, e.g. -L/-H to redirect to another server).
+        if (args[0] === '-s') {
+            assertSerial(args[1]);
+        }
         // Daemon coordination first — propagate any AdbExecError from the
         // manager (binary-missing, spawn-timeout) unchanged. Inside the try
         // block, the catch's err-classifier would unhelpfully rewrap an
@@ -163,6 +169,7 @@ export class AdbClient {
     }
 
     async shell(serial: string, command: string): Promise<string> {
+        assertSerial(serial);
         await this.daemon.ensureReady();
         const { stdout } = await execFileAsync(this.adbPath, ['-s', serial, 'shell', command], {
             maxBuffer: 10 * 1024 * 1024,
@@ -232,6 +239,7 @@ export class AdbClient {
      * pre-enumeration, this comment is the trip-wire to revisit the API.
      */
     shellSpawn(serial: string, command: string): ChildProcess {
+        assertSerial(serial);
         return spawn(this.adbPath, ['-s', serial, 'shell', command], {
             stdio: ['ignore', 'pipe', 'pipe'],
             cwd: this.cwd,

--- a/src/server/goog-device/AdbUtils.ts
+++ b/src/server/goog-device/AdbUtils.ts
@@ -6,6 +6,7 @@ import type { Multiplexer } from '../../packages/multiplexer/Multiplexer';
 import type { FileStats } from '../../types/FileStats';
 import { AdbClient } from '../AdbClient';
 import { Config } from '../Config';
+import { shArg } from '../security/deviceInput';
 
 const execFileAsync = promisify(execFile);
 
@@ -27,7 +28,7 @@ export class AdbUtils {
         // Use stat with format: mode (octal), size, mtime (epoch)
         const output = await adbClient.shell(
             serial,
-            `stat -c '%f %s %Y' "${pathString}" 2>/dev/null || stat -c '%a %s %Y' "${pathString}" 2>/dev/null`,
+            `stat -c '%f %s %Y' ${shArg(pathString)} 2>/dev/null || stat -c '%a %s %Y' ${shArg(pathString)} 2>/dev/null`,
         );
         const parts = output.trim().split(/\s+/);
         if (parts.length >= 3) {
@@ -41,7 +42,7 @@ export class AdbUtils {
 
     public static async readdir(serial: string, pathString: string): Promise<FileStats[]> {
         // Use ls -la to list directory contents
-        const output = await adbClient.shell(serial, `ls -la "${pathString}"`);
+        const output = await adbClient.shell(serial, `ls -la ${shArg(pathString)}`);
         const entries: FileStats[] = [];
         for (const line of output.split('\n')) {
             const trimmed = line.trim();
@@ -95,7 +96,7 @@ export class AdbUtils {
     public static async pipeReadDirToStream(serial: string, pathString: string, stream: Multiplexer): Promise<void> {
         try {
             // Use ls -la for listing, then stat each entry for mode/size/mtime
-            const output = await adbClient.shell(serial, `ls -1a "${pathString}"`);
+            const output = await adbClient.shell(serial, `ls -1a ${shArg(pathString)}`);
             const names = output
                 .split('\n')
                 .map((n) => n.trim())
@@ -114,7 +115,7 @@ export class AdbUtils {
                         mtime = stat.mtime;
                     } catch {
                         // If stat fails, try to determine if it's a directory from ls -la
-                        const laOutput = await adbClient.shell(serial, `ls -lad "${entryPath}" 2>/dev/null`);
+                        const laOutput = await adbClient.shell(serial, `ls -lad ${shArg(entryPath)} 2>/dev/null`);
                         if (laOutput.startsWith('d')) {
                             mode = 0o40755; // directory
                         } else {
@@ -147,7 +148,7 @@ export class AdbUtils {
     public static async pipePullFileToStream(serial: string, pathString: string, stream: Multiplexer): Promise<void> {
         try {
             // Use adb exec-out to stream binary file content
-            const { stdout } = await execFileAsync(Config.getInstance().adbPath, ['-s', serial, 'exec-out', `cat "${pathString}"`], {
+            const { stdout } = await execFileAsync(Config.getInstance().adbPath, ['-s', serial, 'exec-out', `cat ${shArg(pathString)}`], {
                 maxBuffer: 50 * 1024 * 1024,
                 encoding: 'buffer',
             });

--- a/src/server/goog-device/Device.ts
+++ b/src/server/goog-device/Device.ts
@@ -4,6 +4,7 @@ import type { NetInterface } from '../../types/NetInterface';
 import { AdbClient } from '../AdbClient';
 import { Config } from '../Config';
 import { Logger } from '../Logger';
+import { shArg } from '../security/deviceInput';
 import { classifyDeviceKind } from './deviceKind';
 import { Properties } from './Properties';
 
@@ -99,6 +100,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     public killProcess(pid: number): Promise<string> {
+        // Guard against a non-positive/non-integer pid reaching `kill` — a
+        // negative value would target a process group (e.g. `kill -1` = all).
+        if (!Number.isInteger(pid) || pid <= 0) {
+            return Promise.reject(new Error(`invalid pid: ${pid}`));
+        }
         const command = `kill ${pid}`;
         return this.runShellCommand(command);
     }
@@ -155,7 +161,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private async pidOf(processName: string): Promise<number[]> {
-        return this.runShellCommand(`pidof ${processName}`)
+        return this.runShellCommand(`pidof ${shArg(processName)}`)
             .then((output) => {
                 return output
                     .split(' ')
@@ -186,7 +192,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private async grepPs_A(processName: string): Promise<number[]> {
-        return this.runShellCommand(`ps -A | grep ${processName}`)
+        return this.runShellCommand(`ps -A | grep ${shArg(processName)}`)
             .then((output) => {
                 return this.filterPsOutput(processName, output);
             })
@@ -196,7 +202,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private async grepPs(processName: string): Promise<number[]> {
-        return this.runShellCommand(`ps | grep ${processName}`)
+        return this.runShellCommand(`ps | grep ${shArg(processName)}`)
             .then((output) => {
                 return this.filterPsOutput(processName, output);
             })
@@ -208,7 +214,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     private async listProc(processName: string): Promise<number[]> {
         const find = 'find /proc -maxdepth 2 -name cmdline  2>/dev/null';
         const lines = await this.runShellCommand(
-            `for L in \`${find}\`; do grep -sae '^${processName}' $L 2>&1 >/dev/null && echo $L; done`,
+            `for L in \`${find}\`; do grep -sae ${shArg(`^${processName}`)} $L 2>&1 >/dev/null && echo $L; done`,
         );
         const re = /\/proc\/([0-9]+)\/cmdline/;
         const list: number[] = [];

--- a/src/server/goog-device/ScrcpyServer.ts
+++ b/src/server/goog-device/ScrcpyServer.ts
@@ -19,6 +19,9 @@ export class ScrcpyServer {
         if (!Array.isArray(list) || !list.length) return;
 
         for (const pid of list) {
+            if (!Number.isInteger(pid) || pid <= 0) {
+                continue;
+            }
             const output = await device.runShellCommand(`cat /proc/${pid}/cmdline`);
             const args = output.split('\0');
             if (args.includes(SERVER_PACKAGE)) {

--- a/src/server/goog-device/filePush/FilePushReader.ts
+++ b/src/server/goog-device/filePush/FilePushReader.ts
@@ -6,6 +6,7 @@ import { FilePushResponseStatus } from '../../../app/googDevice/filePush/FilePus
 import { AdbClient } from '../../AdbClient';
 import { Config } from '../../Config';
 import { Logger } from '../../Logger';
+import { assertSafeRemotePath } from '../../security/deviceInput';
 
 enum State {
     INITIAL = 0,
@@ -101,7 +102,13 @@ export class FilePushReader {
                     return;
                 }
                 const { fileName, fileSize } = command;
-                if (!fileName) {
+                // The destination is passed to `adb push` as an argv element, so
+                // reject an empty/NUL value or a leading "-" (adb option injection)
+                // before using it.
+                let safeFileName: string;
+                try {
+                    safeFileName = assertSafeRemotePath(fileName);
+                } catch {
                     this.closeWithError(FilePushResponseStatus.ERROR_INVALID_NAME);
                     return;
                 }
@@ -109,7 +116,7 @@ export class FilePushReader {
                     this.closeWithError(FilePushResponseStatus.ERROR_INCORRECT_SIZE);
                     return;
                 }
-                this.fileName = fileName;
+                this.fileName = safeFileName;
                 this.state = State.START;
                 // Create a temp file to accumulate chunks
                 this.tempFilePath = path.join(os.tmpdir(), `adb_push_${this.pushId}_${Date.now()}`);

--- a/src/server/scrcpyOptionsFromQuery.test.ts
+++ b/src/server/scrcpyOptionsFromQuery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { scrcpyOptionsFromQuery } from './scrcpyOptionsFromQuery';
+
+describe('scrcpyOptionsFromQuery', () => {
+    it('accepts a well-formed encoder name', () => {
+        const opts = scrcpyOptionsFromQuery(
+            new URLSearchParams('videoEncoder=OMX.qcom.video.encoder.avc'),
+            'scid1',
+        );
+        expect(opts.videoEncoder).toBe('OMX.qcom.video.encoder.avc');
+    });
+
+    it('drops a videoEncoder containing shell metacharacters (command injection)', () => {
+        const opts = scrcpyOptionsFromQuery(new URLSearchParams('videoEncoder=x;reboot'), 'scid1');
+        expect(opts.videoEncoder).toBeUndefined();
+    });
+
+    it('drops a videoEncoder using command substitution', () => {
+        const opts = scrcpyOptionsFromQuery(new URLSearchParams('videoEncoder=$(reboot)'), 'scid1');
+        expect(opts.videoEncoder).toBeUndefined();
+    });
+
+    it('still parses the other (typed) options unaffected', () => {
+        const opts = scrcpyOptionsFromQuery(new URLSearchParams('maxSize=1024&videoCodec=h265'), 'scid2');
+        expect(opts.maxSize).toBe(1024);
+        expect(opts.videoCodec).toBe('h265');
+        expect(opts.scid).toBe('scid2');
+    });
+});

--- a/src/server/scrcpyOptionsFromQuery.ts
+++ b/src/server/scrcpyOptionsFromQuery.ts
@@ -1,3 +1,4 @@
+import { isSafeEncoderName } from './security/deviceInput';
 import type { ScrcpyOptions } from './ScrcpyOptions';
 
 /**
@@ -45,8 +46,11 @@ export function scrcpyOptionsFromQuery(params: URLSearchParams, scid: string): S
         }
     }
 
+    // videoEncoder is the only free-form string option, and it is serialized
+    // into the `app_process ...` string that runs via `adb shell`. Allowlist it
+    // to a safe charset so it cannot inject shell metacharacters.
     const videoEncoder = params.get('videoEncoder');
-    if (videoEncoder) {
+    if (videoEncoder && isSafeEncoderName(videoEncoder)) {
         options.videoEncoder = videoEncoder;
     }
 

--- a/src/server/security/deviceInput.test.ts
+++ b/src/server/security/deviceInput.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+    assertSafeRemotePath,
+    assertSerial,
+    isSafeEncoderName,
+    isValidSerial,
+    shArg,
+} from './deviceInput';
+
+describe('deviceInput', () => {
+    describe('shArg', () => {
+        it('wraps a plain value in single quotes', () => {
+            expect(shArg('/sdcard/Download')).toBe("'/sdcard/Download'");
+        });
+
+        it('neutralises shell metacharacters by quoting them literally', () => {
+            expect(shArg('x; reboot')).toBe("'x; reboot'");
+            expect(shArg('$(id)')).toBe("'$(id)'");
+            expect(shArg('`id`')).toBe("'`id`'");
+            expect(shArg('a|b>c')).toBe("'a|b>c'");
+        });
+
+        it('escapes embedded single quotes so the quote cannot be broken out of', () => {
+            expect(shArg("a'b")).toBe("'a'\\''b'");
+        });
+
+        it('escapes a quote-breakout attempt into one inert sh token', () => {
+            // Each ' becomes '\'' so sh re-parses the whole thing as the literal
+            // input string rather than executing the embedded `rm`.
+            expect(shArg("'; rm -rf /; '")).toBe("''\\''; rm -rf /; '\\'''");
+        });
+    });
+
+    describe('isValidSerial', () => {
+        it('accepts USB serials, emulator ids and host:port', () => {
+            expect(isValidSerial('emulator-5554')).toBe(true);
+            expect(isValidSerial('0123456789ABCDEF')).toBe(true);
+            expect(isValidSerial('192.168.1.5:5555')).toBe(true);
+        });
+
+        it('rejects a leading dash (adb option injection)', () => {
+            expect(isValidSerial('-Ltcp:evil:1234')).toBe(false);
+            expect(isValidSerial('-H')).toBe(false);
+        });
+
+        it('rejects empty, whitespace, metacharacters and over-long values', () => {
+            expect(isValidSerial('')).toBe(false);
+            expect(isValidSerial('a b')).toBe(false);
+            expect(isValidSerial('a;b')).toBe(false);
+            expect(isValidSerial('a'.repeat(129))).toBe(false);
+        });
+
+        it('rejects non-strings', () => {
+            expect(isValidSerial(undefined)).toBe(false);
+            expect(isValidSerial(123 as unknown)).toBe(false);
+        });
+    });
+
+    describe('assertSerial', () => {
+        it('returns the serial when valid', () => {
+            expect(assertSerial('emulator-5554')).toBe('emulator-5554');
+        });
+
+        it('throws on an invalid serial', () => {
+            expect(() => assertSerial('-H')).toThrow();
+            expect(() => assertSerial('a;b')).toThrow();
+        });
+    });
+
+    describe('isSafeEncoderName', () => {
+        it('accepts real encoder names', () => {
+            expect(isSafeEncoderName('OMX.qcom.video.encoder.avc')).toBe(true);
+            expect(isSafeEncoderName('c2.android.avc.encoder')).toBe(true);
+        });
+
+        it('rejects values with shell metacharacters or spaces', () => {
+            expect(isSafeEncoderName('x;reboot')).toBe(false);
+            expect(isSafeEncoderName('a b')).toBe(false);
+            expect(isSafeEncoderName('$(id)')).toBe(false);
+            expect(isSafeEncoderName('')).toBe(false);
+        });
+    });
+
+    describe('assertSafeRemotePath', () => {
+        it('returns a plausible device path unchanged', () => {
+            expect(assertSafeRemotePath('/sdcard/Download/photo.jpg')).toBe('/sdcard/Download/photo.jpg');
+        });
+
+        it('rejects a leading dash (adb option injection)', () => {
+            expect(() => assertSafeRemotePath('-rf')).toThrow();
+        });
+
+        it('rejects empty values and embedded NUL', () => {
+            expect(() => assertSafeRemotePath('')).toThrow();
+            expect(() => assertSafeRemotePath('a\0b')).toThrow();
+        });
+    });
+});

--- a/src/server/security/deviceInput.ts
+++ b/src/server/security/deviceInput.ts
@@ -1,0 +1,65 @@
+/**
+ * Validation and escaping for untrusted values that flow into adb invocations
+ * or device shell command strings. Browser/WebSocket input (paths, serials,
+ * encoder names, push destinations) is untrusted; `adb shell <cmd>` runs the
+ * command string through the device's /bin/sh, and a serial beginning with "-"
+ * is parsed by adb as an option rather than a positional.
+ */
+
+/**
+ * Wrap an arbitrary string as a single POSIX-sh single-quoted token. Everything
+ * inside single quotes is literal except a single quote itself, which is closed,
+ * escaped, and reopened (`'\''`). Safe to interpolate into an `adb shell` string.
+ */
+export function shArg(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+// adb serials: USB serials, `emulator-NNNN`, and `host:port` for network devices.
+// They never contain whitespace (adb prints them whitespace-delimited) and never
+// start with "-".
+const SERIAL_RE = /^[A-Za-z0-9._:-]{1,128}$/;
+
+export function isValidSerial(serial: unknown): serial is string {
+    return (
+        typeof serial === 'string' &&
+        serial.length > 0 &&
+        !serial.startsWith('-') &&
+        SERIAL_RE.test(serial)
+    );
+}
+
+/** Return the serial when valid, otherwise throw. */
+export function assertSerial(serial: unknown): string {
+    if (!isValidSerial(serial)) {
+        const shown = typeof serial === 'string' ? JSON.stringify(serial) : typeof serial;
+        throw new Error(`invalid adb serial: ${shown}`);
+    }
+    return serial;
+}
+
+// Encoder names look like `OMX.qcom.video.encoder.avc` / `c2.android.avc.encoder`.
+const ENCODER_RE = /^[A-Za-z0-9_.-]{1,128}$/;
+
+export function isSafeEncoderName(name: unknown): name is string {
+    return typeof name === 'string' && ENCODER_RE.test(name);
+}
+
+/**
+ * Validate an on-device push destination. The value is passed to `adb push` as
+ * an argv element (no shell), so the only real hazards are option injection (a
+ * leading "-") and an empty/NUL value; we keep the caller's chosen path
+ * otherwise so the feature still works for arbitrary device locations.
+ */
+export function assertSafeRemotePath(name: unknown): string {
+    if (typeof name !== 'string' || name.length === 0) {
+        throw new Error('invalid remote path: empty');
+    }
+    if (name.startsWith('-')) {
+        throw new Error('invalid remote path: may not start with "-"');
+    }
+    if (name.includes('\0')) {
+        throw new Error('invalid remote path: contains NUL');
+    }
+    return name;
+}

--- a/src/server/security/instanceToken.test.ts
+++ b/src/server/security/instanceToken.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildTokenCookie,
+    getInstanceToken,
+    isValidToken,
+    parseTokenFromCookie,
+    requiresToken,
+    shouldSetTokenCookie,
+} from './instanceToken';
+
+describe('instanceToken', () => {
+    describe('getInstanceToken', () => {
+        it('returns a stable 256-bit hex token within the process', () => {
+            const a = getInstanceToken();
+            expect(a).toMatch(/^[a-f0-9]{64}$/);
+            expect(getInstanceToken()).toBe(a);
+        });
+    });
+
+    describe('isValidToken', () => {
+        it('accepts the instance token', () => {
+            expect(isValidToken(getInstanceToken())).toBe(true);
+        });
+
+        it('rejects a wrong value of the same length', () => {
+            expect(isValidToken('a'.repeat(64))).toBe(false);
+        });
+
+        it('rejects empty / null / undefined', () => {
+            expect(isValidToken('')).toBe(false);
+            expect(isValidToken(null)).toBe(false);
+            expect(isValidToken(undefined)).toBe(false);
+        });
+
+        it('rejects a value of the wrong length', () => {
+            expect(isValidToken('abc')).toBe(false);
+        });
+    });
+
+    describe('parseTokenFromCookie', () => {
+        it('extracts the token from a single-cookie header', () => {
+            expect(parseTokenFromCookie('ws_scrcpy_token=abc123')).toBe('abc123');
+        });
+
+        it('extracts the token among multiple cookies with whitespace', () => {
+            expect(parseTokenFromCookie('foo=1; ws_scrcpy_token=abc123; bar=2')).toBe('abc123');
+        });
+
+        it('returns null when the cookie is absent', () => {
+            expect(parseTokenFromCookie('foo=1; bar=2')).toBeNull();
+            expect(parseTokenFromCookie(undefined)).toBeNull();
+        });
+    });
+
+    describe('buildTokenCookie', () => {
+        it('builds a hardened SameSite=Strict, HttpOnly cookie', () => {
+            const cookie = buildTokenCookie(false);
+            expect(cookie).toContain(`ws_scrcpy_token=${getInstanceToken()}`);
+            expect(cookie).toContain('Path=/');
+            expect(cookie).toContain('SameSite=Strict');
+            expect(cookie).toContain('HttpOnly');
+            expect(cookie).not.toContain('Secure');
+        });
+
+        it('adds the Secure attribute on secure connections', () => {
+            expect(buildTokenCookie(true)).toContain('Secure');
+        });
+    });
+
+    describe('requiresToken', () => {
+        it('requires a token on sensitive API endpoints', () => {
+            expect(requiresToken('POST', '/api/service/install')).toBe(true);
+            expect(requiresToken('GET', '/api/devices')).toBe(true);
+            expect(requiresToken('PATCH', '/api/config')).toBe(true);
+            expect(requiresToken('POST', '/api/server/shutdown')).toBe(true);
+        });
+
+        it('exempts the launcher GET /api/config upgrade probe', () => {
+            expect(requiresToken('GET', '/api/config')).toBe(false);
+            expect(requiresToken('HEAD', '/api/config')).toBe(false);
+        });
+
+        it('does not require a token for static (non-API) requests', () => {
+            expect(requiresToken('GET', '/')).toBe(false);
+            expect(requiresToken('GET', '/bundle.js')).toBe(false);
+        });
+    });
+
+    describe('shouldSetTokenCookie', () => {
+        it('sets the cookie on document responses so the SPA can bootstrap', () => {
+            expect(shouldSetTokenCookie('GET', '/')).toBe(true);
+            expect(shouldSetTokenCookie('GET', '/index.html')).toBe(true);
+            expect(shouldSetTokenCookie('GET', '/devices/abc')).toBe(true);
+        });
+
+        it('does not set the cookie on static assets or API responses', () => {
+            expect(shouldSetTokenCookie('GET', '/bundle.js')).toBe(false);
+            expect(shouldSetTokenCookie('GET', '/style.css')).toBe(false);
+            expect(shouldSetTokenCookie('GET', '/api/config')).toBe(false);
+        });
+
+        it('does not set the cookie on non-GET requests', () => {
+            expect(shouldSetTokenCookie('POST', '/')).toBe(false);
+        });
+    });
+});

--- a/src/server/security/instanceToken.ts
+++ b/src/server/security/instanceToken.ts
@@ -1,0 +1,109 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Per-instance bearer token, layered on top of the Origin/Host allowlist.
+ *
+ * The Origin check blocks cross-site *browser* attacks, but a non-browser
+ * client on the LAN can spoof Origin/Host and reach the (otherwise
+ * unauthenticated) API/WS surface. The token closes that gap: it is minted
+ * fresh each launch, handed to the browser as a SameSite=Strict, HttpOnly
+ * cookie when the SPA document is served, and required on the sensitive API
+ * surface and on every WebSocket handshake. A non-browser caller that never
+ * loaded the page has no cookie and is rejected.
+ *
+ * The launcher's `GET /api/config` upgrade probe is deliberately exempt — it
+ * has no cookie and only reads non-sensitive config to detect the live server.
+ */
+
+const COOKIE_NAME = 'ws_scrcpy_token';
+
+let cachedToken: string | null = null;
+
+/** The token for this process. Generated lazily on first use, then stable. */
+export function getInstanceToken(): string {
+    if (cachedToken === null) {
+        cachedToken = randomBytes(32).toString('hex');
+    }
+    return cachedToken;
+}
+
+/** Build the hardened Set-Cookie value that hands the token to the browser. */
+export function buildTokenCookie(secure: boolean): string {
+    const attrs = [`${COOKIE_NAME}=${getInstanceToken()}`, 'Path=/', 'SameSite=Strict', 'HttpOnly'];
+    if (secure) {
+        attrs.push('Secure');
+    }
+    return attrs.join('; ');
+}
+
+/** Pull the token value out of a Cookie request header. */
+export function parseTokenFromCookie(cookieHeader: string | undefined): string | null {
+    if (!cookieHeader) {
+        return null;
+    }
+    for (const part of cookieHeader.split(';')) {
+        const eq = part.indexOf('=');
+        if (eq === -1) {
+            continue;
+        }
+        if (part.slice(0, eq).trim() === COOKIE_NAME) {
+            return part.slice(eq + 1).trim();
+        }
+    }
+    return null;
+}
+
+/** Constant-time comparison of a provided token against this instance's token. */
+export function isValidToken(provided: string | null | undefined): boolean {
+    if (!provided) {
+        return false;
+    }
+    const expected = getInstanceToken();
+    if (provided.length !== expected.length) {
+        return false;
+    }
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) {
+        return false;
+    }
+    return timingSafeEqual(a, b);
+}
+
+/**
+ * Whether a request to the given API path must carry a valid token. The whole
+ * API surface is protected except the launcher's `GET /api/config` probe.
+ */
+export function requiresToken(method: string | undefined, pathname: string): boolean {
+    if (pathname !== '/api' && !pathname.startsWith('/api/')) {
+        return false;
+    }
+    const m = (method ?? 'GET').toUpperCase();
+    if ((m === 'GET' || m === 'HEAD') && pathname === '/api/config') {
+        return false;
+    }
+    return true;
+}
+
+function pathExtension(pathname: string): string {
+    const lastSlash = pathname.lastIndexOf('/');
+    const lastDot = pathname.lastIndexOf('.');
+    return lastDot > lastSlash && lastDot !== -1 ? pathname.slice(lastDot) : '';
+}
+
+/**
+ * Whether we should attach the token cookie to this response. We set it only on
+ * document responses (the SPA shell) — not static assets or API responses — so
+ * the browser has the cookie before its first API/WS call.
+ */
+export function shouldSetTokenCookie(method: string | undefined, pathname: string): boolean {
+    const m = (method ?? 'GET').toUpperCase();
+    if (m !== 'GET' && m !== 'HEAD') {
+        return false;
+    }
+    if (pathname === '/api' || pathname.startsWith('/api/')) {
+        return false;
+    }
+    const ext = pathExtension(pathname);
+    return ext === '' || ext === '.html';
+}

--- a/src/server/security/originGuard.test.ts
+++ b/src/server/security/originGuard.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { isRequestAllowed, requiresOriginCheck } from './originGuard';
+
+describe('originGuard.isRequestAllowed', () => {
+    describe('Host allowlist (DNS-rebinding defense)', () => {
+        it('allows a same-origin request to a localhost host', () => {
+            expect(isRequestAllowed('http://localhost:8000', 'localhost:8000').allowed).toBe(true);
+        });
+
+        it('allows a same-origin request to an IPv4-literal LAN host', () => {
+            expect(isRequestAllowed('http://192.168.1.5:8000', '192.168.1.5:8000').allowed).toBe(true);
+        });
+
+        it('allows an IPv6-literal localhost host', () => {
+            expect(isRequestAllowed('http://[::1]:8000', '[::1]:8000').allowed).toBe(true);
+        });
+
+        it('rejects a request whose Host is a non-IP domain (DNS rebinding)', () => {
+            const result = isRequestAllowed('http://evil.com', 'evil.com');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toMatch(/host/i);
+        });
+
+        it('rejects a rebinding domain even when Origin equals Host', () => {
+            // The classic DNS-rebinding case: attacker.example resolves to 127.0.0.1,
+            // so Origin === Host and a naive same-origin check would pass.
+            expect(isRequestAllowed('http://attacker.example', 'attacker.example').allowed).toBe(false);
+        });
+
+        it('rejects when the Host header is missing', () => {
+            expect(isRequestAllowed(undefined, undefined).allowed).toBe(false);
+        });
+
+        it('rejects a malformed Host header', () => {
+            expect(isRequestAllowed(undefined, 'not a valid host!!').allowed).toBe(false);
+        });
+    });
+
+    describe('Origin match (CSRF defense)', () => {
+        it('rejects a cross-origin request (Origin does not match Host)', () => {
+            const result = isRequestAllowed('http://evil.com', 'localhost:8000');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toMatch(/origin/i);
+        });
+
+        it('rejects an Origin with a mismatched port', () => {
+            expect(isRequestAllowed('http://localhost:9999', 'localhost:8000').allowed).toBe(false);
+        });
+
+        it('allows a request with no Origin header to an allowed host (non-browser / same-origin GET)', () => {
+            expect(isRequestAllowed(undefined, 'localhost:8000').allowed).toBe(true);
+        });
+
+        it('matches an https Origin to the host', () => {
+            expect(isRequestAllowed('https://localhost:8443', 'localhost:8443').allowed).toBe(true);
+        });
+
+        it('matches a default-port Origin to a port-less Host', () => {
+            expect(isRequestAllowed('http://localhost', 'localhost').allowed).toBe(true);
+        });
+
+        it('rejects the opaque "null" Origin (sandboxed iframe / file://)', () => {
+            const result = isRequestAllowed('null', 'localhost:8000');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toMatch(/origin/i);
+        });
+
+        it('is case-insensitive on the host portion', () => {
+            expect(isRequestAllowed('http://LOCALHOST:8000', 'localhost:8000').allowed).toBe(true);
+        });
+    });
+});
+
+describe('originGuard.requiresOriginCheck', () => {
+    it('gates API GET requests (DNS-rebinding data exfiltration)', () => {
+        expect(requiresOriginCheck('GET', '/api/devices')).toBe(true);
+    });
+
+    it('gates the /api root exactly', () => {
+        expect(requiresOriginCheck('GET', '/api')).toBe(true);
+    });
+
+    it('gates state-changing methods on any path', () => {
+        expect(requiresOriginCheck('POST', '/anything')).toBe(true);
+        expect(requiresOriginCheck('DELETE', '/')).toBe(true);
+        expect(requiresOriginCheck('PATCH', '/api/config')).toBe(true);
+        expect(requiresOriginCheck('PUT', '/api/config')).toBe(true);
+    });
+
+    it('does NOT gate safe static asset GET/HEAD requests (so the page can bootstrap)', () => {
+        expect(requiresOriginCheck('GET', '/')).toBe(false);
+        expect(requiresOriginCheck('GET', '/index.html')).toBe(false);
+        expect(requiresOriginCheck('GET', '/bundle.js')).toBe(false);
+        expect(requiresOriginCheck('HEAD', '/style.css')).toBe(false);
+    });
+
+    it('treats an unknown/missing method as unsafe', () => {
+        expect(requiresOriginCheck(undefined, '/')).toBe(true);
+    });
+
+    it('does not mistake a path that merely starts with "api" for the API surface', () => {
+        expect(requiresOriginCheck('GET', '/apiary.html')).toBe(false);
+    });
+});

--- a/src/server/security/originGuard.test.ts
+++ b/src/server/security/originGuard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isRequestAllowed, requiresOriginCheck } from './originGuard';
+import { isHostAllowed, isRequestAllowed, requiresOriginCheck } from './originGuard';
 
 describe('originGuard.isRequestAllowed', () => {
     describe('Host allowlist (DNS-rebinding defense)', () => {
@@ -68,6 +68,22 @@ describe('originGuard.isRequestAllowed', () => {
         it('is case-insensitive on the host portion', () => {
             expect(isRequestAllowed('http://LOCALHOST:8000', 'localhost:8000').allowed).toBe(true);
         });
+    });
+});
+
+describe('originGuard.isHostAllowed', () => {
+    it('allows localhost and IP-literal hosts', () => {
+        expect(isHostAllowed('localhost:8000')).toBe(true);
+        expect(isHostAllowed('127.0.0.1:8000')).toBe(true);
+        expect(isHostAllowed('[::1]:8000')).toBe(true);
+        expect(isHostAllowed('192.168.1.5')).toBe(true);
+    });
+
+    it('rejects domain hosts and missing/garbage values', () => {
+        expect(isHostAllowed('evil.com')).toBe(false);
+        expect(isHostAllowed('myserver.local')).toBe(false);
+        expect(isHostAllowed(undefined)).toBe(false);
+        expect(isHostAllowed('bad host!!')).toBe(false);
     });
 });
 

--- a/src/server/security/originGuard.ts
+++ b/src/server/security/originGuard.ts
@@ -48,7 +48,7 @@ function hostnameOf(host: string): string | null {
  * machine's own addresses, and still allows legitimate access by IP over the
  * LAN (e.g. http://192.168.1.5:8000).
  */
-function isHostAllowed(host: string | undefined): boolean {
+export function isHostAllowed(host: string | undefined): boolean {
     if (!host) {
         return false;
     }

--- a/src/server/security/originGuard.ts
+++ b/src/server/security/originGuard.ts
@@ -1,0 +1,89 @@
+import { isIP } from 'node:net';
+
+export interface OriginCheckResult {
+    allowed: boolean;
+    reason?: string;
+}
+
+const SAFE_METHODS = new Set(['GET', 'HEAD']);
+
+/**
+ * Whether an HTTP request must pass the Origin/Host check. We gate the entire
+ * API surface (including `GET /api/*`, to stop DNS-rebinding data exfiltration)
+ * and every state-changing method on any path. Safe-method requests for static
+ * assets are left ungated so the page can bootstrap (a cross-origin page that
+ * loads our HTML only gets an opaque response it cannot read).
+ */
+export function requiresOriginCheck(method: string | undefined, pathname: string): boolean {
+    if (pathname === '/api' || pathname.startsWith('/api/')) {
+        return true;
+    }
+    return !method || !SAFE_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * Parse the hostname out of a Host header value (strips the port and any IPv6
+ * brackets). Returns null if the value cannot be parsed.
+ */
+function hostnameOf(host: string): string | null {
+    try {
+        const hostname = new URL(`http://${host}`).hostname.toLowerCase();
+        // WHATWG URL returns IPv6 hostnames bracketed (e.g. "[::1]"); strip the
+        // brackets so isIP() can recognise the literal.
+        if (hostname.startsWith('[') && hostname.endsWith(']')) {
+            return hostname.slice(1, -1);
+        }
+        return hostname;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * A Host is allowed only if its hostname is `localhost` or an IP literal.
+ *
+ * A DNS-rebinding attack requires a *domain name* (so the attacker can later
+ * point it at a loopback/LAN address). Rejecting any Host that is neither
+ * `localhost` nor a raw IP blocks rebinding without having to enumerate the
+ * machine's own addresses, and still allows legitimate access by IP over the
+ * LAN (e.g. http://192.168.1.5:8000).
+ */
+function isHostAllowed(host: string | undefined): boolean {
+    if (!host) {
+        return false;
+    }
+    const hostname = hostnameOf(host);
+    if (!hostname) {
+        return false;
+    }
+    return hostname === 'localhost' || isIP(hostname) !== 0;
+}
+
+/**
+ * Decide whether an incoming HTTP/WS request may be served. Defends the
+ * otherwise-unauthenticated API/WebSocket surface against cross-site (CSRF)
+ * and DNS-rebinding attacks:
+ *
+ *   - Host must be `localhost` or an IP literal (DNS-rebinding defense).
+ *   - If an Origin header is present it must match the Host's origin (CSRF
+ *     defense). A *missing* Origin is allowed at this layer — non-browser
+ *     clients and same-origin GET/HEAD requests omit it; the per-instance
+ *     token closes that remaining gap for non-browser callers.
+ */
+export function isRequestAllowed(
+    origin: string | undefined,
+    host: string | undefined,
+): OriginCheckResult {
+    if (!isHostAllowed(host)) {
+        return { allowed: false, reason: 'host not allowed (possible DNS rebinding)' };
+    }
+    if (origin) {
+        const normalizedOrigin = origin.toLowerCase();
+        const expectedHttp = `http://${host}`.toLowerCase();
+        const expectedHttps = `https://${host}`.toLowerCase();
+        if (normalizedOrigin !== expectedHttp && normalizedOrigin !== expectedHttps) {
+            return { allowed: false, reason: 'cross-origin request rejected' };
+        }
+    }
+    return { allowed: true };
+}

--- a/src/server/security/requestGate.test.ts
+++ b/src/server/security/requestGate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { getInstanceToken } from './instanceToken';
+import { evaluateHttpRequest, evaluateWsConnection } from './requestGate';
+
+const COOKIE = `ws_scrcpy_token=${getInstanceToken()}`;
+
+describe('requestGate.evaluateHttpRequest', () => {
+    it('rejects a cross-origin API request with 403', () => {
+        const d = evaluateHttpRequest('POST', '/api/service/install', 'http://evil.com', 'localhost:8000', COOKIE, false);
+        expect(d.allowed).toBe(false);
+        expect(d).toMatchObject({ status: 403 });
+    });
+
+    it('rejects a same-origin API request that carries no token', () => {
+        const d = evaluateHttpRequest('GET', '/api/devices', 'http://localhost:8000', 'localhost:8000', undefined, false);
+        expect(d.allowed).toBe(false);
+    });
+
+    it('allows a same-origin API request carrying the valid token', () => {
+        const d = evaluateHttpRequest('GET', '/api/devices', 'http://localhost:8000', 'localhost:8000', COOKIE, false);
+        expect(d.allowed).toBe(true);
+    });
+
+    it('allows the launcher GET /api/config probe with no Origin and no token', () => {
+        const d = evaluateHttpRequest('GET', '/api/config', undefined, 'localhost', undefined, false);
+        expect(d.allowed).toBe(true);
+    });
+
+    it('rejects a DNS-rebinding Host even on a document request', () => {
+        const d = evaluateHttpRequest('GET', '/', 'http://evil.com', 'evil.com', undefined, false);
+        expect(d.allowed).toBe(false);
+    });
+
+    it('serves a document request and attaches the token cookie', () => {
+        const d = evaluateHttpRequest('GET', '/', undefined, 'localhost:8000', undefined, false);
+        expect(d.allowed).toBe(true);
+        if (d.allowed) {
+            expect(d.setCookie).toContain('ws_scrcpy_token=');
+            expect(d.setCookie).toContain('SameSite=Strict');
+        }
+    });
+
+    it('does not attach a cookie to static asset responses', () => {
+        const d = evaluateHttpRequest('GET', '/bundle.js', undefined, 'localhost:8000', COOKIE, false);
+        expect(d.allowed).toBe(true);
+        if (d.allowed) {
+            expect(d.setCookie).toBeUndefined();
+        }
+    });
+
+    it('marks the cookie Secure on secure connections', () => {
+        const d = evaluateHttpRequest('GET', '/', undefined, 'localhost:8443', undefined, true);
+        if (d.allowed) {
+            expect(d.setCookie).toContain('Secure');
+        }
+    });
+});
+
+describe('requestGate.evaluateWsConnection', () => {
+    it('rejects a cross-origin WS handshake', () => {
+        expect(evaluateWsConnection('http://evil.com', 'localhost:8000', COOKIE).allowed).toBe(false);
+    });
+
+    it('rejects a same-origin WS handshake with no token', () => {
+        expect(evaluateWsConnection('http://localhost:8000', 'localhost:8000', undefined).allowed).toBe(false);
+    });
+
+    it('allows a same-origin WS handshake carrying the valid token', () => {
+        expect(evaluateWsConnection('http://localhost:8000', 'localhost:8000', COOKIE).allowed).toBe(true);
+    });
+});

--- a/src/server/security/requestGate.ts
+++ b/src/server/security/requestGate.ts
@@ -1,0 +1,74 @@
+import {
+    buildTokenCookie,
+    isValidToken,
+    parseTokenFromCookie,
+    requiresToken,
+    shouldSetTokenCookie,
+} from './instanceToken';
+import { isHostAllowed, isRequestAllowed, requiresOriginCheck } from './originGuard';
+
+export type HttpGateDecision =
+    | { allowed: true; setCookie?: string }
+    | { allowed: false; status: number; reason: string };
+
+export interface WsGateDecision {
+    allowed: boolean;
+    reason?: string;
+}
+
+/**
+ * Decide what to do with an incoming HTTP request. Composes the two defence
+ * layers in order — Origin/Host allowlist first, then the per-instance token —
+ * and, for allowed document requests, signals that the SPA's token cookie
+ * should be attached. This is the single decision the HttpServer applies; the
+ * server only translates it into `res` calls.
+ */
+export function evaluateHttpRequest(
+    method: string | undefined,
+    pathname: string,
+    origin: string | undefined,
+    host: string | undefined,
+    cookieHeader: string | undefined,
+    secure: boolean,
+): HttpGateDecision {
+    // The Host allowlist is universal — a rebinding/foreign Host is never served
+    // (and never handed a token cookie), even for documents and static assets.
+    if (!isHostAllowed(host)) {
+        return { allowed: false, status: 403, reason: 'host not allowed (possible DNS rebinding)' };
+    }
+    // The Origin match only applies to the sensitive surface, so top-level
+    // navigations (which carry no Origin) and asset loads still work.
+    if (requiresOriginCheck(method, pathname)) {
+        const verdict = isRequestAllowed(origin, host);
+        if (!verdict.allowed) {
+            return { allowed: false, status: 403, reason: verdict.reason ?? 'forbidden' };
+        }
+    }
+    if (requiresToken(method, pathname) && !isValidToken(parseTokenFromCookie(cookieHeader))) {
+        return { allowed: false, status: 403, reason: 'missing or invalid token' };
+    }
+    if (shouldSetTokenCookie(method, pathname)) {
+        return { allowed: true, setCookie: buildTokenCookie(secure) };
+    }
+    return { allowed: true };
+}
+
+/**
+ * Decide whether a WebSocket handshake may upgrade. Every legitimate WS client
+ * is the browser, which sends both a same-origin Origin header and the token
+ * cookie, so both layers are always enforced here.
+ */
+export function evaluateWsConnection(
+    origin: string | undefined,
+    host: string | undefined,
+    cookieHeader: string | undefined,
+): WsGateDecision {
+    const verdict = isRequestAllowed(origin, host);
+    if (!verdict.allowed) {
+        return { allowed: false, reason: verdict.reason ?? 'forbidden' };
+    }
+    if (!isValidToken(parseTokenFromCookie(cookieHeader))) {
+        return { allowed: false, reason: 'missing or invalid token' };
+    }
+    return { allowed: true };
+}

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -6,7 +6,7 @@ import * as process from 'process';
 import { TypedEmitter } from '../../common/TypedEmitter';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
-import { isRequestAllowed, requiresOriginCheck } from '../security/originGuard';
+import { evaluateHttpRequest } from '../security/requestGate';
 import { createStaticHandler } from '../StaticFileServer';
 import { Utils } from '../Utils';
 import type { Service } from './Service';
@@ -98,7 +98,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                 if (!serverItem.options) {
                     throw Error('Must provide option for secure server configuration');
                 }
-                const requestHandler = this.createRequestHandler(this.mainHandler);
+                const requestHandler = this.createRequestHandler(this.mainHandler, true);
                 server = https.createServer(serverItem.options, requestHandler);
                 proto = 'https';
             } else {
@@ -130,7 +130,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                         res.end();
                     };
                 } else {
-                    handler = this.createRequestHandler(this.mainHandler);
+                    handler = this.createRequestHandler(this.mainHandler, false);
                 }
                 server = http.createServer(options, handler);
             }
@@ -145,25 +145,34 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
 
     private createRequestHandler(
         fallback?: (req: IncomingMessage, res: ServerResponse) => void,
+        secure = false,
     ): (req: IncomingMessage, res: ServerResponse) => void {
         return (req, res) => {
-            // Origin/Host allowlist — defend the otherwise-unauthenticated API
-            // surface against cross-site (CSRF) and DNS-rebinding attacks. Only
-            // the sensitive surface (the API + state-changing methods) is gated;
-            // static asset GETs pass through so the page can still bootstrap.
             let pathname = '/';
             try {
                 pathname = new URL(req.url || '/', 'http://localhost').pathname;
             } catch {
                 pathname = '/';
             }
-            if (requiresOriginCheck(req.method, pathname)) {
-                const verdict = isRequestAllowed(req.headers.origin, req.headers.host);
-                if (!verdict.allowed) {
-                    res.writeHead(403, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ error: 'forbidden', reason: verdict.reason }));
-                    return;
-                }
+            // Defend the otherwise-unauthenticated API/WS surface: Origin + Host
+            // allowlist (CSRF / DNS-rebinding) plus a per-instance token, with
+            // the SPA's token cookie attached on document responses. See
+            // requestGate for the composed policy.
+            const decision = evaluateHttpRequest(
+                req.method,
+                pathname,
+                req.headers.origin,
+                req.headers.host,
+                req.headers.cookie,
+                secure,
+            );
+            if (!decision.allowed) {
+                res.writeHead(decision.status, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'forbidden', reason: decision.reason }));
+                return;
+            }
+            if (decision.setCookie) {
+                res.setHeader('Set-Cookie', decision.setCookie);
             }
             const tryHandlers = async () => {
                 for (const handler of HttpServer.apiHandlers) {

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -6,6 +6,7 @@ import * as process from 'process';
 import { TypedEmitter } from '../../common/TypedEmitter';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
+import { isRequestAllowed, requiresOriginCheck } from '../security/originGuard';
 import { createStaticHandler } from '../StaticFileServer';
 import { Utils } from '../Utils';
 import type { Service } from './Service';
@@ -146,6 +147,24 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
         fallback?: (req: IncomingMessage, res: ServerResponse) => void,
     ): (req: IncomingMessage, res: ServerResponse) => void {
         return (req, res) => {
+            // Origin/Host allowlist — defend the otherwise-unauthenticated API
+            // surface against cross-site (CSRF) and DNS-rebinding attacks. Only
+            // the sensitive surface (the API + state-changing methods) is gated;
+            // static asset GETs pass through so the page can still bootstrap.
+            let pathname = '/';
+            try {
+                pathname = new URL(req.url || '/', 'http://localhost').pathname;
+            } catch {
+                pathname = '/';
+            }
+            if (requiresOriginCheck(req.method, pathname)) {
+                const verdict = isRequestAllowed(req.headers.origin, req.headers.host);
+                if (!verdict.allowed) {
+                    res.writeHead(403, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'forbidden', reason: verdict.reason }));
+                    return;
+                }
+            }
             const tryHandlers = async () => {
                 for (const handler of HttpServer.apiHandlers) {
                     const handled = await handler.handle(req, res);

--- a/src/server/services/WebSocketServer.ts
+++ b/src/server/services/WebSocketServer.ts
@@ -2,6 +2,7 @@ import type WS from 'ws';
 import { WebSocketServer as WSServer } from 'ws';
 import { Logger } from '../Logger';
 import type { MwFactory } from '../mw/Mw';
+import { isRequestAllowed } from '../security/originGuard';
 import { HttpServer, type ServerAndPort } from './HttpServer';
 import type { Service } from './Service';
 
@@ -38,7 +39,25 @@ export class WebSocketServer implements Service {
         const { server, port } = item;
         const TAG = `WebSocket Server {tcp:${port}}`;
         const log = Logger.for(TAG);
-        const wss = new WSServer({ server });
+        const wss = new WSServer({
+            server,
+            // Origin/Host allowlist at the handshake — a WebSocket is not subject
+            // to the same-origin policy and sends no CORS preflight, so without
+            // this a malicious page could open a control channel to the device.
+            verifyClient: (info, cb) => {
+                const verdict = isRequestAllowed(info.origin, info.req.headers.host);
+                if (!verdict.allowed) {
+                    log.info(
+                        `rejected WS connection (origin="${info.origin ?? ''}" host="${
+                            info.req.headers.host ?? ''
+                        }"): ${verdict.reason}`,
+                    );
+                    cb(false, 403, 'Forbidden');
+                    return;
+                }
+                cb(true);
+            },
+        });
         wss.on('connection', async (ws: WS, request) => {
             if (!request.url) {
                 ws.close(4001, `[${TAG}] Invalid url`);

--- a/src/server/services/WebSocketServer.ts
+++ b/src/server/services/WebSocketServer.ts
@@ -2,7 +2,7 @@ import type WS from 'ws';
 import { WebSocketServer as WSServer } from 'ws';
 import { Logger } from '../Logger';
 import type { MwFactory } from '../mw/Mw';
-import { isRequestAllowed } from '../security/originGuard';
+import { evaluateWsConnection } from '../security/requestGate';
 import { HttpServer, type ServerAndPort } from './HttpServer';
 import type { Service } from './Service';
 
@@ -44,13 +44,24 @@ export class WebSocketServer implements Service {
             // Origin/Host allowlist at the handshake — a WebSocket is not subject
             // to the same-origin policy and sends no CORS preflight, so without
             // this a malicious page could open a control channel to the device.
+            // Origin/Host allowlist + per-instance token at the handshake. A
+            // WebSocket is exempt from the same-origin policy and sends no CORS
+            // preflight, so without this a malicious page could open a control
+            // channel to the device. Every legitimate client is the browser,
+            // which carries the SameSite token cookie; a non-browser caller does
+            // not. (A server restart mints a new token, so an already-open page
+            // must reload to reconnect — expected for a per-instance secret.)
             verifyClient: (info, cb) => {
-                const verdict = isRequestAllowed(info.origin, info.req.headers.host);
-                if (!verdict.allowed) {
+                const decision = evaluateWsConnection(
+                    info.origin,
+                    info.req.headers.host,
+                    info.req.headers.cookie,
+                );
+                if (!decision.allowed) {
                     log.info(
                         `rejected WS connection (origin="${info.origin ?? ''}" host="${
                             info.req.headers.host ?? ''
-                        }"): ${verdict.reason}`,
+                        }"): ${decision.reason}`,
                     );
                     cb(false, 403, 'Forbidden');
                     return;


### PR DESCRIPTION
This is the first tranche of fixes from an internal multi-agent security review of the codebase. It closes the highest-leverage findings; the rest are tracked for follow-up (see the end).

## What changed

**Auth on the HTTP/WS surface (it was wide open).** The API and WebSocket endpoints had no Origin/CORS/auth check, so any page the user happened to visit could drive device control, file deletion, or service management on localhost via CSRF / DNS-rebinding. Two layers now:

- **Origin + Host allowlist** — `Host` must be `localhost` or an IP literal (this is the DNS-rebinding defense), and a present `Origin` must match the host. Enforced in `HttpServer` and at the WebSocket handshake (`verifyClient`).
- **Per-instance token** — minted at launch, handed to the browser as a `SameSite=Strict; HttpOnly` cookie on page load, and required on the sensitive API surface and every WS connection. Normal use is unchanged (the browser carries the cookie); a non-browser caller that never loaded the page is rejected. A server restart mints a new token, so an already-open page must reload to reconnect.

The launcher's `GET /api/config` upgrade probe is deliberately exempt.

**adb / device-shell input.** Untrusted paths, serials, encoder names, and push destinations were interpolated into `adb shell` strings and `adb -s <serial>` argv with no escaping — device-side command injection and adb argument injection. Now: a `shArg` single-quote escaper on every interpolated shell value, serial validation (blocks the leading-`-` option-injection trick), a `videoEncoder` allowlist, and a validated push destination.

**Supply chain.** `swap-appimage-runtime.mjs` embedded the AppImage runtime after checking only its 4 ELF magic bytes. It now verifies a pinned SHA-256 and refuses a mismatch.

**Binary parsers.** `BinaryReader` and the AV1 sequence-header reader now bounds-check untrusted input instead of reading past the buffer (or, for AV1, fabricating `0` bits and feeding bogus dimensions to the decoder).

**Client DOM-XSS.** Server/device strings (dependency names + messages, device ids, file names) are HTML-escaped or assigned as text; the `html` tag helper now escapes quotes so a value can't break out of an attribute; file rows are tracked by a Map instead of an attacker-influenced element id.

## Testing

Every fix was test-first — 88 new tests, suite 959 → 1047. `tsc --noEmit` clean, full `vitest` green, `webpack` build green, re-verified after each area. The client XSS fixes use jsdom tests that feed live payloads and assert the DOM treats them as inert data.

## Not in this PR

The review found 108 issues; this closes 13. The remaining 95 — 7 CRITICAL (mostly latent service/launcher root-`sh -c` / `.bat` injections, plus the two device ops this PR's auth de-fangs to local-only but doesn't eliminate), 51 MAJOR, 37 MINOR — are recorded for a follow-up pass.

One consequence worth flagging for review: the Host allowlist accepts only `localhost`/IP-literal hosts, so a reverse-proxy / domain-served deployment would be rejected. Local + LAN-IP + same-origin iframe embedding are unaffected. If domain deployment should be supported, that needs a config escape hatch (an `allowedHosts` setting, like Syncthing/Jupyter) rather than loosening the default.
