### PR TITLE
Security hardening: device delete-path bounds (#6) + RFC1918 scan restriction (#7)

### DIFF
--- a/src/common/SubnetParser.ts
+++ b/src/common/SubnetParser.ts
@@ -4,6 +4,8 @@ export interface ParsedSubnet {
     raw: string;
     normalized: string;
     hostCount: number;
+    /** True only when every address the subnet covers is within RFC1918. */
+    isPrivate: boolean;
     hosts(): Generator<string>;
 }
 
@@ -23,10 +25,12 @@ export function parseSubnetInput(input: string): ParsedSubnet | ParseError {
 
     // Try bare IP
     if (isValidIp(raw)) {
+        const ipInt = ipToInt(raw);
         return {
             raw,
             normalized: `${raw}/32`,
             hostCount: 1,
+            isPrivate: isRangeWithinRfc1918(ipInt, ipInt),
             *hosts() {
                 yield raw;
             },
@@ -65,11 +69,14 @@ function parseCidr(input: string): ParsedSubnet | ParseError {
     const hostCount = prefix === 32 ? 1 : 2 ** maskBits - 2;
     // /31 is unusual (2 hosts) but legal — we allow it.
     const effectiveHostCount = prefix === 32 ? 1 : prefix === 31 ? 2 : hostCount;
+    const broadcastInt = (networkInt + 2 ** maskBits - 1) >>> 0;
+    const isPrivate = isRangeWithinRfc1918(networkInt, broadcastInt);
 
     return {
         raw: input,
         normalized,
         hostCount: effectiveHostCount,
+        isPrivate,
         *hosts() {
             if (prefix === 32) {
                 yield normalizedIp;
@@ -132,11 +139,13 @@ function parseRange(input: string): ParsedSubnet | ParseError {
     const scanStart = skipFirst ? startInt + 1 : startInt;
     const scanEnd = skipLast ? endInt - 1 : endInt;
     const hostCount = scanEnd >= scanStart ? scanEnd - scanStart + 1 : 0;
+    const isPrivate = isRangeWithinRfc1918(startInt, endInt);
 
     return {
         raw: input,
         normalized: `${startNorm}-${endNorm}`,
         hostCount,
+        isPrivate,
         *hosts() {
             for (let i = scanStart; i <= scanEnd; i++) {
                 yield intToIp(i >>> 0);
@@ -171,4 +180,18 @@ function ipToInt(ip: string): number {
 
 function intToIp(n: number): string {
     return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff].join('.');
+}
+
+// RFC1918 private blocks as inclusive [low, high] unsigned-int bounds.
+const RFC1918_BLOCKS: ReadonlyArray<readonly [number, number]> = [
+    [ipToInt('10.0.0.0'), ipToInt('10.255.255.255')],
+    [ipToInt('172.16.0.0'), ipToInt('172.31.255.255')],
+    [ipToInt('192.168.0.0'), ipToInt('192.168.255.255')],
+];
+
+// A contiguous [lo, hi] address range is private only if it fits entirely
+// within ONE block. The blocks are disjoint and non-adjacent, so a range that
+// straddled two would necessarily include public space between them.
+function isRangeWithinRfc1918(loInt: number, hiInt: number): boolean {
+    return RFC1918_BLOCKS.some(([blockLo, blockHi]) => loInt >= blockLo && hiInt <= blockHi);
 }

--- a/src/server/__tests__/networkScanner.test.ts
+++ b/src/server/__tests__/networkScanner.test.ts
@@ -8,6 +8,7 @@ function makeSubnet(hosts: string[]): ParsedSubnet {
         raw: 'test',
         normalized: `test/${hosts.length}`,
         hostCount: hosts.length,
+        isPrivate: true,
         *hosts() { for (const h of hosts) yield h; },
     };
 }

--- a/src/server/__tests__/scanMw.test.ts
+++ b/src/server/__tests__/scanMw.test.ts
@@ -121,4 +121,36 @@ describe('ScanMw integration', () => {
         client.close();
         await new Promise<void>((r) => wss.close(() => server.close(() => r())));
     });
+
+    it('rejects scan.start targeting a public (non-RFC1918) subnet (SSRF guard)', async () => {
+        const scanner = new NetworkScanner({
+            adbDevices: async () => [],
+            adbMdnsServices: async () => [],
+            adbHandshakeProbe: async () => ({ isAdb: false }),
+            concurrency: 4,
+            progressInterval: 10,
+        });
+        ScanMw.setScanner(scanner);
+
+        const server = http.createServer();
+        const wss = new WebSocketServer({ server });
+        wss.on('connection', (ws, req) => {
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws);
+        });
+        await new Promise<void>((r) => server.listen(0, r));
+        const port = (server.address() as any).port;
+
+        const client = new WebSocket(`ws://127.0.0.1:${port}${SCAN_WS_PATH}`);
+        await new Promise<void>((r) => client.once('open', r));
+
+        const collected = collectMessages(client, (m) => m.type === 'scan.error');
+        client.send(JSON.stringify({ type: 'scan.start', subnets: ['8.8.8.0/24'] }));
+        const messages = await collected;
+
+        expect(messages[0].type).toBe('scan.error');
+        expect((messages[0] as any).details?.[0]?.error).toMatch(/private|RFC ?1918/i);
+
+        client.close();
+        await new Promise<void>((r) => wss.close(() => server.close(() => r())));
+    });
 });

--- a/src/server/__tests__/subnetParser.test.ts
+++ b/src/server/__tests__/subnetParser.test.ts
@@ -203,3 +203,42 @@ describe('parseSubnetInput — errors', () => {
         expect(r.reason).toMatch(/subnet cheat sheet/);
     });
 });
+
+describe('parseSubnetInput — RFC1918 private-range flag', () => {
+    it('flags the three private blocks as private', () => {
+        for (const input of ['10.0.0.0/16', '172.16.0.0/16', '192.168.1.0/24', '10.255.255.255', '172.31.255.255']) {
+            const r = parseSubnetInput(input);
+            if ('reason' in r) throw new Error(`${input}: ${r.reason}`);
+            expect(r.isPrivate).toBe(true);
+        }
+    });
+
+    it('flags public ranges as not private', () => {
+        for (const input of ['8.8.8.0/24', '1.1.1.1', '203.0.113.0/24']) {
+            const r = parseSubnetInput(input);
+            if ('reason' in r) throw new Error(`${input}: ${r.reason}`);
+            expect(r.isPrivate).toBe(false);
+        }
+    });
+
+    it('treats addresses just outside the private blocks as public', () => {
+        for (const input of ['11.0.0.0/24', '172.15.255.255', '172.32.0.0/16', '192.167.255.255', '192.169.0.0/16']) {
+            const r = parseSubnetInput(input);
+            if ('reason' in r) throw new Error(`${input}: ${r.reason}`);
+            expect(r.isPrivate).toBe(false);
+        }
+    });
+
+    it('flags a range that escapes a private block as public', () => {
+        // Starts private (192.168.255.250) but runs past 192.168/16 into public space.
+        const r = parseSubnetInput('192.168.255.250-192.169.0.5');
+        if ('reason' in r) throw new Error(r.reason);
+        expect(r.isPrivate).toBe(false);
+    });
+
+    it('flags a wholly-private cross-/24 range as private', () => {
+        const r = parseSubnetInput('192.168.1.10-192.168.2.10');
+        if ('reason' in r) throw new Error(r.reason);
+        expect(r.isPrivate).toBe(true);
+    });
+});

--- a/src/server/api/DeviceDiscoveryApi.ts
+++ b/src/server/api/DeviceDiscoveryApi.ts
@@ -6,6 +6,7 @@ import { DeviceLabelStore } from '../DeviceLabelStore';
 import { Logger } from '../Logger';
 import { detectSubnet } from '../network/SubnetDetector';
 import { resolveMac } from '../network/MacResolver';
+import { assertDeletablePaths, shArg } from '../security/deviceInput';
 
 const log = Logger.for('DeviceDiscoveryApi');
 
@@ -179,16 +180,26 @@ export class DeviceDiscoveryApi {
             if (req.method === 'POST' && url === '/api/devices/files/delete') {
                 const body = await readBody(req);
                 const { udid, paths } = JSON.parse(body);
-                if (!udid || !Array.isArray(paths) || paths.length === 0) {
+                if (!udid) {
                     res.writeHead(400);
-                    res.end(JSON.stringify({ error: 'udid and paths[] are required' }));
+                    res.end(JSON.stringify({ error: 'udid is required' }));
+                    return true;
+                }
+                let safePaths: string[];
+                try {
+                    // Bound + validate the targets before any privileged delete:
+                    // refuses unbounded lists, traversal, and catastrophic roots
+                    // (/sdcard, /data, …). udid is serial-checked by adbClient.
+                    safePaths = assertDeletablePaths(paths);
+                } catch (e) {
+                    res.writeHead(400);
+                    res.end(JSON.stringify({ error: (e as Error).message }));
                     return true;
                 }
                 const errors: { path: string; error: string }[] = [];
-                for (const filePath of paths) {
+                for (const filePath of safePaths) {
                     try {
-                        const escaped = filePath.replace(/'/g, "'\\''");
-                        await this.adbClient.shell(udid, `rm -rf '${escaped}'`);
+                        await this.adbClient.shell(udid, `rm -rf ${shArg(filePath)}`);
                     } catch (err) {
                         errors.push({ path: filePath, error: (err as Error).message });
                     }

--- a/src/server/mw/ScanMw.ts
+++ b/src/server/mw/ScanMw.ts
@@ -42,6 +42,14 @@ export class ScanMw {
                     const r = parseSubnetInput(raw);
                     if ('reason' in r) {
                         errors.push({ subnet: raw, error: (r as ParseError).reason });
+                    } else if (!r.isPrivate) {
+                        // SSRF / internal port-scan guard: only private (RFC1918)
+                        // targets may be scanned. The auto-detect path only ever
+                        // yields the local subnet; this gates the user-supplied one.
+                        errors.push({
+                            subnet: raw,
+                            error: `"${r.normalized}" is outside the private (RFC1918) ranges (10/8, 172.16/12, 192.168/16); scanning public addresses is not allowed.`,
+                        });
                     } else {
                         parsed.push(r);
                     }

--- a/src/server/security/deviceInput.test.ts
+++ b/src/server/security/deviceInput.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    assertDeletablePaths,
     assertSafeRemotePath,
     assertSerial,
     isSafeEncoderName,
@@ -93,6 +94,59 @@ describe('deviceInput', () => {
         it('rejects empty values and embedded NUL', () => {
             expect(() => assertSafeRemotePath('')).toThrow();
             expect(() => assertSafeRemotePath('a\0b')).toThrow();
+        });
+    });
+
+    describe('assertDeletablePaths', () => {
+        it('returns a bounded list of absolute paths unchanged', () => {
+            const paths = ['/sdcard/Download/a.jpg', '/sdcard/DCIM/b.mp4'];
+            expect(assertDeletablePaths(paths)).toEqual(paths);
+        });
+
+        it('rejects a non-array or empty array', () => {
+            expect(() => assertDeletablePaths(undefined)).toThrow();
+            expect(() => assertDeletablePaths('/sdcard/x' as unknown)).toThrow();
+            expect(() => assertDeletablePaths([])).toThrow();
+        });
+
+        it('rejects more paths than the cap', () => {
+            const tooMany = Array.from({ length: 1001 }, (_, i) => `/sdcard/f${i}`);
+            expect(() => assertDeletablePaths(tooMany)).toThrow();
+        });
+
+        it('rejects a non-string or empty element', () => {
+            expect(() => assertDeletablePaths(['/sdcard/ok', 123 as unknown])).toThrow();
+            expect(() => assertDeletablePaths(['/sdcard/ok', ''])).toThrow();
+        });
+
+        it('rejects a relative path', () => {
+            expect(() => assertDeletablePaths(['sdcard/x'])).toThrow();
+            expect(() => assertDeletablePaths(['./x'])).toThrow();
+        });
+
+        it('rejects path traversal ("." or "..") segments', () => {
+            expect(() => assertDeletablePaths(['/sdcard/../../system'])).toThrow();
+            expect(() => assertDeletablePaths(['/sdcard/.'])).toThrow();
+        });
+
+        it('rejects an embedded NUL', () => {
+            expect(() => assertDeletablePaths(['/sdcard/a\0b'])).toThrow();
+        });
+
+        it('refuses catastrophic storage/system roots', () => {
+            for (const root of ['/', '/sdcard', '/storage', '/storage/emulated/0', '/data', '/system']) {
+                expect(() => assertDeletablePaths([root])).toThrow();
+            }
+        });
+
+        it('refuses a protected root regardless of trailing slashes', () => {
+            expect(() => assertDeletablePaths(['/sdcard/'])).toThrow();
+            expect(() => assertDeletablePaths(['/sdcard///'])).toThrow();
+            expect(() => assertDeletablePaths(['///'])).toThrow();
+        });
+
+        it('allows entries beneath a protected root', () => {
+            expect(assertDeletablePaths(['/sdcard/Download'])).toEqual(['/sdcard/Download']);
         });
     });
 });

--- a/src/server/security/deviceInput.ts
+++ b/src/server/security/deviceInput.ts
@@ -63,3 +63,61 @@ export function assertSafeRemotePath(name: unknown): string {
     }
     return name;
 }
+
+// Device storage/system roots whose recursive deletion would wipe user data or
+// brick the device. The file browser only ever deletes user-selected entries
+// *beneath* these, never the roots themselves, so we refuse them outright
+// (after normalising trailing slashes).
+const PROTECTED_ROOTS = new Set([
+    '/',
+    '/sdcard',
+    '/storage',
+    '/storage/emulated',
+    '/storage/emulated/0',
+    '/data',
+    '/system',
+    '/vendor',
+    '/mnt',
+    '/proc',
+    '/dev',
+]);
+
+// A multi-select delete of more than this many entries is treated as abuse
+// rather than a legitimate UI action.
+const MAX_DELETE_PATHS = 1000;
+
+/**
+ * Validate a list of device paths targeted for a privileged recursive delete
+ * (`rm -rf`). The op is auth-gated, but a bug or a same-origin script could
+ * still drive it, so we defend in depth: the list must be a bounded array of
+ * absolute, well-formed paths with no `.`/`..` traversal segments, and must not
+ * name a catastrophic storage/system root. Returns the validated paths, else
+ * throws.
+ */
+export function assertDeletablePaths(paths: unknown): string[] {
+    if (!Array.isArray(paths) || paths.length === 0) {
+        throw new Error('paths must be a non-empty array');
+    }
+    if (paths.length > MAX_DELETE_PATHS) {
+        throw new Error(`too many paths: ${paths.length} (max ${MAX_DELETE_PATHS})`);
+    }
+    for (const p of paths) {
+        if (typeof p !== 'string' || p.length === 0) {
+            throw new Error('each path must be a non-empty string');
+        }
+        if (p.includes('\0')) {
+            throw new Error('path contains NUL');
+        }
+        if (!p.startsWith('/')) {
+            throw new Error(`path must be absolute: ${JSON.stringify(p)}`);
+        }
+        if (p.split('/').some((seg) => seg === '.' || seg === '..')) {
+            throw new Error(`path may not contain "." or ".." segments: ${JSON.stringify(p)}`);
+        }
+        const normalized = p.replace(/\/+$/, '') || '/';
+        if (PROTECTED_ROOTS.has(normalized)) {
+            throw new Error(`refusing to delete a protected root: ${normalized}`);
+        }
+    }
+    return paths as string[];
+}


### PR DESCRIPTION
Two reachable-now CRITICAL findings from the 2026-06-13 internal review (the tranche after #367), each landed test-first.

## #6 — device delete-path validation

`POST /api/devices/files/delete` passed an unbounded, unvalidated `paths[]` straight into a per-element privileged recursive device delete. An authed or same-origin caller could wipe arbitrary device locations — including the storage and system roots — with no cap on the list size.

`assertDeletablePaths()` (in `security/deviceInput`) now rejects non-arrays, empty or oversized lists (>1000), non-string/empty elements, relative paths, `.`/`..` traversal segments, NUL, and the well-known storage/system roots (refused after trailing-slash normalisation). The handler returns 400 on a bad list and routes escaping through `shArg()`. The serial is already validated by `AdbClient`.

## #7 — network scan restricted to RFC1918 (SSRF)

`scan.start` accepted any syntactically valid subnet and pointed the scanner at it, so the device scanner could be driven as an internal/external port scanner. The parser only checked syntax and the /16 size cap.

`ParsedSubnet` gains an `isPrivate` flag, computed from the parsed integer bounds against the three RFC1918 blocks (10/8, 172.16/12, 192.168/16) — a range counts as private only if it fits entirely within one block. `ScanMw` now rejects any non-private subnet with a clear error before the scan starts. The auto-detect path is unaffected (it only ever yields the local subnet).

## Verification

tsc 0 · vitest 1063 · webpack 0. New tests: `assertDeletablePaths` (10 cases), parser `isPrivate` (5), and a `ScanMw` integration test that a public subnet is rejected.

Unlabeled, so this merges to `main` without cutting a release (rides the next labeled beta). The remaining CRITICALs (#11–15, the service/launcher root-exec cluster) are on a separate branch.
