### PR TITLE
Security hardening: service/launcher root-exec cluster (#11-15)

### DIFF
--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -495,6 +495,31 @@ fn run_capture(exe: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Result<Captur
 //     TRAY_RUN_KEY, TRAY_RUN_VALUE, STALE_HKCU_TRAY_RUN_KEY
 //     (dropped in Phase 4 — 30+ betas with tray_supervisor means any
 //     stale Run-key entries have already been cleaned up)
+/// Reject any value that could break out of a `"..."` quoted batch token or
+/// inject a command when the generated .bat runs elevated (Servy `--postStopPath`
+/// / a SYSTEM scheduled task). cmd.exe does NOT treat double quotes as fully
+/// inert the way POSIX sh does — `%`/`!` still expand and a literal `"` ends the
+/// quoted run — so we refuse the metacharacters that matter in a batch context. (#13)
+pub(crate) fn assert_safe_bat_token(value: &str, what: &str) -> Result<(), String> {
+    const FORBIDDEN: &[char] = &['"', '&', '|', '<', '>', '^', '%', '!', '\r', '\n', '`'];
+    if let Some(c) = value.chars().find(|c| FORBIDDEN.contains(c)) {
+        return Err(format!("refusing to write bat: {what} contains an unsafe character {c:?}"));
+    }
+    Ok(())
+}
+
+/// A Servy/Windows service name is a server-derived constant, but it is
+/// interpolated UNQUOTED into `sc start <name>` / `--name <name>`, so pin it to
+/// a safe charset. (#13)
+pub(crate) fn assert_safe_service_name(name: &str) -> Result<(), String> {
+    if name.is_empty()
+        || !name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+    {
+        return Err(format!("refusing to write bat: invalid service name {name:?}"));
+    }
+    Ok(())
+}
+
 /// §32 Part 4 — write the post-stop bat file at `<data_root>/post-stop/post-stop.bat`.
 /// This bat is invoked by Servy via `--postStopPath` every time the supervised
 /// launcher exits. The bat:
@@ -552,6 +577,21 @@ pub(crate) fn write_post_stop_bat(
 
     let log_dir = data_root.join("logs");
     let log_dir_str = log_dir.to_string_lossy();
+
+    // Validate everything interpolated into the elevated .bat before writing it,
+    // so a hostile value (e.g. from the install-args file) cannot inject a batch
+    // command that runs as SYSTEM. (#13)
+    assert_safe_service_name(service_name)?;
+    for (val, what) in [
+        (servy_path, "servy_path"),
+        (current_launcher_path, "current_launcher_path"),
+        (apply_marker_str.as_ref(), "apply_marker"),
+        (uninstall_marker_str.as_ref(), "uninstall_marker"),
+        (helper_path_str.as_ref(), "helper_path"),
+        (log_dir_str.as_ref(), "log_dir"),
+    ] {
+        assert_safe_bat_token(val, what)?;
+    }
 
     let bat = format!(
         "@echo off\r\n\
@@ -646,6 +686,39 @@ mod tests {
     fn handle_returns_none_when_flag_absent() {
         let args = vec!["launcher.exe".to_string(), "--unrelated".to_string()];
         assert!(handle(&args).is_none());
+    }
+
+    #[test]
+    fn assert_safe_bat_token_rejects_batch_metacharacters() {
+        for bad in [
+            "a\"b", "a&b", "a|b", "a<b", "a>b", "a^b", "a%b", "a!b", "a\rb", "a\nb", "a`b",
+        ] {
+            assert!(assert_safe_bat_token(bad, "x").is_err(), "expected {bad:?} rejected");
+        }
+        assert!(assert_safe_bat_token("C:/app/control/post-stop/post-stop.bat", "x").is_ok());
+    }
+
+    #[test]
+    fn assert_safe_service_name_pins_charset() {
+        assert!(assert_safe_service_name("WsScrcpyWeb").is_ok());
+        assert!(assert_safe_service_name("ws-scrcpy_web.1").is_ok());
+        assert!(assert_safe_service_name("a b").is_err());
+        assert!(assert_safe_service_name("a&start calc").is_err());
+        assert!(assert_safe_service_name("").is_err());
+    }
+
+    #[test]
+    fn write_post_stop_bat_rejects_an_injected_service_name() {
+        let dir = tempdir().unwrap();
+        let r = write_post_stop_bat(dir.path(), "Ws & calc", "C:/app/servy-cli.exe", "C:/app/launcher.exe");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn write_post_stop_bat_writes_for_a_clean_service_name() {
+        let dir = tempdir().unwrap();
+        let r = write_post_stop_bat(dir.path(), "WsScrcpyWeb", "C:/app/servy-cli.exe", "C:/app/launcher.exe");
+        assert!(r.is_ok());
     }
 
     #[test]

--- a/launcher/src/linux_app_uninstall.rs
+++ b/launcher/src/linux_app_uninstall.rs
@@ -217,6 +217,21 @@ pub struct UninstallArgs {
     pub relaunch: String,
 }
 
+/// Validate a `--data-root` before it is forwarded across pkexec into a root
+/// `rm -rf {data_root}/...`. Only the two paths the app actually uses are
+/// allowed; an arbitrary absolute path, a `..` traversal, a relative value or a
+/// flag-shaped value is refused so the privileged delete can never be
+/// retargeted. (#14)
+fn is_valid_data_root(s: &str) -> bool {
+    if s.is_empty() || s.starts_with('-') || !s.starts_with('/') {
+        return false;
+    }
+    if s.split('/').any(|seg| seg == ".." || seg == ".") {
+        return false;
+    }
+    s == "/var/lib/ws-scrcpy-web" || s.ends_with("/.local/share/WsScrcpyWeb")
+}
+
 /// Parse the uninstall flags. Returns `None` (a parse error) on a missing/invalid
 /// `--scope`, a missing/invalid `--machine-wide`, a missing `--data-root`, or
 /// anything other than EXACTLY one of `--keep` / `--wipe`. `--scope none` is a
@@ -262,6 +277,9 @@ pub fn parse_args(args: &[String]) -> Option<UninstallArgs> {
         .position(|a| a == "--data-root")
         .and_then(|i| args.get(i + 1))
         .cloned()?;
+    if !is_valid_data_root(&data_root) {
+        return None;
+    }
     // --relaunch <abs path>  (optional; only read on a pkexec decline)
     let relaunch = args
         .iter()
@@ -832,6 +850,35 @@ mod tests {
         .map(|s| s.to_string())
         .collect();
         assert_eq!(parse_args(&args), None);
+    }
+
+    #[test]
+    fn parse_args_rejects_invalid_data_root() {
+        let with_data_root = |dr: &str| -> Vec<String> {
+            [
+                "--linux-app-uninstall",
+                "--scope",
+                "system",
+                "--machine-wide",
+                "1",
+                "--wipe",
+                "--data-root",
+                dr,
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+        };
+        // The two real data roots are accepted.
+        assert!(parse_args(&with_data_root("/var/lib/ws-scrcpy-web")).is_some());
+        assert!(parse_args(&with_data_root("/home/u/.local/share/WsScrcpyWeb")).is_some());
+        // Arbitrary, traversal, flag-shaped, relative and empty values are
+        // rejected — the elevated `rm -rf {data_root}` must never be retargeted (#14).
+        assert_eq!(parse_args(&with_data_root("/etc")), None);
+        assert_eq!(parse_args(&with_data_root("/var/lib/ws-scrcpy-web/../../etc")), None);
+        assert_eq!(parse_args(&with_data_root("--privileged")), None);
+        assert_eq!(parse_args(&with_data_root("relative/WsScrcpyWeb")), None);
+        assert_eq!(parse_args(&with_data_root("")), None);
     }
 
     #[test]

--- a/launcher/src/supervisor.rs
+++ b/launcher/src/supervisor.rs
@@ -253,6 +253,15 @@ pub fn run() -> Result<(i32, Option<Arc<AtomicBool>>)> {
 
                 let bat_path = paths.data_root.join("control").join("uninstall-now.bat");
                 let task_name = "WsScrcpyWebUninstall";
+                // Defense in depth (#13): refuse to write the elevated uninstall bat
+                // if any interpolated path carries a batch metacharacter.
+                if let Err(e) = crate::elevated_runner::assert_safe_bat_token(&log_dir.to_string_lossy(), "log_dir")
+                    .and_then(|()| crate::elevated_runner::assert_safe_bat_token(&servy_path.to_string_lossy(), "servy_path"))
+                    .and_then(|()| crate::elevated_runner::assert_safe_bat_token(&launcher_path.to_string_lossy(), "launcher_path"))
+                {
+                    log::error(&format!("supervisor: refusing to write uninstall bat: {e}"));
+                    return Ok((code, tray_stop_flag.clone()));
+                }
                 let bat_content = format!(
                     "@echo off\r\n\
                      echo %date% %time% [uninstall-now] starting >> \"{log}\\uninstall-now.log\"\r\n\

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1540,7 +1540,7 @@ describe('ServiceApi', () => {
 
                 expect(fakePkexec).toHaveBeenCalledTimes(1);
                 const [script, label] = fakePkexec.mock.calls[0]!;
-                expect(script).toContain(`cp "${appImagePath}" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`);
+                expect(script).toContain(`cp '${appImagePath}' "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`);
                 expect(script).toContain('bin_t');
                 expect(label).toBe('install-system-wide');
             } finally {

--- a/src/server/service/SystemdClient.test.ts
+++ b/src/server/service/SystemdClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript, buildMachineWideUpdateScript } from './SystemdClient';
+import { SystemdClient, renderUnitFile, STAGED_SYSTEM_DIR, systemctlArgv, buildServiceUnitEnv, buildMachineWideInstallScript, buildMachineWideUpdateScript, buildSystemUninstallScript } from './SystemdClient';
+import { shQuote } from './shellEscape';
 
 describe('system-scope staging', () => {
     const baseOpts = {
@@ -114,7 +115,7 @@ describe('buildMachineWideInstallScript', () => {
             (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
         );
         expect(s).toContain('mkdir -p /opt/ws-scrcpy-web');
-        expect(s).toContain('cp "/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
+        expect(s).toContain(`cp '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage' "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`);
         expect(s).toContain('chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
         expect(s).toContain("semanage fcontext -a -t bin_t '/opt/ws-scrcpy-web(/.*)?'");
         expect(s).toContain('restorecon -Rv "/opt/ws-scrcpy-web"');
@@ -123,7 +124,7 @@ describe('buildMachineWideInstallScript', () => {
         expect(s).toContain('Exec=/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage');     // every user launches the shared /opt binary
         expect(s).not.toContain('dependencies');   // binary only — deps stay per-user ~/.local
         expect(s).not.toContain('systemctl');      // no service install here
-        expect(s).toContain('rm -f "/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage"');  // final step: delete the original (true relocate)
+        expect(s).toContain(`rm -f '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage'`);  // final step: delete the original (true relocate)
     });
 
     it('installs the menu icon into the hicolor theme + refreshes the icon cache when iconSource is given', () => {
@@ -139,7 +140,7 @@ describe('buildMachineWideInstallScript', () => {
         // .desktop's `Icon=ws-scrcpy-web` resolves to (also the path the launcher
         // uninstaller's SYS_ICON teardown removes).
         expect(s).toContain('mkdir -p /usr/share/icons/hicolor/256x256/apps');
-        expect(s).toContain('cp "/tmp/.mount_x/.DirIcon" /usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png');
+        expect(s).toContain(`cp '/tmp/.mount_x/.DirIcon' /usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png`);
         expect(s).toContain('/usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png');
         // best-effort cache refresh, mirroring the update-desktop-database subshell.
         expect(s).toContain('gtk-update-icon-cache');
@@ -147,7 +148,7 @@ describe('buildMachineWideInstallScript', () => {
         // ordering: icon install lands AFTER the .desktop write and BEFORE the home-AppImage delete.
         const desktopIdx = s.indexOf('/usr/share/applications/ws-scrcpy-web.desktop');
         const iconIdx = s.indexOf('/usr/share/icons/hicolor/256x256/apps/ws-scrcpy-web.png');
-        const rmIdx = s.indexOf('rm -f "/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage"');
+        const rmIdx = s.indexOf(`rm -f '/home/u/Downloads/WsScrcpyWeb-linux-beta.AppImage'`);
         expect(desktopIdx).toBeGreaterThanOrEqual(0);
         expect(desktopIdx).toBeLessThan(iconIdx);
         expect(iconIdx).toBeLessThan(rmIdx);
@@ -205,7 +206,7 @@ describe('buildMachineWideUpdateScript', () => {
         );
         // 2. move the staged download into place (rename, not cp).
         expect(s).toContain(
-            `/usr/bin/mv -f "${args.stagedAppImage}" "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`,
+            `/usr/bin/mv -f '${args.stagedAppImage}' "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"`,
         );
         // 3. chmod the new binary executable.
         expect(s).toContain('/usr/bin/chmod 0755 "/opt/ws-scrcpy-web/WsScrcpyWeb.AppImage"');
@@ -246,5 +247,63 @@ describe('buildMachineWideUpdateScript', () => {
         expect(s).toContain('/usr/bin/mv -f');
         expect(s).toContain('/usr/bin/printf');
         expect(s).toContain('/usr/sbin/restorecon');
+    });
+});
+
+describe('root-script shell-escaping (review #11)', () => {
+    it('single-quote-escapes a hostile sourceAppImage in the install script', () => {
+        const evil = '/tmp/x$(id).AppImage';
+        const s = buildMachineWideInstallScript(
+            { sourceAppImage: evil, version: '1.0.0' },
+            (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+        );
+        // the payload appears ONLY inside a single-quoted (inert) literal,
+        expect(s).toContain(shQuote(evil));
+        // never in a double-quoted slot the root shell would expand.
+        expect(s).not.toContain(`"${evil}"`);
+    });
+
+    it('single-quote-escapes a hostile version (single-quote breakout)', () => {
+        const evil = "1.0'; id; '";
+        const s = buildMachineWideInstallScript(
+            { sourceAppImage: '/tmp/a.AppImage', version: evil },
+            (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+        );
+        expect(s).toContain(shQuote(evil));
+    });
+
+    it('single-quote-escapes a hostile stagedAppImage in the update script', () => {
+        const evil = '/tmp/s$(id).AppImage.new';
+        const s = buildMachineWideUpdateScript(
+            { stagedAppImage: evil, version: '1.0.0' },
+            (t) => `/usr/bin/${t}`, (t) => `/usr/sbin/${t}`,
+        );
+        expect(s).toContain(shQuote(evil));
+        expect(s).not.toContain(`"${evil}"`);
+    });
+});
+
+describe('buildSystemUninstallScript (review #12)', () => {
+    it('builds disable/rm/daemon-reload with the unit and path single-quoted', () => {
+        const s = buildSystemUninstallScript(
+            'ws-scrcpy-web',
+            '/etc/systemd/system/ws-scrcpy-web.service',
+            '/usr/bin/systemctl',
+        );
+        expect(s).toContain(`/usr/bin/systemctl disable --now 'ws-scrcpy-web.service' || true`);
+        expect(s).toContain(`rm -f '/etc/systemd/system/ws-scrcpy-web.service'`);
+        expect(s).toContain('/usr/bin/systemctl daemon-reload');
+    });
+
+    it('single-quote-escapes a hostile unitPath', () => {
+        const evil = '/etc/systemd/system/x$(id).service';
+        const s = buildSystemUninstallScript('ws-scrcpy-web', evil, '/usr/bin/systemctl');
+        expect(s).toContain(shQuote(evil));
+        expect(s).not.toContain(`"${evil}"`);
+    });
+
+    it('rejects a service name carrying shell metacharacters', () => {
+        expect(() => buildSystemUninstallScript('a;id', '/x', '/usr/bin/systemctl')).toThrow(/service name/);
+        expect(() => buildSystemUninstallScript('a b', '/x', '/usr/bin/systemctl')).toThrow();
     });
 });

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -44,6 +44,7 @@ import type {
     ServiceStatus,
 } from './ServiceClient';
 import { resolveSystemTool } from './systemTools';
+import { assertServiceName, shQuote } from './shellEscape';
 
 const execFileAsync = promisify(execFile);
 
@@ -313,9 +314,9 @@ export function buildMachineWideInstallScript(
     ].join('\\n');
     const steps = [
         `${mkdir} -p ${STAGED_SYSTEM_DIR}`,
-        `${cp} "${args.sourceAppImage}" "${staged}"`,
+        `${cp} ${shQuote(args.sourceAppImage)} "${staged}"`,
         `${chmod} 0755 "${staged}"`,
-        `${printf} '%s' '${args.version}' > ${SYSTEM_OPT_VERSION_FILE}`,
+        `${printf} '%s' ${shQuote(args.version)} > ${SYSTEM_OPT_VERSION_FILE}`,
         // bin_t add + restorecon as INDEPENDENT `;`-separated steps (whole subshell
         // `|| true`) so neither a re-install's "already defined" nor the `-m`-to-
         // unchanged failure can short-circuit the restorecon (beta.61 #9 fix). No chcon.
@@ -337,7 +338,7 @@ export function buildMachineWideInstallScript(
     if (args.iconSource) {
         const iconCache = binTool('gtk-update-icon-cache');
         steps.push(
-            `( ${mkdir} -p ${SYSTEM_ICON_DIR} && ${cp} "${args.iconSource}" ${SYSTEM_ICON_FILE} && ( ${iconCache} -f /usr/share/icons/hicolor || true ) || true )`,
+            `( ${mkdir} -p ${SYSTEM_ICON_DIR} && ${cp} ${shQuote(args.iconSource)} ${SYSTEM_ICON_FILE} && ( ${iconCache} -f /usr/share/icons/hicolor || true ) || true )`,
         );
     }
     // Final step — remove the original (home) AppImage now that the binary
@@ -346,7 +347,7 @@ export function buildMachineWideInstallScript(
     // running process (the inode stays alive for the live FUSE mount until it
     // exits / re-execs to /opt). `|| true` so a failed cleanup never aborts an
     // otherwise-successful install.
-    steps.push(`( ${rm} -f "${args.sourceAppImage}" || true )`);
+    steps.push(`( ${rm} -f ${shQuote(args.sourceAppImage)} || true )`);
     return steps.join(' && ');
 }
 
@@ -393,10 +394,25 @@ export function buildMachineWideUpdateScript(
     const restorecon = sbinTool('restorecon');
     return [
         `${mv} -f "${target}" "${backup}"`,
-        `${mv} -f "${args.stagedAppImage}" "${target}"`,
+        `${mv} -f ${shQuote(args.stagedAppImage)} "${target}"`,
         `${chmod} 0755 "${target}"`,
         `( ${restorecon} -v "${target}" || ${chcon} -t bin_t "${target}" || true )`,
-        `${printf} '%s' '${args.version}' > ${SYSTEM_OPT_VERSION_FILE}`,
+        `${printf} '%s' ${shQuote(args.version)} > ${SYSTEM_OPT_VERSION_FILE}`,
+    ].join(' && ');
+}
+
+/**
+ * Build the privileged shell script for a system-scope uninstall (run via one
+ * pkexec). The service name is validated and every interpolated value is
+ * single-quoted so nothing in `name` / `unitPath` can break out of the root
+ * `sh -c` (review finding #12).
+ */
+export function buildSystemUninstallScript(name: string, unitPath: string, systemctl: string): string {
+    assertServiceName(name);
+    return [
+        `${systemctl} disable --now ${shQuote(`${name}.service`)} || true`,
+        `rm -f ${shQuote(unitPath)}`,
+        `${systemctl} daemon-reload`,
     ].join(' && ');
 }
 
@@ -587,11 +603,7 @@ export class SystemdClient implements ServiceClient {
         if (scope === 'system' && process.getuid?.() !== 0) {
             const unitPath = this.systemUnitPath(name);
             const systemctl = resolveSystemTool('systemctl');
-            const cmd = [
-                `${systemctl} disable --now ${name}.service || true`,
-                `rm -f "${unitPath}"`,
-                `${systemctl} daemon-reload`,
-            ].join(' && ');
+            const cmd = buildSystemUninstallScript(name, unitPath, systemctl);
             await runPkexec(cmd, 'uninstall (system scope)');
         } else {
             const baseArgs = scope === 'user' ? ['--user'] : [];

--- a/src/server/service/shellEscape.test.ts
+++ b/src/server/service/shellEscape.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { assertServiceName, shQuote } from './shellEscape';
+
+describe('shQuote', () => {
+    it('wraps a plain value in single quotes', () => {
+        expect(shQuote('/opt/ws-scrcpy-web')).toBe("'/opt/ws-scrcpy-web'");
+    });
+
+    it('neutralises double-quote / $() / backtick breakouts (root pkexec context)', () => {
+        expect(shQuote('a"; reboot; "b')).toBe(`'a"; reboot; "b'`);
+        expect(shQuote('$(reboot)')).toBe("'$(reboot)'");
+        expect(shQuote('`reboot`')).toBe("'`reboot`'");
+    });
+
+    it('escapes embedded single quotes so the quote cannot be broken out of', () => {
+        expect(shQuote("a'b")).toBe("'a'\\''b'");
+        expect(shQuote("'; rm -rf /; '")).toBe("''\\''; rm -rf /; '\\'''");
+    });
+});
+
+describe('assertServiceName', () => {
+    it('accepts normal unit base names', () => {
+        expect(assertServiceName('ws-scrcpy-web')).toBe('ws-scrcpy-web');
+        expect(assertServiceName('WsScrcpyWeb')).toBe('WsScrcpyWeb');
+        expect(assertServiceName('a_b.c-1')).toBe('a_b.c-1');
+    });
+
+    it('rejects names with shell metacharacters, spaces, or slashes', () => {
+        expect(() => assertServiceName('a b')).toThrow();
+        expect(() => assertServiceName('a;reboot')).toThrow();
+        expect(() => assertServiceName('a/b')).toThrow();
+        expect(() => assertServiceName('$(reboot)')).toThrow();
+        expect(() => assertServiceName('')).toThrow();
+    });
+
+    it('rejects non-strings', () => {
+        expect(() => assertServiceName(undefined as unknown as string)).toThrow();
+    });
+});

--- a/src/server/service/shellEscape.ts
+++ b/src/server/service/shellEscape.ts
@@ -1,0 +1,29 @@
+/**
+ * Helpers for safely building shell command strings that run with elevated
+ * privileges (e.g. `pkexec sh -c ...`). Any string-typed or untrusted value
+ * interpolated into such a script runs as root, so it must be quoted or
+ * validated. POSIX single-quoting makes a value an inert literal; a single
+ * quote is the only character that has to be escaped (close, escaped-quote,
+ * reopen: `'\''`).
+ */
+
+/** POSIX single-quote a value so it is an inert literal inside `sh -c`. */
+export function shQuote(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+const SERVICE_NAME_RE = /^[A-Za-z0-9_.-]+$/;
+
+/**
+ * Validate a systemd service/unit base name. Service names are server-derived
+ * constants today, but they are interpolated into privileged commands, so we
+ * pin them to a safe charset rather than trust the caller. Returns the name on
+ * success, otherwise throws.
+ */
+export function assertServiceName(name: string): string {
+    if (typeof name !== 'string' || !SERVICE_NAME_RE.test(name)) {
+        const shown = typeof name === 'string' ? JSON.stringify(name) : typeof name;
+        throw new Error(`invalid service name: ${shown}`);
+    }
+    return name;
+}

--- a/src/server/service/systemServiceCli.test.ts
+++ b/src/server/service/systemServiceCli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { installSystemService, uninstallSystemService, systemServiceStatus, parseSystemServiceArgs, runSystemServiceCli, type CommandRunner } from './systemServiceCli';
+import { installSystemService, uninstallSystemService, systemServiceStatus, parseSystemServiceArgs, runSystemServiceCli, assertSafeRootDir, type CommandRunner } from './systemServiceCli';
 
 function recordingRunner() {
     const calls: string[][] = [];
@@ -14,6 +14,7 @@ const deps = {
     tool: (t: string) => `/usr/bin/${t}`,
     sbinTool: (t: string) => `/usr/sbin/${t}`,
     writeFile: vi.fn(),
+    lstat: () => ({ uid: 0, mode: 0o755, isSymbolicLink: false }),
 };
 
 describe('installSystemService', () => {
@@ -36,6 +37,36 @@ describe('installSystemService', () => {
     it('throws if not root', async () => {
         const { run } = recordingRunner();
         await expect(installSystemService({ port: 8000 }, { ...deps, getuid: () => 1000, run })).rejects.toThrow(/root|euid|sudo/i);
+    });
+
+    it('aborts before any cp/restorecon when a target dir is a symlink (#15)', async () => {
+        const { run, calls } = recordingRunner();
+        const lstat = (p: string) =>
+            p === '/opt/ws-scrcpy-web'
+                ? { uid: 0, mode: 0o755, isSymbolicLink: true }
+                : { uid: 0, mode: 0o755, isSymbolicLink: false };
+        await expect(installSystemService({ port: 8000 }, { ...deps, run, lstat })).rejects.toThrow(/symlink/i);
+        const flat = calls.map((c) => c.join(' '));
+        expect(flat.some((c) => c.startsWith('/usr/sbin/restorecon'))).toBe(false);
+        expect(flat.some((c) => c.startsWith('/usr/bin/cp '))).toBe(false);
+    });
+});
+
+describe('assertSafeRootDir (review #15)', () => {
+    const safe = { uid: 0, mode: 0o755, isSymbolicLink: false };
+    it('accepts a root-owned, non-symlink, non-world-writable dir', () => {
+        expect(() => assertSafeRootDir('/opt/ws-scrcpy-web', () => safe)).not.toThrow();
+    });
+    it('rejects a symlink (symlink-swap / TOCTOU defense)', () => {
+        expect(() => assertSafeRootDir('/opt/ws-scrcpy-web', () => ({ ...safe, isSymbolicLink: true }))).toThrow(/symlink/i);
+    });
+    it('rejects a non-root-owned dir', () => {
+        expect(() => assertSafeRootDir('/opt/ws-scrcpy-web', () => ({ ...safe, uid: 1000 }))).toThrow(/root/i);
+    });
+    it('rejects a group- or world-writable dir', () => {
+        expect(() => assertSafeRootDir('/x', () => ({ ...safe, mode: 0o777 }))).toThrow(/writable/i);
+        expect(() => assertSafeRootDir('/x', () => ({ ...safe, mode: 0o775 }))).toThrow(/writable/i);
+        expect(() => assertSafeRootDir('/x', () => ({ ...safe, mode: 0o757 }))).toThrow(/writable/i);
     });
 });
 

--- a/src/server/service/systemServiceCli.ts
+++ b/src/server/service/systemServiceCli.ts
@@ -24,6 +24,7 @@ export interface CoreDeps {
     depsSource: string;
     tool: (t: string) => string;       // /usr/bin resolver
     sbinTool: (t: string) => string;   // /usr/sbin resolver (semanage/restorecon)
+    lstat: (path: string) => { uid: number; mode: number; isSymbolicLink: boolean };
 }
 
 const UNIT_PATH = `/etc/systemd/system/${WS_SCRCPY_SERVICE_NAME}.service`;
@@ -36,6 +37,27 @@ function assertRoot(getuid: () => number): void {
     }
 }
 
+/**
+ * Before any privileged copy/chmod/relabel, assert a target directory is a
+ * real, root-owned directory that group/other cannot write — defeating a
+ * symlink swap or TOCTOU that would redirect root's `cp`/`chmod`/`restorecon -R`
+ * onto an attacker-chosen path. (#15)
+ */
+export function assertSafeRootDir(path: string, lstat: CoreDeps['lstat']): void {
+    const st = lstat(path);
+    if (st.isSymbolicLink) {
+        throw new Error(`refusing to operate on ${path}: it is a symlink`);
+    }
+    if (st.uid !== 0) {
+        throw new Error(`refusing to operate on ${path}: not root-owned (uid ${st.uid})`);
+    }
+    if ((st.mode & 0o022) !== 0) {
+        throw new Error(
+            `refusing to operate on ${path}: group/other-writable (mode ${(st.mode & 0o777).toString(8)})`,
+        );
+    }
+}
+
 export async function installSystemService(opts: { port: number }, d: CoreDeps): Promise<void> {
     assertRoot(d.getuid);
     const mkdir = d.tool('mkdir'), cp = d.tool('cp'), chmod = d.tool('chmod'), systemctl = d.tool('systemctl');
@@ -43,6 +65,11 @@ export async function installSystemService(opts: { port: number }, d: CoreDeps):
 
     await d.run([mkdir, '-p', STAGED_SYSTEM_DIR]);
     await d.run([mkdir, '-p', SYSTEM_STATE_DIR]);
+    // Guard against a symlink/TOCTOU swap before root copies or relabels into
+    // these predictable dirs (#15): each must be a real, root-owned,
+    // non-world-writable directory.
+    assertSafeRootDir(STAGED_SYSTEM_DIR, d.lstat);
+    assertSafeRootDir(SYSTEM_STATE_DIR, d.lstat);
     await d.run([cp, d.appImageSource, STAGED_BIN]);
     await d.run([chmod, '0755', STAGED_BIN]);
     await d.run([mkdir, '-p', STAGED_SYSTEM_DEPS_DIR]);
@@ -175,6 +202,7 @@ export function makeProductionCoreDeps(): CliDeps {
         getuid: () => process.getuid?.() ?? 0,
         run,
         writeFile: (p, content, opts) => fs.writeFileSync(p, content, opts),
+        lstat: (p) => { const s = fs.lstatSync(p); return { uid: s.uid, mode: s.mode, isSymbolicLink: s.isSymbolicLink() }; },
         removeFile: (p) => { try { fs.unlinkSync(p); } catch { /* already gone */ } },
         existsCheck: (p) => fs.existsSync(p),
         appImageSource: process.env['APPIMAGE'] ?? process.execPath,


### PR DESCRIPTION
The remaining CRITICAL tier from the 2026-06-13 internal review — the service/launcher root-exec cluster — each landed test-first. All are privilege-escalation-grade and currently latent (the inputs are server-derived constants today), but the values are exported / string-typed and reach a root shell, so this is defense in depth before any future caller makes them reachable.

## #11 / #12 — root pkexec script values (`SystemdClient.ts`)

The machine-wide install/update builders and the system-scope uninstall build scripts that run as root via `pkexec sh -c`, interpolating values (sourceAppImage, version, iconSource, stagedAppImage) with naive double quotes, and the uninstall interpolated the service name **unquoted**. A new `shellEscape.ts` adds `shQuote` (POSIX single-quote) + `assertServiceName`; every interpolated value is now quoted/validated, and the uninstall command is extracted to a testable `buildSystemUninstallScript`.

## #15 — symlink / TOCTOU guard (`systemServiceCli.ts`)

`installSystemService` ran `cp` / `chmod` / `restorecon -R` as root over the predictable `/opt` + `/var/lib` dirs with no check. `assertSafeRootDir` now lstat-asserts each is a real (non-symlink), root-owned, non-group/other-writable directory before any privileged op.

## #13 — elevated `.bat` injection (Rust — `elevated_runner.rs` + `supervisor.rs`)

`write_post_stop_bat` interpolates the service name (unquoted), the servy/launcher paths and data-root-derived paths into a `.bat` run elevated (Servy `--postStopPath` / a SYSTEM task). `assert_safe_bat_token` (reject `" & | < > ^ % ! CR LF` backtick) + `assert_safe_service_name` guard it, and the supervisor's `uninstall-now.bat` gets the same guard.

## #14 — `--data-root` allowlist (Rust — `linux_app_uninstall.rs`)

The uninstall's `--data-root` was read as the next token, unvalidated, then forwarded across pkexec into a root recursive delete of `{data_root}/…`. `is_valid_data_root` now requires an absolute, traversal-free path matching exactly `/var/lib/ws-scrcpy-web` or ending in `/.local/share/WsScrcpyWeb`.

## Verification

- TS: tsc 0 · vitest 1080 · webpack 0 (+25 tests across the security modules).
- Rust: native `cargo test` 122 + clippy clean (#13, Windows-side); `cross` x86_64-unknown-linux-gnu test + clippy clean (#14, Linux-side).

Unlabeled, so this merges to `main` without cutting a release. This closes the CRITICAL tier from the review; 50 MAJOR + 37 MINOR remain (tracked in the ledger).
