### PR TITLE
Security hardening: server-robustness MAJORs — body cap (#22), config allowlist (#21), adb timeout (#23)

### DIFF
--- a/src/server/AdbClient.ts
+++ b/src/server/AdbClient.ts
@@ -45,14 +45,17 @@ interface AdbExecOptions {
     timeoutMs?: number;
 }
 
-// Default timeouts for short-lived control-plane commands. Anything not on
-// this list (push/pull, arbitrary shell) stays unbounded — caller decides.
-const DEFAULT_TIMEOUT_MS = {
+// Default timeouts for short-lived control-plane commands. push/pull stay
+// unbounded (large transfers); a one-shot arbitrary `shell` is bounded so a
+// hung device command can't pin the server forever (#23) — genuinely
+// long-running / streaming commands go through shellSpawn instead.
+export const DEFAULT_TIMEOUT_MS = {
     devices: 5_000,
     mdnsServices: 8_000,
     connect: 8_000,
     disconnect: 5_000,
     forwardOps: 5_000,
+    shell: 30_000,
 } as const;
 
 export function parseMdnsOutput(output: string): MdnsDevice[] {
@@ -168,14 +171,12 @@ export class AdbClient {
             });
     }
 
-    async shell(serial: string, command: string): Promise<string> {
-        assertSerial(serial);
-        await this.daemon.ensureReady();
-        const { stdout } = await execFileAsync(this.adbPath, ['-s', serial, 'shell', command], {
-            maxBuffer: 10 * 1024 * 1024,
-            cwd: this.cwd,
-        });
-        return stdout.trim();
+    async shell(serial: string, command: string, timeoutMs: number = DEFAULT_TIMEOUT_MS.shell): Promise<string> {
+        // Route through exec so a one-shot `adb shell` inherits the daemon
+        // coordination, the maxBuffer output cap, error classification, and a
+        // default timeout — it must not be able to hang the server forever (#23).
+        const output = await this.exec(['-s', serial, 'shell', command], { timeoutMs });
+        return output.trim();
     }
 
     async push(serial: string, local: string, remote: string): Promise<void> {

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -208,6 +208,13 @@ function isInteger(n: unknown): n is number {
  */
 type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: string };
 
+/**
+ * The config keys that may be set via `updateAppConfig` — exactly the AppConfig
+ * fields that carry a default. Anything else (an unknown key, or a
+ * prototype-pollution key like `__proto__`) is rejected rather than persisted. (#21)
+ */
+const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set(Object.keys(APP_CONFIG_DEFAULTS));
+
 function validateField<K extends keyof AppConfig>(key: K, value: unknown): ValidationResult<AppConfig[K]> {
     switch (key) {
         case 'webPort': {
@@ -642,6 +649,15 @@ export class Config {
     public updateAppConfig(partial: Partial<AppConfig>): { config: AppConfig; restartRequired: boolean } {
         const merged: AppConfig = { ...this._appConfig };
         for (const key of Object.keys(partial) as (keyof AppConfig)[]) {
+            // Reject prototype-pollution keys and anything not a known AppConfig
+            // field rather than persisting arbitrary keys to config.json (#21).
+            const k = key as string;
+            if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+                throw new ConfigValidationError('illegal config key', k);
+            }
+            if (!KNOWN_CONFIG_KEYS.has(k)) {
+                throw new ConfigValidationError(`unknown config key: ${k}`, k);
+            }
             const value = partial[key];
             if (value === undefined) continue;
             const r = validateField(key, value);

--- a/src/server/__tests__/Config.test.ts
+++ b/src/server/__tests__/Config.test.ts
@@ -120,6 +120,22 @@ describe('Config — AppConfig extension', () => {
         expect(() => cfg.updateAppConfig({ channel: 'nightly' as 'stable' })).toThrow(ConfigValidationError);
     });
 
+    it('updateAppConfig rejects an unknown config key (no arbitrary persistence)', () => {
+        setup({});
+        const cfg = Config.getInstance();
+        expect(() => cfg.updateAppConfig(JSON.parse('{"bogusKey":1}'))).toThrow(ConfigValidationError);
+    });
+
+    it('updateAppConfig rejects prototype-pollution keys', () => {
+        setup({});
+        const cfg = Config.getInstance();
+        for (const key of ['__proto__', 'constructor', 'prototype']) {
+            expect(() => cfg.updateAppConfig(JSON.parse(`{"${key}":{"x":1}}`))).toThrow(ConfigValidationError);
+        }
+        // global prototype untouched
+        expect(({} as Record<string, unknown>)['x']).toBeUndefined();
+    });
+
     it('updateAppConfig throws ConfigValidationError on out-of-range interval', () => {
         setup({});
         const cfg = Config.getInstance();

--- a/src/server/__tests__/adbClient.test.ts
+++ b/src/server/__tests__/adbClient.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { describe, expect, it } from 'vitest';
-import { AdbClient, AdbExecError, parseMdnsOutput, parseSerialFromMdnsName } from '../AdbClient';
+import { AdbClient, AdbExecError, DEFAULT_TIMEOUT_MS, parseMdnsOutput, parseSerialFromMdnsName } from '../AdbClient';
 import { tempDir } from '../util/disposable';
 
 describe('parseMdnsOutput', () => {
@@ -139,6 +139,20 @@ describe('AdbClient — error surfacing', () => {
             expect((err as AdbExecError).adbPath).toBe(process.execPath);
         }
         // §25 — temp dir disposed by `using td = tempDir(...)` above.
+    });
+
+    it('shell routes through the exec path (typed AdbExecError)', async () => {
+        // node rejects the synthetic args and exits non-zero; routing shell
+        // through exec surfaces failures as a typed AdbExecError. (#23)
+        const client = new AdbClient(process.execPath);
+        await expect(client.shell('emulator-5554', 'getprop')).rejects.toBeInstanceOf(AdbExecError);
+    });
+
+    it('bounds one-shot adb shell with a default timeout (#23)', () => {
+        // Previously arbitrary `shell` stayed unbounded ("caller decides"); a
+        // hung device command could pin the server forever.
+        expect(DEFAULT_TIMEOUT_MS.shell).toBeGreaterThan(0);
+        expect(DEFAULT_TIMEOUT_MS.shell).toBeLessThanOrEqual(60_000);
     });
 
     // mdnsServices "no longer swallows errors" was previously tested by passing

--- a/src/server/api/ConfigApi.ts
+++ b/src/server/api/ConfigApi.ts
@@ -4,19 +4,9 @@ import * as fs from 'node:fs';
 import type { AppConfigEnvelope, AppConfigPatchResponse } from '../../common/ConfigEvents';
 import { Config, ConfigValidationError } from '../Config';
 import { Logger } from '../Logger';
+import { BodyTooLargeError, readBodyCapped } from './utils';
 
 const log = Logger.for('ConfigApi');
-
-function readBody(req: IncomingMessage): Promise<string> {
-    return new Promise((resolve, reject) => {
-        let body = '';
-        req.on('data', (chunk: Buffer) => {
-            body += chunk.toString();
-        });
-        req.on('end', () => resolve(body));
-        req.on('error', reject);
-    });
-}
 
 export class ConfigApi {
     async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
@@ -38,7 +28,17 @@ export class ConfigApi {
             }
 
             if (req.method === 'PATCH' && url === '/api/config') {
-                const body = await readBody(req);
+                let body: string;
+                try {
+                    body = await readBodyCapped(req);
+                } catch (err) {
+                    if (err instanceof BodyTooLargeError) {
+                        res.writeHead(413);
+                        res.end(JSON.stringify({ error: 'Request body too large', field: '' }));
+                        return true;
+                    }
+                    throw err;
+                }
                 let parsed: unknown;
                 try {
                     parsed = body.length === 0 ? {} : JSON.parse(body);

--- a/src/server/api/DeviceDiscoveryApi.ts
+++ b/src/server/api/DeviceDiscoveryApi.ts
@@ -7,6 +7,7 @@ import { Logger } from '../Logger';
 import { detectSubnet } from '../network/SubnetDetector';
 import { resolveMac } from '../network/MacResolver';
 import { assertDeletablePaths, shArg } from '../security/deviceInput';
+import { BodyTooLargeError, readBodyCapped } from './utils';
 
 const log = Logger.for('DeviceDiscoveryApi');
 
@@ -214,6 +215,11 @@ export class DeviceDiscoveryApi {
             res.end(JSON.stringify({ error: 'Not found' }));
             return true;
         } catch (err: any) {
+            if (err instanceof BodyTooLargeError) {
+                res.writeHead(413);
+                res.end(JSON.stringify({ error: 'request body too large' }));
+                return true;
+            }
             log.error(`${req.method} ${req.url} threw: ${err?.message ?? String(err)}`);
             res.writeHead(500);
             res.end(JSON.stringify({ error: err.message }));
@@ -223,12 +229,7 @@ export class DeviceDiscoveryApi {
 }
 
 function readBody(req: IncomingMessage): Promise<string> {
-    return new Promise((resolve, reject) => {
-        let body = '';
-        req.on('data', (chunk: Buffer) => {
-            body += chunk.toString();
-        });
-        req.on('end', () => resolve(body));
-        req.on('error', reject);
-    });
+    // Capped to bound memory on a hostile/oversized body (#22); handle()'s catch
+    // maps BodyTooLargeError to a 413.
+    return readBodyCapped(req);
 }

--- a/src/server/api/utils.test.ts
+++ b/src/server/api/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { IncomingMessage } from 'node:http';
+import { Readable } from 'node:stream';
+import { BodyTooLargeError, MAX_BODY_BYTES, readBodyCapped, readJsonBody } from './utils';
+
+function reqFrom(chunks: Array<Buffer | string>): IncomingMessage {
+    return Readable.from(
+        chunks.map((c) => (typeof c === 'string' ? Buffer.from(c) : c)),
+    ) as unknown as IncomingMessage;
+}
+
+describe('readBodyCapped', () => {
+    it('returns the full body when under the cap', async () => {
+        expect(await readBodyCapped(reqFrom(['{"a":1}']), 1024)).toBe('{"a":1}');
+    });
+
+    it('rejects with BodyTooLargeError and destroys the request on overflow', async () => {
+        const req = reqFrom([Buffer.alloc(2048, 0x61)]);
+        await expect(readBodyCapped(req, 1024)).rejects.toBeInstanceOf(BodyTooLargeError);
+        expect((req as unknown as { destroyed: boolean }).destroyed).toBe(true);
+    });
+
+    it('counts cumulative chunk size against the cap', async () => {
+        const req = reqFrom([Buffer.alloc(600), Buffer.alloc(600)]);
+        await expect(readBodyCapped(req, 1024)).rejects.toBeInstanceOf(BodyTooLargeError);
+    });
+
+    it('exposes a sane default cap', () => {
+        expect(MAX_BODY_BYTES).toBeGreaterThanOrEqual(64 * 1024);
+    });
+});
+
+describe('readJsonBody', () => {
+    it('parses a JSON object', async () => {
+        expect(await readJsonBody(reqFrom(['{"a":1}']))).toEqual({ a: 1 });
+    });
+
+    it('returns {} on empty, non-object, or invalid JSON', async () => {
+        expect(await readJsonBody(reqFrom([]))).toEqual({});
+        expect(await readJsonBody(reqFrom(['[1,2]']))).toEqual({});
+        expect(await readJsonBody(reqFrom(['not json']))).toEqual({});
+    });
+
+    it('returns {} (best-effort) when the body exceeds the cap', async () => {
+        expect(await readJsonBody(reqFrom([Buffer.alloc(2048, 0x61)]), 1024)).toEqual({});
+    });
+});

--- a/src/server/api/utils.ts
+++ b/src/server/api/utils.ts
@@ -2,35 +2,82 @@
 import type { IncomingMessage } from 'http';
 
 /**
- * Drain `req` and parse a JSON body. Returns `{}` on empty body, parse failure,
- * or non-object payloads (arrays, primitives). Best-effort by design — callers
- * that need strict validation should layer it on top of the returned object.
- *
- * Originally lived in ServiceApi.ts (P4b); extracted here for reuse by
- * UpdatesApi (P5) and any future PATCH endpoints. Behavior preserved exactly.
+ * Cap on request-body size. Every body this server reads (config patch, device
+ * connect/label/delete, scan) is tiny JSON; 1 MiB is generous. Beyond it we
+ * treat the request as abusive and drop it rather than buffering unbounded
+ * memory — an unauthenticated memory DoS otherwise. (#22)
  */
-export function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
-    return new Promise((resolve) => {
-        let body = '';
+export const MAX_BODY_BYTES = 1024 * 1024;
+
+/** Thrown by `readBodyCapped` when a request body exceeds the cap. */
+export class BodyTooLargeError extends Error {
+    constructor(limit: number) {
+        super(`request body exceeds ${limit} bytes`);
+        this.name = 'BodyTooLargeError';
+    }
+}
+
+/**
+ * Drain `req` into a UTF-8 string, capping total size at `limit`. On overflow
+ * the request is destroyed and the promise rejects with BodyTooLargeError — the
+ * caller should respond 413. Buffers are concatenated (not string-appended) so a
+ * multi-byte UTF-8 sequence split across chunks decodes correctly. (#22)
+ */
+export function readBodyCapped(req: IncomingMessage, limit = MAX_BODY_BYTES): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let size = 0;
+        let settled = false;
+        const chunks: Buffer[] = [];
         req.on('data', (chunk: Buffer) => {
-            body += chunk.toString();
-        });
-        req.on('end', () => {
-            if (body.length === 0) {
-                resolve({});
+            if (settled) return;
+            size += chunk.length;
+            if (size > limit) {
+                settled = true;
+                reject(new BodyTooLargeError(limit));
+                req.destroy();
                 return;
             }
-            try {
-                const parsed = JSON.parse(body);
-                if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-                    resolve(parsed as Record<string, unknown>);
-                    return;
-                }
-            } catch {
-                // fall through
-            }
-            resolve({});
+            chunks.push(chunk);
         });
-        req.on('error', () => resolve({}));
+        req.on('end', () => {
+            if (settled) return;
+            settled = true;
+            resolve(Buffer.concat(chunks).toString('utf8'));
+        });
+        req.on('error', (err) => {
+            if (settled) return;
+            settled = true;
+            reject(err);
+        });
     });
+}
+
+/**
+ * Drain `req` and parse a JSON body. Returns `{}` on empty body, parse failure,
+ * non-object payloads (arrays, primitives), or an over-cap/aborted body —
+ * best-effort by design, so callers that need strict validation should layer it
+ * on top of the returned object. Memory is bounded by `readBodyCapped`. (#22)
+ */
+export async function readJsonBody(
+    req: IncomingMessage,
+    limit = MAX_BODY_BYTES,
+): Promise<Record<string, unknown>> {
+    let body: string;
+    try {
+        body = await readBodyCapped(req, limit);
+    } catch {
+        return {}; // overflow / aborted socket → best-effort empty
+    }
+    if (body.length === 0) {
+        return {};
+    }
+    try {
+        const parsed = JSON.parse(body);
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+    } catch {
+        // fall through to {}
+    }
+    return {};
 }

--- a/src/server/mw/ScanMw.ts
+++ b/src/server/mw/ScanMw.ts
@@ -3,6 +3,25 @@ import { parseSubnetInput, type ParsedSubnet, type ParseError } from '../../comm
 import { NetworkScanner } from '../network/NetworkScanner';
 import type { ScanClientMessage, ScanServerMessage } from '../../common/ScanMessage';
 
+// Scan control messages (a small list of subnets) are tiny; cap them so a
+// hostile client cannot drive memory via the JSON.parse below. The WS server's
+// maxPayload bounds the frame, but it is shared with the (large) device streams,
+// so we cap per-message here. (#22)
+const MAX_SCAN_MESSAGE_BYTES = 256 * 1024;
+
+function rawDataByteLength(data: WS.RawData): number {
+    if (Buffer.isBuffer(data)) {
+        return data.length;
+    }
+    if (Array.isArray(data)) {
+        return data.reduce((n, b) => n + b.length, 0);
+    }
+    if (data instanceof ArrayBuffer) {
+        return data.byteLength;
+    }
+    return 0;
+}
+
 export class ScanMw {
     private static scanner: NetworkScanner | null = null;
 
@@ -23,6 +42,10 @@ export class ScanMw {
         }
 
         const onMessage = (data: WS.RawData): void => {
+            if (rawDataByteLength(data) > MAX_SCAN_MESSAGE_BYTES) {
+                ScanMw.send(ws, { type: 'scan.error', reason: 'message too large' });
+                return;
+            }
             let msg: ScanClientMessage;
             try {
                 msg = JSON.parse(data.toString());


### PR DESCRIPTION
Three reachable-now MAJOR findings from the 2026-06-13 review's server-robustness cluster, each landed test-first.

## #22 — request-body size cap (memory DoS)

Every HTTP body reader accumulated `body += chunk.toString()` with no limit, and the scan WS handler parsed an arbitrarily large message. Added `readBodyCapped` + `BodyTooLargeError` + `MAX_BODY_BYTES` (1 MiB) to `api/utils` (destroys the request on overflow); `ConfigApi` / `DeviceDiscoveryApi` route through it and return 413 on overflow (dropping their duplicated `readBody` — clears MINOR #72); `ScanMw` caps each control message at 256 KiB.

## #21 — config-key allowlist + prototype pollution

`Config.updateAppConfig`'s switch default accepted any unknown key, so an authed PATCH could persist arbitrary keys to config.json, and `(merged as any)[key] = value` honoured `__proto__` / `constructor` / `prototype`. Added a `KNOWN_CONFIG_KEYS` allowlist (from `APP_CONFIG_DEFAULTS`) plus an explicit dangerous-key guard; both reject with `ConfigValidationError` (400).

## #23 — one-shot adb shell timeout

`AdbClient.shell` ran an arbitrary `adb shell` with a 10 MiB output cap but no timeout. Routed it through `exec()` with a 30s default (`DEFAULT_TIMEOUT_MS.shell`, overridable), inheriting the output cap, SIGKILL-on-timeout, and typed `AdbExecError`. Streaming commands already use `shellSpawn`, which is unaffected.

## Verification

tsc 0 · vitest 1091 · webpack 0 (+11 tests). Unlabeled, so this merges to `main` without cutting a release.

The remaining MAJOR work starts with #20 (PATH-based binary resolution / Local-Dependencies-Only) — a cross-platform TS + Rust change that will land as its own PR.
