### PR TITLE
Security #20 (TS): resolve OS tools to absolute paths — resolveSystemTool cross-platform + network sites

### DIFF
--- a/src/server/network/MacResolver.ts
+++ b/src/server/network/MacResolver.ts
@@ -6,6 +6,7 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { resolveSystemTool } from '../service/systemTools';
 
 const execFileAsync = promisify(execFile);
 
@@ -16,7 +17,9 @@ export interface MacResolverDeps {
 
 const DEFAULT_DEPS: MacResolverDeps = {
     runCommand: async (bin, args) => {
-        const { stdout } = await execFileAsync(bin, args, { timeout: 2000, maxBuffer: 1024 * 1024 });
+        // Resolve the OS tool (arp/ip) to an absolute path so it can't be
+        // hijacked via $PATH / %PATH% (#20).
+        const { stdout } = await execFileAsync(resolveSystemTool(bin), args, { timeout: 2000, maxBuffer: 1024 * 1024 });
         return stdout;
     },
     platform: process.platform,

--- a/src/server/network/SubnetDetector.ts
+++ b/src/server/network/SubnetDetector.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process';
 import * as os from 'os';
 import { promisify } from 'util';
+import { resolveSystemTool } from '../service/systemTools';
 
 const execFileAsync = promisify(execFile);
 
@@ -22,7 +23,9 @@ const DEFAULT_DEPS: DetectorDeps = {
     runCommand: async (cmd: string) => {
         const [bin, ...args] = splitCommand(cmd);
         if (!bin) throw new Error('empty command');
-        const { stdout } = await execFileAsync(bin, args, { timeout: 3000, maxBuffer: 1024 * 1024 });
+        // Resolve the OS tool (ip/route) to an absolute path so it can't be
+        // hijacked via $PATH / %PATH% (#20).
+        const { stdout } = await execFileAsync(resolveSystemTool(bin), args, { timeout: 3000, maxBuffer: 1024 * 1024 });
         return stdout;
     },
     platform: process.platform,

--- a/src/server/service/systemTools.test.ts
+++ b/src/server/service/systemTools.test.ts
@@ -1,25 +1,44 @@
 import { describe, it, expect } from 'vitest';
 import { resolveSystemTool, buildDetachedSpawn } from './systemTools';
 
-describe('resolveSystemTool', () => {
+describe('resolveSystemTool — POSIX', () => {
     it('returns the first candidate that exists', () => {
         const exists = (p: string) => p === '/usr/bin/systemctl';
-        expect(resolveSystemTool('systemctl', exists)).toBe('/usr/bin/systemctl');
+        expect(resolveSystemTool('systemctl', exists, 'linux')).toBe('/usr/bin/systemctl');
     });
 
     it('prefers /usr/bin over /bin when both exist', () => {
         const exists = (p: string) => p === '/usr/bin/pkexec' || p === '/bin/pkexec';
-        expect(resolveSystemTool('pkexec', exists)).toBe('/usr/bin/pkexec');
+        expect(resolveSystemTool('pkexec', exists, 'linux')).toBe('/usr/bin/pkexec');
     });
 
     it('checks sbin locations for admin tools (semanage/restorecon)', () => {
         const exists = (p: string) => p === '/usr/sbin/semanage';
-        expect(resolveSystemTool('semanage', exists)).toBe('/usr/sbin/semanage');
+        expect(resolveSystemTool('semanage', exists, 'linux')).toBe('/usr/sbin/semanage');
     });
 
     it('falls back to the bare name when no absolute path exists', () => {
         const exists = (_p: string) => false;
-        expect(resolveSystemTool('systemctl', exists)).toBe('systemctl');
+        expect(resolveSystemTool('systemctl', exists, 'linux')).toBe('systemctl');
+    });
+});
+
+describe('resolveSystemTool — Windows', () => {
+    it('resolves OS tools under System32 (PATH-hijack defense, #20)', () => {
+        const exists = (p: string) => p.toLowerCase().endsWith('system32\\taskkill.exe');
+        const resolved = resolveSystemTool('taskkill', exists, 'win32');
+        expect(resolved.toLowerCase()).toContain('system32');
+        expect(resolved.toLowerCase().endsWith('taskkill.exe')).toBe(true);
+    });
+
+    it('appends .exe when probing a bare Windows tool name', () => {
+        const seen: string[] = [];
+        resolveSystemTool('icacls', (p) => { seen.push(p); return false; }, 'win32');
+        expect(seen.some((p) => p.toLowerCase().endsWith('system32\\icacls.exe'))).toBe(true);
+    });
+
+    it('falls back to the bare tool name when absent', () => {
+        expect(resolveSystemTool('arp', () => false, 'win32')).toBe('arp');
     });
 });
 

--- a/src/server/service/systemTools.ts
+++ b/src/server/service/systemTools.ts
@@ -1,21 +1,39 @@
 /**
- * Resolve an OS tool to its absolute path, scanning the canonical bin/sbin
- * locations in priority order. Closes the PATH-hijack surface required by the
- * Local-Dependencies-Only rule: we never invoke systemctl/pkexec/etc. by bare
- * name (which would resolve via $PATH). Falls back to the bare name only when
- * no absolute candidate exists, so the failure surfaces as a clear ENOENT
+ * Resolve an OS tool to its absolute path, scanning the canonical system
+ * locations in priority order (POSIX: /usr/bin,/bin,/usr/sbin,/sbin; Windows:
+ * %SystemRoot%\System32). Closes the PATH-hijack surface flagged by review #20
+ * and required by the Local-Dependencies-Only rule: OS tools
+ * (systemctl/pkexec/taskkill/icacls/ip/arp/route/…) are never invoked by bare
+ * name, which would resolve via $PATH / %PATH%. Falls back to the bare name only
+ * when no absolute candidate exists, so the failure surfaces as a clear ENOENT
  * rather than a silent miss.
  */
 import * as fs from 'node:fs';
 
-/** Search order: user bins first (/usr/bin, /bin), then admin bins (/usr/sbin, /sbin). */
-const SEARCH_DIRS = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'] as const;
+/** POSIX search order: user bins first (/usr/bin, /bin), then admin bins (/usr/sbin, /sbin). */
+const POSIX_SEARCH_DIRS = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'] as const;
+
+/** Windows OS tools (taskkill, icacls, arp, route, …) live under %SystemRoot%\System32. */
+function windowsSystemDirs(): string[] {
+    const root = process.env['SystemRoot'] || process.env['windir'] || 'C:\\Windows';
+    return [`${root}\\System32`, root];
+}
 
 export function resolveSystemTool(
     tool: string,
     exists: (p: string) => boolean = fs.existsSync,
+    platform: NodeJS.Platform = process.platform,
 ): string {
-    for (const dir of SEARCH_DIRS) {
+    if (platform === 'win32') {
+        // OS tools live in System32; append .exe if the caller passed a bare name.
+        const exe = /\.(exe|cmd|bat)$/i.test(tool) ? tool : `${tool}.exe`;
+        for (const dir of windowsSystemDirs()) {
+            const candidate = `${dir}\\${exe}`;
+            if (exists(candidate)) return candidate;
+        }
+        return tool;
+    }
+    for (const dir of POSIX_SEARCH_DIRS) {
         const candidate = `${dir}/${tool}`;
         if (exists(candidate)) return candidate;
     }


### PR DESCRIPTION
The TypeScript portion of review finding #20 (PATH-based binary resolution / Local-Dependencies-Only).

`resolveSystemTool` resolved OS tools to absolute paths on **Linux only** (/usr/bin,/bin,/usr/sbin,/sbin) with a bare-name fallback; `MacResolver` (arp/ip) and `SubnetDetector` (ip/route) called **bare names directly**, bypassing it. So on Windows — and on those bypass paths everywhere — an OS tool could be resolved via `$PATH` / `%PATH%` (a hijack surface).

- `resolveSystemTool` is now platform-aware: Windows resolves under `%SystemRoot%\System32` (appending `.exe`); POSIX is unchanged. The bare-name fallback (clear ENOENT rather than a silent miss) is retained.
- `MacResolver` and `SubnetDetector` route their default command runners through `resolveSystemTool`, so `ip` / `arp` / `route` resolve to an absolute path.

## Verification

tsc 0 · vitest 1094 · webpack 0 (+3 Windows resolver tests; the existing POSIX tests are pinned to `platform: 'linux'` so they stay deterministic on the Windows CI leg).

## Remaining for #20

The launcher's **Rust** `taskkill` / `icacls` calls (bare names via `elevated_runner::silent_command`) still resolve via `%PATH%`. A follow-up will add a System32-resolving helper (`silent_os_tool`) and route those sites through it — it needs careful cfg-gating + native `cargo` + `cross` verification, so it lands separately. Tracked in the project breadcrumb.
