### PR TITLE
Security #20 (Rust): resolve launcher OS tools to absolute System32 paths — taskkill/icacls (no %PATH%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The configuration endpoint rejects unknown and prototype-polluting keys.** A `PATCH /api/config` may only set known settings; arbitrary keys (and `__proto__` / `constructor` / `prototype`) are refused instead of being persisted.
 - **Request bodies are size-capped.** Oversized HTTP request bodies and scan messages are dropped instead of buffered without limit, removing an unauthenticated memory-exhaustion path.
 - **One-shot `adb shell` commands now run under a timeout.** A device command that never returns can no longer pin the server indefinitely.
-- **Network helper tools resolve to absolute system paths instead of via `PATH`.** The OS commands used for LAN/MAC discovery (`ip`, `arp`, `route`) resolve under the canonical system directories rather than the search path, closing a binary-hijack surface (the underlying tool resolver is now cross-platform; the remaining launcher utilities follow).
+- **OS helper tools resolve to absolute system paths instead of via `PATH`.** The system commands the app shells out to — `ip`/`arp`/`route` for LAN and MAC discovery, and the Windows launcher's own `taskkill`/`icacls` service utilities — now resolve under their canonical system directories (`%SystemRoot%\System32` on Windows, `/usr/bin` and friends on POSIX) rather than the executable search path, closing a binary-hijack surface.
 
 ## [0.1.30-beta.65] - 2026-06-12
 

--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -418,7 +418,7 @@ fn uninstall_service(args: &UninstallServiceArgs) -> ElevatedResult {
     // current session. Best-effort — no tray process means no kill,
     // not an error.
     log::info("uninstall-service: invoking taskkill /F /IM ws-scrcpy-web-tray.exe");
-    match silent_command("taskkill")
+    match silent_os_tool("taskkill")
         .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
         .output()
     {
@@ -470,6 +470,42 @@ pub(crate) fn silent_command(exe: impl AsRef<std::ffi::OsStr>) -> Command {
 #[cfg(not(windows))]
 pub(crate) fn silent_command(exe: impl AsRef<std::ffi::OsStr>) -> Command {
     Command::new(exe)
+}
+
+/// Build the absolute path of an OS-provided Windows tool under
+/// `<system_root>\System32` (with a `.exe` suffix). Pure core of
+/// `system32_tool`, split out so it is unit-testable without reading the
+/// environment.
+#[cfg(windows)]
+fn system32_path(system_root: &str, name: &str) -> String {
+    format!(r"{system_root}\System32\{name}.exe")
+}
+
+/// Resolve an OS-provided Windows tool (`taskkill`, `icacls` — never an app
+/// dependency, which lives under the local deps folder) to its absolute
+/// `%SystemRoot%\System32` path. Keys off `%SystemRoot%` like the TS-side
+/// `resolveSystemTool`, falling back to `C:\Windows`.
+#[cfg(windows)]
+fn system32_tool(name: &str) -> String {
+    let root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+    system32_path(&root, name)
+}
+
+/// `silent_command` for an OS-provided tool, resolved to an absolute path on
+/// Windows so it cannot be hijacked via `%PATH%` (review #20 /
+/// Local-Dependencies-Only). Cross-platform: non-Windows callers
+/// (`uninstall_service`, `on_uninstall`) compile under `cross`, so the
+/// bare-name fallback exists only to keep those paths compiling — `taskkill` /
+/// `icacls` are Windows-only at run time.
+pub(crate) fn silent_os_tool(name: &str) -> Command {
+    #[cfg(windows)]
+    {
+        silent_command(system32_tool(name))
+    }
+    #[cfg(not(windows))]
+    {
+        silent_command(name)
+    }
 }
 
 fn run_capture(exe: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Result<CapturedOutput, String> {
@@ -719,6 +755,24 @@ mod tests {
         let dir = tempdir().unwrap();
         let r = write_post_stop_bat(dir.path(), "WsScrcpyWeb", "C:/app/servy-cli.exe", "C:/app/launcher.exe");
         assert!(r.is_ok());
+    }
+
+    // OS tools (taskkill/icacls) must resolve under <SystemRoot>\System32 with
+    // a .exe suffix — never via %PATH% (#20 / Local-Dependencies-Only). Pure
+    // core split out from the env-reading `system32_tool` so it is testable.
+    #[cfg(windows)]
+    #[test]
+    fn system32_path_builds_absolute_system32_path() {
+        assert_eq!(
+            system32_path(r"C:\Windows", "taskkill"),
+            r"C:\Windows\System32\taskkill.exe"
+        );
+        // Honors a non-C: SystemRoot — the reason we key off %SystemRoot%
+        // rather than hardcoding C:\Windows.
+        assert_eq!(
+            system32_path(r"D:\Win", "icacls"),
+            r"D:\Win\System32\icacls.exe"
+        );
     }
 
     #[test]

--- a/launcher/src/hooks.rs
+++ b/launcher/src/hooks.rs
@@ -229,7 +229,7 @@ fn grant_data_root_acl(data_root: &Path) {
     // /C = continue on per-file errors (defensive).
     // /Q = suppress success spam.
     let target = data_root.as_os_str();
-    let result = crate::elevated_runner::silent_command("icacls")
+    let result = crate::elevated_runner::silent_os_tool("icacls")
         .arg(target)
         .args(["/grant", "*S-1-5-11:(OI)(CI)M", "/T", "/C", "/Q"])
         // Suppress icacls's "Successfully processed N files" chatter —
@@ -277,7 +277,7 @@ fn grant_data_root_acl(_data_root: &Path) {
 #[cfg(windows)]
 fn grant_install_root_acl(install_root: &Path) {
     let target = install_root.as_os_str();
-    let result = crate::elevated_runner::silent_command("icacls")
+    let result = crate::elevated_runner::silent_os_tool("icacls")
         .arg(target)
         .args(["/grant", "*S-1-5-11:(OI)(CI)M", "/T", "/C", "/Q"])
         .stdout(std::process::Stdio::null())
@@ -432,7 +432,7 @@ fn on_uninstall(install_root: &Path, data_root: &Path) -> i32 {
     //     renamed file).
     //   - leaves an HKCU\...\Run\WsScrcpyWebTray entry pointing at a
     //     non-existent path, which is benign on next login but messy.
-    let _ = crate::elevated_runner::silent_command("taskkill")
+    let _ = crate::elevated_runner::silent_os_tool("taskkill")
         .args(["/F", "/IM", "ws-scrcpy-web-tray.exe"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/launcher/src/tray_supervisor.rs
+++ b/launcher/src/tray_supervisor.rs
@@ -78,7 +78,7 @@ pub(crate) fn reap_tray_on_terminal_exit(data_root: &Path) {
         return;
     }
     log::info("tray-supervisor: terminal exit; reaping tray helper");
-    let _ = crate::elevated_runner::silent_command("taskkill")
+    let _ = crate::elevated_runner::silent_os_tool("taskkill")
         .args(["/F", "/IM", TRAY_PROCESS_NAME])
         .output();
 }
@@ -170,7 +170,7 @@ fn tray_supervisor_loop(
                     if persisted_mode { "service" } else { "local" },
                     if cfg_install_mode { "service" } else { "local" },
                 ));
-                let _ = crate::elevated_runner::silent_command("taskkill")
+                let _ = crate::elevated_runner::silent_os_tool("taskkill")
                     .args(["/F", "/IM", TRAY_PROCESS_NAME])
                     .output();
             }


### PR DESCRIPTION
Closes the Rust half of security review finding **#20** (PATH-based binary resolution / Local-Dependencies-Only). The TS half — `ip`/`arp`/`route` plus the cross-platform `resolveSystemTool` — landed in #371; this finishes #20.

## What

The Rust launcher invoked `taskkill` and `icacls` by **bare name** at six sites (`elevated_runner.rs`, `hooks.rs`, `tray_supervisor.rs`), so they resolved through `%PATH%` — a binary-hijack surface and a Local-Dependencies-Only gap.

- New `silent_os_tool(name)` in `elevated_runner`: on Windows it resolves the tool under `%SystemRoot%\System32` (via `system32_tool` → `system32_path`, falling back to `C:\Windows`), mirroring the TS `resolveSystemTool`; on non-Windows it falls back to the bare name.
- All six `taskkill`/`icacls` sites now route through it. The absolute-path callers (the detached tray spawn, the servy-cli path) stay on `silent_command`, unchanged.

## Why the helper is cross-platform

`uninstall_service` and `on_uninstall` are not `#[cfg(windows)]` — they compile and unit-test under `cross`. A Windows-only helper would break the Linux build with a missing symbol, so `silent_os_tool` is cross-platform with a bare-name fallback, while `system32_tool`/`system32_path` stay `#[cfg(windows)]` (referenced only from the cfg-gated branch, so no Linux dead-code warning under `-D warnings`).

## Verification

- native `cargo test`: 122 + 1
- native `cargo clippy --all-targets -- -D warnings`: clean
- `cross x86_64-unknown-linux-gnu` clippy `-D warnings`: clean (the cfg-gating check)
- `cross x86_64-unknown-linux-gnu test`: 128 + 1

Unlabeled → no release; rides the next labeled beta.
