### PR TITLE
Security #24: static handler 404s missing assets + nosniff/SAMEORIGIN headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Request bodies are size-capped.** Oversized HTTP request bodies and scan messages are dropped instead of buffered without limit, removing an unauthenticated memory-exhaustion path.
 - **One-shot `adb shell` commands now run under a timeout.** A device command that never returns can no longer pin the server indefinitely.
 - **OS helper tools resolve to absolute system paths instead of via `PATH`.** The system commands the app shells out to — `ip`/`arp`/`route` for LAN and MAC discovery, and the Windows launcher's own `taskkill`/`icacls` service utilities — now resolve under their canonical system directories (`%SystemRoot%\System32` on Windows, `/usr/bin` and friends on POSIX) rather than the executable search path, closing a binary-hijack surface.
+- **The web server returns a proper `404` for missing files and sends anti-sniffing and anti-clickjacking headers.** A request for a path that doesn't exist used to return the app's HTML shell with `200 OK`; now only in-app route navigations fall back to the shell, while a missing asset (or an unknown API path) gets a `404`. Every static response also carries `X-Content-Type-Options: nosniff` (preventing MIME-sniffing) and `X-Frame-Options: SAMEORIGIN` (blocking cross-origin framing, while still allowing the documented same-origin embedding).
 
 ## [0.1.30-beta.65] - 2026-06-12
 

--- a/src/server/StaticFileServer.ts
+++ b/src/server/StaticFileServer.ts
@@ -17,6 +17,25 @@ const MIME_TYPES: Record<string, string> = {
     '.map': 'application/json',
 };
 
+// Security headers applied to every static response. `nosniff` stops the
+// browser MIME-sniffing a response (so a 404 or a wrong-typed asset can't be
+// reinterpreted as script); `SAMEORIGIN` blocks cross-origin framing
+// (clickjacking) while still allowing the same-origin iframe embedding the app
+// documents. (#24)
+const SECURITY_HEADERS = {
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'SAMEORIGIN',
+} as const;
+
+// A missing path falls back to the SPA shell only for a navigation: an
+// HTML-accepting request for an extensionless (route-like) path. Asset requests
+// (those with a file extension) and non-HTML requests (e.g. an `/api/*` XHR)
+// get a 404 instead of a 200 + index.html, so a missing asset is no longer
+// served as the HTML shell. (#24)
+export function isSpaNavigation(urlPath: string, accept: string | undefined): boolean {
+    return (accept ?? '').includes('text/html') && path.extname(urlPath) === '';
+}
+
 export function createStaticHandler(publicDir: string): (req: IncomingMessage, res: ServerResponse) => void {
     return (req, res) => {
         const urlPath = new URL(req.url || '/', `http://${req.headers.host}`).pathname;
@@ -25,22 +44,28 @@ export function createStaticHandler(publicDir: string): (req: IncomingMessage, r
         // Normalize and prevent directory traversal
         filePath = path.resolve(filePath);
         if (!filePath.startsWith(path.resolve(publicDir))) {
-            res.writeHead(403);
+            res.writeHead(403, { 'Content-Type': 'text/plain', ...SECURITY_HEADERS });
             res.end('Forbidden');
             return;
         }
 
         fs.stat(filePath, (err, stats) => {
             if (err || !stats.isFile()) {
-                // Serve index.html as fallback for SPA routing
-                const indexPath = path.join(publicDir, 'index.html');
-                res.writeHead(200, { 'Content-Type': 'text/html' });
-                fs.createReadStream(indexPath).pipe(res);
+                if (isSpaNavigation(urlPath, req.headers.accept)) {
+                    // Navigation to a client-side route → serve the SPA shell.
+                    const indexPath = path.join(publicDir, 'index.html');
+                    res.writeHead(200, { 'Content-Type': 'text/html', ...SECURITY_HEADERS });
+                    fs.createReadStream(indexPath).pipe(res);
+                } else {
+                    // Missing asset (or a non-navigation request) → 404, not the shell.
+                    res.writeHead(404, { 'Content-Type': 'text/plain', ...SECURITY_HEADERS });
+                    res.end('Not Found');
+                }
                 return;
             }
             const ext = path.extname(filePath).toLowerCase();
             const contentType = MIME_TYPES[ext] || 'application/octet-stream';
-            res.writeHead(200, { 'Content-Type': contentType });
+            res.writeHead(200, { 'Content-Type': contentType, ...SECURITY_HEADERS });
             fs.createReadStream(filePath).pipe(res);
         });
     };

--- a/src/server/__tests__/StaticFileServer.test.ts
+++ b/src/server/__tests__/StaticFileServer.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { isSpaNavigation } from '../StaticFileServer';
+
+// #24 — a missing path falls back to the SPA shell ONLY for a navigation: an
+// HTML-accepting request for an extensionless (route-like) path. Asset requests
+// and non-HTML requests (e.g. /api/* XHRs) get a 404 instead of a 200 + index.
+describe('isSpaNavigation', () => {
+    it('treats an HTML-accepting request for an extensionless route as a navigation', () => {
+        expect(isSpaNavigation('/devices', 'text/html,application/xhtml+xml,*/*')).toBe(true);
+        expect(isSpaNavigation('/', 'text/html')).toBe(true);
+    });
+
+    it('treats a request with a file extension as a non-navigation (asset)', () => {
+        expect(isSpaNavigation('/app.js', 'text/html')).toBe(false);
+        expect(isSpaNavigation('/img/logo.png', 'text/html')).toBe(false);
+    });
+
+    it('treats a non-HTML request as a non-navigation (e.g. an /api XHR)', () => {
+        expect(isSpaNavigation('/api/devices', '*/*')).toBe(false);
+        expect(isSpaNavigation('/api/devices', undefined)).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes review finding **#24** (MAJOR).

## What

`StaticFileServer` returned `index.html` with **`200`** for every miss — a missing `/app.js`, image, or unknown `/api/*` path was all served as the HTML shell — and no response set anti-sniffing/anti-framing headers.

- **SPA fallback only for navigations.** A new pure `isSpaNavigation(urlPath, accept)` returns true only for an HTML-accepting request to an extensionless (route-like) path. A missing **asset** (has an extension) or a non-HTML request (e.g. an `/api/*` XHR) now gets a **`404`** instead of the shell.
- **Security headers on every response** (200/403/404): `X-Content-Type-Options: nosniff` and `X-Frame-Options: SAMEORIGIN`. SAMEORIGIN blocks cross-origin framing (clickjacking) while still permitting the documented *same-origin* iframe embedding.

## Verification

- `tsc --noEmit`: 0
- vitest: 1097 (3 new in `StaticFileServer.test.ts`, TDD red→green)
- webpack `build:dev`: compiled clean

Unlabeled -> no release; rides the next labeled beta.

Note: the `Host`-header URL base + possible double-`writeHead` on the 500 path (review **#74**, MINOR) are out of scope here — separate finding.
