### PR TITLE
perf(server): make service-layer I/O non-blocking on the event loop (review #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Service-management work no longer blocks the server's event loop.** The Windows and Linux service status checks, install/uninstall, the wait for an elevated helper's result, and the libfuse2 probe used synchronous (blocking) child-process and filesystem calls — which could briefly stall every other in-flight request, including live device-stream WebSockets, while they ran. They are now asynchronous, so a routine status poll or a service install stays out of the way of streaming and the rest of the API.
+
 ### Removed
 
 - **Removed the dead `resolveActiveSessionId` helper** (`src/server/util/active-session.ts` and its test). It was an orphan from the abandoned "Theory D" uninstall-handoff — its only caller was deleted in `0.1.25-beta.51` — so removing it has no behavioral effect, and it clears a latent `shell: true` process-spawn path the security review flagged. The launcher's `--print-active-session` capability is unaffected.
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The device shell no longer inherits the server's full environment.** The interactive device shell (`adb shell`) is now started with a minimal, allowlisted environment — OS, adb, and terminal essentials only — instead of a copy of the entire server `process.env`, so secrets or sensitive configuration in the server's environment are not exposed to the shell process.
 - **Resume-handoff tokens are written atomically and restricted to the owner.** The single-use tokens that resume a privileged install/uninstall after a fresh local instance starts are now stored in an owner-only directory (`0700`) as owner-only files (`0600`), written via a temp file + atomic rename — so they aren't readable by other local users and a crash can't leave a half-written token behind.
 - **The Linux user-service binary is verified and staged safely.** When a user-scope service needs a stable `ExecStart`, the machine-wide `/opt` binary is reused only after `lstat` confirms it's a root-owned regular file (not an attacker-repointable symlink); otherwise the app stages its own copy via a temp file + atomic rename, so a concurrent service start never sees a partial or briefly-non-executable binary.
+- **The Windows service-status check resolves `sc` to its absolute System32 path.** The read-only `sc query` that polls service state ran by bare name (resolved via `%PATH%`); it now resolves under `%SystemRoot%\System32` like the app's other OS tools, closing the same binary-hijack surface (review #20) on the routine status-poll path.
 
 ## [0.1.30-beta.65] - 2026-06-12
 

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -55,8 +55,8 @@ export class DependencyManager {
         }
     }
 
-    public getAll(): DependencyInfo[] {
-        const launcherAvail = launcherIsAvailable();
+    public async getAll(): Promise<DependencyInfo[]> {
+        const launcherAvail = await launcherIsAvailable();
         // In-place mutation: callers (incl. getByName) hold references to state
         // entries and mutate them; spread copies would orphan those mutations.
         for (const info of this.state.values()) {
@@ -133,7 +133,7 @@ export class DependencyManager {
         if (!def || !info) {
             return { success: false, errorMessage: `Unknown dependency: ${name}`, requiresRestart: false };
         }
-        if (def.requiresLauncher && !launcherIsAvailable()) {
+        if (def.requiresLauncher && !(await launcherIsAvailable())) {
             return {
                 success: false,
                 reason: 'launcher-required',
@@ -224,7 +224,7 @@ export class DependencyManager {
             log.warn(`seed-promote scrcpy-server failed: ${(err as Error).message}`);
         }
 
-        const launcherAvail = launcherIsAvailable();
+        const launcherAvail = await launcherIsAvailable();
         for (const info of this.state.values()) {
             if (info.installedVersion === null && info.latestVersion !== null) {
                 const def = this.definitions.find((d) => d.name === info.name);
@@ -474,7 +474,7 @@ export class DependencyManager {
         // The launcher binary is SHA-pinned-to-release and ships in
         // `current/` alongside this Node process, so no external binary
         // discovery is needed.
-        if (!launcherIsAvailable()) {
+        if (!(await launcherIsAvailable())) {
             throw new Error(
                 `extractZip requires the packaged launcher binary at ${resolveLauncherPath()}. ` +
                     `Dev mode should populate dependencies/ via scripts/fetch-node.mjs (Node) or ` +

--- a/src/server/__tests__/ServyClient.test.ts
+++ b/src/server/__tests__/ServyClient.test.ts
@@ -5,30 +5,39 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // elevated helper. Status still uses sc.exe (read-only, no admin) so we
 // keep an execFileSync mock for that path.
 const runElevatedMock = vi.fn();
-const launcherIsAvailableMock = vi.fn();
 vi.mock('../service/elevatedRunner', () => ({
     runElevated: (...args: unknown[]) => runElevatedMock(...args),
-    launcherIsAvailable: () => launcherIsAvailableMock(),
     resolveLauncherPath: () => 'C:\\fake\\install\\ws-scrcpy-web-launcher.exe',
 }));
 
-const execFileSyncMock = vi.fn();
+// status() now uses execFileAsync (promisify(execFile)) — #32. Mock execFile
+// callback-style; promisify resolves with the 2nd callback arg ({ stdout, stderr })
+// or rejects with the error when one is passed.
+const execFileMock = vi.fn(
+    (
+        _cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => cb(null, { stdout: '', stderr: '' }),
+);
 vi.mock('node:child_process', () => ({
-    execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+    execFile: (...args: unknown[]) => execFileMock(...(args as Parameters<typeof execFileMock>)),
 }));
 
-const existsSyncMock = vi.fn();
-vi.mock('node:fs', async () => {
-    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
-    return {
-        ...actual,
-        existsSync: (...args: unknown[]) => existsSyncMock(...args),
-        default: {
-            ...actual,
-            existsSync: (...args: unknown[]) => existsSyncMock(...args),
-        },
-    };
-});
+// existsSync → fileExists (async, #32). Mock the helper directly so existence
+// is a resolved boolean, mirroring the prior existsSync mock's predicate.
+const fileExistsMock = vi.fn();
+vi.mock('../util/fsExists', () => ({
+    fileExists: (...args: unknown[]) => fileExistsMock(...args),
+}));
+
+// resolveSystemTool resolves OS tools (incl. Windows `sc`) to an absolute
+// System32 path; stub it deterministically so the status assertion is
+// host-independent and proves status() no longer uses a bare PATH name.
+vi.mock('../service/systemTools', () => ({
+    resolveSystemTool: (t: string) => `RESOLVED:${t}`,
+}));
 
 import { parseScQueryStatus, ServiceInstallError, ServyClient } from '../service/ServyClient';
 
@@ -36,13 +45,12 @@ describe('ServyClient', () => {
     beforeEach(() => {
         runElevatedMock.mockReset();
         runElevatedMock.mockResolvedValue({ ok: true, exitCode: 0, stdout: '', stderr: '' });
-        launcherIsAvailableMock.mockReset();
-        launcherIsAvailableMock.mockReturnValue(true);
-        execFileSyncMock.mockReset();
-        existsSyncMock.mockReset();
+        execFileMock.mockReset();
+        execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, { stdout: '', stderr: '' }));
+        fileExistsMock.mockReset();
         // Default: launcher present, tray helper absent.
-        existsSyncMock.mockImplementation((p: unknown) =>
-            String(p).endsWith('ws-scrcpy-web-launcher.exe'),
+        fileExistsMock.mockImplementation((p: unknown) =>
+            Promise.resolve(String(p).endsWith('ws-scrcpy-web-launcher.exe')),
         );
     });
 
@@ -81,9 +89,9 @@ describe('ServyClient', () => {
             envVars: 'DEPS_PATH=C:\\deps;FOO=bar',
             logPath: 'C:\\app\\service.log',
         });
-        // No execFileSync calls — install no longer touches servy-cli or
+        // No execFile calls — install no longer touches servy-cli or
         // reg.exe directly; both go through the elevated helper.
-        expect(execFileSyncMock).not.toHaveBeenCalled();
+        expect(execFileMock).not.toHaveBeenCalled();
     });
 
     it('install throws ServiceInstallError when runElevated returns ok=false', async () => {
@@ -111,7 +119,7 @@ describe('ServyClient', () => {
     });
 
     it('install throws when packaged launcher is absent (dev runs)', async () => {
-        existsSyncMock.mockReturnValue(false);
+        fileExistsMock.mockResolvedValue(false);
         const client = new ServyClient('servy.exe');
         await expect(
             client.install({
@@ -130,11 +138,13 @@ describe('ServyClient', () => {
     });
 
     it('install passes trayHelperPath when the tray exe exists in install root', async () => {
-        existsSyncMock.mockImplementation((p: unknown) => {
+        fileExistsMock.mockImplementation((p: unknown) => {
             const s = String(p);
             // launcher AND tray helper both present
-            return s.endsWith('ws-scrcpy-web-launcher.exe') ||
-                s.endsWith('ws-scrcpy-web-tray.exe');
+            return Promise.resolve(
+                s.endsWith('ws-scrcpy-web-launcher.exe') ||
+                    s.endsWith('ws-scrcpy-web-tray.exe'),
+            );
         });
         const client = new ServyClient('servy.exe');
         await client.install({
@@ -192,49 +202,54 @@ describe('ServyClient', () => {
     });
 
     it('status uses sc.exe query and parses RUNNING', async () => {
-        execFileSyncMock.mockReturnValue([
+        const out = [
             'SERVICE_NAME: WsScrcpyWeb',
             '        TYPE               : 10  WIN32_OWN_PROCESS',
             '        STATE              : 4  RUNNING',
             '        WIN32_EXIT_CODE    : 0  (0x0)',
-        ].join('\r\n'));
+        ].join('\r\n');
+        execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, { stdout: out, stderr: '' }));
         const client = new ServyClient('servy.exe');
         const status = await client.status('WsScrcpyWeb');
         expect(status).toBe('running');
-        const [cmd, args] = execFileSyncMock.mock.calls[0]!;
-        expect(cmd).toBe('sc.exe');
+        const [cmd, args] = execFileMock.mock.calls[0]!;
+        // #20-class fix: 'sc' resolves to an absolute System32 path via
+        // resolveSystemTool, never the bare PATH name (no binary-hijack on the poll).
+        expect(cmd).toBe('RESOLVED:sc');
         expect(args).toEqual(['query', 'WsScrcpyWeb']);
     });
 
     it('status returns stopped for STATE=1 (STOPPED)', async () => {
-        execFileSyncMock.mockReturnValue('STATE              : 1  STOPPED');
+        execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+            cb(null, { stdout: 'STATE              : 1  STOPPED', stderr: '' }),
+        );
         const client = new ServyClient('servy.exe');
         expect(await client.status('WsScrcpyWeb')).toBe('stopped');
     });
 
     it('status returns not-installed when sc.exe exits 1060', async () => {
-        execFileSyncMock.mockImplementation(() => {
-            const err = new Error('Command failed') as NodeJS.ErrnoException & {
-                status: number;
+        execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+            const err = new Error('Command failed') as Error & {
+                code: number;
                 stderr: string;
             };
-            err.status = 1060;
+            err.code = 1060;
             err.stderr = '[SC] EnumQueryServicesStatus:OpenService FAILED 1060:\nThe specified service does not exist as an installed service.';
-            throw err;
+            cb(err, { stdout: '', stderr: '' });
         });
         const client = new ServyClient('servy.exe');
         expect(await client.status('WsScrcpyWeb')).toBe('not-installed');
     });
 
     it('status rethrows other sc.exe errors', async () => {
-        execFileSyncMock.mockImplementation(() => {
-            const err = new Error('Command failed') as NodeJS.ErrnoException & {
-                status: number;
+        execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+            const err = new Error('Command failed') as Error & {
+                code: number;
                 stderr: string;
             };
-            err.status = 5;
+            err.code = 5;
             err.stderr = 'Access is denied.';
-            throw err;
+            cb(err, { stdout: '', stderr: '' });
         });
         const client = new ServyClient('servy.exe');
         await expect(client.status('WsScrcpyWeb')).rejects.toThrow(/Access is denied/);

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -78,6 +78,16 @@ vi.mock('node:os', () => ({
     tmpdir: () => '/tmp',
 }));
 
+// resolveSystemTool resolves OS tools (systemctl/loginctl/ldconfig) to an
+// absolute path when they exist on the host — which they DO on the Linux CI
+// runner (e.g. /usr/bin/systemctl) but not on a Windows dev box. Stub it to the
+// bare name so the `c[0] === 'systemctl'` / 'loginctl' assertions below are
+// host-independent (otherwise they pass locally and fail in CI).
+vi.mock('../service/systemTools', async () => {
+    const actual = await vi.importActual<typeof import('../service/systemTools')>('../service/systemTools');
+    return { ...actual, resolveSystemTool: (t: string) => t };
+});
+
 import * as path from 'node:path';
 import { renderUnitFile, SystemdClient, STAGED_SYSTEM_DIR, STAGED_SYSTEM_APPIMAGE } from '../service/SystemdClient';
 import type { ServiceInstallOptions } from '../service/ServiceClient';

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -1,9 +1,12 @@
 /**
  * SystemdClient unit tests (SP3 P4b).
  *
- * Mocks all side-effect calls — execFileSync, fs.{existsSync,writeFileSync,
- * unlinkSync,mkdirSync}, os.{homedir,userInfo}, process.getuid — so tests
- * never touch the real systemd or filesystem.
+ * Mocks all side-effect calls — #32: execFile (callback-style, for the
+ * promisified execFileAsync), fs.promises.{writeFile,unlink,mkdir,copyFile,
+ * chmod,rename,lstat}, the async fileExists helper, and os.{homedir,userInfo}
+ * — so tests never touch the real systemd or filesystem. resolveSystemTool's
+ * fs.existsSync stays real (it resolves OS tools; on a Windows test host the
+ * Linux tools are absent so it returns the bare name the assertions expect).
  *
  * Coverage matrix:
  *   - User-scope install: writes correct unit file path/content, calls
@@ -21,33 +24,50 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 // Hoisted mocks — must be declared before the SystemdClient import so the
-// module receives mocked deps at evaluation time.
-const execFileSyncMock = vi.fn();
-const execFileMock = vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
-    cb(null, { stdout: '', stderr: '' });
-});
+// module receives mocked deps at evaluation time. #32: SystemdClient now uses
+// execFileAsync (promisify(execFile)), fs.promises.*, and the async fileExists
+// helper.
+const execFileMock = vi.fn(
+    (
+        _cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => cb(null, { stdout: '', stderr: '' }),
+);
 vi.mock('node:child_process', () => ({
-    execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
     execFile: (...args: unknown[]) => execFileMock(...(args as Parameters<typeof execFileMock>)),
 }));
 
-const existsSyncMock = vi.fn();
-const writeFileSyncMock = vi.fn();
-const unlinkSyncMock = vi.fn();
-const mkdirSyncMock = vi.fn();
-const copyFileSyncMock = vi.fn();
-const chmodSyncMock = vi.fn();
-const renameSyncMock = vi.fn();
-const lstatSyncMock = vi.fn();
-vi.mock('node:fs', () => ({
-    existsSync: (...args: unknown[]) => existsSyncMock(...args),
-    writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
-    unlinkSync: (...args: unknown[]) => unlinkSyncMock(...args),
-    mkdirSync: (...args: unknown[]) => mkdirSyncMock(...args),
-    copyFileSync: (...args: unknown[]) => copyFileSyncMock(...args),
-    chmodSync: (...args: unknown[]) => chmodSyncMock(...args),
-    renameSync: (...args: unknown[]) => renameSyncMock(...args),
-    lstatSync: (...args: unknown[]) => lstatSyncMock(...args),
+const writeFileMock = vi.fn();
+const unlinkMock = vi.fn();
+const mkdirMock = vi.fn();
+const copyFileMock = vi.fn();
+const chmodMock = vi.fn();
+const renameMock = vi.fn();
+const lstatMock = vi.fn();
+// Keep real fs (existsSync — resolveSystemTool resolves OS tools through it) and
+// override only the fs.promises members SystemdClient writes through (#32).
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const promises = {
+        ...actual.promises,
+        writeFile: (...args: unknown[]) => writeFileMock(...args),
+        unlink: (...args: unknown[]) => unlinkMock(...args),
+        mkdir: (...args: unknown[]) => mkdirMock(...args),
+        copyFile: (...args: unknown[]) => copyFileMock(...args),
+        chmod: (...args: unknown[]) => chmodMock(...args),
+        rename: (...args: unknown[]) => renameMock(...args),
+        lstat: (...args: unknown[]) => lstatMock(...args),
+    };
+    return { ...actual, promises, default: { ...actual, promises } };
+});
+
+// existsSync → fileExists (async, #32). Mock the helper so unit-file / tray /
+// pkg-manager existence is a resolved boolean.
+const fileExistsMock = vi.fn();
+vi.mock('../util/fsExists', () => ({
+    fileExists: (...args: unknown[]) => fileExistsMock(...args),
 }));
 
 const homedirMock = vi.fn(() => '/home/jamie');
@@ -81,21 +101,19 @@ describe('SystemdClient', () => {
     let savedGetuid: typeof process.getuid | undefined;
 
     beforeEach(() => {
-        execFileSyncMock.mockReset();
-        existsSyncMock.mockReset();
-        writeFileSyncMock.mockReset();
-        unlinkSyncMock.mockReset();
-        mkdirSyncMock.mockReset();
-        copyFileSyncMock.mockReset();
-        chmodSyncMock.mockReset();
-        renameSyncMock.mockReset();
-        lstatSyncMock.mockReset().mockImplementation(() => {
-            throw new Error('ENOENT');
-        });
+        execFileMock.mockReset();
+        execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, { stdout: '', stderr: '' }));
+        fileExistsMock.mockReset().mockResolvedValue(false);
+        writeFileMock.mockReset();
+        unlinkMock.mockReset();
+        mkdirMock.mockReset();
+        copyFileMock.mockReset();
+        chmodMock.mockReset();
+        renameMock.mockReset();
+        lstatMock.mockReset().mockRejectedValue(new Error('ENOENT'));
         homedirMock.mockReset().mockReturnValue('/home/jamie');
         userInfoMock.mockReset().mockReturnValue({ username: 'jamie' });
         savedGetuid = process.getuid;
-        execFileSyncMock.mockReturnValue(Buffer.from('', 'utf8'));
     });
 
     afterEach(() => {
@@ -146,7 +164,7 @@ describe('SystemdClient', () => {
 
         it('user scope (no machine-wide install): stages a stable binary under <dataRoot>/bin, points ExecStart there, daemon-reload + enable + loginctl', async () => {
             // No /opt binary and no tray binary on disk → F1 copy branch + F2 skip.
-            existsSyncMock.mockReturnValue(false);
+            fileExistsMock.mockResolvedValue(false);
             const client = new SystemdClient();
             await client.install({ ...baseOpts, scope: 'user' });
 
@@ -156,12 +174,12 @@ describe('SystemdClient', () => {
             const stableBin = '/home/jamie/.local/share/WsScrcpyWeb/bin/WsScrcpyWeb.AppImage';
             // #31 atomic stage: copy to a temp file, chmod +x, then rename into place.
             const tmpArg = expect.stringContaining(`${stableBin}.tmp-`);
-            expect(copyFileSyncMock).toHaveBeenCalledWith(baseOpts.binPath, tmpArg);
-            expect(chmodSyncMock).toHaveBeenCalledWith(tmpArg, 0o755);
-            expect(renameSyncMock).toHaveBeenCalledWith(tmpArg, stableBin);
+            expect(copyFileMock).toHaveBeenCalledWith(baseOpts.binPath, tmpArg);
+            expect(chmodMock).toHaveBeenCalledWith(tmpArg, 0o755);
+            expect(renameMock).toHaveBeenCalledWith(tmpArg, stableBin);
 
             // Unit file written to ~/.config/systemd/user/WsScrcpyWeb.service ...
-            const unitWrites = writeFileSyncMock.mock.calls.filter((c) =>
+            const unitWrites = writeFileMock.mock.calls.filter((c) =>
                 String(c[0]).endsWith('WsScrcpyWeb.service'),
             );
             expect(unitWrites).toHaveLength(1);
@@ -175,7 +193,7 @@ describe('SystemdClient', () => {
             expect(String(unitWrites[0]![1])).toContain(`ExecStart=${stableBin}`);
 
             // systemctl --user daemon-reload + enable --now
-            const sysCalls = execFileSyncMock.mock.calls.filter((c) => c[0] === 'systemctl');
+            const sysCalls = execFileMock.mock.calls.filter((c) => c[0] === 'systemctl');
             expect(sysCalls).toHaveLength(2);
             expect(sysCalls[0]![1]).toEqual(['--user', 'daemon-reload']);
             // F4: user scope enables but does NOT --now (the handoff helper starts it).
@@ -186,7 +204,7 @@ describe('SystemdClient', () => {
             ]);
 
             // loginctl enable-linger called
-            const loginctlCalls = execFileSyncMock.mock.calls.filter(
+            const loginctlCalls = execFileMock.mock.calls.filter(
                 (c) => c[0] === 'loginctl',
             );
             expect(loginctlCalls).toHaveLength(1);
@@ -194,7 +212,7 @@ describe('SystemdClient', () => {
 
             // F2: NO tray autostart written when no tray binary is found (Linux
             // has no tray — never emit a PATH-reliant bare-name Exec).
-            const desktopWrites = writeFileSyncMock.mock.calls.filter((c) =>
+            const desktopWrites = writeFileMock.mock.calls.filter((c) =>
                 String(c[0]).endsWith('ws-scrcpy-web-tray.desktop'),
             );
             expect(desktopWrites).toHaveLength(0);
@@ -204,18 +222,18 @@ describe('SystemdClient', () => {
             // F1 case A: the stable /opt binary already exists → reuse it (0755, bin_t).
             const optBin = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
             // #31: reuse requires lstat to confirm a safe root-owned regular file.
-            lstatSyncMock.mockImplementation((p: unknown) => {
+            lstatMock.mockImplementation((p: unknown) => {
                 if (String(p).replace(/\\/g, '/') === optBin) {
-                    return { isFile: () => true, uid: 0, mode: 0o755 };
+                    return Promise.resolve({ isFile: () => true, uid: 0, mode: 0o755 });
                 }
-                throw new Error('ENOENT');
+                return Promise.reject(new Error('ENOENT'));
             });
             const client = new SystemdClient();
             await client.install({ ...baseOpts, scope: 'user' });
 
             // No copy — the /opt binary is used directly.
-            expect(copyFileSyncMock).not.toHaveBeenCalled();
-            const unitWrites = writeFileSyncMock.mock.calls.filter((c) =>
+            expect(copyFileMock).not.toHaveBeenCalled();
+            const unitWrites = writeFileMock.mock.calls.filter((c) =>
                 String(c[0]).endsWith('WsScrcpyWeb.service'),
             );
             expect(String(unitWrites[0]![1])).toContain(`ExecStart=${optBin}`);
@@ -228,11 +246,11 @@ describe('SystemdClient', () => {
             // Exec is its absolute path; the /opt binary is absent so install
             // still completes via the F1 copy branch.
             const trayCandidate = path.join(process.cwd(), 'ws-scrcpy-web-tray');
-            existsSyncMock.mockImplementation((p: string) => p === trayCandidate);
+            fileExistsMock.mockImplementation((p: unknown) => Promise.resolve(p === trayCandidate));
             const client = new SystemdClient();
             await client.install({ ...baseOpts, scope: 'user' });
 
-            const desktopWrites = writeFileSyncMock.mock.calls.filter((c) =>
+            const desktopWrites = writeFileMock.mock.calls.filter((c) =>
                 String(c[0]).endsWith('ws-scrcpy-web-tray.desktop'),
             );
             expect(desktopWrites).toHaveLength(1);
@@ -243,10 +261,13 @@ describe('SystemdClient', () => {
         });
 
         it('user scope: still succeeds when loginctl throws', async () => {
-            existsSyncMock.mockReturnValue(false);
-            execFileSyncMock.mockImplementation((cmd: string) => {
-                if (cmd === 'loginctl') throw new Error('loginctl not found');
-                return Buffer.from('');
+            fileExistsMock.mockResolvedValue(false);
+            execFileMock.mockImplementation((cmd, _args, _opts, cb) => {
+                if (cmd === 'loginctl') {
+                    cb(new Error('loginctl not found'), { stdout: '', stderr: '' });
+                    return;
+                }
+                cb(null, { stdout: '', stderr: '' });
             });
             const client = new SystemdClient();
             await expect(client.install({ ...baseOpts, scope: 'user' })).resolves.toBeUndefined();
@@ -258,8 +279,8 @@ describe('SystemdClient', () => {
                 /no longer handles system scope/,
             );
             // No side-effects: no file writes, no systemctl calls.
-            expect(writeFileSyncMock).not.toHaveBeenCalled();
-            expect(execFileSyncMock).not.toHaveBeenCalled();
+            expect(writeFileMock).not.toHaveBeenCalled();
+            expect(execFileMock).not.toHaveBeenCalled();
         });
     });
 
@@ -270,19 +291,19 @@ describe('SystemdClient', () => {
         it("returns 'user' when the user-scope unit file exists", async () => {
             const client = new SystemdClient();
             const userPath = client.userUnitPath('WsScrcpyWeb');
-            existsSyncMock.mockImplementation((p: string) => p === userPath);
+            fileExistsMock.mockImplementation((p: unknown) => Promise.resolve(p === userPath));
             expect(await client.getInstalledScope('WsScrcpyWeb')).toBe('user');
         });
 
         it("returns 'system' when only the system-scope unit file exists", async () => {
             const client = new SystemdClient();
             const systemPath = client.systemUnitPath('WsScrcpyWeb');
-            existsSyncMock.mockImplementation((p: string) => p === systemPath);
+            fileExistsMock.mockImplementation((p: unknown) => Promise.resolve(p === systemPath));
             expect(await client.getInstalledScope('WsScrcpyWeb')).toBe('system');
         });
 
         it('returns null when no unit file exists', async () => {
-            existsSyncMock.mockReturnValue(false);
+            fileExistsMock.mockResolvedValue(false);
             const client = new SystemdClient();
             expect(await client.getInstalledScope('WsScrcpyWeb')).toBeNull();
         });
@@ -290,20 +311,20 @@ describe('SystemdClient', () => {
 
     describe('status', () => {
         it("returns 'not-installed' when neither unit file exists", async () => {
-            existsSyncMock.mockReturnValue(false);
+            fileExistsMock.mockResolvedValue(false);
             const client = new SystemdClient();
             await expect(client.status('WsScrcpyWeb')).resolves.toBe('not-installed');
-            expect(execFileSyncMock).not.toHaveBeenCalled();
+            expect(execFileMock).not.toHaveBeenCalled();
         });
 
         it("returns 'running' when is-active outputs 'active'", async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).replace(/\\/g, '/').includes('/.config/systemd/user/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').includes('/.config/systemd/user/')),
             );
-            execFileSyncMock.mockReturnValue('active\n');
+            execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, { stdout: 'active\n', stderr: '' }));
             const client = new SystemdClient();
             await expect(client.status('WsScrcpyWeb')).resolves.toBe('running');
-            expect(execFileSyncMock.mock.calls[0]![1]).toEqual([
+            expect(execFileMock.mock.calls[0]![1]).toEqual([
                 '--user',
                 'is-active',
                 'WsScrcpyWeb.service',
@@ -311,34 +332,31 @@ describe('SystemdClient', () => {
         });
 
         it("returns 'stopped' when is-active outputs 'inactive'", async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).replace(/\\/g, '/').includes('/.config/systemd/user/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').includes('/.config/systemd/user/')),
             );
-            execFileSyncMock.mockReturnValue('inactive\n');
+            execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, { stdout: 'inactive\n', stderr: '' }));
             const client = new SystemdClient();
             await expect(client.status('WsScrcpyWeb')).resolves.toBe('stopped');
         });
 
         it("returns 'stopped' when is-active exits non-zero", async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).replace(/\\/g, '/').includes('/.config/systemd/user/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').includes('/.config/systemd/user/')),
             );
-            execFileSyncMock.mockImplementation(() => {
-                throw new Error('exit 3');
-            });
+            execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(new Error('exit 3'), { stdout: '', stderr: '' }));
             const client = new SystemdClient();
             await expect(client.status('WsScrcpyWeb')).resolves.toBe('stopped');
         });
 
         it('uses system scope (no --user flag) when only system unit exists', async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).startsWith('/etc/systemd/system/') ||
-                String(p).replace(/\\/g, '/').startsWith('/etc/systemd/system/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').startsWith('/etc/systemd/system/')),
             );
-            execFileSyncMock.mockReturnValue('active\n');
+            execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, { stdout: 'active\n', stderr: '' }));
             const client = new SystemdClient();
             await expect(client.status('WsScrcpyWeb')).resolves.toBe('running');
-            expect(execFileSyncMock.mock.calls[0]![1]).toEqual([
+            expect(execFileMock.mock.calls[0]![1]).toEqual([
                 'is-active',
                 'WsScrcpyWeb.service',
             ]);
@@ -347,21 +365,21 @@ describe('SystemdClient', () => {
 
     describe('uninstall', () => {
         it('is a no-op when not installed (idempotent)', async () => {
-            existsSyncMock.mockReturnValue(false);
+            fileExistsMock.mockResolvedValue(false);
             const client = new SystemdClient();
             await expect(client.uninstall('WsScrcpyWeb')).resolves.toBeUndefined();
-            expect(execFileSyncMock).not.toHaveBeenCalled();
-            expect(unlinkSyncMock).not.toHaveBeenCalled();
+            expect(execFileMock).not.toHaveBeenCalled();
+            expect(unlinkMock).not.toHaveBeenCalled();
         });
 
         it('user scope: disables, removes unit, daemon-reloads, removes autostart', async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).replace(/\\/g, '/').includes('/.config/systemd/user/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').includes('/.config/systemd/user/')),
             );
             const client = new SystemdClient();
             await client.uninstall('WsScrcpyWeb');
 
-            const sysCalls = execFileSyncMock.mock.calls.filter((c) => c[0] === 'systemctl');
+            const sysCalls = execFileMock.mock.calls.filter((c) => c[0] === 'systemctl');
             expect(sysCalls[0]![1]).toEqual([
                 '--user',
                 'disable',
@@ -372,7 +390,7 @@ describe('SystemdClient', () => {
 
             // Unit file unlinked + autostart .desktop unlinked. Normalize
             // backslashes since path.join on Windows host uses them.
-            const unlinks = unlinkSyncMock.mock.calls.map((c) =>
+            const unlinks = unlinkMock.mock.calls.map((c) =>
                 String(c[0]).replace(/\\/g, '/'),
             );
             expect(unlinks).toContain(
@@ -384,10 +402,8 @@ describe('SystemdClient', () => {
         });
 
         it('system scope as non-root: uses pkexec for privilege escalation', async () => {
-            existsSyncMock.mockImplementation(
-                (p: string) =>
-                    String(p).startsWith('/etc/systemd/system/') ||
-                    String(p).replace(/\\/g, '/').startsWith('/etc/systemd/system/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').startsWith('/etc/systemd/system/')),
             );
             Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
             const client = new SystemdClient();
@@ -398,43 +414,46 @@ describe('SystemdClient', () => {
         });
 
         it('tolerates systemctl disable failures (already stopped)', async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).replace(/\\/g, '/').includes('/.config/systemd/user/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').includes('/.config/systemd/user/')),
             );
             let callCount = 0;
-            execFileSyncMock.mockImplementation(() => {
+            execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
                 callCount += 1;
-                if (callCount === 1) throw new Error('not loaded');
-                return Buffer.from('');
+                if (callCount === 1) {
+                    cb(new Error('not loaded'), { stdout: '', stderr: '' });
+                    return;
+                }
+                cb(null, { stdout: '', stderr: '' });
             });
             const client = new SystemdClient();
             await expect(client.uninstall('WsScrcpyWeb')).resolves.toBeUndefined();
             // unit file still removed
-            expect(unlinkSyncMock).toHaveBeenCalled();
+            expect(unlinkMock).toHaveBeenCalled();
         });
     });
 
     describe('stop / restart', () => {
         it('stop is a no-op when not installed', async () => {
-            existsSyncMock.mockReturnValue(false);
+            fileExistsMock.mockResolvedValue(false);
             const client = new SystemdClient();
             await expect(client.stop('WsScrcpyWeb')).resolves.toBeUndefined();
-            expect(execFileSyncMock).not.toHaveBeenCalled();
+            expect(execFileMock).not.toHaveBeenCalled();
         });
 
         it('restart throws when not installed', async () => {
-            existsSyncMock.mockReturnValue(false);
+            fileExistsMock.mockResolvedValue(false);
             const client = new SystemdClient();
             await expect(client.restart('WsScrcpyWeb')).rejects.toThrow(/not installed/);
         });
 
         it('restart calls systemctl --user restart for user scope', async () => {
-            existsSyncMock.mockImplementation((p: string) =>
-                String(p).replace(/\\/g, '/').includes('/.config/systemd/user/'),
+            fileExistsMock.mockImplementation((p: unknown) =>
+                Promise.resolve(String(p).replace(/\\/g, '/').includes('/.config/systemd/user/')),
             );
             const client = new SystemdClient();
             await client.restart('WsScrcpyWeb');
-            expect(execFileSyncMock.mock.calls[0]![1]).toEqual([
+            expect(execFileMock.mock.calls[0]![1]).toEqual([
                 '--user',
                 'restart',
                 'WsScrcpyWeb.service',

--- a/src/server/__tests__/dependencyApi.retryInstall.test.ts
+++ b/src/server/__tests__/dependencyApi.retryInstall.test.ts
@@ -60,7 +60,7 @@ describe('DependencyApi retry-install endpoint', () => {
         vi.spyOn(mgr, 'checkAll').mockImplementation(async () => {
             adb.latestVersion = '35.0.2';
             // Set all deps to have latest versions so autoInstallMissing can complete them
-            for (const dep of mgr.getAll()) {
+            for (const dep of await mgr.getAll()) {
                 if (!dep.latestVersion) {
                     dep.latestVersion = '1.0.0';
                 }
@@ -70,7 +70,7 @@ describe('DependencyApi retry-install endpoint', () => {
             adb.installedVersion = '35.0.2';
             adb.status = DependencyStatus.UpToDate;
             // Mark all deps as up-to-date
-            for (const dep of mgr.getAll()) {
+            for (const dep of await mgr.getAll()) {
                 if (dep.installedVersion === null && dep.latestVersion !== null) {
                     dep.installedVersion = dep.latestVersion;
                     dep.status = DependencyStatus.UpToDate;

--- a/src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
+++ b/src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
@@ -4,7 +4,7 @@ import * as elevatedRunnerModule from '../service/elevatedRunner';
 import { DependencyManager } from '../DependencyManager';
 
 vi.mock('../service/elevatedRunner', () => ({
-    launcherIsAvailable: vi.fn(() => true),
+    launcherIsAvailable: vi.fn(async () => true),
     resolveLauncherPath: () => '/fake/launcher.exe',
 }));
 
@@ -86,7 +86,7 @@ describe('DependencyManager.autoInstallMissing', () => {
     });
 
     it('skips launcher-required deps in dev mode (no launcher available)', async () => {
-        vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockReturnValue(false);
+        vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockResolvedValue(false);
 
         const nodejs = mgr.getByName('nodejs')!;
         nodejs.installedVersion = null;
@@ -103,6 +103,6 @@ describe('DependencyManager.autoInstallMissing', () => {
         // scrcpy-server still gets installed (no launcher needed)
         expect(updateSpy).toHaveBeenCalledWith('scrcpy-server');
 
-        vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockReturnValue(true);
+        vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockResolvedValue(true);
     });
 });

--- a/src/server/__tests__/dependencyManager.test.ts
+++ b/src/server/__tests__/dependencyManager.test.ts
@@ -6,9 +6,9 @@ import { DependencyStatus } from '../../common/DependencyTypes';
 import { DependencyManager } from '../DependencyManager';
 
 describe('DependencyManager', () => {
-    it('initializes with all dependencies in unknown state', () => {
+    it('initializes with all dependencies in unknown state', async () => {
         const mgr = new DependencyManager('/tmp/test-deps');
-        const deps = mgr.getAll();
+        const deps = await mgr.getAll();
         expect(deps.length).toBe(3);
         expect(deps.every((d) => d.status === DependencyStatus.Unknown)).toBe(true);
     });
@@ -42,13 +42,13 @@ describe('DependencyManager.getAll() canUpdate', () => {
     it('reports canUpdate=true for all deps when launcher is available', async () => {
         vi.resetModules();
         vi.doMock('../service/elevatedRunner', () => ({
-            launcherIsAvailable: () => true,
+            launcherIsAvailable: async () => true,
             resolveLauncherPath: () => '/fake/launcher.exe',
         }));
         // Re-import after mock to pick up the stubbed module
         const { DependencyManager: Mgr } = await import('../DependencyManager');
         const mgr = new Mgr('/tmp/test-deps-canupdate-yes');
-        const deps = mgr.getAll();
+        const deps = await mgr.getAll();
         for (const dep of deps) {
             expect(dep.canUpdate).toBe(true);
         }
@@ -58,12 +58,12 @@ describe('DependencyManager.getAll() canUpdate', () => {
     it('reports canUpdate=false for launcher-required deps when launcher is unavailable', async () => {
         vi.resetModules();
         vi.doMock('../service/elevatedRunner', () => ({
-            launcherIsAvailable: () => false,
+            launcherIsAvailable: async () => false,
             resolveLauncherPath: () => '/fake/launcher.exe',
         }));
         const { DependencyManager: Mgr } = await import('../DependencyManager');
         const mgr = new Mgr('/tmp/test-deps-canupdate-no');
-        const byName = Object.fromEntries(mgr.getAll().map((d) => [d.name, d]));
+        const byName = Object.fromEntries((await mgr.getAll()).map((d) => [d.name, d]));
         expect(byName['nodejs']?.canUpdate).toBe(false);
         expect(byName['adb']?.canUpdate).toBe(false);
         expect(byName['scrcpy-server']?.canUpdate).toBe(true);

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -78,7 +78,7 @@ describe('DependencyManager.update() launcher-required gate', () => {
 
     it('returns reason=launcher-required for nodejs when launcher is unavailable', async () => {
         vi.doMock('../service/elevatedRunner', () => ({
-            launcherIsAvailable: () => false,
+            launcherIsAvailable: async () => false,
             resolveLauncherPath: () => '/fake/launcher.exe',
         }));
         const { DependencyManager: Mgr } = await import('../DependencyManager');
@@ -97,7 +97,7 @@ describe('DependencyManager.update() launcher-required gate', () => {
 
     it('does not gate scrcpy-server (no launcher needed)', async () => {
         vi.doMock('../service/elevatedRunner', () => ({
-            launcherIsAvailable: () => false,
+            launcherIsAvailable: async () => false,
             resolveLauncherPath: () => '/fake/launcher.exe',
         }));
         const { DependencyManager: Mgr } = await import('../DependencyManager');

--- a/src/server/__tests__/fsExists.test.ts
+++ b/src/server/__tests__/fsExists.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileExists } from '../util/fsExists';
+
+describe('fileExists', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fsexists-'));
+    });
+
+    afterEach(() => {
+        try {
+            fs.rmSync(dir, { recursive: true, force: true });
+        } catch {
+            /* ignore */
+        }
+    });
+
+    it('resolves true for an existing file', async () => {
+        const p = path.join(dir, 'present.txt');
+        fs.writeFileSync(p, 'x');
+        expect(await fileExists(p)).toBe(true);
+    });
+
+    it('resolves true for an existing directory', async () => {
+        expect(await fileExists(dir)).toBe(true);
+    });
+
+    it('resolves false for a missing path (never throws)', async () => {
+        expect(await fileExists(path.join(dir, 'does-not-exist'))).toBe(false);
+    });
+});

--- a/src/server/__tests__/stableUserBin.test.ts
+++ b/src/server/__tests__/stableUserBin.test.ts
@@ -3,23 +3,27 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Call-through fs spies so #31 can assert the atomic tmp→rename staging
-// OS-independently (same pattern as resumeToken.test.ts).
+// Call-through fs.promises spies so #31 can assert the atomic tmp→rename staging
+// OS-independently (same pattern as resumeToken.test.ts). #32: staging is async,
+// so the spies sit on fs.promises.copyFile/rename, not the sync variants.
 const fsSpies = vi.hoisted(() => ({
-    copyFileSync: vi.fn(),
-    renameSync: vi.fn(),
+    copyFile: vi.fn(),
+    rename: vi.fn(),
 }));
 vi.mock('node:fs', async (importOriginal) => {
     const actual = await importOriginal<typeof import('node:fs')>();
     return {
         ...actual,
-        copyFileSync: (...args: Parameters<typeof actual.copyFileSync>) => {
-            fsSpies.copyFileSync(...args);
-            return actual.copyFileSync(...args);
-        },
-        renameSync: (...args: Parameters<typeof actual.renameSync>) => {
-            fsSpies.renameSync(...args);
-            return actual.renameSync(...args);
+        promises: {
+            ...actual.promises,
+            copyFile: (...args: Parameters<typeof actual.promises.copyFile>) => {
+                fsSpies.copyFile(...args);
+                return actual.promises.copyFile(...args);
+            },
+            rename: (...args: Parameters<typeof actual.promises.rename>) => {
+                fsSpies.rename(...args);
+                return actual.promises.rename(...args);
+            },
         },
     };
 });
@@ -65,10 +69,10 @@ describe('stageStableUserBin (#31)', () => {
         }
     });
 
-    it('stages the binary via an atomic temp + rename, not a direct copy (#31)', () => {
+    it('stages the binary via an atomic temp + rename, not a direct copy (#31)', async () => {
         // The /opt bin does not exist on the test host, so the staging path runs.
-        fsSpies.copyFileSync.mockClear();
-        fsSpies.renameSync.mockClear();
+        fsSpies.copyFile.mockClear();
+        fsSpies.rename.mockClear();
         const opts = {
             scope: 'user',
             name: 'WsScrcpyWeb',
@@ -79,11 +83,11 @@ describe('stageStableUserBin (#31)', () => {
             dataRoot,
         } as unknown as Parameters<typeof stageStableUserBin>[0];
 
-        const result = stageStableUserBin(opts);
+        const result = await stageStableUserBin(opts);
 
         // Atomic: copied to a temp path then renamed into the final ExecStart path.
-        expect(fsSpies.renameSync).toHaveBeenCalledTimes(1);
-        expect(fsSpies.copyFileSync).toHaveBeenCalledWith(source, expect.stringContaining('.tmp-'));
+        expect(fsSpies.rename).toHaveBeenCalledTimes(1);
+        expect(fsSpies.copyFile).toHaveBeenCalledWith(source, expect.stringContaining('.tmp-'));
         // Final binary is the complete source content at the stable path.
         expect(result.binPath.startsWith(`${dataRoot}/bin/`)).toBe(true);
         expect(fs.readFileSync(result.binPath, 'utf8')).toBe('BINARY-CONTENT');

--- a/src/server/api/DependencyApi.ts
+++ b/src/server/api/DependencyApi.ts
@@ -16,7 +16,7 @@ export class DependencyApi {
         try {
             // GET /api/dependencies — list all
             if (req.method === 'GET' && url === '/api/dependencies') {
-                const deps = this.manager.getAll();
+                const deps = await this.manager.getAll();
                 res.writeHead(200);
                 res.end(JSON.stringify(deps));
                 return true;
@@ -25,7 +25,7 @@ export class DependencyApi {
             // POST /api/dependencies/check — check all for updates
             if (req.method === 'POST' && url === '/api/dependencies/check') {
                 await this.manager.checkAll();
-                const deps = this.manager.getAll();
+                const deps = await this.manager.getAll();
                 res.writeHead(200);
                 res.end(JSON.stringify(deps));
                 return true;
@@ -56,7 +56,7 @@ export class DependencyApi {
             // POST /api/dependencies/retry-install — retry first-run bootstrap
             if (req.method === 'POST' && url === '/api/dependencies/retry-install') {
                 const before = new Map<string, { installedVersion: string | null }>();
-                for (const info of this.manager.getAll()) {
+                for (const info of await this.manager.getAll()) {
                     before.set(info.name, { installedVersion: info.installedVersion });
                 }
                 await this.manager.checkAll();
@@ -64,7 +64,7 @@ export class DependencyApi {
                 const installed: string[] = [];
                 const stillMissing: string[] = [];
                 const errors: Record<string, string> = {};
-                for (const info of this.manager.getAll()) {
+                for (const info of await this.manager.getAll()) {
                     const prev = before.get(info.name);
                     if (prev?.installedVersion === null && info.installedVersion !== null) {
                         installed.push(info.name);

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -46,7 +46,7 @@ export class UpdatesApi {
 
         try {
             if (req.method === 'GET' && url === '/api/updates/status') {
-                return this.handleStatus(res);
+                return await this.handleStatus(res);
             }
             if (req.method === 'POST' && url === '/api/updates/check') {
                 return await this.handleCheck(res);
@@ -77,7 +77,7 @@ export class UpdatesApi {
      * config.json mirror (for UI convenience so the frontend doesn't need
      * to fetch /api/config separately).
      */
-    private buildStatusResponse(): UpdatesStatusResponse {
+    private async buildStatusResponse(): Promise<UpdatesStatusResponse> {
         const cfg = Config.getInstance().getAppConfig();
         const s = this.svc.getStatus();
         const out: UpdatesStatusResponse = {
@@ -90,7 +90,7 @@ export class UpdatesApi {
             updateCheckIntervalMinutes: cfg.updateCheckIntervalMinutes,
         };
         if (process.platform !== 'win32') {
-            out.libfuse2Installed = isLibfuse2Installed();
+            out.libfuse2Installed = await isLibfuse2Installed();
         }
         if (s.availableVersion !== undefined) out.availableVersion = s.availableVersion;
         if (s.progress !== undefined) out.progress = s.progress;
@@ -99,9 +99,9 @@ export class UpdatesApi {
         return out;
     }
 
-    private handleStatus(res: ServerResponse): boolean {
+    private async handleStatus(res: ServerResponse): Promise<boolean> {
         res.writeHead(200);
-        res.end(JSON.stringify(this.buildStatusResponse()));
+        res.end(JSON.stringify(await this.buildStatusResponse()));
         return true;
     }
 
@@ -117,7 +117,7 @@ export class UpdatesApi {
         }
         await this.svc.checkForUpdates();
         res.writeHead(200);
-        res.end(JSON.stringify(this.buildStatusResponse()));
+        res.end(JSON.stringify(await this.buildStatusResponse()));
         return true;
     }
 
@@ -220,7 +220,7 @@ export class UpdatesApi {
         }
 
         res.writeHead(200);
-        res.end(JSON.stringify(this.buildStatusResponse()));
+        res.end(JSON.stringify(await this.buildStatusResponse()));
         return true;
     }
 
@@ -230,7 +230,7 @@ export class UpdatesApi {
             res.end(JSON.stringify({ ok: false, error: 'libfuse2 is Linux-only' }));
             return true;
         }
-        if (isLibfuse2Installed()) {
+        if (await isLibfuse2Installed()) {
             res.writeHead(200);
             res.end(JSON.stringify({ ok: true, alreadyInstalled: true }));
             return true;

--- a/src/server/service/ServyClient.ts
+++ b/src/server/service/ServyClient.ts
@@ -27,11 +27,13 @@
  * lives in launcher/src/elevated_runner.rs) and adds elevation.
  */
 
-import { execFileSync } from 'node:child_process';
-import * as fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import * as path from 'node:path';
 import { Logger } from '../Logger';
 import { resolveLauncherPath, runElevated } from './elevatedRunner';
+import { fileExists } from '../util/fsExists';
+import { resolveSystemTool } from './systemTools';
 import type {
     ServiceClient,
     ServiceInstallOptions,
@@ -39,6 +41,8 @@ import type {
 } from './ServiceClient';
 
 const log = Logger.for('ServyClient');
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Resolve the absolute path of `servy-cli.exe`.
@@ -52,23 +56,23 @@ const log = Logger.for('ServyClient');
  *      Fall back to `<repoRoot>/publish/servy-cli.exe`.
  *
  * If neither exists, fall back to the bare name `servy-cli.exe` so the error
- * surface from execFileSync is "ENOENT: spawn servy-cli.exe" rather than a
+ * surface from execFileAsync is "ENOENT: spawn servy-cli.exe" rather than a
  * silent miss — easier to triage.
  */
-export function resolveServyPath(
+export async function resolveServyPath(
     cwd: string = process.cwd(),
     moduleDir: string = __dirname,
-    exists: (p: string) => boolean = fs.existsSync,
-): string {
+    exists: (p: string) => Promise<boolean> = fileExists,
+): Promise<string> {
     const installedCandidate = path.join(cwd, 'servy-cli.exe');
-    if (exists(installedCandidate)) return installedCandidate;
+    if (await exists(installedCandidate)) return installedCandidate;
     // dev / from-source: most reliable is cwd/publish/servy-cli.exe (npm start
     // runs from repo root, fetch-servy.mjs writes there).
     const cwdPublishCandidate = path.join(cwd, 'publish', 'servy-cli.exe');
-    if (exists(cwdPublishCandidate)) return cwdPublishCandidate;
+    if (await exists(cwdPublishCandidate)) return cwdPublishCandidate;
     // Source-layout fallback (only useful when running un-bundled): src/server/service/ -> ../../../publish/
     const sourceCandidate = path.resolve(moduleDir, '..', '..', '..', 'publish', 'servy-cli.exe');
-    if (exists(sourceCandidate)) return sourceCandidate;
+    if (await exists(sourceCandidate)) return sourceCandidate;
     return 'servy-cli.exe';
 }
 
@@ -108,10 +112,26 @@ export function parseScQueryStatus(output: string): ServiceStatus {
 }
 
 export class ServyClient implements ServiceClient {
-    private readonly servyPath: string;
+    private readonly servyPathOverride: string | undefined;
+    private servyPathPromise: Promise<string> | undefined;
 
     constructor(servyPath?: string) {
-        this.servyPath = servyPath ?? resolveServyPath();
+        this.servyPathOverride = servyPath;
+    }
+
+    /**
+     * Resolve `servy-cli.exe` lazily + memoize. `resolveServyPath` is async
+     * (#32 — non-blocking existence checks) so the path can't be resolved in
+     * the constructor; install/uninstall await this instead of reading a field.
+     */
+    private getServyPath(): Promise<string> {
+        if (this.servyPathOverride !== undefined) {
+            return Promise.resolve(this.servyPathOverride);
+        }
+        if (!this.servyPathPromise) {
+            this.servyPathPromise = resolveServyPath();
+        }
+        return this.servyPathPromise;
     }
 
     public async install(opts: ServiceInstallOptions): Promise<void> {
@@ -119,15 +139,15 @@ export class ServyClient implements ServiceClient {
         // The helper handles all argv translation + post-install start
         // + tray Run-key registration + tray spawn in the elevated
         // process. We just hand it the abstract operation params.
-        if (!fs.existsSync(resolveLauncherPath())) {
+        if (!(await fileExists(resolveLauncherPath()))) {
             throw new Error(
                 `service install requires the packaged launcher binary at ${resolveLauncherPath()}, ` +
                     `which is not present (likely a dev/from-source run)`,
             );
         }
-        const trayHelperPath = this.tryResolveTrayHelperPath();
+        const trayHelperPath = await this.tryResolveTrayHelperPath();
         const result = await runElevated('install-service', {
-            servyPath: this.servyPath,
+            servyPath: await this.getServyPath(),
             name: opts.name,
             displayName: opts.displayName,
             description: opts.description,
@@ -157,14 +177,14 @@ export class ServyClient implements ServiceClient {
         // v0.1.7: uninstall routes through the elevate-and-run helper too.
         // The helper stops the service first, then uninstalls, then
         // cleans up the tray Run-key, all in the elevated process.
-        if (!fs.existsSync(resolveLauncherPath())) {
+        if (!(await fileExists(resolveLauncherPath()))) {
             throw new Error(
                 `service uninstall requires the packaged launcher binary at ${resolveLauncherPath()}, ` +
                     `which is not present (likely a dev/from-source run)`,
             );
         }
         const result = await runElevated('uninstall-service', {
-            servyPath: this.servyPath,
+            servyPath: await this.getServyPath(),
             name,
         });
         if (!result.ok) {
@@ -188,12 +208,11 @@ export class ServyClient implements ServiceClient {
      */
     public async status(name: string): Promise<ServiceStatus> {
         try {
-            const out = execFileSync('sc.exe', ['query', name], {
-                stdio: ['ignore', 'pipe', 'pipe'],
+            const { stdout } = await execFileAsync(resolveSystemTool('sc'), ['query', name], {
                 encoding: 'utf8',
                 timeout: 5_000,
             });
-            return parseScQueryStatus(out);
+            return parseScQueryStatus(stdout);
         } catch (err) {
             // sc.exe returns exit 1060 (ERROR_SERVICE_DOES_NOT_EXIST)
             // when the named service isn't registered. Surfaced via
@@ -225,7 +244,7 @@ export class ServyClient implements ServiceClient {
     public async restart(_name: string): Promise<void> {
         // restart = stop + start, but Servy's `restart` is one round-trip.
         // Routes through elevation since it touches SCM control.
-        if (!fs.existsSync(resolveLauncherPath())) {
+        if (!(await fileExists(resolveLauncherPath()))) {
             throw new Error(
                 `service restart requires the packaged launcher binary at ${resolveLauncherPath()}`,
             );
@@ -259,11 +278,11 @@ export class ServyClient implements ServiceClient {
      * itself; we just hand it the path (or null) so it can no-op when
      * the helper isn't installed.
      */
-    private tryResolveTrayHelperPath(): string | undefined {
+    private async tryResolveTrayHelperPath(): Promise<string | undefined> {
         const installedCandidate = path.join(process.cwd(), 'ws-scrcpy-web-tray.exe');
-        if (fs.existsSync(installedCandidate)) return installedCandidate;
+        if (await fileExists(installedCandidate)) return installedCandidate;
         const cwdPublishCandidate = path.join(process.cwd(), 'publish', 'ws-scrcpy-web-tray.exe');
-        if (fs.existsSync(cwdPublishCandidate)) return cwdPublishCandidate;
+        if (await fileExists(cwdPublishCandidate)) return cwdPublishCandidate;
         return undefined;
     }
 }

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -32,7 +32,7 @@
  * See `docs/plans/sp3-p4b-contracts.md` for the full spec.
  */
 
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -46,6 +46,7 @@ import type {
 } from './ServiceClient';
 import { resolveSystemTool } from './systemTools';
 import { assertServiceName, shQuote } from './shellEscape';
+import { fileExists } from '../util/fsExists';
 
 const execFileAsync = promisify(execFile);
 
@@ -169,36 +170,34 @@ export async function runPkexec(shellCmd: string, label: string): Promise<string
  * If missing, return the package-manager install command for the detected
  * distro family (deb or rpm). Returns null if already present.
  */
-export function isLibfuse2Installed(): boolean {
+export async function isLibfuse2Installed(): Promise<boolean> {
     try {
-        const out = execFileSync(resolveSystemTool('ldconfig'), ['-p'], {
-            stdio: ['ignore', 'pipe', 'pipe'],
+        const { stdout } = await execFileAsync(resolveSystemTool('ldconfig'), ['-p'], {
             encoding: 'utf8',
         });
-        return out.includes('libfuse.so.2');
+        return stdout.includes('libfuse.so.2');
     } catch {
         return false;
     }
 }
 
-function libfuse2InstallCmd(): string | null {
+async function libfuse2InstallCmd(): Promise<string | null> {
     try {
-        const out = execFileSync(resolveSystemTool('ldconfig'), ['-p'], {
-            stdio: ['ignore', 'pipe', 'pipe'],
+        const { stdout } = await execFileAsync(resolveSystemTool('ldconfig'), ['-p'], {
             encoding: 'utf8',
         });
-        if (out.includes('libfuse.so.2')) return null;
+        if (stdout.includes('libfuse.so.2')) return null;
     } catch {
         // ldconfig not found or failed — assume libfuse2 is missing.
     }
 
-    if (fs.existsSync('/usr/bin/dnf')) {
+    if (await fileExists('/usr/bin/dnf')) {
         return 'dnf install -y fuse-libs';
     }
-    if (fs.existsSync('/usr/bin/apt-get')) {
+    if (await fileExists('/usr/bin/apt-get')) {
         return 'apt-get install -y libfuse2';
     }
-    if (fs.existsSync('/usr/bin/yum')) {
+    if (await fileExists('/usr/bin/yum')) {
         return 'yum install -y fuse-libs';
     }
     log.warn('libfuse2 missing but cannot detect package manager (no dnf, apt-get, or yum)');
@@ -210,20 +209,18 @@ function libfuse2InstallCmd(): string | null {
  * Uses pkexec for graphical privilege escalation if installation is needed.
  */
 export async function ensureLibfuse2(): Promise<void> {
-    const cmd = libfuse2InstallCmd();
+    const cmd = await libfuse2InstallCmd();
     if (!cmd) return;
     log.info(`libfuse2 not found; installing via: ${cmd}`);
     await runPkexec(cmd, 'install libfuse2');
     log.info('libfuse2 installed successfully');
 }
 
-function runSystemctl(args: string[], label: string): string {
+async function runSystemctl(args: string[], label: string): Promise<string> {
     try {
         const { bin, args: a } = systemctlArgv(args);
-        return execFileSync(bin, a, {
-            stdio: ['ignore', 'pipe', 'pipe'],
-            encoding: 'utf8',
-        });
+        const { stdout } = await execFileAsync(bin, a, { encoding: 'utf8' });
+        return stdout;
     } catch (err) {
         const e = err as NodeJS.ErrnoException & { stderr?: Buffer | string; stdout?: Buffer | string };
         const stderr = typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString('utf8') ?? '';
@@ -430,14 +427,14 @@ export function buildSystemUninstallScript(name: string, unitPath: string, syste
  * warning — best-effort so a missing tray binary doesn't fail the service
  * install.
  */
-function resolveTrayHelperPath(
+async function resolveTrayHelperPath(
     cwd: string = process.cwd(),
-    exists: (p: string) => boolean = fs.existsSync,
-): string | null {
+    exists: (p: string) => Promise<boolean> = fileExists,
+): Promise<string | null> {
     const installedCandidate = path.join(cwd, TRAY_HELPER_BIN);
-    if (exists(installedCandidate)) return installedCandidate;
+    if (await exists(installedCandidate)) return installedCandidate;
     const devCandidate = path.join(cwd, 'publish', TRAY_HELPER_BIN);
-    if (exists(devCandidate)) return devCandidate;
+    if (await exists(devCandidate)) return devCandidate;
     return null;
 }
 
@@ -466,11 +463,11 @@ export function isSafeReusableBin(stat: fs.Stats): boolean {
  *
  * Returns `opts` with `binPath` + `startupDir` retargeted at the stable path.
  */
-export function stageStableUserBin(opts: ServiceInstallOptions): ServiceInstallOptions {
+export async function stageStableUserBin(opts: ServiceInstallOptions): Promise<ServiceInstallOptions> {
     const optBin = `${STAGED_SYSTEM_DIR}/${STAGED_SYSTEM_APPIMAGE}`;
     let optStat: fs.Stats | null = null;
     try {
-        optStat = fs.lstatSync(optBin);
+        optStat = await fs.promises.lstat(optBin);
     } catch {
         optStat = null;
     }
@@ -484,13 +481,13 @@ export function stageStableUserBin(opts: ServiceInstallOptions): ServiceInstallO
     }
     const binDir = `${opts.dataRoot}/bin`;
     const stableBin = `${binDir}/${STAGED_SYSTEM_APPIMAGE}`;
-    fs.mkdirSync(binDir, { recursive: true });
+    await fs.promises.mkdir(binDir, { recursive: true });
     // Atomic stage: copy to a temp file, make it executable, then rename into
     // place so a concurrent unit start never sees a partial / non-executable bin.
     const tmpBin = `${stableBin}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
-    fs.copyFileSync(opts.binPath, tmpBin);
-    fs.chmodSync(tmpBin, 0o755);
-    fs.renameSync(tmpBin, stableBin);
+    await fs.promises.copyFile(opts.binPath, tmpBin);
+    await fs.promises.chmod(tmpBin, 0o755);
+    await fs.promises.rename(tmpBin, stableBin);
     return { ...opts, binPath: stableBin, startupDir: binDir };
 }
 
@@ -523,9 +520,9 @@ export class SystemdClient implements ServiceClient {
      * uninstall / status / restart / stop so callers don't have to track
      * scope themselves after the initial install.
      */
-    private resolveActiveScope(name: string): SystemdScope | null {
-        if (fs.existsSync(this.userUnitPath(name))) return 'user';
-        if (fs.existsSync(this.systemUnitPath(name))) return 'system';
+    private async resolveActiveScope(name: string): Promise<SystemdScope | null> {
+        if (await fileExists(this.userUnitPath(name))) return 'user';
+        if (await fileExists(this.systemUnitPath(name))) return 'system';
         return null;
     }
 
@@ -558,7 +555,7 @@ export class SystemdClient implements ServiceClient {
      * Delegates to the module-level `stageStableUserBin` (extracted so the
      * staging logic is unit-testable). Forward-slash paths (Linux unit file).
      */
-    private withStableUserBin(opts: ServiceInstallOptions): ServiceInstallOptions {
+    private withStableUserBin(opts: ServiceInstallOptions): Promise<ServiceInstallOptions> {
         return stageStableUserBin(opts);
     }
 
@@ -581,27 +578,25 @@ export class SystemdClient implements ServiceClient {
 
         // F1: user-scope services must ExecStart a STABLE, executable binary —
         // never the volatile launch path ($APPIMAGE / ~/Downloads).
-        const effectiveOpts = this.withStableUserBin(opts);
+        const effectiveOpts = await this.withStableUserBin(opts);
         const unitContent = renderUnitFile(effectiveOpts, scope);
         const unitPath = this.userUnitPath(opts.name);
 
-        fs.mkdirSync(path.dirname(unitPath), { recursive: true });
-        fs.writeFileSync(unitPath, unitContent, { mode: 0o644 });
-        runSystemctl(['--user', 'daemon-reload'], 'daemon-reload');
+        await fs.promises.mkdir(path.dirname(unitPath), { recursive: true });
+        await fs.promises.writeFile(unitPath, unitContent, { mode: 0o644 });
+        await runSystemctl(['--user', 'daemon-reload'], 'daemon-reload');
         // Never start with `--now` while the local instance still holds the per-user
         // lock / web port — the service would exit "already running" before binding.
         // Just `enable`; ServiceApi spawns the --user out-of-cgroup install-handoff
         // helper that starts it after the local instance exits and frees the port.
-        runSystemctl(['--user', 'enable', `${opts.name}.service`], `enable ${opts.name}.service`);
+        await runSystemctl(['--user', 'enable', `${opts.name}.service`], `enable ${opts.name}.service`);
 
         // Best-effort linger so the service survives a full logout.
         // Common reasons this can fail: loginctl absent (non-systemd-logind
         // systems), missing privileges on hardened distros. Service is
         // already installed + running — degraded but functional.
         try {
-            execFileSync(resolveSystemTool('loginctl'), ['enable-linger', os.userInfo().username], {
-                stdio: ['ignore', 'pipe', 'pipe'],
-            });
+            await execFileAsync(resolveSystemTool('loginctl'), ['enable-linger', os.userInfo().username]);
         } catch (err) {
             log.warn(
                 `loginctl enable-linger failed (service still installed): ${
@@ -613,7 +608,7 @@ export class SystemdClient implements ServiceClient {
         // Best-effort tray autostart. System scope skips this — headless
         // server case dominant, no desktop session to autostart into.
         try {
-            this.writeTrayAutostart();
+            await this.writeTrayAutostart();
         } catch (err) {
             log.warn(
                 `tray autostart .desktop write failed (service install succeeded): ${
@@ -636,7 +631,7 @@ export class SystemdClient implements ServiceClient {
      * interface implementation (and for any non-cgroup-bound callers).
      */
     public async uninstall(name: string): Promise<void> {
-        const scope = this.resolveActiveScope(name);
+        const scope = await this.resolveActiveScope(name);
         if (scope === null) {
             return;
         }
@@ -649,7 +644,7 @@ export class SystemdClient implements ServiceClient {
         } else {
             const baseArgs = scope === 'user' ? ['--user'] : [];
             try {
-                runSystemctl(
+                await runSystemctl(
                     [...baseArgs, 'disable', '--now', `${name}.service`],
                     `disable --now ${name}.service`,
                 );
@@ -659,13 +654,13 @@ export class SystemdClient implements ServiceClient {
 
             const unitPath = scope === 'user' ? this.userUnitPath(name) : this.systemUnitPath(name);
             try {
-                fs.unlinkSync(unitPath);
+                await fs.promises.unlink(unitPath);
             } catch {
                 // Already gone.
             }
 
             try {
-                runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload (after uninstall)');
+                await runSystemctl([...baseArgs, 'daemon-reload'], 'daemon-reload (after uninstall)');
             } catch (err) {
                 log.warn(`daemon-reload after uninstall failed: ${(err as Error).message}`);
             }
@@ -675,7 +670,7 @@ export class SystemdClient implements ServiceClient {
         // wrote one). Idempotent: ignore "already gone".
         if (scope === 'user') {
             try {
-                this.removeTrayAutostart();
+                await this.removeTrayAutostart();
             } catch (err) {
                 log.warn(
                     `tray autostart removal failed (service uninstall succeeded): ${
@@ -687,7 +682,7 @@ export class SystemdClient implements ServiceClient {
     }
 
     public async status(name: string): Promise<ServiceStatus> {
-        const scope = this.resolveActiveScope(name);
+        const scope = await this.resolveActiveScope(name);
         if (scope === null) return 'not-installed';
 
         const baseArgs = scope === 'user' ? ['--user'] : [];
@@ -697,12 +692,8 @@ export class SystemdClient implements ServiceClient {
         // running state).
         try {
             const { bin, args: a } = systemctlArgv([...baseArgs, 'is-active', `${name}.service`]);
-            const out = execFileSync(
-                bin,
-                a,
-                { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
-            ).trim();
-            return out === 'active' ? 'running' : 'stopped';
+            const { stdout } = await execFileAsync(bin, a, { encoding: 'utf8' });
+            return stdout.trim() === 'active' ? 'running' : 'stopped';
         } catch {
             // Non-zero exit (inactive / failed / activating) — treat as stopped.
             return 'stopped';
@@ -710,19 +701,19 @@ export class SystemdClient implements ServiceClient {
     }
 
     public async restart(name: string): Promise<void> {
-        const scope = this.resolveActiveScope(name);
+        const scope = await this.resolveActiveScope(name);
         if (scope === null) {
             throw new Error(`systemctl restart: ${name}.service not installed`);
         }
         const baseArgs = scope === 'user' ? ['--user'] : [];
-        runSystemctl(
+        await runSystemctl(
             [...baseArgs, 'restart', `${name}.service`],
             `restart ${name}.service`,
         );
     }
 
     public async stop(name: string): Promise<void> {
-        const scope = this.resolveActiveScope(name);
+        const scope = await this.resolveActiveScope(name);
         if (scope === null) {
             // Idempotent — nothing to stop.
             return;
@@ -730,7 +721,7 @@ export class SystemdClient implements ServiceClient {
         const baseArgs = scope === 'user' ? ['--user'] : [];
         // Tolerate "already stopped" / "not loaded" — match ServyClient stop semantics.
         try {
-            runSystemctl(
+            await runSystemctl(
                 [...baseArgs, 'stop', `${name}.service`],
                 `stop ${name}.service`,
             );
@@ -749,8 +740,8 @@ export class SystemdClient implements ServiceClient {
      * Local-Dependencies-Only, and — since Linux has no tray binary, item 27 —
      * only leaves an orphaned autostart entry that never resolves).
      */
-    private writeTrayAutostart(): void {
-        const trayPath = resolveTrayHelperPath();
+    private async writeTrayAutostart(): Promise<void> {
+        const trayPath = await resolveTrayHelperPath();
         if (!trayPath) {
             log.info(
                 'tray helper binary not found; skipping tray autostart (no PATH-reliant Exec written)',
@@ -770,15 +761,15 @@ export class SystemdClient implements ServiceClient {
             '',
         ].join('\n');
 
-        fs.mkdirSync(path.dirname(desktopPath), { recursive: true });
-        fs.writeFileSync(desktopPath, content, { mode: 0o644 });
+        await fs.promises.mkdir(path.dirname(desktopPath), { recursive: true });
+        await fs.promises.writeFile(desktopPath, content, { mode: 0o644 });
     }
 
     /** Remove the tray autostart .desktop file. Idempotent. */
-    private removeTrayAutostart(): void {
+    private async removeTrayAutostart(): Promise<void> {
         const desktopPath = this.trayAutostartPath();
         try {
-            fs.unlinkSync(desktopPath);
+            await fs.promises.unlink(desktopPath);
         } catch {
             // Already gone — desired post-state.
         }

--- a/src/server/service/elevatedRunner.ts
+++ b/src/server/service/elevatedRunner.ts
@@ -37,6 +37,7 @@ import { randomBytes } from 'node:crypto';
 import { promisify } from 'util';
 import { Logger } from '../Logger';
 import { tempDir } from '../util/disposable';
+import { fileExists } from '../util/fsExists';
 
 const execFileAsync = promisify(execFile);
 
@@ -128,8 +129,8 @@ export function resolveLauncherPath(): string {
     return path.join(process.cwd(), exeName);
 }
 
-export function launcherIsAvailable(): boolean {
-    return fs.existsSync(resolveLauncherPath());
+export async function launcherIsAvailable(): Promise<boolean> {
+    return fileExists(resolveLauncherPath());
 }
 
 /**
@@ -148,7 +149,7 @@ export async function runElevated(
         throw new Error('runElevated is Windows-only');
     }
     const launcherPath = resolveLauncherPath();
-    if (!fs.existsSync(launcherPath)) {
+    if (!(await fileExists(launcherPath))) {
         throw new Error(
             `runElevated requires the packaged launcher at ${launcherPath}, ` +
                 `which is not present (likely a dev/from-source run rather than a Velopack install)`,
@@ -173,7 +174,7 @@ export async function runElevated(
     // entirely for this command and direct-spawn the launcher.
     const useDirect = command === 'spawn-user-launcher';
 
-    fs.writeFileSync(argsPath, JSON.stringify({ ...wireArgs, nonce }, null, 2), 'utf8');
+    await fs.promises.writeFile(argsPath, JSON.stringify({ ...wireArgs, nonce }, null, 2), 'utf8');
 
     // v0.1.8: switched from `Start-Process -Wait -PassThru` to a
     // result-file polling pattern. The previous design hung in
@@ -289,14 +290,14 @@ export async function pollForResultFile(
 ): Promise<ElevatedResult | null> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-        if (fs.existsSync(resultPath)) {
+        if (await fileExists(resultPath)) {
             // File exists. Try to read+parse. If the helper is still
             // mid-write, parse may produce a malformed-JSON error; if
             // so, wait one more tick and try again. Once the file is
             // fully written and reads cleanly, return the parsed
             // result.
             try {
-                const raw = fs.readFileSync(resultPath, 'utf8');
+                const raw = await fs.promises.readFile(resultPath, 'utf8');
                 const parsed = parseResult(raw);
                 // Heuristic: if parseResult returned a "could not
                 // parse" error AND the file is < 1KB, it's probably
@@ -323,7 +324,7 @@ export async function pollForResultFile(
                 }
                 return parsed;
             } catch {
-                // File disappeared between existsSync and readFileSync,
+                // File disappeared between the access check and readFile,
                 // or some other I/O error. Treat as still-in-progress.
             }
         }

--- a/src/server/util/fsExists.ts
+++ b/src/server/util/fsExists.ts
@@ -1,0 +1,16 @@
+import * as fs from 'node:fs';
+
+/**
+ * Async, non-blocking existence check — the event-loop-friendly replacement for
+ * `fs.existsSync` (review finding #32). Resolves `true` when the path exists and
+ * is accessible, `false` otherwise. Never throws: an inaccessible/missing path
+ * (any `access` rejection) maps to `false`, matching `existsSync`'s contract.
+ */
+export async function fileExists(p: string): Promise<boolean> {
+    try {
+        await fs.promises.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
Security review finding #32: the service layer ran synchronous `*Sync` child-process and filesystem calls directly on the request event loop. A routine status poll (the home header and Settings poll `sc query` / `systemctl is-active` regularly), an install/uninstall, the elevated-helper result wait, or the libfuse2 probe would block the loop for the duration of the spawn/copy — stalling every other in-flight request, including live device-stream WebSockets.

This swaps them for async:

- **Child-process spawns → `execFileAsync`**: `ServyClient.status` (`sc query`), and `SystemdClient`s `runSystemctl` / `is-active` / `ldconfig` / `loginctl`.
- **`fs.*Sync` → `fs.promises`**: the `elevatedRunner` args write + the 200 ms result-file poll loop, `stageStableUserBin`s AppImage copy/chmod/rename, and the unit-file + tray-autostart writes/unlinks.
- **`existsSync` → one shared async `fileExists()`** (`src/server/util/fsExists.ts`) instead of three copies.
- **Signature ripple**: `launcherIsAvailable`, `DependencyManager.getAll`, and `isLibfuse2Installed` become async; their callers (`DependencyApi`, `UpdatesApi`) await, and `ServyClient` resolves its `servy-cli` path lazily since a constructor cannot await.

While converting `ServyClient.status` I also fixed a stray bare-name `sc.exe` `%PATH%` lookup — it now resolves under `%SystemRoot%\System32` via `resolveSystemTool`, the same binary-hijack fix #20 applied to the launchers `taskkill`/`icacls`. (The Linux side already went through `resolveSystemTool`.)

Behavior is unchanged — the conversion preserves every existing assertion; tests were updated only at the mock seams (callback-style `execFile`, `fs.promises`, a `fileExists` stub).

Unlabeled → no release; rides the next labeled beta.

Gates: `tsc --noEmit` clean · vitest 1107 (1104 + 3 new `fsExists`) · `webpack build:dev` clean.