### PR TITLE
fix(common): ControlCenterCommand pid validation + SemVer-aware compareVersions (review #57, #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Removed the dead `resolveActiveSessionId` helper** (`src/server/util/active-session.ts` and its test). It was an orphan from the abandoned "Theory D" uninstall-handoff — its only caller was deleted in `0.1.25-beta.51` — so removing it has no behavioral effect, and it clears a latent `shell: true` process-spawn path the security review flagged. The launcher's `--print-active-session` capability is unaffected.
 
+### Fixed
+
+- **The "kill server" control command rejects an invalid process id instead of silently accepting it.** The pid check used `&&` where it needed `||`, so a non-numeric or non-positive pid passed validation; it's now rejected, and a command that arrives without its `data` object fails with a clear error rather than crashing on an undefined property read.
+- **Beta update detection is fixed.** The version comparison split on `.` and ran `Number` over each part, so a tag like `0.1.30-beta.65` became `NaN` and prereleases compared as garbage — a stable `0.1.30` could even look *older* than `0.1.30-beta.1`. It now parses SemVer prerelease tags: the release core compares numerically, a stable release outranks its prerelease, and prerelease identifiers compare per SemVer (so `beta.2 < beta.10`, not string order).
+
 ### Security
 
 - **The HTTP API and WebSocket endpoints now enforce an Origin and Host allowlist.** Requests from another web origin, and requests whose `Host` header is not `localhost` or an IP literal (DNS-rebinding), are rejected — closing a cross-site path by which a malicious page could reach device control, file deletion, and service management.

--- a/src/common/ControlCenterCommand.ts
+++ b/src/common/ControlCenterCommand.ts
@@ -12,11 +12,15 @@ export class ControlCenterCommand {
 
     public static fromJSON(json: string): ControlCenterCommand {
         const body = JSON.parse(json);
-        if (!body) {
+        if (!body || typeof body !== 'object') {
             throw new Error('Invalid input');
         }
         const command = new ControlCenterCommand();
-        const data = (command.data = body.data);
+        const data = body.data;
+        if (!data || typeof data !== 'object') {
+            throw new Error('Invalid input: missing "data"');
+        }
+        command.data = data;
         command.id = body.id;
         command.type = body.type;
 
@@ -25,7 +29,7 @@ export class ControlCenterCommand {
         }
         switch (body.type) {
             case this.KILL_SERVER:
-                if (typeof data.pid !== 'number' && data.pid <= 0) {
+                if (typeof data.pid !== 'number' || data.pid <= 0) {
                     throw new Error('Invalid "pid" value');
                 }
                 command.pid = data.pid;

--- a/src/common/DependencyTypes.ts
+++ b/src/common/DependencyTypes.ts
@@ -28,16 +28,79 @@ export interface UpdateResult {
     reason?: 'launcher-required' | undefined;
 }
 
-export function compareVersions(a: string | null, b: string | null): number {
-    if (a === null || b === null) return -1;
-    const pa = a.replace(/^v/, '').split('.').map(Number);
-    const pb = b.replace(/^v/, '').split('.').map(Number);
-    const len = Math.max(pa.length, pb.length);
+interface ParsedVersion {
+    /** Numeric release segments, e.g. 1.2.3 → [1, 2, 3]. */
+    release: number[];
+    /** Dot-separated prerelease identifiers, e.g. beta.4 → ['beta', '4']; [] for a stable release. */
+    pre: string[];
+}
+
+function parseVersion(v: string): ParsedVersion {
+    const cleaned = v.replace(/^v/, '');
+    const dash = cleaned.indexOf('-');
+    const core = dash === -1 ? cleaned : cleaned.slice(0, dash);
+    const preRaw = dash === -1 ? '' : cleaned.slice(dash + 1);
+    const release = core.split('.').map((s) => Number(s) || 0);
+    const pre = preRaw === '' ? [] : preRaw.split('.');
+    return { release, pre };
+}
+
+/**
+ * Compare two prerelease identifier lists per SemVer §11: numeric identifiers
+ * have lower precedence than alphanumeric ones, numeric compare numerically,
+ * alphanumeric compare in ASCII order, and a larger set of fields wins when all
+ * preceding fields are equal.
+ */
+function comparePrerelease(a: string[], b: string[]): number {
+    const len = Math.max(a.length, b.length);
     for (let i = 0; i < len; i++) {
-        const na = pa[i] ?? 0;
-        const nb = pb[i] ?? 0;
+        if (i >= a.length) return -1; // a ran out of identifiers first → lower precedence
+        if (i >= b.length) return 1;
+        const ai = a[i]!;
+        const bi = b[i]!;
+        const an = /^\d+$/.test(ai) ? Number(ai) : null;
+        const bn = /^\d+$/.test(bi) ? Number(bi) : null;
+        if (an !== null && bn !== null) {
+            if (an !== bn) return an < bn ? -1 : 1;
+        } else if (an !== null) {
+            return -1; // numeric < alphanumeric
+        } else if (bn !== null) {
+            return 1;
+        } else if (ai !== bi) {
+            return ai < bi ? -1 : 1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * Compare two version strings. Returns -1 if a < b, 1 if a > b, 0 if equal.
+ *
+ * Handles SemVer prerelease tags (e.g. `1.0.0-beta.2`): the release core is
+ * compared numerically, a stable release outranks its prerelease
+ * (`1.0.0 > 1.0.0-beta`), and prerelease identifiers compare per SemVer §11
+ * (so `beta.2 < beta.10`, not string order). `null` is the lowest version (no
+ * version present): both null → equal; one null → it is the older side.
+ */
+export function compareVersions(a: string | null, b: string | null): number {
+    if (a === null && b === null) return 0;
+    if (a === null) return -1;
+    if (b === null) return 1;
+
+    const va = parseVersion(a);
+    const vb = parseVersion(b);
+
+    const len = Math.max(va.release.length, vb.release.length);
+    for (let i = 0; i < len; i++) {
+        const na = va.release[i] ?? 0;
+        const nb = vb.release[i] ?? 0;
         if (na < nb) return -1;
         if (na > nb) return 1;
     }
-    return 0;
+
+    // Equal release cores: a stable build (no prerelease) outranks a prerelease.
+    if (va.pre.length === 0 && vb.pre.length === 0) return 0;
+    if (va.pre.length === 0) return 1;
+    if (vb.pre.length === 0) return -1;
+    return comparePrerelease(va.pre, vb.pre);
 }

--- a/src/common/__tests__/controlCenterCommand.test.ts
+++ b/src/common/__tests__/controlCenterCommand.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { ControlCenterCommand } from '../ControlCenterCommand';
+
+describe('ControlCenterCommand.fromJSON', () => {
+    it('parses a valid KILL_SERVER command', () => {
+        const cmd = ControlCenterCommand.fromJSON(
+            JSON.stringify({
+                id: 1,
+                type: ControlCenterCommand.KILL_SERVER,
+                data: { udid: 'dev1', pid: 1234 },
+            }),
+        );
+        expect(cmd.getType()).toBe(ControlCenterCommand.KILL_SERVER);
+        expect(cmd.getId()).toBe(1);
+        expect(cmd.getUdid()).toBe('dev1');
+        expect(cmd.getPid()).toBe(1234);
+    });
+
+    it('parses START_SERVER (no pid required)', () => {
+        const cmd = ControlCenterCommand.fromJSON(
+            JSON.stringify({ id: 2, type: ControlCenterCommand.START_SERVER, data: { udid: 'dev2' } }),
+        );
+        expect(cmd.getType()).toBe(ControlCenterCommand.START_SERVER);
+        expect(cmd.getUdid()).toBe('dev2');
+    });
+
+    it('rejects KILL_SERVER with a non-positive pid (|| not &&)', () => {
+        // The bug: `typeof pid !== 'number' && pid <= 0` only throws when pid is
+        // BOTH non-numeric AND <= 0, so a valid-typed but non-positive pid slips through.
+        expect(() =>
+            ControlCenterCommand.fromJSON(
+                JSON.stringify({ id: 1, type: ControlCenterCommand.KILL_SERVER, data: { udid: 'd', pid: 0 } }),
+            ),
+        ).toThrow(/Invalid "pid"/);
+        expect(() =>
+            ControlCenterCommand.fromJSON(
+                JSON.stringify({ id: 1, type: ControlCenterCommand.KILL_SERVER, data: { udid: 'd', pid: -5 } }),
+            ),
+        ).toThrow(/Invalid "pid"/);
+    });
+
+    it('rejects KILL_SERVER with a non-numeric or missing pid', () => {
+        expect(() =>
+            ControlCenterCommand.fromJSON(
+                JSON.stringify({ id: 1, type: ControlCenterCommand.KILL_SERVER, data: { udid: 'd', pid: '1234' } }),
+            ),
+        ).toThrow(/Invalid "pid"/);
+        expect(() =>
+            ControlCenterCommand.fromJSON(
+                JSON.stringify({ id: 1, type: ControlCenterCommand.KILL_SERVER, data: { udid: 'd' } }),
+            ),
+        ).toThrow(/Invalid "pid"/);
+    });
+
+    it('throws a clean error (not an undefined deref) when data is missing', () => {
+        let msg = '';
+        try {
+            ControlCenterCommand.fromJSON(
+                JSON.stringify({ id: 1, type: ControlCenterCommand.START_SERVER }),
+            );
+            throw new Error('expected fromJSON to throw');
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toMatch(/Invalid input/);
+        // The original bug surfaced as a TypeError reading `data.udid` of undefined.
+        expect(msg).not.toMatch(/Cannot read propert/i);
+    });
+
+    it('throws on an unknown command type', () => {
+        expect(() =>
+            ControlCenterCommand.fromJSON(JSON.stringify({ id: 1, type: 'bogus', data: { udid: 'd' } })),
+        ).toThrow(/Unknown command/);
+    });
+
+    it('throws on a falsy JSON body', () => {
+        expect(() => ControlCenterCommand.fromJSON('null')).toThrow(/Invalid input/);
+    });
+});

--- a/src/common/__tests__/dependencyTypes.test.ts
+++ b/src/common/__tests__/dependencyTypes.test.ts
@@ -18,12 +18,34 @@ describe('compareVersions', () => {
         expect(compareVersions('35', '35.0.1')).toBe(-1);
     });
 
-    it('returns -1 when either version is null', () => {
+    it('treats null as the lowest version (asymmetric)', () => {
+        // null = "no version" = lowest. The only case the real caller
+        // (DependencyManager.resolveStatus) reaches is a null INSTALLED version
+        // vs a non-null latest → -1 (install/update available). The reverse and
+        // both-null cases are defensive but must be consistent, not always -1.
         expect(compareVersions(null, '1.0.0')).toBe(-1);
-        expect(compareVersions('1.0.0', null)).toBe(-1);
+        expect(compareVersions('1.0.0', null)).toBe(1);
+        expect(compareVersions(null, null)).toBe(0);
     });
 
     it('strips leading v from version strings', () => {
         expect(compareVersions('v1.2.3', 'v1.2.3')).toBe(0);
+    });
+
+    it('orders a stable release above its prerelease (1.0.0 > 1.0.0-beta)', () => {
+        // The bug: `.split('.').map(Number)` turns `30-beta` into NaN, so stable
+        // vs beta compared equal/garbage and beta update detection broke.
+        expect(compareVersions('0.1.30', '0.1.30-beta.1')).toBe(1);
+        expect(compareVersions('0.1.30-beta.1', '0.1.30')).toBe(-1);
+    });
+
+    it('orders prerelease identifiers numerically, not as strings', () => {
+        expect(compareVersions('0.1.30-beta.2', '0.1.30-beta.10')).toBe(-1);
+        expect(compareVersions('0.1.30-beta.10', '0.1.30-beta.2')).toBe(1);
+        expect(compareVersions('0.1.30-beta.5', '0.1.30-beta.5')).toBe(0);
+    });
+
+    it('orders prerelease tags lexically (alpha < beta)', () => {
+        expect(compareVersions('1.0.0-alpha', '1.0.0-beta')).toBe(-1);
     });
 });


### PR DESCRIPTION
The two correctness bugs from the security review — the highest-priority items left in the MAJOR tier (the only ones that are wrong-behavior rather than perf/cleanup).

**#57 — `ControlCenterCommand.fromJSON`** (`src/common/ControlCenterCommand.ts`)
- The KILL_SERVER pid check was `typeof pid !== ''number'' && pid <= 0`, so it only rejected a pid that was *both* non-numeric *and* <= 0 — a negative, zero, or string pid passed straight through. Now `||`.
- `data.udid` was read before checking `body.data` existed, so a command with no `data` threw `TypeError: Cannot read properties of undefined` instead of a clean validation error. Now guarded.

**#58 — `compareVersions`** (`src/common/DependencyTypes.ts`)
- `.split(''.'').map(Number)` turned `0.1.30-beta.65` into `NaN`, so prereleases compared as garbage — a stable `0.1.30` could compare as *older* than `0.1.30-beta.1`, breaking beta update detection. Replaced with a SemVer-aware compare: numeric release core, a stable release outranks its prerelease, and prerelease identifiers compare per SemVer 11 (`beta.2 < beta.10`).
- `null` is now the lowest version, handled asymmetrically (both null -> 0; one null -> it is the older side) instead of always returning -1. The only case the real caller (`resolveStatus`) reaches — null installed vs a real latest -> -1 — is unchanged.

New `controlCenterCommand.test.ts` (7 cases) + 3 added `compareVersions` cases; one existing assertion (`compareVersions(''1.0.0'', null)`) corrected from -1 to 1 (an unreachable, wrong case).

Unlabeled -> no release; rides the next labeled beta.

Gates: `tsc --noEmit` 0 · vitest 1114 · `webpack build:dev` clean.