### PR TITLE
fix(launcher): operation-server robustness — sec #52–#55

### DIFF
--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -188,6 +188,44 @@ pub fn delete_port_file(data_root: &Path) {
     let _ = std::fs::remove_file(&path);
 }
 
+/// What to do after a single failed bind attempt in `bind_with_probe`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BindAttempt {
+    /// Advance to the next candidate port.
+    NextPort,
+    /// Wait, then retry the same port (transient contention).
+    RetrySamePort,
+    /// Stop probing and fail.
+    GiveUp,
+}
+
+/// Decide the next action after a failed bind. `in_use` = the error was
+/// `AddrInUse` (transient — the current holder may release the port);
+/// `has_more_ports` = a higher candidate port remains; `timed_out` = the
+/// per-port retry window has elapsed.
+///
+/// §54: a non-`AddrInUse` error (e.g. permission denied) is permanent for this
+/// port, so retrying the same port can never help — advance to the next port
+/// if one exists, otherwise give up immediately. Only `AddrInUse` waits and
+/// retries the same port. (The old code slept-and-retried every error kind on
+/// the same port for the full timeout, then gave up without trying the rest.)
+fn classify_bind_failure(in_use: bool, has_more_ports: bool, timed_out: bool) -> BindAttempt {
+    if has_more_ports {
+        // A higher port is available — advance regardless of error kind. For
+        // AddrInUse this is the old "try next" fast-path; for a permanent error
+        // it's the fix (don't burn the retry window on a dead port).
+        return BindAttempt::NextPort;
+    }
+    // Last candidate port.
+    if in_use && !timed_out {
+        // Transient contention, window still open — wait and retry this port.
+        BindAttempt::RetrySamePort
+    } else {
+        // Permanent error, or the retry window has elapsed — give up.
+        BindAttempt::GiveUp
+    }
+}
+
 pub fn bind_with_probe(
     start_port: u16,
     max_offset: u16,
@@ -203,27 +241,39 @@ pub fn bind_with_probe(
             match TcpListener::bind(("127.0.0.1", port)) {
                 Ok(listener) => return Ok((listener, port)),
                 Err(e) => {
-                    let is_in_use = e.kind() == std::io::ErrorKind::AddrInUse;
-                    if is_in_use && offset < max_offset {
-                        log::info(&format!(
-                            "operation-server: port {port} in use, trying next"
-                        ));
-                        break; // try next port
-                    }
-                    if bind_start.elapsed() >= retry_timeout {
-                        if is_in_use {
-                            log::error(&format!(
-                                "operation-server: all ports {start_port}..={} in use after {retry_timeout:?}",
-                                start_port.saturating_add(max_offset)
-                            ));
+                    let in_use = e.kind() == std::io::ErrorKind::AddrInUse;
+                    let has_more_ports = offset < max_offset;
+                    let timed_out = bind_start.elapsed() >= retry_timeout;
+                    match classify_bind_failure(in_use, has_more_ports, timed_out) {
+                        BindAttempt::NextPort => {
+                            if in_use {
+                                log::info(&format!(
+                                    "operation-server: port {port} in use, trying next"
+                                ));
+                            } else {
+                                log::info(&format!(
+                                    "operation-server: bind 127.0.0.1:{port} failed ({e}), trying next"
+                                ));
+                            }
+                            break; // try next port
+                        }
+                        BindAttempt::RetrySamePort => {
+                            thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
+                        }
+                        BindAttempt::GiveUp => {
+                            if in_use {
+                                log::error(&format!(
+                                    "operation-server: all ports {start_port}..={} in use after {retry_timeout:?}",
+                                    start_port.saturating_add(max_offset)
+                                ));
+                            } else {
+                                log::error(&format!(
+                                    "operation-server: bind 127.0.0.1:{port} failed: {e}"
+                                ));
+                            }
                             return Err(3);
                         }
-                        log::error(&format!(
-                            "operation-server: bind 127.0.0.1:{port} failed after {retry_timeout:?}: {e}"
-                        ));
-                        return Err(3);
                     }
-                    thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
                 }
             }
         }
@@ -1618,5 +1668,28 @@ mod tests {
             serde_json::from_str(body).expect("api redirect body must be valid JSON");
         assert!(parsed["error"].is_null());
         assert_eq!(parsed["redirect"], evil, "redirect must round-trip verbatim");
+    }
+
+    // ----- §54: bind_with_probe must not retry permanent errors on the same
+    // port -----
+    // The old loop slept-and-retried the SAME port for the full timeout on a
+    // permanent error (e.g. permission denied), then gave up WITHOUT trying the
+    // remaining ports. The decision is now a pure function: only AddrInUse
+    // (transient) waits on the same port; any other error advances immediately.
+
+    #[test]
+    fn classify_bind_failure_decision_table() {
+        use super::BindAttempt;
+        // AddrInUse + a higher port available → advance immediately.
+        assert!(matches!(super::classify_bind_failure(true, true, false), BindAttempt::NextPort));
+        // AddrInUse on the last port, window still open → wait + retry same port.
+        assert!(matches!(super::classify_bind_failure(true, false, false), BindAttempt::RetrySamePort));
+        // AddrInUse on the last port, window elapsed → give up.
+        assert!(matches!(super::classify_bind_failure(true, false, true), BindAttempt::GiveUp));
+        // Permanent error with ports left → advance (FIX: was retry-same-port).
+        assert!(matches!(super::classify_bind_failure(false, true, false), BindAttempt::NextPort));
+        // Permanent error on the last port → give up at once, no retry (FIX).
+        assert!(matches!(super::classify_bind_failure(false, false, false), BindAttempt::GiveUp));
+        assert!(matches!(super::classify_bind_failure(false, false, true), BindAttempt::GiveUp));
     }
 }

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -862,7 +862,18 @@ fn handle_connection(mut stream: TcpStream, redirect_state: Arc<Mutex<Option<Str
     let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
     let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
 
-    let mut reader = BufReader::new(stream.try_clone().unwrap_or_else(|_| stream.try_clone().expect("clone failed twice")));
+    // §52 — a failed try_clone is fatal for this one connection but not for
+    // the server: return (closing the socket) instead of panicking. The old
+    // double-clone + `expect` would abort the process on a network-reachable
+    // clone failure (e.g. fd exhaustion).
+    let cloned = match stream.try_clone() {
+        Ok(c) => c,
+        Err(e) => {
+            log::error(&format!("operation-server: connection stream clone failed ({e})"));
+            return;
+        }
+    };
+    let mut reader = BufReader::new(cloned);
     let mut request_line = String::new();
     if reader.read_line(&mut request_line).is_err() {
         return;

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -922,7 +922,9 @@ fn build_response(path: &str, redirect: Option<&str>, variant: OperationVariant)
     if path.starts_with("/api/") {
         if path == "/api/discover" {
             if let Some(url) = redirect {
-                let body = format!(r#"{{"status":"ready","redirect":"{url}"}}"#);
+                // §53 — encode via serde_json so the redirect is always
+                // escaped and the body stays valid JSON regardless of contents.
+                let body = serde_json::json!({ "status": "ready", "redirect": url }).to_string();
                 return format!(
                     "HTTP/1.1 200 OK\r\n\
                      Content-Type: application/json\r\n\
@@ -952,10 +954,9 @@ fn build_response(path: &str, redirect: Option<&str>, variant: OperationVariant)
         }
 
         if let Some(url) = redirect {
-            // Naive JSON string encoding — port-only URLs (http://localhost:NNNN/)
-            // contain no characters that need escaping. If the redirect ever
-            // grows beyond port-only, swap to a real JSON encoder.
-            let body = format!(r#"{{"error":null,"redirect":"{}"}}"#, url);
+            // §53 — encode via serde_json so the redirect is always escaped
+            // and the body stays valid JSON regardless of URL contents.
+            let body = serde_json::json!({ "error": null, "redirect": url }).to_string();
             return format!(
                 "HTTP/1.1 200 OK\r\n\
                  Content-Type: application/json\r\n\
@@ -1589,5 +1590,33 @@ mod tests {
             0,
             "guard must release the slot even when the handler panics"
         );
+    }
+
+    // ----- §53: redirect URL must be JSON-escaped in build_response -----
+    // The redirect string is interpolated into the /api JSON bodies. Today it
+    // is always a safe port-only URL, but raw string interpolation emits
+    // invalid JSON the moment it carries a quote/backslash. Encode via
+    // serde_json so the body is always valid JSON and the field round-trips.
+
+    #[test]
+    fn build_response_escapes_redirect_in_discover_ready_body() {
+        let evil = r#"http://localhost:8000/a"b\c"#;
+        let resp = super::build_response("/api/discover", Some(evil), super::OperationVariant::ApplyUpdate);
+        let body = resp.split("\r\n\r\n").nth(1).expect("response body");
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).expect("discover body must be valid JSON");
+        assert_eq!(parsed["status"], "ready");
+        assert_eq!(parsed["redirect"], evil, "redirect must round-trip verbatim");
+    }
+
+    #[test]
+    fn build_response_escapes_redirect_in_api_redirect_body() {
+        let evil = r#"http://localhost:8000/a"b\c"#;
+        let resp = super::build_response("/api/config", Some(evil), super::OperationVariant::ApplyUpdate);
+        let body = resp.split("\r\n\r\n").nth(1).expect("response body");
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).expect("api redirect body must be valid JSON");
+        assert!(parsed["error"].is_null());
+        assert_eq!(parsed["redirect"], evil, "redirect must round-trip verbatim");
     }
 }

--- a/launcher/src/windows_app_uninstall.rs
+++ b/launcher/src/windows_app_uninstall.rs
@@ -270,6 +270,24 @@ fn run_uninstall_in_place(a: &UninstallArgs) -> i32 {
     0
 }
 
+/// Decode a temp-dir path from a UTF-16 buffer and the length reported by
+/// `GetTempPath2W`/`GetTempPathW`. Returns `None` for a zero length (API
+/// failure) or a length that reaches or exceeds the buffer.
+///
+/// §55: on success these APIs return the count of chars copied EXCLUDING the
+/// NUL terminator, so a valid result always leaves room for the NUL and is
+/// strictly `< buf.len()`. A `len >= buf.len()` can't be a real success (it
+/// would mean the buffer was too small — the API returns the required size
+/// instead), so reject it rather than slicing to the brim of an undocumented
+/// MAX_PATH cap. Not exploitable as written (the W variants cap at MAX_PATH),
+/// but fail closed.
+fn temp_path_from_buf(buf: &[u16], len: usize) -> Option<std::path::PathBuf> {
+    if len == 0 || len >= buf.len() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(String::from_utf16_lossy(&buf[..len])))
+}
+
 /// Resolve the context-appropriate temp directory: the user's temp under a
 /// user token, the hardened `C:\Windows\SystemTemp` under a SYSTEM/system-
 /// service token. `GetTempPath2W` is the SYSTEM-safe API (Win10 1903+); fall
@@ -278,19 +296,16 @@ fn resolve_temp_dir() -> Option<std::path::PathBuf> {
     use windows::Win32::Storage::FileSystem::{GetTempPath2W, GetTempPathW};
     // Buffer is MAX_PATH (260) + 1. On success these return the length copied
     // (excluding NUL); if the buffer were too small they'd instead return the
-    // REQUIRED size (> buf.len()) WITHOUT filling it. The W variants cap the
-    // path at MAX_PATH so that can't happen here — but fail closed rather than
-    // slice out of bounds (panic=abort would kill the cleaner before it
+    // REQUIRED size WITHOUT filling it. The W variants cap the path at MAX_PATH
+    // so that can't happen here — but temp_path_from_buf fails closed rather
+    // than slice out of bounds (panic=abort would kill the cleaner before it
     // deletes) or read an unfilled buffer.
     let mut buf = [0u16; 261];
     let mut len = unsafe { GetTempPath2W(Some(&mut buf)) } as usize;
     if len == 0 {
         len = unsafe { GetTempPathW(Some(&mut buf)) } as usize;
     }
-    if len == 0 || len > buf.len() {
-        return None;
-    }
-    Some(std::path::PathBuf::from(String::from_utf16_lossy(&buf[..len])))
+    temp_path_from_buf(&buf, len)
 }
 
 /// Phase 1: copy this launcher to temp and spawn it as the logging-disabled
@@ -420,6 +435,28 @@ mod tests {
 
     const UPDATE_EXE: &str = r"C:\Program Files\WsScrcpyWeb\Update.exe";
     const DATA_ROOT: &str = r"C:\ProgramData\WsScrcpyWeb";
+
+    // ── §55: temp-path buffer bound ───────────────────────────────────────
+
+    #[test]
+    fn temp_path_from_buf_rejects_zero_and_out_of_bounds_lengths() {
+        let buf = [0u16; 8];
+        assert!(temp_path_from_buf(&buf, 0).is_none(), "zero length (API failure) -> None");
+        assert!(temp_path_from_buf(&buf, 9).is_none(), "len > buf.len() -> None");
+        // §55: a successful GetTempPath*W leaves room for the NUL terminator,
+        // so len == buf.len() can't be a valid result -- reject it too (>=),
+        // rather than slicing to the brim of an undocumented cap.
+        assert!(temp_path_from_buf(&buf, 8).is_none(), "len == buf.len() -> None");
+    }
+
+    #[test]
+    fn temp_path_from_buf_decodes_valid_utf16() {
+        let mut buf = [0u16; 16];
+        let s: Vec<u16> = r"C:\Temp".encode_utf16().collect();
+        buf[..s.len()].copy_from_slice(&s);
+        let p = temp_path_from_buf(&buf, s.len()).expect("valid length must decode");
+        assert_eq!(p.to_string_lossy(), r"C:\Temp");
+    }
 
     // ── Pure builder tests ────────────────────────────────────────────────
 


### PR DESCRIPTION
Four small launcher-robustness fixes from the security review, each its own TDD'd commit. All in non-cfg-linux modules, so Windows `cargo` compiles/gates them fully.

### #52 — `handle_connection` panic on double `try_clone`
The handler cloned the stream twice and `expect`-panicked on the second failure — a network-reachable panic that could abort the process on fd exhaustion. Now a single `try_clone` that logs and returns (closing the socket) on error. *(Error path can't be forced in a unit test; mechanical panic→return.)*

### #53 — redirect URL interpolated into JSON unescaped
`build_response` built the `/api` JSON bodies with raw string formatting — invalid JSON the moment the redirect URL carried a quote/backslash. Both bodies now encode via `serde_json::json!`. Latent today (redirect is always a port-only URL) but defensively correct.
Tests: `build_response_escapes_redirect_in_{discover_ready,api_redirect}_body`.

### #54 — `bind_with_probe` masked permanent bind errors
The retry loop slept-and-retried the *same* port for the full timeout on **any** error, so a permanent failure (e.g. permission denied) burned the window and gave up without trying the remaining ports. Decision extracted into a pure `classify_bind_failure()`: only `AddrInUse` waits and retries the same port; any other error advances immediately (or gives up on the last port).
Test: `classify_bind_failure_decision_table` (6-case table).

### #55 — `GetTempPath2W` buffer-slice bound
`resolve_temp_dir` accepted a reported length up to and including `buf.len()` before slicing, but a successful `GetTempPath*W` always leaves room for the NUL terminator (valid length is strictly `< buf.len()`). Extracted a pure `temp_path_from_buf()` that rejects `len >= buf.len()` (was `>`). Not exploitable as written (the W variants cap at MAX_PATH) but fails closed.
Tests: `temp_path_from_buf_rejects_zero_and_out_of_bounds_lengths` + `temp_path_from_buf_decodes_valid_utf16`.

---

`cargo test` 141 pass / 0 fail · `cargo clippy --all-targets -- -D warnings` clean.

`release:none` — rides the next labeled beta.
