### PR TITLE
fix(client): client-perf lifecycle + leak fixes (sec #34-#38)

### DIFF
--- a/src/app/client/BaseDeviceTracker.test.ts
+++ b/src/app/client/BaseDeviceTracker.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BaseDeviceDescriptor } from '../../types/BaseDeviceDescriptor';
+import type { ParamsDeviceTracker } from '../../types/ParamsDeviceTracker';
+import { BaseDeviceTracker } from './BaseDeviceTracker';
+
+// Minimal concrete subclass. BaseDeviceTracker is abstract — it requires
+// buildDeviceRow plus the ManagerClient abstract socket hooks. The
+// ManagerClient constructor only builds the URL (no socket opened until
+// openNewConnection() is called), and the BaseDeviceTracker constructor does
+// not open a connection, so this is safe to instantiate without a real
+// WebSocket. We stub openNewConnection so the reconnect timer's callback is
+// observable.
+class TestTracker extends BaseDeviceTracker<BaseDeviceDescriptor, never> {
+    public openCount = 0;
+    public buildRowCount = 0;
+
+    public static override readonly ACTION = 'test-tracker';
+
+    public constructor() {
+        super({ type: 'android', action: 'test-tracker' } as ParamsDeviceTracker, 'ws://test/');
+    }
+
+    // Build a simple identifiable row. The base is responsible for tagging it
+    // with data-udid and inserting it via the diff/patch path.
+    protected buildDeviceRow(tbody: Element, device: BaseDeviceDescriptor, context?: unknown): void {
+        this.buildRowCount++;
+        const row = document.createElement('div');
+        row.className = 'device';
+        row.setAttribute('data-state', device.state);
+        if (context && typeof context === 'object') {
+            const label = (context as Record<string, string>)[device.udid];
+            if (label) {
+                row.setAttribute('data-label', label);
+            }
+        }
+        tbody.appendChild(row);
+    }
+
+    // Part A seam: fetched ONCE per table refresh, not once per row.
+    protected override fetchRowContext(): Promise<unknown> {
+        return fetch('/api/devices/labels').then((r) => r.json());
+    }
+
+    protected onSocketOpen(): void {
+        // no-op
+    }
+
+    protected override openNewConnection(): never {
+        this.openCount++;
+        return undefined as never;
+    }
+
+    public callOnSocketClose(): void {
+        this.onSocketClose({ reason: 'test' } as CloseEvent);
+    }
+
+    // Test helpers
+    public setDescriptors(list: BaseDeviceDescriptor[]): void {
+        this.descriptors = list;
+    }
+
+    public refresh(): Promise<void> {
+        return this.refreshDeviceTable();
+    }
+
+    public getBlock(): HTMLElement | null {
+        return document.getElementById(this.elementId);
+    }
+}
+
+describe('BaseDeviceTracker reconnect timer lifecycle (#35)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('does NOT reconnect after destroy() even once the 2s timer would fire', () => {
+        const tracker = new TestTracker();
+        tracker.callOnSocketClose();
+        tracker.destroy();
+        vi.advanceTimersByTime(5000);
+        expect(tracker.openCount).toBe(0);
+    });
+
+    it('reconnects after 2s when NOT destroyed', () => {
+        const tracker = new TestTracker();
+        tracker.callOnSocketClose();
+        vi.advanceTimersByTime(2000);
+        expect(tracker.openCount).toBe(1);
+        tracker.destroy();
+    });
+});
+
+const devA: BaseDeviceDescriptor = { udid: 'A', state: 'device' };
+const devB: BaseDeviceDescriptor = { udid: 'B', state: 'device' };
+const devC: BaseDeviceDescriptor = { udid: 'C', state: 'device' };
+
+describe('BaseDeviceTracker label-fetch caching (#34 Part A)', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ A: 'Alpha', B: 'Bravo' }) });
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        document.body.innerHTML = '';
+    });
+
+    it('fetches /api/devices/labels ONCE per refresh, not once per row', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA, devB]);
+
+        await tracker.refresh();
+        // 2 devices, but only ONE labels fetch for the whole refresh.
+        const labelCalls = fetchMock.mock.calls.filter((c) => c[0] === '/api/devices/labels');
+        expect(labelCalls).toHaveLength(1);
+
+        // Second refresh → one more fetch (one per build).
+        await tracker.refresh();
+        const labelCalls2 = fetchMock.mock.calls.filter((c) => c[0] === '/api/devices/labels');
+        expect(labelCalls2).toHaveLength(2);
+
+        tracker.destroy();
+    });
+
+    it('passes the fetched label map into row building', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA, devB]);
+        await tracker.refresh();
+
+        const block = tracker.getBlock();
+        const rowA = block?.querySelector('[data-udid="A"]');
+        const rowB = block?.querySelector('[data-udid="B"]');
+        expect(rowA?.getAttribute('data-label')).toBe('Alpha');
+        expect(rowB?.getAttribute('data-label')).toBe('Bravo');
+
+        tracker.destroy();
+    });
+});
+
+describe('BaseDeviceTracker diff/patch by udid (#34 Part B)', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        document.body.innerHTML = '';
+    });
+
+    it('preserves the SAME DOM node for an unchanged device across rebuilds', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA, devB]);
+        await tracker.refresh();
+
+        const block = tracker.getBlock()!;
+        const rowABefore = block.querySelector('[data-udid="A"]');
+        const rowBBefore = block.querySelector('[data-udid="B"]');
+        expect(rowABefore).not.toBeNull();
+        expect(rowBBefore).not.toBeNull();
+
+        // Rebuild with [A, C]: A unchanged, B removed, C added.
+        tracker.setDescriptors([devA, devC]);
+        await tracker.refresh();
+
+        const rowAAfter = block.querySelector('[data-udid="A"]');
+        const rowBAfter = block.querySelector('[data-udid="B"]');
+        const rowCAfter = block.querySelector('[data-udid="C"]');
+
+        // A's node is the SAME object (not recreated).
+        expect(rowAAfter).toBe(rowABefore);
+        // B removed.
+        expect(rowBAfter).toBeNull();
+        // C added.
+        expect(rowCAfter).not.toBeNull();
+    });
+
+    it('does NOT rebuild every row on every refresh (unchanged rows are not re-built)', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA, devB]);
+        await tracker.refresh();
+        const builtAfterFirst = tracker.buildRowCount;
+        expect(builtAfterFirst).toBe(2);
+
+        // Identical descriptors → no rows rebuilt.
+        tracker.setDescriptors([{ udid: 'A', state: 'device' }, { udid: 'B', state: 'device' }]);
+        await tracker.refresh();
+        expect(tracker.buildRowCount).toBe(builtAfterFirst);
+
+        tracker.destroy();
+    });
+
+    it('rebuilds a row in place when its descriptor changed', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA]);
+        await tracker.refresh();
+        const block = tracker.getBlock()!;
+        expect(block.querySelector('[data-udid="A"]')?.getAttribute('data-state')).toBe('device');
+
+        // Same udid, different state → row updated in place.
+        tracker.setDescriptors([{ udid: 'A', state: 'offline' }]);
+        await tracker.refresh();
+        expect(block.querySelector('[data-udid="A"]')?.getAttribute('data-state')).toBe('offline');
+        // Still exactly one A row.
+        expect(block.querySelectorAll('[data-udid="A"]')).toHaveLength(1);
+
+        tracker.destroy();
+    });
+
+    it('orders rows to match the descriptor list', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA, devB]);
+        await tracker.refresh();
+
+        // Reverse order plus a new device.
+        tracker.setDescriptors([devC, devB, devA]);
+        await tracker.refresh();
+
+        const block = tracker.getBlock()!;
+        const udids = Array.from(block.querySelectorAll('[data-udid]')).map((el) => el.getAttribute('data-udid'));
+        expect(udids).toEqual(['C', 'B', 'A']);
+
+        tracker.destroy();
+    });
+
+    it('shows the empty-state card when there are no devices', async () => {
+        const tracker = new TestTracker();
+        tracker.setDescriptors([devA]);
+        await tracker.refresh();
+        const block = tracker.getBlock()!;
+        expect(block.querySelector('[data-udid="A"]')).not.toBeNull();
+
+        tracker.setDescriptors([]);
+        await tracker.refresh();
+        expect(block.querySelector('[data-udid="A"]')).toBeNull();
+        expect(block.querySelector('.empty-state-card')).not.toBeNull();
+
+        tracker.destroy();
+    });
+});

--- a/src/app/client/BaseDeviceTracker.ts
+++ b/src/app/client/BaseDeviceTracker.ts
@@ -86,6 +86,11 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
     protected id = '';
     private created = false;
     private messageId = 0;
+    private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // §34: tracks the last-rendered serialized descriptor per udid so a refresh
+    // can skip rebuilding rows whose descriptor is unchanged (diff/patch instead
+    // of clear-and-rebuild). Cleared on destroy with the row nodes.
+    private lastRenderedByUdid: Map<string, string> = new Map();
 
     protected constructor(
         params: ParamsDeviceTracker,
@@ -110,22 +115,147 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
         return ++this.messageId;
     }
 
+    /**
+     * §34: fire-and-forget entry point kept for the many synchronous callers
+     * (constructors, onSocketMessage). Delegates to the async diff/patch
+     * refresh, which fetches per-refresh row context (e.g. the device-label map)
+     * exactly once instead of once per row.
+     */
     protected buildDeviceTable(): void {
+        void this.refreshDeviceTable();
+    }
+
+    /**
+     * §34: build the device list by DIFFING the existing DOM rows (keyed by
+     * udid via data-udid) against this.descriptors rather than tearing the whole
+     * block down and rebuilding every row on every WebSocket message:
+     *  - rows for new udids are built and appended,
+     *  - rows for gone udids are removed,
+     *  - rows whose descriptor is unchanged are left as the SAME node
+     *    (preserves scroll/focus and avoids a per-message rebuild storm),
+     *  - changed rows are rebuilt in place,
+     *  - finally the surviving/new rows are reordered to match descriptor order.
+     *
+     * Row context (the label map) is fetched ONCE here and passed into each
+     * buildDeviceRow call — eliminating the prior per-row /api/devices/labels
+     * request storm.
+     */
+    protected async refreshDeviceTable(): Promise<void> {
         const data = this.descriptors;
         const devices = this.getOrCreateTableHolder();
         const tbody = this.getOrBuildTableBody(devices);
+        const block = this.getTrackerBlock(tbody);
+        this.setNameValue(block, this.trackerName);
 
-        const block = this.getOrCreateTrackerBlock(tbody, this.trackerName);
+        const context = await this.fetchRowContext();
+
         if (data.length === 0) {
-            const empty = document.createElement('div');
-            empty.className = 'empty-state-card';
-            empty.textContent = 'No devices connected.';
-            block.appendChild(empty);
-        } else {
-            data.forEach((item) => {
-                this.buildDeviceRow(block, item);
-            });
+            this.removeAllDeviceRows(block);
+            this.lastRenderedByUdid.clear();
+            if (!block.querySelector('.empty-state-card')) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state-card';
+                empty.textContent = 'No devices connected.';
+                block.appendChild(empty);
+            }
+            return;
         }
+
+        // Devices present — drop any empty-state card.
+        block.querySelector('.empty-state-card')?.remove();
+
+        const desiredUdids = new Set(data.map((d) => d.udid));
+
+        // Remove rows for devices that are gone.
+        this.getDeviceRows(block).forEach((el) => {
+            const udid = el.getAttribute('data-udid');
+            if (udid !== null && !desiredUdids.has(udid)) {
+                el.remove();
+                this.lastRenderedByUdid.delete(udid);
+            }
+        });
+
+        // Add new rows / rebuild changed rows. New nodes are appended to the end
+        // of the block by buildDeviceRow; we reorder afterwards.
+        for (const device of data) {
+            const udid = device.udid;
+            const serialized = BaseDeviceTracker.serializeDescriptor(device);
+            const existing = this.getDeviceRow(block, udid);
+            if (existing && this.lastRenderedByUdid.get(udid) === serialized) {
+                continue; // unchanged — keep the existing node
+            }
+            const newRow = this.buildAndTagRow(block, device, udid, context);
+            if (existing && newRow) {
+                existing.replaceWith(newRow);
+            } else if (existing && !newRow) {
+                // buildDeviceRow produced nothing (defensive) — drop stale node.
+                existing.remove();
+            }
+            this.lastRenderedByUdid.set(udid, serialized);
+        }
+
+        // Reorder surviving device rows to match descriptor order. appendChild
+        // MOVES existing nodes (preserving identity), so unchanged rows keep
+        // their node while ending up in the right position.
+        for (const device of data) {
+            const row = this.getDeviceRow(block, device.udid);
+            if (row) {
+                block.appendChild(row);
+            }
+        }
+    }
+
+    /**
+     * §34: per-refresh context passed to buildDeviceRow. Default: none.
+     * DeviceTracker overrides this to fetch the device-label map a single time
+     * for the whole refresh.
+     */
+    protected fetchRowContext(): Promise<unknown> {
+        return Promise.resolve(undefined);
+    }
+
+    /**
+     * §34: invoke the subclass row builder (which appends its row to `block`),
+     * then capture and tag that row with data-udid so the diff can find it next
+     * refresh. Returns the tagged row, or undefined if no row was appended.
+     */
+    private buildAndTagRow(block: Element, device: DD, udid: string, context: unknown): Element | undefined {
+        const before = block.lastElementChild;
+        this.buildDeviceRow(block, device, context);
+        const appended = block.lastElementChild;
+        if (!appended || appended === before) {
+            return undefined;
+        }
+        appended.setAttribute('data-udid', udid);
+        return appended;
+    }
+
+    private getDeviceRows(block: Element): Element[] {
+        return Array.from(block.querySelectorAll('[data-udid]'));
+    }
+
+    private getDeviceRow(block: Element, udid: string): Element | null {
+        // Match by attribute selector. udids can contain ':' and other chars, so
+        // escape the quote/backslash that would break the selector string. (We
+        // avoid the global CSS.escape since it isn't present in every test env.)
+        const escaped = udid.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return block.querySelector(`[data-udid="${escaped}"]`);
+    }
+
+    private removeAllDeviceRows(block: Element): void {
+        this.getDeviceRows(block).forEach((el) => el.remove());
+    }
+
+    private static serializeDescriptor(device: BaseDeviceDescriptor): string {
+        // Stable-enough change key: JSON with sorted keys so property order
+        // can't cause spurious rebuilds.
+        const source = device as unknown as Record<string, unknown>;
+        const keys = Object.keys(source).sort();
+        const ordered: Record<string, unknown> = {};
+        for (const k of keys) {
+            ordered[k] = source[k];
+        }
+        return JSON.stringify(ordered);
     }
 
     private setNameValue(parent: Element | null, name: string): void {
@@ -143,30 +273,43 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
         parent.insertBefore(nameEl, parent.firstChild);
     }
 
-    private getOrCreateTrackerBlock(parent: Element, controlCenterName: string): Element {
+    /**
+     * §34: get-or-create the tracker block WITHOUT clearing its children — the
+     * diff/patch refresh manages row lifecycle itself. (Previously this cleared
+     * all children on every call, forcing a full rebuild.)
+     */
+    private getTrackerBlock(parent: Element): Element {
         let el = document.getElementById(this.elementId);
         if (!el) {
             el = document.createElement('div');
             el.id = this.elementId;
             parent.appendChild(el);
             this.created = true;
-        } else {
-            while (el.children.length) {
-                el.removeChild(el.children[0]!);
-            }
         }
-        this.setNameValue(el, controlCenterName);
         return el;
     }
 
-    protected abstract buildDeviceRow(tbody: Element, device: DD): void;
+    /**
+     * @param tbody   the tracker block the row should be appended to
+     * @param device  the descriptor to render
+     * @param context §34 per-refresh context (e.g. the device-label map),
+     *                fetched once by refreshDeviceTable. Optional so existing
+     *                callers/overrides compile; DeviceTracker uses it.
+     */
+    protected abstract buildDeviceRow(tbody: Element, device: DD, context?: unknown): void;
 
     protected onSocketClose(event: CloseEvent): void {
         if (this.destroyed) {
             return;
         }
         console.log(TAG, `Connection closed: ${event.reason}`);
-        setTimeout(() => {
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = null;
+            // Re-check destroyed: destroy() may have run between scheduling and
+            // firing (e.g. the user navigated away during the 2s window).
+            if (this.destroyed) {
+                return;
+            }
             this.openNewConnection();
         }, 2000);
     }
@@ -265,6 +408,11 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
 
     public override destroy(): void {
         super.destroy();
+        if (this.reconnectTimer !== null) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        this.lastRenderedByUdid.clear();
         if (this.created) {
             const el = document.getElementById(this.elementId);
             if (el) {

--- a/src/app/client/DependencyPanel.test.ts
+++ b/src/app/client/DependencyPanel.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type DependencyInfo, DependencyStatus } from '../../common/DependencyTypes';
 import { DependencyPanel } from './DependencyPanel';
 
@@ -35,5 +35,39 @@ describe('DependencyPanel XSS', () => {
         ]);
         const body = panel.getElement().querySelector('tbody');
         expect(body?.querySelector('img')).toBeNull();
+    });
+});
+
+describe('DependencyPanel polling lifecycle (#36)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it('stops polling after destroy() — the interval no longer fires load()', () => {
+        const panel = new DependencyPanel();
+        (panel as any).startPolling();
+        const loadSpy = vi.spyOn(panel as any, 'load');
+
+        // One interval before destroy → load() fires.
+        vi.advanceTimersByTime(15_000);
+        expect(loadSpy).toHaveBeenCalledTimes(1);
+
+        panel.destroy();
+        loadSpy.mockClear();
+
+        // After destroy, advancing well past several intervals → no more load().
+        vi.advanceTimersByTime(60_000);
+        expect(loadSpy).not.toHaveBeenCalled();
+    });
+
+    it('destroy() is idempotent / safe to call without polling started', () => {
+        const panel = new DependencyPanel();
+        expect(() => panel.destroy()).not.toThrow();
     });
 });

--- a/src/app/client/DependencyPanel.ts
+++ b/src/app/client/DependencyPanel.ts
@@ -49,6 +49,14 @@ export class DependencyPanel {
         return this.container;
     }
 
+    /**
+     * Tear down: stop the background poll interval so it doesn't keep firing
+     * (and keep this instance alive) after the panel is removed from the DOM.
+     */
+    destroy(): void {
+        this.stopPolling();
+    }
+
     private startPolling(): void {
         if (this.pollHandle !== null) return;
         this.pollHandle = setInterval(() => {

--- a/src/app/client/FirstRunBanner.test.ts
+++ b/src/app/client/FirstRunBanner.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type DependencyInfo, DependencyStatus } from '../../common/DependencyTypes';
 import { FirstRunBanner } from './FirstRunBanner';
 
@@ -22,5 +22,45 @@ describe('FirstRunBanner XSS', () => {
         const el = banner.getElement();
         expect(el.querySelector('img')).toBeNull();
         expect(el.textContent).toContain('<img src=x onerror=alert(1)>');
+    });
+});
+
+describe('FirstRunBanner polling lifecycle (#36)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // Return a pending dep so refresh() keeps the banner (and polling) alive
+        // — otherwise refresh() self-stops polling when nothing is pending.
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => [dep('SomeDep')],
+            }),
+        );
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it('stops polling after destroy() — the interval no longer fires refresh()', () => {
+        const banner = new FirstRunBanner();
+        (banner as any).startPolling();
+        const refreshSpy = vi.spyOn(banner as any, 'refresh');
+
+        vi.advanceTimersByTime(15_000);
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+        banner.destroy();
+        refreshSpy.mockClear();
+
+        vi.advanceTimersByTime(60_000);
+        expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    it('destroy() is safe to call without polling started', () => {
+        const banner = new FirstRunBanner();
+        expect(() => banner.destroy()).not.toThrow();
     });
 });

--- a/src/app/client/FirstRunBanner.ts
+++ b/src/app/client/FirstRunBanner.ts
@@ -25,6 +25,14 @@ export class FirstRunBanner {
         return this.container;
     }
 
+    /**
+     * Tear down: stop the background poll interval so it doesn't keep firing
+     * (and keep this instance alive) after the banner is removed from the DOM.
+     */
+    destroy(): void {
+        this.stopPolling();
+    }
+
     private startPolling(): void {
         if (this.pollHandle !== null) return;
         this.pollHandle = setInterval(() => {

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -182,7 +182,12 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         return urlObject;
     }
 
-    protected buildDeviceRow(tbody: Element, device: GoogDeviceDescriptor): void {
+    protected override buildDeviceRow(tbody: Element, device: GoogDeviceDescriptor, context?: unknown): void {
+        // §34 Part A: the per-refresh device-label map (fetched once by
+        // fetchRowContext) arrives as context. Fall back to an empty map so a
+        // failed/absent fetch just renders "Unnamed Device".
+        const labels: Record<string, string> =
+            context && typeof context === 'object' ? (context as Record<string, string>) : {};
         const fullName = `${this.id}_${Util.escapeUdid(device.udid)}`;
         const isActive = device.state === DeviceState.DEVICE;
         const deviceName = device['ro.product.model']?.startsWith(device['ro.product.manufacturer'])
@@ -210,7 +215,7 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
             const nameCell = nameRow.querySelector('td:last-child') as HTMLTableCellElement;
             if (nameCell) {
                 const serial = device['ro.serialno'] || '';
-                DeviceTracker.buildLabelCell(nameCell, serial);
+                DeviceTracker.buildLabelCell(nameCell, serial, labels);
             }
         }
 
@@ -456,6 +461,21 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         });
     }
 
+    /**
+     * §34 Part A: fetch the device-label map ONCE per table refresh. The
+     * resolved map is passed into every buildDeviceRow call for this refresh,
+     * replacing the previous per-row GET /api/devices/labels storm. A failed
+     * fetch resolves to an empty map (rows render "Unnamed Device").
+     */
+    protected override async fetchRowContext(): Promise<Record<string, string>> {
+        try {
+            const res = await fetch('/api/devices/labels');
+            return (await res.json()) as Record<string, string>;
+        } catch {
+            return {};
+        }
+    }
+
     protected override getChannelCode(): string {
         return ChannelCode.GTRC;
     }
@@ -471,19 +491,17 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         }
     }
 
-    private static buildLabelCell(cell: HTMLTableCellElement, serial: string): void {
-        const renderDisplay = async () => {
-            let label = '';
-            if (serial) {
-                try {
-                    const res = await fetch('/api/devices/labels');
-                    const labels: Record<string, string> = await res.json();
-                    label = labels[serial] || '';
-                } catch {
-                    // Couldn't fetch labels — show unnamed
-                }
-            }
-
+    private static buildLabelCell(
+        cell: HTMLTableCellElement,
+        serial: string,
+        labels: Record<string, string>,
+    ): void {
+        // §34 Part A: the label map is fetched ONCE per table refresh
+        // (fetchRowContext) and injected here, instead of each row issuing its
+        // own GET /api/devices/labels — which produced a request storm scaling
+        // with device count. renderDisplay takes the label to show directly so
+        // the save() flow can re-render with the just-typed value, no refetch.
+        const renderDisplay = (label = labels[serial] || '') => {
             cell.innerHTML = '';
             cell.className = 'device-name-cell';
 
@@ -527,14 +545,16 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                         // Save failed — will show old label
                     }
                 }
-                renderDisplay();
+                // Re-render with the just-typed value so the UI reflects the
+                // save immediately (the per-refresh label map updates next poll).
+                renderDisplay(newLabel);
             };
             saveBtn.addEventListener('click', save);
             cell.appendChild(saveBtn);
 
             input.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter') save();
-                if (e.key === 'Escape') renderDisplay();
+                if (e.key === 'Escape') renderDisplay(currentLabel);
             });
 
             input.focus();

--- a/src/app/googDevice/client/FileListingClient.ts
+++ b/src/app/googDevice/client/FileListingClient.ts
@@ -100,6 +100,17 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
     private rowsByName: Map<string, HTMLElement> = new Map();
     private tableBody: HTMLElement;
     private channels: Set<Multiplexer> = new Set();
+    // Bound hashchange handler — stored so destroy() can removeEventListener the
+    // exact same reference (an inline arrow would be unremovable).
+    private readonly onHashChange = (): void => {
+        const hash = location.hash.replace(/#!/, '');
+        const params = new URLSearchParams(hash);
+        if (params.get('action') !== ACTION.FILE_LISTING) return;
+        const hashPath = params.get('path');
+        if (hashPath && hashPath !== this.path) {
+            this.loadContent(hashPath);
+        }
+    };
     constructor(params: ParamsFileListing) {
         super(params);
         this.parent = document.body;
@@ -107,15 +118,10 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
         this.path = this.params.path;
         this.openNewConnection();
         this.setBodyClass('file-listing');
-        window.addEventListener('hashchange', () => {
-            const hash = location.hash.replace(/#!/, '');
-            const params = new URLSearchParams(hash);
-            if (params.get('action') !== ACTION.FILE_LISTING) return;
-            const hashPath = params.get('path');
-            if (hashPath && hashPath !== this.path) {
-                this.loadContent(hashPath);
-            }
-        });
+        // Store the handler reference so destroy() can remove it. An inline
+        // arrow passed directly to addEventListener is unremovable and leaks
+        // the whole client (closure over `this`) for the page lifetime.
+        window.addEventListener('hashchange', this.onHashChange);
         this.name = `${TAG} [${this.serial}]`;
         this.tableBodyId = `${Util.escapeUdid(this.serial)}_list`;
         this.wrapperId = `wrapper_${this.tableBodyId}`;
@@ -304,6 +310,14 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
 
     protected onSocketOpen(): void {
         this.loadContent(this.path);
+    }
+
+    public override destroy(): void {
+        super.destroy();
+        // Remove the hashchange listener registered in the constructor. Without
+        // this the client (and its DOM/closure graph) leaks on every navigation
+        // away from a file-listing view.
+        window.removeEventListener('hashchange', this.onHashChange);
     }
 
     protected loadContent(path: string, entry?: Entry, anchor?: HTMLElement, pathToLoadAfter = ''): void {

--- a/src/app/googDevice/client/ListFilesModal.ts
+++ b/src/app/googDevice/client/ListFilesModal.ts
@@ -10,6 +10,7 @@ import { createFileIconForEntry } from './FileIconUtils';
 import { AdbkitFilePushStream } from '../filePush/AdbkitFilePushStream';
 import FilePushHandler, { type DragAndPushListener, type PushUpdateParams } from '../filePush/FilePushHandler';
 import { ManagerClient } from '../../client/ManagerClient';
+import { attachFsChannelKeepAlive } from './fsChannelKeepAlive';
 import { basename, resolve } from '../../pathUtils';
 
 const TAG = '[ListFilesModal]';
@@ -210,6 +211,13 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
         this.channels.clear();
         this.downloads.clear();
         this.uploads.clear();
+
+        // Detach the keep-alive 'empty' handler before closing the FSLS channel
+        // so the listener (and its hold on the channel) is released. (#38)
+        if (this.detachFsChannelKeepAlive) {
+            this.detachFsChannelKeepAlive();
+            this.detachFsChannelKeepAlive = undefined;
+        }
 
         // Close the FSLS channel
         if (this.fsChannel && (this.fsChannel.readyState === this.fsChannel.OPEN || this.fsChannel.readyState === this.fsChannel.CONNECTING)) {
@@ -416,6 +424,11 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
     // ManagerClient creates this via createChannel(getChannelInitData()).
     // loadDirectory creates command sub-channels on THIS channel, not on the root multiplexer.
     private fsChannel?: Multiplexer | undefined;
+    // Disposer that removes the FSLS channel's keep-alive 'empty' handler.
+    // Stored so onBeforeClose can detach it (the handler closes over nothing,
+    // but leaving it registered keeps the listener — and the channel ref —
+    // around). See attachFsChannelKeepAlive. (#38)
+    private detachFsChannelKeepAlive?: (() => void) | undefined;
 
     private connectAndLoad(): void {
         this.wsUrl = this.buildWebSocketUrl();
@@ -459,9 +472,9 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
             // Prevent the FSLS channel from being cleaned up by the root multiplexer's
             // 'empty' handler when it temporarily has no sub-channels (e.g., between STAT
             // finishing and LIST starting). We control the lifecycle via onBeforeClose.
-            this.fsChannel.on('empty', () => {
-                // no-op: keep the FSLS channel alive
-            });
+            // The disposer detaches this exact handler when the modal closes so it
+            // doesn't leak (an inline arrow here would be unremovable).
+            this.detachFsChannelKeepAlive = attachFsChannelKeepAlive(this.fsChannel);
 
             this.fsChannel.addEventListener('close', (ev) => {
                 const ce = ev as CloseEvent;

--- a/src/app/googDevice/client/__tests__/DeviceTrackerLabelCell.test.ts
+++ b/src/app/googDevice/client/__tests__/DeviceTrackerLabelCell.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeviceTracker } from '../DeviceTracker';
+
+// §34 Part A: buildLabelCell must NOT fetch /api/devices/labels per row. The
+// label map is fetched once per table refresh (fetchRowContext) and injected.
+describe('DeviceTracker.buildLabelCell label injection (#34 Part A)', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    it('renders the injected label without fetching per row', async () => {
+        const cell = document.createElement('td');
+        const labels: Record<string, string> = { 'serial-1': 'Living Room TV' };
+
+        // New signature: (cell, serial, labels)
+        (DeviceTracker as any).buildLabelCell(cell, 'serial-1', labels);
+
+        // Let any microtasks settle.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const nameText = cell.querySelector('.device-name-text');
+        expect(nameText?.textContent).toBe('Living Room TV');
+        // The whole point: no per-row label fetch.
+        const labelFetches = fetchMock.mock.calls.filter((c) => c[0] === '/api/devices/labels');
+        expect(labelFetches).toHaveLength(0);
+    });
+
+    it('renders "Unnamed Device" when the serial has no injected label', async () => {
+        const cell = document.createElement('td');
+        (DeviceTracker as any).buildLabelCell(cell, 'serial-2', { 'serial-1': 'X' });
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const nameText = cell.querySelector('.device-name-text');
+        expect(nameText?.textContent).toBe('Unnamed Device');
+        expect(nameText?.classList.contains('unnamed')).toBe(true);
+    });
+});

--- a/src/app/googDevice/client/__tests__/FileListingClient.test.ts
+++ b/src/app/googDevice/client/__tests__/FileListingClient.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ACTION } from '../../../../common/Action';
+import type { ParamsFileListing } from '../../../../types/ParamsFileListing';
+
+// Minimal WebSocket stub. jsdom does not implement WebSocket. Reporting
+// readyState=CONNECTING(0) makes Multiplexer buffer outgoing frames instead of
+// calling send(), so FileListingClient's constructor completes without a real
+// socket. We only need addEventListener/removeEventListener/send/close to exist.
+class MockWebSocket {
+    public readonly CONNECTING = 0;
+    public readonly OPEN = 1;
+    public readonly CLOSING = 2;
+    public readonly CLOSED = 3;
+    public readyState = 0; // CONNECTING
+    public binaryType = 'blob';
+    public url: string;
+    constructor(url: string) {
+        this.url = url;
+    }
+    public addEventListener(): void {
+        // no-op
+    }
+    public removeEventListener(): void {
+        // no-op
+    }
+    public send(): void {
+        // no-op
+    }
+    public close(): void {
+        // no-op
+    }
+}
+
+const params: ParamsFileListing = {
+    action: ACTION.FILE_LISTING,
+    udid: 'serial123',
+    path: '/data/local/tmp',
+} as ParamsFileListing;
+
+describe('FileListingClient hashchange listener lifecycle (#37)', () => {
+    let addSpy: ReturnType<typeof vi.spyOn>;
+    let removeSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+        // ManagerClient.sockets is a static Map keyed by URL — clear so each
+        // test builds a fresh multiplexer.
+        addSpy = vi.spyOn(window, 'addEventListener');
+        removeSpy = vi.spyOn(window, 'removeEventListener');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        document.body.innerHTML = '';
+        location.hash = '';
+    });
+
+    function getHashchangeHandler(): EventListener | undefined {
+        const call = addSpy.mock.calls.find((c: unknown[]) => c[0] === 'hashchange');
+        return call?.[1] as EventListener | undefined;
+    }
+
+    it('removes the SAME hashchange handler reference on destroy()', async () => {
+        const { FileListingClient } = await import('../FileListingClient');
+        const client = FileListingClient.start(params);
+
+        const registered = getHashchangeHandler();
+        expect(registered).toBeTypeOf('function');
+
+        client.destroy();
+
+        const removedCall = removeSpy.mock.calls.find((c: unknown[]) => c[0] === 'hashchange');
+        expect(removedCall).toBeDefined();
+        // Same reference passed to add and remove.
+        expect(removedCall?.[1]).toBe(registered);
+    });
+
+    it('does not react to hashchange after destroy()', async () => {
+        const { FileListingClient } = await import('../FileListingClient');
+        const client = FileListingClient.start(params);
+        const loadSpy = vi.spyOn(client as any, 'loadContent');
+
+        client.destroy();
+
+        // Simulate a hash navigation that WOULD have triggered loadContent.
+        location.hash = `#!action=${ACTION.FILE_LISTING}&path=/sdcard`;
+        window.dispatchEvent(new Event('hashchange'));
+
+        expect(loadSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/googDevice/client/fsChannelKeepAlive.test.ts
+++ b/src/app/googDevice/client/fsChannelKeepAlive.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { attachFsChannelKeepAlive } from './fsChannelKeepAlive';
+
+// Minimal channel-like stub exposing the TypedEmitter on/off surface that
+// Multiplexer provides. We don't need a real Multiplexer to verify the
+// register/unregister symmetry that prevents the 'empty'-handler leak (#38).
+function makeChannel() {
+    return {
+        on: vi.fn(),
+        off: vi.fn(),
+    };
+}
+
+describe('attachFsChannelKeepAlive (#38)', () => {
+    it("registers an 'empty' handler on attach", () => {
+        const channel = makeChannel();
+        attachFsChannelKeepAlive(channel);
+        expect(channel.on).toHaveBeenCalledTimes(1);
+        expect(channel.on.mock.calls[0]![0]).toBe('empty');
+        expect(channel.on.mock.calls[0]![1]).toBeTypeOf('function');
+    });
+
+    it("detaches the SAME 'empty' handler reference via the returned disposer", () => {
+        const channel = makeChannel();
+        const detach = attachFsChannelKeepAlive(channel);
+        const registered = channel.on.mock.calls[0]![1];
+
+        detach();
+
+        expect(channel.off).toHaveBeenCalledTimes(1);
+        expect(channel.off.mock.calls[0]![0]).toBe('empty');
+        // Same reference passed to on() and off() — the whole point: an
+        // anonymous inline handler could never be removed.
+        expect(channel.off.mock.calls[0]![1]).toBe(registered);
+    });
+
+    it('the registered handler is a no-op (keeps the channel alive, does not close it)', () => {
+        const channel = makeChannel();
+        attachFsChannelKeepAlive(channel);
+        const registered = channel.on.mock.calls[0]![1] as (c: unknown) => void;
+        // Should not throw and should not call anything on the channel.
+        expect(() => registered(channel)).not.toThrow();
+    });
+});

--- a/src/app/googDevice/client/fsChannelKeepAlive.ts
+++ b/src/app/googDevice/client/fsChannelKeepAlive.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimal channel surface needed to keep the FSLS channel alive. Both
+ * Multiplexer and any test stub expose this `on`/`off` pair (from TypedEmitter).
+ */
+export interface KeepAliveChannel {
+    on(eventName: 'empty', fn: (channel: unknown) => void): void;
+    off(eventName: 'empty', fn: (channel: unknown) => void): void;
+}
+
+/**
+ * Register a no-op 'empty' handler on the FSLS channel and return a disposer
+ * that removes that exact handler reference.
+ *
+ * Why: the root multiplexer auto-closes a channel that transiently has no
+ * sub-channels (e.g. between STAT finishing and LIST starting). The FSLS
+ * channel's lifecycle is owned by the modal, so we suppress that auto-close by
+ * registering an 'empty' handler. Registering it inline (an anonymous arrow)
+ * leaks it — `off` needs the same reference. This helper keeps the register /
+ * unregister symmetric so onBeforeClose can detach it. (#38)
+ */
+export function attachFsChannelKeepAlive(channel: KeepAliveChannel): () => void {
+    const handler = (): void => {
+        // no-op: keep the FSLS channel alive
+    };
+    channel.on('empty', handler);
+    return (): void => {
+        channel.off('empty', handler);
+    };
+}


### PR DESCRIPTION
Sub-PR 1 of 3 for the client-perf cluster. Five frontend lifecycle/leak fixes, full TDD.

### #34 — device-table rebuild storm (biggest)
- **Diff/patch by udid:** `BaseDeviceTracker` now diffs DOM rows (keyed by `data-udid`) against `this.descriptors` instead of clearing the block and rebuilding every row on every WS message — unchanged rows keep their node (preserves scroll/focus), gone rows are removed, changed rows rebuilt in place, then reordered to match.
- **Label cache:** `/api/devices/labels` is fetched **once per refresh** (`fetchRowContext`) and injected into every row, replacing the per-row fetch storm that scaled with device count.

### #35 — reconnect `setTimeout` leak
Store the timer id, `clearTimeout` in `destroy()`, re-check `destroyed` at fire time. Was an unbounded reconnect after teardown.

### #36 — polling interval leak
`destroy()` clearing the interval added to `DependencyPanel` + `FirstRunBanner`. ⚠️ See note below.

### #37 — `hashchange` listener leak
`FileListingClient` stores the handler reference and `removeEventListener`s it in `destroy()`; the inline arrow was unremovable and leaked the client per navigation.

### #38 — `Multiplexer.on('empty')` without `off`
Extracted `attachFsChannelKeepAlive()` (returns a disposer); `ListFilesModal.onBeforeClose()` disposes it before closing the channel.

---

**Full TDD** — new tests: `BaseDeviceTracker.test.ts`, `DeviceTrackerLabelCell.test.ts`, `FileListingClient.test.ts`, `fsChannelKeepAlive.test.ts`; extended `DependencyPanel.test.ts` + `FirstRunBanner.test.ts`.
**Gates:** `tsc --noEmit` clean · `vitest` **1141 pass / 0 fail**.

**Note (#36):** `DependencyPanel`/`FirstRunBanner` are created once in `index.ts` and never torn down (no SPA nav / unload path), so `destroy()` has no caller yet — it's defensive/future-proofing rather than fixing an active runtime leak. Flagged for follow-up.

`release:none`.
