### PR TITLE
fix(player): client-perf video hot-path fixes (sec #39,#41-#44)

### DIFF
--- a/src/app/googDevice/client/RollingWindow.ts
+++ b/src/app/googDevice/client/RollingWindow.ts
@@ -1,0 +1,60 @@
+/**
+ * Fixed-capacity rolling window over numbers with an O(1) running average.
+ *
+ * Replaces the per-frame `array.shift()` + full `array.reduce()` churn in the
+ * stream degradation path: `push()` evicts the oldest element and updates a
+ * running sum in O(1), and `average()` is sum/count with no iteration.
+ *
+ * Backed by a ring buffer so eviction never shifts elements.
+ */
+export class RollingWindow {
+    private readonly buffer: number[];
+    private readonly capacity: number;
+    private start = 0;
+    private size = 0;
+    private sum = 0;
+
+    constructor(capacity: number) {
+        if (capacity <= 0) {
+            throw new Error(`RollingWindow capacity must be > 0, got ${capacity}`);
+        }
+        this.capacity = capacity;
+        this.buffer = new Array<number>(capacity);
+    }
+
+    /** Number of values currently held (<= capacity). */
+    get count(): number {
+        return this.size;
+    }
+
+    /** Append a value, evicting the oldest when at capacity. O(1). */
+    public push(value: number): void {
+        if (this.size < this.capacity) {
+            const index = (this.start + this.size) % this.capacity;
+            this.buffer[index] = value;
+            this.size++;
+            this.sum += value;
+        } else {
+            // Full: overwrite the oldest slot, advance start, adjust running sum.
+            const evicted = this.buffer[this.start]!;
+            this.buffer[this.start] = value;
+            this.start = (this.start + 1) % this.capacity;
+            this.sum += value - evicted;
+        }
+    }
+
+    /** Mean of the held values, or 0 when empty. O(1). */
+    public average(): number {
+        if (this.size === 0) {
+            return 0;
+        }
+        return this.sum / this.size;
+    }
+
+    /** Drop all values and reset the running sum. */
+    public clear(): void {
+        this.start = 0;
+        this.size = 0;
+        this.sum = 0;
+    }
+}

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -30,6 +30,7 @@ import { UhidManager } from '../UhidManager';
 import { UhidMouseHandler } from '../UhidMouseHandler';
 import { ConfigureScrcpy } from './ConfigureScrcpy';
 import { DeviceTracker } from './DeviceTracker';
+import { RollingWindow } from './RollingWindow';
 
 type StartParams = {
     udid: string;
@@ -140,7 +141,12 @@ export class StreamClientScrcpy
     private fitToScreen?: boolean | undefined;
     private demuxer?: ScrcpyDemuxer | undefined;
     private audioPlayer?: AudioPlayer | undefined;
-    private frameSizes: number[] = [];
+    // Fixed 30-frame rolling window with an O(1) running average — replaces the
+    // per-frame shift()/reduce() churn on the video hot path. `frameSampleCount`
+    // tracks how many frames we have observed (for the initial baseline build).
+    private static readonly FRAME_WINDOW_SIZE = 30;
+    private frameSizes = new RollingWindow(StreamClientScrcpy.FRAME_WINDOW_SIZE);
+    private frameSampleCount = 0;
     private baselineFrameSize = 0;
     private degradationCount = 0;
     private lastRefreshTime = 0;
@@ -280,13 +286,14 @@ export class StreamClientScrcpy
         // Track frame sizes for degradation detection (skip config frames)
         if (!isConfig && data.length > 0) {
             this.frameSizes.push(data.length);
-            // Build baseline from first 30 frames
-            if (this.frameSizes.length === 30) {
-                this.baselineFrameSize = this.frameSizes.reduce((a, b) => a + b, 0) / 30;
+            this.frameSampleCount++;
+            // Build baseline from first 30 frames (window is full at this point)
+            if (this.frameSampleCount === StreamClientScrcpy.FRAME_WINDOW_SIZE) {
+                this.baselineFrameSize = this.frameSizes.average();
             }
-            // Keep rolling window of 30 frames
-            if (this.frameSizes.length > 30) {
-                this.frameSizes.shift();
+            // Once past the baseline window, evaluate degradation each frame.
+            // The window evicts the oldest sample in O(1) on every push above.
+            if (this.frameSampleCount > StreamClientScrcpy.FRAME_WINDOW_SIZE) {
                 this.checkForDegradation();
             }
         }
@@ -496,9 +503,9 @@ export class StreamClientScrcpy
         // Don't check within 30s of a refresh (was 10s — too aggressive)
         if (now - this.lastRefreshTime < 30000) return;
         // Need at least 10 samples for a reliable average
-        if (this.frameSizes.length < 10) return;
+        if (this.frameSizes.count < 10) return;
 
-        const avg = this.frameSizes.reduce((a, b) => a + b, 0) / this.frameSizes.length;
+        const avg = this.frameSizes.average();
         // If average frame size drops below 10% of baseline for sustained period
         // (was 25% — too sensitive for static content like screensavers)
         if (avg < this.baselineFrameSize * 0.1) {
@@ -509,7 +516,8 @@ export class StreamClientScrcpy
                     `Quality degradation detected (avg=${Math.round(avg)} vs baseline=${Math.round(this.baselineFrameSize)}), refreshing stream`,
                 );
                 this.degradationCount = 0;
-                this.frameSizes = [];
+                this.frameSizes.clear();
+                this.frameSampleCount = 0;
                 this.baselineFrameSize = 0;
                 this.refreshStream();
             }
@@ -521,7 +529,8 @@ export class StreamClientScrcpy
     public refreshStream(): void {
         console.log(TAG, 'Refreshing stream (reconnect for fresh keyframe)');
         this.lastRefreshTime = Date.now();
-        this.frameSizes = [];
+        this.frameSizes.clear();
+        this.frameSampleCount = 0;
         this.baselineFrameSize = 0;
         this.degradationCount = 0;
 

--- a/src/app/googDevice/client/__tests__/RollingWindow.test.ts
+++ b/src/app/googDevice/client/__tests__/RollingWindow.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { RollingWindow } from '../RollingWindow';
+
+/**
+ * Naive reference average over a capacity-bounded window — the slow shift()/reduce()
+ * implementation RollingWindow replaces. Used as the oracle for the O(1) version.
+ */
+function naiveAverage(values: number[], capacity: number): number {
+    const window = values.slice(-capacity);
+    if (window.length === 0) {
+        return 0;
+    }
+    return window.reduce((a, b) => a + b, 0) / window.length;
+}
+
+describe('RollingWindow', () => {
+    it('reports count and average correctly before reaching capacity', () => {
+        const w = new RollingWindow(30);
+        expect(w.count).toBe(0);
+        expect(w.average()).toBe(0);
+        w.push(10);
+        w.push(20);
+        w.push(30);
+        expect(w.count).toBe(3);
+        expect(w.average()).toBe(20);
+    });
+
+    it('evicts the oldest value once capacity is exceeded (fixed window of 30)', () => {
+        const w = new RollingWindow(30);
+        // Push 30 ones, then a 31st value of 301 — the first 1 should be evicted.
+        for (let i = 0; i < 30; i++) {
+            w.push(1);
+        }
+        expect(w.count).toBe(30);
+        expect(w.average()).toBe(1);
+        w.push(301);
+        // Still 30 elements: 29 ones + one 301 → (29 + 301) / 30 = 11
+        expect(w.count).toBe(30);
+        expect(w.average()).toBeCloseTo((29 + 301) / 30, 10);
+    });
+
+    it('matches the naive shift()/reduce() reference across a long random sequence', () => {
+        const capacity = 30;
+        const w = new RollingWindow(capacity);
+        const seen: number[] = [];
+        let seed = 12345;
+        const rand = () => {
+            // deterministic LCG so the test is reproducible
+            seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+            return seed % 5000;
+        };
+        for (let i = 0; i < 500; i++) {
+            const v = rand();
+            seen.push(v);
+            w.push(v);
+            expect(w.average()).toBeCloseTo(naiveAverage(seen, capacity), 6);
+            expect(w.count).toBe(Math.min(seen.length, capacity));
+        }
+    });
+
+    it('does not drift after many evictions (running sum stays exact for integers)', () => {
+        const w = new RollingWindow(3);
+        w.push(100);
+        w.push(200);
+        w.push(300);
+        expect(w.average()).toBe(200);
+        w.push(400); // evicts 100 → [200,300,400]
+        w.push(500); // evicts 200 → [300,400,500]
+        expect(w.average()).toBe(400);
+    });
+
+    it('clear() empties the window and resets the running sum', () => {
+        const w = new RollingWindow(30);
+        w.push(50);
+        w.push(70);
+        w.clear();
+        expect(w.count).toBe(0);
+        expect(w.average()).toBe(0);
+        w.push(10);
+        expect(w.average()).toBe(10);
+    });
+});

--- a/src/app/player/BaseCanvasBasedPlayer.ts
+++ b/src/app/player/BaseCanvasBasedPlayer.ts
@@ -2,6 +2,7 @@ import type { DisplayInfo } from '../DisplayInfo';
 import type ScreenInfo from '../ScreenInfo';
 import type VideoSettings from '../VideoSettings';
 import { BasePlayer, type PlaybackQuality } from './BasePlayer';
+import { shouldDropBacklog } from './backlogDrop';
 
 type DecodedFrame = {
     width: number;
@@ -207,23 +208,22 @@ export abstract class BaseCanvasBasedPlayer extends BasePlayer {
         }
     }
 
-    public override pushFrame(frame: Uint8Array): void {
-        super.pushFrame(frame);
-        if (BasePlayer.isIFrame(frame)) {
-            if (this.videoSettings) {
-                const { maxFps } = this.videoSettings;
-                if (this.framesList.length > maxFps / 2) {
-                    const dropped = this.framesList.length;
-                    this.framesList = [];
-                    this.videoStats.push({
-                        decodedFrames: 0,
-                        droppedFrames: dropped,
-                        inputBytes: 0,
-                        inputFrames: 0,
-                        timestamp: Date.now(),
-                    });
-                }
-            }
+    public override pushFrame(frame: Uint8Array, isKeyframe?: boolean): void {
+        super.pushFrame(frame, isKeyframe);
+        // Prefer the demuxer's real keyframe flag (works for H.264/H.265/AV1);
+        // fall back to the H.264-only NAL check when no flag is supplied so
+        // existing callers keep their previous behavior (finding #43).
+        const keyframe = typeof isKeyframe === 'boolean' ? isKeyframe : BasePlayer.isIFrame(frame);
+        if (this.videoSettings && shouldDropBacklog(keyframe, this.framesList.length, this.videoSettings.maxFps)) {
+            const dropped = this.framesList.length;
+            this.framesList = [];
+            this.videoStats.push({
+                decodedFrames: 0,
+                droppedFrames: dropped,
+                inputBytes: 0,
+                inputFrames: 0,
+                timestamp: Date.now(),
+            });
         }
         this.framesList.push(frame);
         this.shiftFrame();

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -5,6 +5,7 @@ import ScreenInfo from '../ScreenInfo';
 import Size from '../Size';
 import Util from '../Util';
 import VideoSettings from '../VideoSettings';
+import { AnimationFrameGuard } from './animationFrameGuard';
 
 interface BitrateStat {
     timestamp: number;
@@ -80,7 +81,9 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
     private totalStatsCounter = 0;
     private dirtyStatsWidth = 0;
     private state: number = BasePlayer.STATE['STOPPED']!;
-    private qualityAnimationId?: number | undefined;
+    // Single guarded rAF handle for the quality-stats loop — prevents the
+    // double-start / cancel-leak the raw id allowed (finding #44).
+    private readonly qualityStatsRaf = new AnimationFrameGuard();
     private showQualityStats = BasePlayer.DEFAULT_SHOW_QUALITY_STATS;
     protected receivedFirstFrame = false;
     private statLines: string[] = [];
@@ -320,23 +323,32 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
 
     public stop(): void {
         this.state = BasePlayer.STATE['STOPPED']!;
+        // Cancel any pending stats frame so the loop cannot run after stop (no leak).
+        this.qualityStatsRaf.stop();
     }
 
     public getState(): number {
         return this.state;
     }
 
-    public pushFrame(frame: Uint8Array): void {
+    // `isKeyframe` is accepted so subclasses (BaseCanvasBasedPlayer) and callers
+    // can plumb the demuxer's real keyframe flag through a single signature; the
+    // base stats path itself does not need it.
+    public pushFrame(frame: Uint8Array, _isKeyframe?: boolean): void {
         if (!this.receivedFirstFrame) {
             this.receivedFirstFrame = true;
-            if (typeof this.qualityAnimationId !== 'number') {
-                this.qualityAnimationId = requestAnimationFrame(this.updateQualityStats);
-            }
+            // Guarded: a no-op if a stats frame is already pending (no double-start).
+            this.scheduleQualityStats();
         }
         this.inputBytes.push({
             timestamp: Date.now(),
             bytes: frame.byteLength,
         });
+    }
+
+    /** Start the quality-stats rAF loop, unless one is already pending. */
+    private scheduleQualityStats(): void {
+        this.qualityStatsRaf.start(this.updateQualityStats);
     }
 
     public abstract getPreferredVideoSetting(): VideoSettings;
@@ -402,6 +414,9 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
 
     protected resetStats(): void {
         this.receivedFirstFrame = false;
+        // Cancel the pending stats frame; clearing receivedFirstFrame lets the next
+        // pushFrame re-arm the loop cleanly without a second concurrent loop (#44).
+        this.qualityStatsRaf.stop();
         this.totalStatsCounter = 0;
         this.totalStats = {
             droppedFrames: 0,
@@ -446,7 +461,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
         }
         this.drawStats();
         if (this.state !== BasePlayer.STATE['STOPPED']!) {
-            this.qualityAnimationId = requestAnimationFrame(this.updateQualityStats);
+            this.scheduleQualityStats();
         }
     };
 

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -6,8 +6,9 @@ import VideoSettings from '../VideoSettings';
 import { OBU_TYPE, obuType, parseAv1ConfigRecord, parseAv1SequenceHeader } from './av1-utils';
 import { BaseCanvasBasedPlayer } from './BaseCanvasBasedPlayer';
 import { BasePlayer } from './BasePlayer';
-import { parseSPS } from './h264-utils';
+import { parseSPS, stripEmulationPrevention } from './h264-utils';
 import { HEVC_NAL_TYPE, hevcNalType, parseHevcSPS } from './h265-utils';
+import { buildDecoderConfig } from './webCodecsConfig';
 
 function toHex(value: number) {
     return value.toString(16).padStart(2, '0').toUpperCase();
@@ -32,6 +33,9 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     }
 
     private static parseSPSCodecString(data: Uint8Array): { codec: string; width: number; height: number } {
+        // Strip RBSP emulation-prevention bytes before bitstream parsing, mirroring
+        // the H.265 path (parseHevcSPS strips internally). An SPS containing a
+        // 00 00 03 triple would otherwise be mis-parsed (finding #42).
         const {
             profile_idc,
             constraint_set_flags,
@@ -44,7 +48,7 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
             frame_crop_top_offset,
             frame_crop_bottom_offset,
             sar,
-        } = parseSPS(data);
+        } = parseSPS(stripEmulationPrevention(data));
 
         const sarScale = sar[0] / sar[1];
         const codec = `avc1.${[profile_idc, constraint_set_flags, level_idc].map(toHex).join('')}`;
@@ -99,8 +103,9 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
      * Replaces the old pushFrame(Uint8Array) → decode() pipeline.
      */
     public pushVideoFrame(data: Uint8Array, pts: bigint, isConfig: boolean, isKeyframe: boolean): void {
-        // Track stats via BasePlayer
-        BasePlayer.prototype.pushFrame.call(this, data);
+        // Track stats via BasePlayer. Pass the demuxer's real keyframe flag so the
+        // shared signature carries it (works for H.264/H.265/AV1) — see finding #43.
+        BasePlayer.prototype.pushFrame.call(this, data, isKeyframe);
 
         if (isConfig) {
             let result: { codec: string; width?: number; height?: number } | null = null;
@@ -124,12 +129,17 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
                 if (this.decoder.state === 'configured') {
                     this.decoder.flush().catch(() => {});
                 }
-                this.decoder.configure({
-                    codec: result.codec,
-                    codedWidth: codedW,
-                    codedHeight: codedH,
-                    optimizeForLatency: true,
-                } as VideoDecoderConfig);
+                // Supply SPS/PPS (and VPS for H.265) once via `description` so the
+                // per-frame keyframe path no longer concatenates config + frame data.
+                this.decoder.configure(
+                    buildDecoderConfig({
+                        codec: result.codec,
+                        detectedCodec: this.detectedCodec,
+                        codedWidth: codedW,
+                        codedHeight: codedH,
+                        configData: data,
+                    }),
+                );
             }
             this.configData = new Uint8Array(data);
             return;
@@ -142,28 +152,17 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
                 this.receivedFirstFrame = true;
             }
 
-            if (this.detectedCodec === 'av1') {
-                // AV1: no config prepending needed
-                this.decoder.decode(
-                    new EncodedVideoChunk({
-                        type: 'key',
-                        timestamp: Number(pts),
-                        data,
-                    }),
-                );
-            } else {
-                // H.264/H.265: prepend config (SPS/PPS or VPS/SPS/PPS)
-                const fullData = new Uint8Array(this.configData.length + data.length);
-                fullData.set(this.configData);
-                fullData.set(data, this.configData.length);
-                this.decoder.decode(
-                    new EncodedVideoChunk({
-                        type: 'key',
-                        timestamp: Number(pts),
-                        data: fullData,
-                    }),
-                );
-            }
+            // SPS/PPS (and VPS for H.265) were handed to the decoder via the
+            // `description` field of VideoDecoderConfig at configure() time, and
+            // AV1 carries its sequence header inline — so decode the keyframe
+            // data directly with no per-frame config concatenation (finding #41).
+            this.decoder.decode(
+                new EncodedVideoChunk({
+                    type: 'key',
+                    timestamp: Number(pts),
+                    data,
+                }),
+            );
             return;
         }
 

--- a/src/app/player/__tests__/animationFrameGuard.test.ts
+++ b/src/app/player/__tests__/animationFrameGuard.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AnimationFrameGuard } from '../animationFrameGuard';
+
+/**
+ * Finding #44: the quality-stats requestAnimationFrame loop must not double-start
+ * (a second start while one is pending) and must be cancelable (stop() cancels
+ * the pending frame so it cannot leak after the player stops). AnimationFrameGuard
+ * encapsulates a single rAF handle with guarded start + cancel; raf/caf are
+ * injectable so it unit-tests in node with no DOM.
+ */
+describe('AnimationFrameGuard', () => {
+    function makeFakes() {
+        let nextId = 1;
+        const pending = new Map<number, FrameRequestCallback>();
+        const raf = vi.fn((cb: FrameRequestCallback) => {
+            const id = nextId++;
+            pending.set(id, cb);
+            return id;
+        });
+        const caf = vi.fn((id: number) => {
+            pending.delete(id);
+        });
+        const fire = (id: number) => {
+            const cb = pending.get(id);
+            pending.delete(id);
+            cb?.(performance.now?.() ?? 0);
+        };
+        return { raf, caf, fire, pending };
+    }
+
+    it('schedules one frame on start and reports pending', () => {
+        const { raf, caf } = makeFakes();
+        const g = new AnimationFrameGuard(raf, caf);
+        const cb = vi.fn();
+        g.start(cb);
+        expect(raf).toHaveBeenCalledTimes(1);
+        expect(g.isPending()).toBe(true);
+    });
+
+    it('does NOT double-start while a frame is already pending', () => {
+        const { raf, caf } = makeFakes();
+        const g = new AnimationFrameGuard(raf, caf);
+        const cb = vi.fn();
+        g.start(cb);
+        g.start(cb); // second start must be a no-op
+        g.start(cb);
+        expect(raf).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop() cancels the pending frame with the stored id and clears pending', () => {
+        const { raf, caf } = makeFakes();
+        const g = new AnimationFrameGuard(raf, caf);
+        const cb = vi.fn();
+        g.start(cb);
+        const id = raf.mock.results[0]!.value as number;
+        g.stop();
+        expect(caf).toHaveBeenCalledTimes(1);
+        expect(caf).toHaveBeenCalledWith(id);
+        expect(g.isPending()).toBe(false);
+    });
+
+    it('stop() is a no-op when nothing is pending (no cancelAnimationFrame call)', () => {
+        const { raf, caf } = makeFakes();
+        const g = new AnimationFrameGuard(raf, caf);
+        g.stop();
+        expect(caf).not.toHaveBeenCalled();
+    });
+
+    it('clears pending when the frame fires, allowing a fresh reschedule (loop)', () => {
+        const { raf, caf, fire } = makeFakes();
+        const g = new AnimationFrameGuard(raf, caf);
+        const cb = vi.fn();
+        g.start(cb);
+        const id = raf.mock.results[0]!.value as number;
+        fire(id);
+        expect(cb).toHaveBeenCalledTimes(1);
+        // After firing, the guard must no longer be pending, so a reschedule works.
+        expect(g.isPending()).toBe(false);
+        g.start(cb);
+        expect(raf).toHaveBeenCalledTimes(2);
+    });
+
+    it('a stop() after a fire does not cancel a frame that already ran', () => {
+        const { raf, caf, fire } = makeFakes();
+        const g = new AnimationFrameGuard(raf, caf);
+        g.start(vi.fn());
+        const id = raf.mock.results[0]!.value as number;
+        fire(id);
+        g.stop();
+        expect(caf).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/player/__tests__/backlogDrop.test.ts
+++ b/src/app/player/__tests__/backlogDrop.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDropBacklog } from '../backlogDrop';
+
+/**
+ * Finding #43: the backlog-drop decision must trigger on a REAL keyframe (the
+ * demuxer's PTS_FLAG_KEYFRAME bit), not the H.264-only NAL check (isIFrame),
+ * which silently misses H.265/AV1 keyframes. The decision itself is:
+ *   drop  ⇔  isKeyframe && framesListLength > maxFps / 2
+ */
+describe('shouldDropBacklog', () => {
+    it('drops when a keyframe arrives and the backlog exceeds maxFps/2', () => {
+        expect(shouldDropBacklog(true, 9, 15)).toBe(true); // 9 > 7.5
+    });
+
+    it('does not drop on a keyframe when the backlog is at or below maxFps/2', () => {
+        expect(shouldDropBacklog(true, 7, 15)).toBe(false); // 7 <= 7.5
+        expect(shouldDropBacklog(true, 0, 15)).toBe(false);
+    });
+
+    it('never drops on a non-keyframe regardless of backlog size', () => {
+        expect(shouldDropBacklog(false, 100, 15)).toBe(false);
+    });
+
+    it('drops on a NON-H.264 keyframe that isIFrame would have missed', () => {
+        // The caller passes the demuxer keyframe flag; the byte content (H.265/AV1)
+        // is irrelevant to this decision — only the boolean and backlog matter.
+        expect(shouldDropBacklog(true, 16, 30)).toBe(true); // 16 > 15
+        expect(shouldDropBacklog(true, 30, 30)).toBe(true); // 30 > 15
+    });
+
+    it('uses strict greater-than against maxFps/2 (boundary)', () => {
+        expect(shouldDropBacklog(true, 5, 10)).toBe(false); // 5 == 10/2, not >
+        expect(shouldDropBacklog(true, 6, 10)).toBe(true); // 6 > 5
+    });
+});

--- a/src/app/player/__tests__/basePlayerStatsRaf.test.ts
+++ b/src/app/player/__tests__/basePlayerStatsRaf.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Finding #44 at the BasePlayer level: stop() must cancelAnimationFrame the
+ * stored stats-loop id, and the loop must not double-start (a second pushFrame
+ * while a frame is pending creates no second loop). resetStats() must also cancel.
+ *
+ * We stub raf/caf globally BEFORE constructing so AnimationFrameGuard's default
+ * params capture the stubs, then drive a minimal concrete BasePlayer subclass.
+ */
+
+let rafSpy: ReturnType<typeof vi.fn>;
+let cafSpy: ReturnType<typeof vi.fn>;
+let pending: Map<number, FrameRequestCallback>;
+
+describe('BasePlayer quality-stats rAF lifecycle (finding #44)', () => {
+    beforeEach(() => {
+        let nextId = 1;
+        pending = new Map();
+        rafSpy = vi.fn((cb: FrameRequestCallback) => {
+            const id = nextId++;
+            pending.set(id, cb);
+            return id;
+        });
+        cafSpy = vi.fn((id: number) => {
+            pending.delete(id);
+        });
+        vi.stubGlobal('requestAnimationFrame', rafSpy);
+        vi.stubGlobal('cancelAnimationFrame', cafSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    async function makePlayer() {
+        const { BasePlayer } = await import('../BasePlayer');
+        const VideoSettingsMod = await import('../../VideoSettings');
+        const VideoSettings = VideoSettingsMod.default;
+        class TestPlayer extends BasePlayer {
+            public getImageDataURL(): string {
+                return '';
+            }
+            public getPreferredVideoSetting() {
+                return new VideoSettings({ bitrate: 8_000_000, maxFps: 15, iFrameInterval: 2 });
+            }
+            protected calculateMomentumStats(): void {
+                /* no-op for stats lifecycle test */
+            }
+            public getFitToScreenStatus(): boolean {
+                return false;
+            }
+            public loadVideoSettings() {
+                return new VideoSettings({ bitrate: 8_000_000, maxFps: 15, iFrameInterval: 2 });
+            }
+        }
+        return new TestPlayer('udid');
+    }
+
+    it('starts exactly one stats frame on first pushFrame and does not double-start', async () => {
+        const player = await makePlayer();
+        player.pushFrame(new Uint8Array([0, 0, 0, 1, 0x65]));
+        expect(rafSpy).toHaveBeenCalledTimes(1);
+        // Second pushFrame while a frame is still pending must NOT schedule again.
+        player.pushFrame(new Uint8Array([0, 0, 0, 1, 0x41]));
+        expect(rafSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop() cancels the pending stats frame with the stored id', async () => {
+        const player = await makePlayer();
+        player.pushFrame(new Uint8Array([0, 0, 0, 1, 0x65]));
+        const id = rafSpy.mock.results[0]!.value as number;
+        player.stop();
+        expect(cafSpy).toHaveBeenCalledTimes(1);
+        expect(cafSpy).toHaveBeenCalledWith(id);
+    });
+
+    it('after stop() a fresh pushFrame can start a new loop (re-arm), still only one', async () => {
+        const player = await makePlayer();
+        player.pushFrame(new Uint8Array([0, 0, 0, 1, 0x65]));
+        player.stop();
+        // receivedFirstFrame is still true after stop(), so pushFrame won't re-arm;
+        // setVideoSettings()/resetStats() clears it. Simulate the reset path:
+        player.setVideoSettings(player.getVideoSettings(), false, false);
+        player.pushFrame(new Uint8Array([0, 0, 0, 1, 0x65]));
+        // raf called: initial + after re-arm = 2; never two concurrent (cancel happened).
+        expect(rafSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('setVideoSettings/resetStats cancels a pending frame (no leaked loop)', async () => {
+        const player = await makePlayer();
+        player.pushFrame(new Uint8Array([0, 0, 0, 1, 0x65]));
+        expect(cafSpy).not.toHaveBeenCalled();
+        player.setVideoSettings(player.getVideoSettings(), false, false); // calls resetStats()
+        expect(cafSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/app/player/__tests__/h264SpsEmulation.test.ts
+++ b/src/app/player/__tests__/h264SpsEmulation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { parseSPS, stripEmulationPrevention } from '../h264-utils';
+
+/**
+ * Finding #42 (b): the H.264 SPS path must strip RBSP emulation-prevention bytes
+ * (00 00 03 -> 00 00) before bitstream parsing, exactly as the H.265 path does.
+ * Without stripping, an SPS containing a 00 00 03 triple is mis-parsed (the bit
+ * reader consumes the stray 0x03), corrupting the dimensions handed to
+ * VideoDecoder.configure().
+ */
+
+/** Inverse of stripEmulationPrevention: insert 0x03 to RBSP-protect 00 00 0x runs. */
+function addEmulationPrevention(rbsp: Uint8Array): Uint8Array {
+    const out: number[] = [];
+    let zeros = 0;
+    for (const b of rbsp) {
+        if (zeros >= 2 && b <= 0x03) {
+            out.push(0x03);
+            zeros = 0;
+        }
+        out.push(b);
+        zeros = b === 0x00 ? zeros + 1 : 0;
+    }
+    return new Uint8Array(out);
+}
+
+// A real H.264 baseline SPS (avc1.42001E), no emulation bytes — parses cleanly.
+// The trailing 00 00 00 sits past the SPS fields parseSPS reads (it stops after
+// the VUI), so it does not affect the parse; it gives addEmulationPrevention a
+// 00 00 <small> run to protect, proving the strip round-trips.
+const cleanSps = new Uint8Array([
+    0x67, 0x42, 0x00, 0x1e, 0x8c, 0x8d, 0x40, 0xa0, 0x2f, 0xf9, 0x70, 0x11, 0x00, 0x00, 0x00,
+]);
+
+describe('H.264 SPS emulation-prevention handling', () => {
+    it('exposes stripEmulationPrevention from h264-utils (shared NAL helper)', () => {
+        expect(typeof stripEmulationPrevention).toBe('function');
+        expect(Array.from(stripEmulationPrevention(new Uint8Array([0x00, 0x00, 0x03, 0x01])))).toEqual([
+            0x00, 0x00, 0x01,
+        ]);
+    });
+
+    it('strip() exactly reverses emulation-prevention insertion', () => {
+        const protectedSps = addEmulationPrevention(cleanSps);
+        expect(Array.from(stripEmulationPrevention(protectedSps))).toEqual(Array.from(cleanSps));
+    });
+
+    it('parseSPS on a stripped emulation-protected SPS matches the clean parse', () => {
+        const baseline = parseSPS(cleanSps);
+        const protectedSps = addEmulationPrevention(cleanSps);
+        // Sanity: ensure the protected form actually differs (an emulation byte was inserted).
+        expect(protectedSps.length).toBeGreaterThan(cleanSps.length);
+        const viaStrip = parseSPS(stripEmulationPrevention(protectedSps));
+        expect(viaStrip).toEqual(baseline);
+    });
+});

--- a/src/app/player/__tests__/stripEmulationPrevention.test.ts
+++ b/src/app/player/__tests__/stripEmulationPrevention.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { stripEmulationPrevention } from '../h265-utils';
+
+describe('stripEmulationPrevention', () => {
+    it('returns a Uint8Array', () => {
+        const out = stripEmulationPrevention(new Uint8Array([1, 2, 3]));
+        expect(out).toBeInstanceOf(Uint8Array);
+    });
+
+    it('removes a single emulation-prevention sequence (00 00 03 -> 00 00)', () => {
+        const input = new Uint8Array([0x00, 0x00, 0x03, 0x01]);
+        const out = stripEmulationPrevention(input);
+        expect(Array.from(out)).toEqual([0x00, 0x00, 0x01]);
+    });
+
+    it('removes multiple non-adjacent emulation sequences', () => {
+        const input = new Uint8Array([0xaa, 0x00, 0x00, 0x03, 0x12, 0x34, 0x00, 0x00, 0x03, 0x56]);
+        const out = stripEmulationPrevention(input);
+        expect(Array.from(out)).toEqual([0xaa, 0x00, 0x00, 0x12, 0x34, 0x00, 0x00, 0x56]);
+    });
+
+    it('handles adjacent/overlapping emulation runs (00 00 03 00 00 03 ..)', () => {
+        // 00 00 03 00 00 03 00 -> after removing the first 03 we get 00 00 [00] ...
+        // Decoder semantics: each "00 00 03" with the 03 as emulation byte collapses to "00 00".
+        const input = new Uint8Array([0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x04]);
+        const out = stripEmulationPrevention(input);
+        expect(Array.from(out)).toEqual([0x00, 0x00, 0x00, 0x00, 0x04]);
+    });
+
+    it('does NOT strip 00 00 03 when not the start of an emulation triple boundary (e.g. 00 03)', () => {
+        // No "00 00 03" anywhere — nothing should change.
+        const input = new Uint8Array([0x00, 0x03, 0x00, 0x01, 0x02]);
+        const out = stripEmulationPrevention(input);
+        expect(Array.from(out)).toEqual([0x00, 0x03, 0x00, 0x01, 0x02]);
+    });
+
+    it('does not strip a trailing 00 00 with no following 03', () => {
+        const input = new Uint8Array([0x05, 0x06, 0x00, 0x00]);
+        const out = stripEmulationPrevention(input);
+        expect(Array.from(out)).toEqual([0x05, 0x06, 0x00, 0x00]);
+    });
+
+    it('leaves data without emulation bytes unchanged', () => {
+        const input = new Uint8Array([0x67, 0x42, 0x00, 0x1e, 0x8c]);
+        const out = stripEmulationPrevention(input);
+        expect(Array.from(out)).toEqual([0x67, 0x42, 0x00, 0x1e, 0x8c]);
+    });
+
+    it('handles an empty input', () => {
+        const out = stripEmulationPrevention(new Uint8Array([]));
+        expect(Array.from(out)).toEqual([]);
+    });
+});

--- a/src/app/player/__tests__/webCodecsConfig.test.ts
+++ b/src/app/player/__tests__/webCodecsConfig.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { buildDecoderConfig } from '../webCodecsConfig';
+
+describe('buildDecoderConfig', () => {
+    it('carries the SPS/PPS config bytes via description for H.264', () => {
+        const configData = new Uint8Array([0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1e, 0, 0, 0, 1, 0x68, 0xce]);
+        const cfg = buildDecoderConfig({
+            codec: 'avc1.42001E',
+            detectedCodec: 'h264',
+            codedWidth: 1280,
+            codedHeight: 720,
+            configData,
+        });
+        expect(cfg.codec).toBe('avc1.42001E');
+        expect(cfg.codedWidth).toBe(1280);
+        expect(cfg.codedHeight).toBe(720);
+        expect(cfg.optimizeForLatency).toBe(true);
+        // The whole point of #41: the SPS/PPS travels in `description`, not prepended per frame.
+        expect(cfg.description).toBeInstanceOf(Uint8Array);
+        expect(Array.from(cfg.description as Uint8Array)).toEqual(Array.from(configData));
+    });
+
+    it('carries the VPS/SPS/PPS config bytes via description for H.265', () => {
+        const configData = new Uint8Array([0, 0, 0, 1, 0x40, 0x01, 0, 0, 0, 1, 0x42, 0x01]);
+        const cfg = buildDecoderConfig({
+            codec: 'hev1.1.6.L93.B0',
+            detectedCodec: 'h265',
+            codedWidth: 1920,
+            codedHeight: 1088,
+            configData,
+        });
+        expect(cfg.description).toBeInstanceOf(Uint8Array);
+        expect(Array.from(cfg.description as Uint8Array)).toEqual(Array.from(configData));
+    });
+
+    it('does NOT set a description for AV1 (config record is handled differently)', () => {
+        const configData = new Uint8Array([0x81, 0x05, 0x0c, 0x00]);
+        const cfg = buildDecoderConfig({
+            codec: 'av01.0.04M.08',
+            detectedCodec: 'av1',
+            codedWidth: 1920,
+            codedHeight: 1080,
+            configData,
+        });
+        expect(cfg.description).toBeUndefined();
+    });
+
+    it('returns a description copy that is decoupled from the source buffer', () => {
+        const configData = new Uint8Array([0, 0, 0, 1, 0x67, 0x42]);
+        const cfg = buildDecoderConfig({
+            codec: 'avc1.42001E',
+            detectedCodec: 'h264',
+            codedWidth: 640,
+            codedHeight: 480,
+            configData,
+        });
+        const desc = cfg.description as Uint8Array;
+        // Mutating the original config buffer must not corrupt the decoder description.
+        configData[4] = 0xff;
+        expect(desc[4]).toBe(0x67);
+    });
+});

--- a/src/app/player/__tests__/webCodecsPlayerKeyframe.test.ts
+++ b/src/app/player/__tests__/webCodecsPlayerKeyframe.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Behavioural guard for finding #41: on a keyframe, WebCodecsPlayer must hand the
+ * raw frame bytes to the decoder UNPREPENDED (the SPS/PPS now travel via the
+ * VideoDecoderConfig.description set at configure() time), and the configure()
+ * call must include that `description`.
+ *
+ * We stub the WebCodecs globals and the canvas 2d context so the player can be
+ * instantiated and driven in jsdom without real WebCodecs support.
+ */
+
+type Chunk = { type: string; timestamp: number; data: Uint8Array };
+
+let decodedChunks: Chunk[] = [];
+let lastConfig: VideoDecoderConfig | undefined;
+let decoderState: string;
+
+class FakeVideoDecoder {
+    public state = 'unconfigured';
+    constructor(_init: unknown) {
+        decoderState = 'unconfigured';
+    }
+    configure(cfg: VideoDecoderConfig) {
+        lastConfig = cfg;
+        this.state = 'configured';
+        decoderState = 'configured';
+    }
+    decode(chunk: Chunk) {
+        decodedChunks.push(chunk);
+    }
+    flush() {
+        return Promise.resolve();
+    }
+    close() {
+        this.state = 'closed';
+    }
+    static isConfigSupported() {
+        return Promise.resolve({ supported: true });
+    }
+}
+
+class FakeEncodedVideoChunk {
+    public type: string;
+    public timestamp: number;
+    public data: Uint8Array;
+    constructor(init: Chunk) {
+        this.type = init.type;
+        this.timestamp = init.timestamp;
+        // Copy the bytes the player handed us so later buffer reuse can't rewrite history.
+        this.data = new Uint8Array(init.data);
+    }
+}
+
+// Minimal H.264 config frame (SPS NAL type 7 after the 00 00 00 01 start code).
+const H264_CONFIG = new Uint8Array([
+    0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1e, 0x8c, 0x8d, 0x40, 0xa0, 0x2f, 0xf9, 0x70, 0x11, 0x00, 0x00, 0x00, 1, 0x68, 0xce,
+    0x3c, 0x80,
+]);
+// A keyframe payload that does NOT contain the SPS/PPS — proves we don't rely on prepend.
+const H264_KEYFRAME = new Uint8Array([0, 0, 0, 1, 0x65, 0xaa, 0xbb, 0xcc, 0xdd]);
+
+describe('WebCodecsPlayer keyframe decode (finding #41)', () => {
+    beforeEach(() => {
+        decodedChunks = [];
+        lastConfig = undefined;
+        decoderState = 'unconfigured';
+        vi.stubGlobal('VideoDecoder', FakeVideoDecoder);
+        vi.stubGlobal('EncodedVideoChunk', FakeEncodedVideoChunk);
+        // jsdom's canvas has no 2d context without the `canvas` pkg — stub it.
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+            drawImage: vi.fn(),
+            clearRect: vi.fn(),
+            fillRect: vi.fn(),
+            measureText: () => ({ actualBoundingBoxLeft: 0, actualBoundingBoxRight: 0 }),
+            fillText: vi.fn(),
+            save: vi.fn(),
+            restore: vi.fn(),
+        } as unknown as CanvasRenderingContext2D);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('configures with a description and decodes keyframe data unprepended', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1280, 720);
+
+        // Config frame: should drive a configure() carrying the SPS/PPS via description.
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        expect(decoderState).toBe('configured');
+        expect(lastConfig).toBeDefined();
+        expect(lastConfig?.description).toBeInstanceOf(Uint8Array);
+        expect(Array.from(lastConfig?.description as Uint8Array)).toEqual(Array.from(H264_CONFIG));
+
+        // Keyframe: the chunk data must equal the raw keyframe bytes — NOT config+frame.
+        player.pushVideoFrame(H264_KEYFRAME, 100n, false, true);
+        expect(decodedChunks.length).toBe(1);
+        const chunk = decodedChunks[0]!;
+        expect(chunk.type).toBe('key');
+        expect(chunk.data.length).toBe(H264_KEYFRAME.length); // would be longer if prepended
+        expect(Array.from(chunk.data)).toEqual(Array.from(H264_KEYFRAME));
+    });
+});

--- a/src/app/player/animationFrameGuard.ts
+++ b/src/app/player/animationFrameGuard.ts
@@ -1,0 +1,48 @@
+/**
+ * Guards a single requestAnimationFrame handle so a rAF-driven loop cannot
+ * double-start or leak (finding #44).
+ *
+ * - `start(cb)` schedules a frame only if none is already pending (no
+ *   double-start). The handle is cleared the instant the frame fires, so the
+ *   callback may call `start` again to keep a loop running.
+ * - `stop()` cancels any pending frame and clears the handle (no leak after the
+ *   owner stops); it is a no-op when nothing is pending.
+ *
+ * raf/caf are injectable for unit testing without a DOM.
+ */
+type Raf = (cb: FrameRequestCallback) => number;
+type Caf = (handle: number) => void;
+
+export class AnimationFrameGuard {
+    private id: number | null = null;
+
+    constructor(
+        private readonly raf: Raf = requestAnimationFrame,
+        private readonly caf: Caf = cancelAnimationFrame,
+    ) {}
+
+    public isPending(): boolean {
+        return this.id !== null;
+    }
+
+    /** Schedule one frame, unless one is already pending. */
+    public start(cb: FrameRequestCallback): void {
+        if (this.id !== null) {
+            return;
+        }
+        this.id = this.raf((time) => {
+            // Clear before invoking so the callback can reschedule cleanly and a
+            // subsequent stop() won't try to cancel an already-fired frame.
+            this.id = null;
+            cb(time);
+        });
+    }
+
+    /** Cancel the pending frame, if any. */
+    public stop(): void {
+        if (this.id !== null) {
+            this.caf(this.id);
+            this.id = null;
+        }
+    }
+}

--- a/src/app/player/backlogDrop.ts
+++ b/src/app/player/backlogDrop.ts
@@ -1,0 +1,12 @@
+/**
+ * Pure decision for the canvas backlog-drop on the decode path.
+ *
+ * When a keyframe arrives and the undecoded backlog has grown past half the
+ * target frame rate, the player flushes the backlog (the keyframe lets it
+ * resync cleanly). This used to be gated on `BasePlayer.isIFrame`, which only
+ * recognises H.264 IDR NALs and silently missed H.265/AV1 keyframes (finding
+ * #43). The keyframe signal now comes from the demuxer's PTS_FLAG_KEYFRAME.
+ */
+export function shouldDropBacklog(isKeyframe: boolean, framesListLength: number, maxFps: number): boolean {
+    return isKeyframe && framesListLength > maxFps / 2;
+}

--- a/src/app/player/h264-utils.ts
+++ b/src/app/player/h264-utils.ts
@@ -16,6 +16,35 @@ export const NALU_TYPE = {
     PPS: 8,
 } as const;
 
+// ── RBSP emulation-prevention ───────────────────────────────────
+
+/**
+ * Strip RBSP emulation prevention bytes (00 00 03 → 00 00).
+ * Must be done before bitstream parsing on any NAL unit data (H.264 and H.265).
+ *
+ * Writes into a pre-sized Uint8Array (output can never exceed input length) and
+ * returns a subarray view of the bytes actually written — avoids the boxed
+ * `number[]` + per-element push() a naive implementation incurs.
+ *
+ * Canonical home for the shared NAL helper; h265-utils re-exports it.
+ */
+export function stripEmulationPrevention(data: Uint8Array): Uint8Array {
+    const out = new Uint8Array(data.length);
+    let n = 0;
+    let i = 0;
+    while (i < data.length) {
+        if (i + 2 < data.length && data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 3) {
+            out[n++] = 0;
+            out[n++] = 0;
+            i += 3; // skip the 0x03 emulation-prevention byte
+        } else {
+            out[n++] = data[i]!;
+            i++;
+        }
+    }
+    return out.subarray(0, n);
+}
+
 // ── BitStream (Exp-Golomb reader) ───────────────────────────────
 
 export class BitStream {

--- a/src/app/player/h265-utils.ts
+++ b/src/app/player/h265-utils.ts
@@ -1,5 +1,8 @@
 // src/app/player/h265-utils.ts
-import { BitStream } from './h264-utils';
+import { BitStream, stripEmulationPrevention } from './h264-utils';
+
+// Re-export the shared NAL helper so existing importers of '../h265-utils' keep working.
+export { stripEmulationPrevention };
 
 export const HEVC_NAL_TYPE = {
     VPS: 32,
@@ -15,25 +18,6 @@ export interface HevcCodecInfo {
     codec: string;
     width: number;
     height: number;
-}
-
-/**
- * Strip RBSP emulation prevention bytes (00 00 03 → 00 00).
- * Must be done before bitstream parsing on any NAL unit data.
- */
-function stripEmulationPrevention(data: Uint8Array): Uint8Array {
-    const out: number[] = [];
-    let i = 0;
-    while (i < data.length) {
-        if (i + 2 < data.length && data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 3) {
-            out.push(0, 0);
-            i += 3; // skip the 0x03 byte
-        } else {
-            out.push(data[i]!);
-            i++;
-        }
-    }
-    return new Uint8Array(out);
 }
 
 export function parseHevcSPS(data: Uint8Array): HevcCodecInfo {

--- a/src/app/player/webCodecsConfig.ts
+++ b/src/app/player/webCodecsConfig.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure builder for the {@link VideoDecoderConfig} passed to
+ * `VideoDecoder.configure()`.
+ *
+ * For H.264 / H.265 the SPS/PPS (and VPS) parameter sets are supplied once via
+ * `description`, so the per-frame hot path no longer has to prepend the config
+ * bytes to every keyframe (see finding #41). AV1 carries its sequence header in
+ * the keyframe data itself, so no `description` is set for it.
+ */
+export interface BuildDecoderConfigParams {
+    /** WebCodecs codec string, e.g. `avc1.42E01E` / `hev1.1.6.L93.B0` / `av01.0.04M.08`. */
+    codec: string;
+    detectedCodec: 'h264' | 'h265' | 'av1' | null;
+    codedWidth: number;
+    codedHeight: number;
+    /** Raw config NAL bytes (Annex B SPS/PPS or VPS/SPS/PPS) captured from the config frame. */
+    configData: Uint8Array;
+}
+
+export function buildDecoderConfig(params: BuildDecoderConfigParams): VideoDecoderConfig {
+    const config: VideoDecoderConfig = {
+        codec: params.codec,
+        codedWidth: params.codedWidth,
+        codedHeight: params.codedHeight,
+        optimizeForLatency: true,
+    };
+    // H.264/H.265: hand the parameter sets to the decoder once via `description`.
+    // Copy so the decoder's view can't be mutated by later reuse of the source buffer.
+    if (params.detectedCodec === 'h264' || params.detectedCodec === 'h265') {
+        config.description = new Uint8Array(params.configData);
+    }
+    return config;
+}


### PR DESCRIPTION
Sub-PR 2 of 3 for the client-perf cluster — video decode hot path. Full TDD, pure logic extracted where possible.

- **#39** — `StreamClientScrcpy` degradation path now uses a fixed `RollingWindow(30)` with a running sum (O(1)/frame) instead of `shift()` + full `reduce()` every frame.
- **#41** — `WebCodecsPlayer` supplies SPS/PPS once via `VideoDecoderConfig.description` (`buildDecoderConfig`) and stops prepending `configData` to every keyframe — eliminates the per-keyframe concat copy.
- **#42** — `stripEmulationPrevention` rewritten with a pre-sized `Uint8Array` (no boxed `number[]`), moved to `h264-utils` as the canonical home (`h265-utils` re-exports it). H.264 SPS is now emulation-stripped before parse, matching H.265.
- **#43** — backlog-drop now keys off the demuxer's real `isKeyframe` (plumbed through `pushFrame`, falling back to `isIFrame`) instead of the H.264-only NAL check — so it works for H.265/AV1 (`shouldDropBacklog`).
- **#44** — `BasePlayer` stats `requestAnimationFrame` guarded via `AnimationFrameGuard`: `stop()`/`resetStats()` `cancelAnimationFrame` the stored id; no double-start.

Extracted + unit-tested pure helpers: `RollingWindow`, `buildDecoderConfig`, `stripEmulationPrevention`, `shouldDropBacklog`, `AnimationFrameGuard`; jsdom tests for the WebCodecs config + rAF lifecycle.

**Gates:** `tsc --noEmit` clean · `vitest` **1177 pass / 0 fail**.

**Note:** #41's `description` path is verified at the config/contract level but not yet against a real browser `VideoDecoder` — runtime decode (H.264 + H.265) is owed in smoke testing.

`release:none`.
