### PR TITLE
fix(client): client-perf audio/input/logging fixes (sec #40,#45,#46,#47)

### DIFF
--- a/src/app/audio/AudioPlayer.ts
+++ b/src/app/audio/AudioPlayer.ts
@@ -1,5 +1,6 @@
 // src/app/audio/AudioPlayer.ts
 import { PCM_WORKLET_NAME, PCM_WORKLET_SOURCE } from './PcmWorklet';
+import { decodeS16LEToFloat32Planar } from './pcmConvert';
 
 export class AudioPlayer {
     private audioContext?: AudioContext;
@@ -132,23 +133,9 @@ export class AudioPlayer {
     private pushRawPcm(data: Uint8Array): void {
         if (!this.workletReady) return;
 
-        const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-        const sampleCount = (data.byteLength / 2) | 0;
         const channelCount = 2;
-        const framesPerChannel = (sampleCount / channelCount) | 0;
-
-        const channels: Float32Array[] = [];
-        for (let ch = 0; ch < channelCount; ch++) {
-            channels.push(new Float32Array(framesPerChannel));
-        }
-
-        for (let i = 0; i < framesPerChannel; i++) {
-            for (let ch = 0; ch < channelCount; ch++) {
-                const sampleIndex = i * channelCount + ch;
-                const int16 = view.getInt16(sampleIndex * 2, true);
-                channels[ch]![i] = int16 / 32768;
-            }
-        }
+        const channels = decodeS16LEToFloat32Planar(data, channelCount);
+        const framesPerChannel = channels[0]?.length ?? 0;
 
         this.workletNode!.port.postMessage(
             { channels, numFrames: framesPerChannel },

--- a/src/app/audio/__tests__/pcmConvert.test.ts
+++ b/src/app/audio/__tests__/pcmConvert.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { decodeS16LEToFloat32Planar } from '../pcmConvert';
+
+/** Build a Uint8Array from a list of little-endian signed 16-bit samples. */
+function s16le(...samples: number[]): Uint8Array {
+    const buf = new Uint8Array(samples.length * 2);
+    const view = new DataView(buf.buffer);
+    samples.forEach((s, i) => {
+        view.setInt16(i * 2, s, true);
+    });
+    return buf;
+}
+
+describe('decodeS16LEToFloat32Planar', () => {
+    it('de-interleaves stereo samples into per-channel buffers', () => {
+        // interleaved L,R,L,R: ch0 = [L0,L1], ch1 = [R0,R1]
+        const data = s16le(100, 200, 300, 400);
+        const channels = decodeS16LEToFloat32Planar(data, 2);
+        expect(channels).toHaveLength(2);
+        expect(channels[0]).toHaveLength(2);
+        expect(channels[1]).toHaveLength(2);
+        expect(Array.from(channels[0]!)).toEqual([100 / 32768, 300 / 32768]);
+        expect(Array.from(channels[1]!)).toEqual([200 / 32768, 400 / 32768]);
+    });
+
+    it('converts full-scale and edge samples correctly (incl. negatives)', () => {
+        // ch0 = [0, -1.0], ch1 = [0.999969..., -3.05e-5]
+        const data = s16le(0, 32767, -32768, -1);
+        const channels = decodeS16LEToFloat32Planar(data, 2);
+        expect(channels[0]![0]).toBe(0);
+        expect(channels[0]![1]).toBe(-1.0); // -32768/32768
+        expect(channels[1]![0]).toBeCloseTo(32767 / 32768, 12);
+        expect(channels[1]![1]).toBeCloseTo(-1 / 32768, 12);
+    });
+
+    it('matches a DataView.getInt16 reference for a random-ish pattern', () => {
+        const samples = [1, -1, 12345, -12345, 32767, -32768, 0, 5, -5, 999, -1000, 31000];
+        const data = s16le(...samples);
+        const channelCount = 2;
+        const channels = decodeS16LEToFloat32Planar(data, channelCount);
+
+        // Reference: replicate the original DataView per-sample loop.
+        const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+        const sampleCount = (data.byteLength / 2) | 0;
+        const framesPerChannel = (sampleCount / channelCount) | 0;
+        const ref: number[][] = [[], []];
+        for (let i = 0; i < framesPerChannel; i++) {
+            for (let ch = 0; ch < channelCount; ch++) {
+                const int16 = view.getInt16((i * channelCount + ch) * 2, true);
+                ref[ch]!.push(int16 / 32768);
+            }
+        }
+        expect(Array.from(channels[0]!)).toEqual(ref[0]);
+        expect(Array.from(channels[1]!)).toEqual(ref[1]);
+    });
+
+    it('supports mono', () => {
+        const data = s16le(16384, -16384, 32767);
+        const channels = decodeS16LEToFloat32Planar(data, 1);
+        expect(channels).toHaveLength(1);
+        expect(Array.from(channels[0]!)).toEqual([16384 / 32768, -16384 / 32768, 32767 / 32768]);
+    });
+
+    it('handles a non-zero byteOffset (subarray view) correctly', () => {
+        // Place samples after a 4-byte header, hand a subarray to the decoder.
+        const full = new Uint8Array(4 + 2 * 4);
+        const view = new DataView(full.buffer);
+        view.setInt16(4 + 0, 1000, true);
+        view.setInt16(4 + 2, 2000, true);
+        view.setInt16(4 + 4, 3000, true);
+        view.setInt16(4 + 6, 4000, true);
+        const slice = full.subarray(4);
+        const channels = decodeS16LEToFloat32Planar(slice, 2);
+        expect(Array.from(channels[0]!)).toEqual([1000 / 32768, 3000 / 32768]);
+        expect(Array.from(channels[1]!)).toEqual([2000 / 32768, 4000 / 32768]);
+    });
+
+    it('drops a trailing partial frame (odd sample count for stereo)', () => {
+        // 3 samples, stereo → 1 full frame, last sample ignored
+        const data = s16le(10, 20, 30);
+        const channels = decodeS16LEToFloat32Planar(data, 2);
+        expect(channels[0]).toHaveLength(1);
+        expect(channels[1]).toHaveLength(1);
+        expect(Array.from(channels[0]!)).toEqual([10 / 32768]);
+        expect(Array.from(channels[1]!)).toEqual([20 / 32768]);
+    });
+});

--- a/src/app/audio/pcmConvert.ts
+++ b/src/app/audio/pcmConvert.ts
@@ -1,0 +1,51 @@
+// src/app/audio/pcmConvert.ts
+
+/**
+ * Convert interleaved signed-16-bit little-endian PCM into per-channel planar
+ * Float32 buffers (one Float32Array per channel), de-interleaving and scaling
+ * S16 -> Float32 by dividing by 32768.
+ *
+ * Performance: this uses a single `Int16Array` view over the input plus direct
+ * indexing instead of a per-sample `DataView.getInt16(...)` call (the old hot
+ * path in AudioPlayer.pushRawPcm), which fired once per sample per frame.
+ *
+ * Endianness: `Int16Array` is host-endian. The wire format is little-endian, so
+ * the fast path assumes a little-endian host — true for all browser/Node
+ * targets ws-scrcpy-web runs on (x86/ARM in LE mode). If a big-endian host were
+ * ever in play this fast path would mis-read; that is the same assumption the
+ * surrounding decode pipeline already makes. A trailing partial frame (when the
+ * sample count isn't a whole multiple of `channelCount`) is dropped, matching
+ * the original `| 0` truncation behaviour.
+ *
+ * Alignment: `Int16Array(buffer, byteOffset, len)` requires an even byteOffset.
+ * A `Uint8Array` subarray can land on an odd offset; in that (rare) case we copy
+ * into a fresh aligned buffer first so the view is always valid.
+ */
+export function decodeS16LEToFloat32Planar(data: Uint8Array, channelCount: number): Float32Array[] {
+    const sampleCount = (data.byteLength / 2) | 0;
+    const framesPerChannel = (sampleCount / channelCount) | 0;
+
+    let samples: Int16Array;
+    if (data.byteOffset % 2 === 0) {
+        samples = new Int16Array(data.buffer, data.byteOffset, sampleCount);
+    } else {
+        // Odd byteOffset — can't view directly; copy the exact sample bytes into
+        // an aligned buffer (still no per-sample DataView calls).
+        const aligned = data.slice(0, sampleCount * 2);
+        samples = new Int16Array(aligned.buffer, aligned.byteOffset, sampleCount);
+    }
+
+    const channels: Float32Array[] = [];
+    for (let ch = 0; ch < channelCount; ch++) {
+        channels.push(new Float32Array(framesPerChannel));
+    }
+
+    for (let i = 0; i < framesPerChannel; i++) {
+        const base = i * channelCount;
+        for (let ch = 0; ch < channelCount; ch++) {
+            channels[ch]![i] = samples[base + ch]! / 32768;
+        }
+    }
+
+    return channels;
+}

--- a/src/app/googDevice/client/ListFilesModal.ts
+++ b/src/app/googDevice/client/ListFilesModal.ts
@@ -12,6 +12,7 @@ import FilePushHandler, { type DragAndPushListener, type PushUpdateParams } from
 import { ManagerClient } from '../../client/ManagerClient';
 import { attachFsChannelKeepAlive } from './fsChannelKeepAlive';
 import { basename, resolve } from '../../pathUtils';
+import { debugLog } from '../../util/debugLog';
 
 const TAG = '[ListFilesModal]';
 const ICON_SIZE_KEY = 'file-browser-icon-size';
@@ -454,13 +455,13 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
         // Command sub-channels (STAT/LIST/RECV) are created on THIS channel.
         const initChannel = (): void => {
             const initData = this.getChannelInitData();
-            console.log(TAG, 'wsUrl:', this.wsUrl, 'mux readyState:', this.multiplexer?.readyState, 'sockets:', [...ManagerClient.sockets.keys()]);
+            debugLog(TAG, 'wsUrl:', this.wsUrl, 'mux readyState:', this.multiplexer?.readyState, 'sockets:', [...ManagerClient.sockets.keys()]);
             this.fsChannel = this.multiplexer!.createChannel(initData);
 
-            console.log(TAG, 'FSLS channel created, readyState:', this.fsChannel.readyState);
+            debugLog(TAG, 'FSLS channel created, readyState:', this.fsChannel.readyState);
 
             this.fsChannel.addEventListener('open', () => {
-                console.log(TAG, 'FSLS channel opened, readyState:', this.fsChannel?.readyState);
+                debugLog(TAG, 'FSLS channel opened, readyState:', this.fsChannel?.readyState);
                 // Set up upload handler (needs the FSLS channel for AdbkitFilePushStream)
                 const pushStream = new AdbkitFilePushStream(this.fsChannel!, this as any);
                 this.filePushHandler = new FilePushHandler(this.bodyEl, pushStream);
@@ -478,7 +479,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
 
             this.fsChannel.addEventListener('close', (ev) => {
                 const ce = ev as CloseEvent;
-                console.log(TAG, 'FSLS channel closed, code:', ce.code, 'reason:', ce.reason);
+                debugLog(TAG, 'FSLS channel closed, code:', ce.code, 'reason:', ce.reason);
             });
         };
 
@@ -527,9 +528,9 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
     }
 
     private loadDirectory(path: string): void {
-        console.log(TAG, 'loadDirectory:', path, 'fsChannel:', !!this.fsChannel, 'readyState:', this.fsChannel?.readyState);
+        debugLog(TAG, 'loadDirectory:', path, 'fsChannel:', !!this.fsChannel, 'readyState:', this.fsChannel?.readyState);
         if (!this.fsChannel || this.fsChannel.readyState !== this.fsChannel.OPEN) {
-            console.log(TAG, 'loadDirectory BAILED — fsChannel not ready');
+            debugLog(TAG, 'loadDirectory BAILED — fsChannel not ready');
             return;
         }
         this.showLoading();
@@ -551,9 +552,9 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
     }
 
     private sendCommand(cmd: string, path: string, entry?: Entry, pathToLoadAfter = ''): void {
-        console.log(TAG, 'sendCommand:', cmd, path, 'fsChannel:', !!this.fsChannel, 'readyState:', this.fsChannel?.readyState);
+        debugLog(TAG, 'sendCommand:', cmd, path, 'fsChannel:', !!this.fsChannel, 'readyState:', this.fsChannel?.readyState);
         if (!this.fsChannel) {
-            console.log(TAG, 'sendCommand BAILED — no fsChannel');
+            debugLog(TAG, 'sendCommand BAILED — no fsChannel');
             return;
         }
 
@@ -570,7 +571,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
         // (same pattern as FileListingClient.loadContent — this.ws.createChannel(payload))
         try {
             const channel = this.fsChannel.createChannel(payload);
-            console.log(TAG, 'Sub-channel created for', cmd, 'readyState:', channel.readyState);
+            debugLog(TAG, 'Sub-channel created for', cmd, 'readyState:', channel.readyState);
             this.channels.add(channel);
 
         const download: Download = {
@@ -600,7 +601,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
                 this.entries = this.pendingEntries.slice();
                 this.pendingEntries = [];
                 this.currentPath = dl?.path ?? this.currentPath;
-                console.log(TAG, 'Channel closed: directory listing complete,', this.entries.length, 'entries for path:', this.currentPath);
+                debugLog(TAG, 'Channel closed: directory listing complete,', this.entries.length, 'entries for path:', this.currentPath);
                 this.applyFilterAndSort();
                 this.renderBreadcrumbs();
                 this.renderFileList();
@@ -619,7 +620,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
     private handleReply(channel: Multiplexer, e: MessageEvent): void {
         const data = new Uint8Array(e.data);
         const reply = new TextDecoder('ascii').decode(data.subarray(0, 4));
-        console.log(TAG, 'handleReply:', reply, 'dataLen:', data.length);
+        debugLog(TAG, 'handleReply:', reply, 'dataLen:', data.length);
 
         switch (reply) {
             case Protocol.DENT: {
@@ -646,7 +647,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
                     // Directory listing complete
                     this.entries = this.pendingEntries.slice();
                     this.pendingEntries = [];
-                    console.log(TAG, 'DONE: directory listing complete,', this.entries.length, 'entries for path:', download?.path);
+                    debugLog(TAG, 'DONE: directory listing complete,', this.entries.length, 'entries for path:', download?.path);
                     this.currentPath = download?.path ?? this.currentPath;
                     this.applyFilterAndSort();
                     this.renderBreadcrumbs();

--- a/src/app/interactionHandler/FeaturedInteractionHandler.ts
+++ b/src/app/interactionHandler/FeaturedInteractionHandler.ts
@@ -7,6 +7,7 @@ import MotionEvent from '../MotionEvent';
 import type { BasePlayer } from '../player/BasePlayer';
 import type ScreenInfo from '../ScreenInfo';
 import { type InteractionEvents, InteractionHandler, type KeyEventNames } from './InteractionHandler';
+import { shouldHandleMultiTouchKey } from './multiTouchKey';
 
 const TAG = '[FeaturedTouchHandler]';
 
@@ -184,11 +185,17 @@ export class FeaturedInteractionHandler extends InteractionHandler {
         if (!this.lastPosition) {
             return;
         }
+        const { ctrlKey, shiftKey } = event;
+        // The synthetic multi-touch gesture is gated on Ctrl/Shift; plain keys
+        // and held-key repeats can't change it. Bail early to avoid rebuilding
+        // a multi-touch event on every key (incl. auto-repeats). (#46)
+        if (!shouldHandleMultiTouchKey({ repeat: event.repeat, ctrlKey, shiftKey })) {
+            return;
+        }
         const screenInfo = this.player.getScreenInfo();
         if (!screenInfo) {
             return;
         }
-        const { ctrlKey, shiftKey } = event;
         const { target, button, buttons, clientY, clientX } = this.lastPosition;
         const type = InteractionHandler.SIMULATE_MULTI_TOUCH;
         const props = { ctrlKey, shiftKey, type, target, button, buttons, clientX, clientY };

--- a/src/app/interactionHandler/InteractionHandler.ts
+++ b/src/app/interactionHandler/InteractionHandler.ts
@@ -8,6 +8,7 @@ import type { BasePlayer } from '../player/BasePlayer';
 import type ScreenInfo from '../ScreenInfo';
 import Size from '../Size';
 import Util from '../Util';
+import { isPointerReleaseType } from './pointerRelease';
 
 interface Touch {
     action: number;
@@ -191,7 +192,10 @@ export abstract class InteractionHandler {
     protected static getPointerId(type: string, identifier: number): number {
         if (this.idToPointerMap.has(identifier)) {
             const pointerId = this.idToPointerMap.get(identifier) as number;
-            if (type === 'touchend' || type === 'touchcancel') {
+            // Release on touchend/touchcancel AND mouseup — the mouse path adds
+            // on mousedown (identifier 0) and previously never freed it, leaking
+            // the static maps on every mouse interaction. (#47)
+            if (isPointerReleaseType(type)) {
                 this.idToPointerMap.delete(identifier);
                 this.pointerToIdMap.delete(pointerId);
             }

--- a/src/app/interactionHandler/__tests__/multiTouchKey.test.ts
+++ b/src/app/interactionHandler/__tests__/multiTouchKey.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { shouldHandleMultiTouchKey } from '../multiTouchKey';
+
+describe('shouldHandleMultiTouchKey', () => {
+    it('returns false for held-key repeats (even with a modifier)', () => {
+        expect(shouldHandleMultiTouchKey({ repeat: true, ctrlKey: true, shiftKey: false })).toBe(false);
+        expect(shouldHandleMultiTouchKey({ repeat: true, ctrlKey: false, shiftKey: true })).toBe(false);
+        expect(shouldHandleMultiTouchKey({ repeat: true, ctrlKey: true, shiftKey: true })).toBe(false);
+    });
+
+    it('returns false when no relevant modifier (ctrl/shift) is held', () => {
+        expect(shouldHandleMultiTouchKey({ repeat: false, ctrlKey: false, shiftKey: false })).toBe(false);
+    });
+
+    it('returns true on a non-repeat key with ctrl held', () => {
+        expect(shouldHandleMultiTouchKey({ repeat: false, ctrlKey: true, shiftKey: false })).toBe(true);
+    });
+
+    it('returns true on a non-repeat key with shift held', () => {
+        expect(shouldHandleMultiTouchKey({ repeat: false, ctrlKey: false, shiftKey: true })).toBe(true);
+    });
+
+    it('returns true on a non-repeat key with both modifiers held', () => {
+        expect(shouldHandleMultiTouchKey({ repeat: false, ctrlKey: true, shiftKey: true })).toBe(true);
+    });
+
+    it('treats a missing repeat field as not-a-repeat', () => {
+        expect(shouldHandleMultiTouchKey({ ctrlKey: true, shiftKey: false })).toBe(true);
+        expect(shouldHandleMultiTouchKey({ ctrlKey: false, shiftKey: false })).toBe(false);
+    });
+});

--- a/src/app/interactionHandler/__tests__/pointerRelease.test.ts
+++ b/src/app/interactionHandler/__tests__/pointerRelease.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isPointerReleaseType } from '../pointerRelease';
+
+describe('isPointerReleaseType', () => {
+    it('is true for touchend, touchcancel and mouseup', () => {
+        expect(isPointerReleaseType('touchend')).toBe(true);
+        expect(isPointerReleaseType('touchcancel')).toBe(true);
+        expect(isPointerReleaseType('mouseup')).toBe(true);
+    });
+
+    it('is false for non-release interaction types', () => {
+        expect(isPointerReleaseType('touchstart')).toBe(false);
+        expect(isPointerReleaseType('touchmove')).toBe(false);
+        expect(isPointerReleaseType('mousedown')).toBe(false);
+        expect(isPointerReleaseType('mousemove')).toBe(false);
+        expect(isPointerReleaseType('wheel')).toBe(false);
+        expect(isPointerReleaseType('')).toBe(false);
+    });
+});

--- a/src/app/interactionHandler/multiTouchKey.ts
+++ b/src/app/interactionHandler/multiTouchKey.ts
@@ -1,0 +1,29 @@
+// src/app/interactionHandler/multiTouchKey.ts
+
+/** The subset of a KeyboardEvent the multi-touch gesture predicate reads. */
+export interface MultiTouchKeyState {
+    /** True when this is an OS key-repeat (held key). Treated as absent => false. */
+    repeat?: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+}
+
+/**
+ * Whether a key event should trigger the synthetic multi-touch rebuild.
+ *
+ * The synthetic multi-touch (pinch/spread) gesture is gated by Ctrl/Shift in
+ * `getTouch()`, so a key event with neither modifier can never change the
+ * gesture — there's no point rebuilding the touch event for it. Held-key
+ * repeats are also dropped: the gesture state doesn't change across repeats of
+ * the same modifier, so re-running `buildTouchEvent` on every auto-repeat is
+ * pure overhead (the #46 hot path).
+ *
+ * Returns true only for a non-repeat key while at least one of Ctrl/Shift is
+ * held.
+ */
+export function shouldHandleMultiTouchKey(state: MultiTouchKeyState): boolean {
+    if (state.repeat) {
+        return false;
+    }
+    return state.ctrlKey || state.shiftKey;
+}

--- a/src/app/interactionHandler/pointerRelease.ts
+++ b/src/app/interactionHandler/pointerRelease.ts
@@ -1,0 +1,16 @@
+// src/app/interactionHandler/pointerRelease.ts
+
+/**
+ * Interaction types that END a pointer and so should release its entry from the
+ * process-global pointer-id maps in InteractionHandler.getPointerId.
+ *
+ * touchend / touchcancel release a touch pointer. mouseup is the natural pair of
+ * mousedown (the mouse add path, identifier 0); without it the mouse entry was
+ * never deleted and leaked the static map across every mouse interaction. (#47)
+ */
+const POINTER_RELEASE_TYPES: ReadonlySet<string> = new Set(['touchend', 'touchcancel', 'mouseup']);
+
+/** True when an interaction type ends a pointer and its id mapping should be freed. */
+export function isPointerReleaseType(type: string): boolean {
+    return POINTER_RELEASE_TYPES.has(type);
+}

--- a/src/app/util/__tests__/debugLog.test.ts
+++ b/src/app/util/__tests__/debugLog.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEBUG_STORAGE_KEY, debugError, debugLog, isDebugEnabled } from '../debugLog';
+
+beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+});
+
+afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+});
+
+describe('isDebugEnabled', () => {
+    it('is false when the flag is unset', () => {
+        expect(isDebugEnabled()).toBe(false);
+    });
+
+    it("is true only when the flag is exactly 'true'", () => {
+        localStorage.setItem(DEBUG_STORAGE_KEY, 'true');
+        expect(isDebugEnabled()).toBe(true);
+    });
+
+    it("is false for non-'true' values", () => {
+        localStorage.setItem(DEBUG_STORAGE_KEY, '1');
+        expect(isDebugEnabled()).toBe(false);
+        localStorage.setItem(DEBUG_STORAGE_KEY, 'TRUE');
+        expect(isDebugEnabled()).toBe(false);
+        localStorage.setItem(DEBUG_STORAGE_KEY, 'yes');
+        expect(isDebugEnabled()).toBe(false);
+        localStorage.setItem(DEBUG_STORAGE_KEY, '');
+        expect(isDebugEnabled()).toBe(false);
+    });
+
+    it('reads from the ws-scrcpy-web-debug key', () => {
+        expect(DEBUG_STORAGE_KEY).toBe('ws-scrcpy-web-debug');
+    });
+});
+
+describe('debugLog', () => {
+    it('does NOT call console.log when the flag is unset', () => {
+        const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        debugLog('hello', 1, 2);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call console.log when the flag is false', () => {
+        localStorage.setItem(DEBUG_STORAGE_KEY, 'false');
+        const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        debugLog('hello');
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("calls console.log with all args when the flag is 'true'", () => {
+        localStorage.setItem(DEBUG_STORAGE_KEY, 'true');
+        const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        debugLog('[TAG]', 'msg', 42);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith('[TAG]', 'msg', 42);
+    });
+});
+
+describe('debugError', () => {
+    it('does NOT call console.error when the flag is unset', () => {
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        debugError('boom');
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("calls console.error with all args when the flag is 'true'", () => {
+        localStorage.setItem(DEBUG_STORAGE_KEY, 'true');
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        debugError('[TAG]', 'bad', { x: 1 });
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith('[TAG]', 'bad', { x: 1 });
+    });
+});
+
+describe('debugLog without localStorage (non-browser env)', () => {
+    it('does not throw when localStorage access throws', () => {
+        const original = globalThis.localStorage;
+        // Simulate an environment where reading localStorage throws (e.g. blocked storage).
+        Object.defineProperty(globalThis, 'localStorage', {
+            configurable: true,
+            get() {
+                throw new Error('localStorage blocked');
+            },
+        });
+        using _restore = {
+            [Symbol.dispose](): void {
+                Object.defineProperty(globalThis, 'localStorage', {
+                    configurable: true,
+                    value: original,
+                });
+            },
+        };
+        expect(() => isDebugEnabled()).not.toThrow();
+        expect(isDebugEnabled()).toBe(false);
+        const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        expect(() => debugLog('x')).not.toThrow();
+        expect(spy).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/util/debugLog.ts
+++ b/src/app/util/debugLog.ts
@@ -1,0 +1,48 @@
+/**
+ * Tiny localStorage-gated debug logger for ws-scrcpy-web.
+ *
+ * Verbose per-message / per-frame / lifecycle traces in hot paths (e.g. the
+ * file-listing protocol in ListFilesModal) are silenced by default and only
+ * surface when the `ws-scrcpy-web-debug` localStorage flag is set to the exact
+ * string `'true'`. This mirrors the localStorage convention used by
+ * themeEmbed.ts / AudioSettingsStore.
+ *
+ * Set in the browser console to enable:
+ *   localStorage.setItem('ws-scrcpy-web-debug', 'true')
+ *
+ * Genuine user-facing errors should NOT use this — they should always surface
+ * via plain `console.error`. This is only for the debug scaffolding.
+ */
+
+export const DEBUG_STORAGE_KEY = 'ws-scrcpy-web-debug';
+
+/**
+ * True only when the debug flag is present and exactly `'true'`. Guards against
+ * environments where `localStorage` is unavailable or throws (e.g. blocked
+ * storage, non-browser runtimes) by treating any failure as "disabled".
+ */
+export function isDebugEnabled(): boolean {
+    try {
+        return globalThis.localStorage?.getItem(DEBUG_STORAGE_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+/** No-op unless the debug flag is enabled; otherwise forwards to console.log. */
+export function debugLog(...args: unknown[]): void {
+    if (isDebugEnabled()) {
+        console.log(...args);
+    }
+}
+
+/**
+ * No-op unless the debug flag is enabled; otherwise forwards to console.error.
+ * Use ONLY for debug-scaffolding errors — keep always-surface errors on plain
+ * console.error.
+ */
+export function debugError(...args: unknown[]): void {
+    if (isDebugEnabled()) {
+        console.error(...args);
+    }
+}


### PR DESCRIPTION
Sub-PR 3 of 3 for the client-perf cluster — audio, input, logging. Full TDD, pure helpers extracted.

- **#40** — `ListFilesModal`'s verbose per-message/per-channel debug logs are gated behind a `localStorage` flag (`ws-scrcpy-web-debug`) via a new `debugLog` util (matches the themeEmbed localStorage convention). Genuine `console.error` reporting stays always-on.
- **#45** — `AudioPlayer` PCM decode uses a single `Int16Array` view + direct indexing (`decodeS16LEToFloat32Planar`) instead of per-sample `DataView.getInt16`.
- **#46** — `FeaturedInteractionHandler.onKey` bails on `event.repeat` and non-modifier keys (`shouldHandleMultiTouchKey`) instead of re-firing `buildTouchEvent` on every key event.
- **#47** — `InteractionHandler.getPointerId` releases the static pointer maps on `mouseup` too (`isPointerReleaseType`), not only `touchend`/`touchcancel`.

Extracted + unit-tested pure helpers: `debugLog`, `decodeS16LEToFloat32Planar`, `shouldHandleMultiTouchKey`, `isPointerReleaseType`.

**Gates:** `tsc --noEmit` clean · `vitest` **1201 pass / 0 fail**.

**Notes:** #45 assumes a little-endian host (matches the existing decode pipeline; odd-byteOffset path handled by an aligned copy). #47's `mouseup` release is **defensive** — `getPointerId` is currently reached only via the touch path, so it forward-proofs rather than fixing an active mouse leak.

`release:none`. This completes the client-perf cluster (#34–47).
