### PR TITLE
fix(client): wire #36 teardown caller + #34 refresh coalescing guard

### DIFF
--- a/src/app/client/BaseDeviceTracker.ts
+++ b/src/app/client/BaseDeviceTracker.ts
@@ -91,6 +91,11 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
     // can skip rebuilding rows whose descriptor is unchanged (diff/patch instead
     // of clear-and-rebuild). Cleared on destroy with the row nodes.
     private lastRenderedByUdid: Map<string, string> = new Map();
+    // §34: coalescing guard for the now-async refresh. `refreshing` = a refresh
+    // is in flight; `refreshPending` = at least one more refresh was requested
+    // while it ran (collapsed into a single re-run).
+    private refreshing = false;
+    private refreshPending = false;
 
     protected constructor(
         params: ParamsDeviceTracker,
@@ -126,6 +131,30 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
     }
 
     /**
+     * §34: coalescing wrapper. refreshDeviceTable is async (it awaits the
+     * per-refresh row-context fetch), so rapid WS messages could otherwise
+     * interleave two diff passes over the same DOM. If a refresh is already in
+     * flight, mark a re-run pending and return; the in-flight pass loops once
+     * more after it finishes, capturing the latest descriptors. At most one
+     * extra pass runs no matter how many refreshes pile up while one is active.
+     */
+    protected async refreshDeviceTable(): Promise<void> {
+        if (this.refreshing) {
+            this.refreshPending = true;
+            return;
+        }
+        this.refreshing = true;
+        try {
+            do {
+                this.refreshPending = false;
+                await this.doRefreshDeviceTable();
+            } while (this.refreshPending);
+        } finally {
+            this.refreshing = false;
+        }
+    }
+
+    /**
      * §34: build the device list by DIFFING the existing DOM rows (keyed by
      * udid via data-udid) against this.descriptors rather than tearing the whole
      * block down and rebuilding every row on every WebSocket message:
@@ -140,7 +169,7 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
      * buildDeviceRow call — eliminating the prior per-row /api/devices/labels
      * request storm.
      */
-    protected async refreshDeviceTable(): Promise<void> {
+    private async doRefreshDeviceTable(): Promise<void> {
         const data = this.descriptors;
         const devices = this.getOrCreateTableHolder();
         const tbody = this.getOrBuildTableBody(devices);

--- a/src/app/client/BaseDeviceTrackerCoalesce.test.ts
+++ b/src/app/client/BaseDeviceTrackerCoalesce.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BaseDeviceDescriptor } from '../../types/BaseDeviceDescriptor';
+import type { ParamsDeviceTracker } from '../../types/ParamsDeviceTracker';
+import { BaseDeviceTracker } from './BaseDeviceTracker';
+
+// Minimal concrete subclass whose per-refresh row-context resolves via fetch,
+// so we can hold a refresh "in flight" and observe coalescing (#34).
+class CoalesceTracker extends BaseDeviceTracker<BaseDeviceDescriptor, never> {
+    public static override readonly ACTION = 'coalesce-tracker';
+
+    public constructor() {
+        super({ type: 'android', action: 'coalesce-tracker' } as ParamsDeviceTracker, 'ws://test/');
+    }
+
+    protected buildDeviceRow(tbody: Element, device: BaseDeviceDescriptor): void {
+        const row = document.createElement('div');
+        row.setAttribute('data-state', device.state);
+        tbody.appendChild(row);
+    }
+
+    protected override fetchRowContext(): Promise<unknown> {
+        return fetch('/api/devices/labels').then((r) => r.json());
+    }
+
+    protected onSocketOpen(): void {
+        // no-op
+    }
+
+    public setDescriptors(list: BaseDeviceDescriptor[]): void {
+        this.descriptors = list;
+    }
+
+    public refresh(): Promise<void> {
+        return this.refreshDeviceTable();
+    }
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe('BaseDeviceTracker refresh coalescing (#34)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        document.body.innerHTML = '';
+    });
+
+    it('coalesces concurrent refreshes — an in-flight refresh causes at most ONE re-run', async () => {
+        const resolvers: Array<(v: unknown) => void> = [];
+        const fetchMock = vi.fn(
+            () => new Promise<unknown>((resolve) => { resolvers.push(resolve); }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const tracker = new CoalesceTracker();
+        tracker.setDescriptors([{ udid: 'A', state: 'device' } as BaseDeviceDescriptor]);
+
+        // Three refreshes fired back-to-back; only the first starts its fetch,
+        // the other two collapse into a single pending re-run.
+        const p1 = tracker.refresh();
+        const p2 = tracker.refresh();
+        const p3 = tracker.refresh();
+        await tick();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // Finish the in-flight refresh → exactly one coalesced re-run fires.
+        resolvers[0]!({ json: async () => ({}) });
+        await tick();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        // Finish the re-run → nothing further scheduled.
+        resolvers[1]!({ json: async () => ({}) });
+        await Promise.all([p1, p2, p3]);
+        await tick();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -5,6 +5,7 @@ import '../style/home.css';
 import { shouldShowBookmark } from './client/bookmarkGate';
 import { DependencyPanel } from './client/DependencyPanel';
 import { FirstRunBanner } from './client/FirstRunBanner';
+import { onPageTeardown } from './util/onPageTeardown';
 import { HostTracker } from './client/HostTracker';
 import { NetworkDiscoveryPanel } from './client/NetworkDiscoveryPanel';
 import { createSettingsHeader } from './client/SettingsHeader';
@@ -290,7 +291,13 @@ window.onload = async (): Promise<void> => {
     pageContainer.className = 'page-container';
     document.body.appendChild(pageContainer);
 
+    // §36: capture the page-lifetime singletons so their polling intervals can
+    // be released on page teardown (see onPageTeardown below).
+    let firstRunBanner: FirstRunBanner | undefined;
+    let dependencyPanel: DependencyPanel | undefined;
+
     FirstRunBanner.create().then((banner) => {
+        firstRunBanner = banner;
         pageContainer.insertBefore(banner.getElement(), pageContainer.firstChild);
     });
 
@@ -314,7 +321,16 @@ window.onload = async (): Promise<void> => {
     pageContainer.appendChild(discoveryPanel.getElement());
 
     DependencyPanel.create().then((depPanel) => {
+        dependencyPanel = depPanel;
         pageContainer.appendChild(depPanel.getElement());
+    });
+
+    // §36: DependencyPanel + FirstRunBanner poll on intervals for the page
+    // lifetime; release them on teardown so the intervals don't keep firing into
+    // bfcache/unload. destroy() (= stopPolling) is idempotent.
+    onPageTeardown(() => {
+        firstRunBanner?.destroy();
+        dependencyPanel?.destroy();
     });
 
     HostTracker.start();

--- a/src/app/util/onPageTeardown.test.ts
+++ b/src/app/util/onPageTeardown.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { onPageTeardown } from './onPageTeardown';
+
+describe('onPageTeardown (#36)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('registers the cleanup on both pagehide and beforeunload', () => {
+        const add = vi.spyOn(window, 'addEventListener');
+        onPageTeardown(() => undefined);
+        const events = add.mock.calls.map((c) => c[0]);
+        expect(events).toContain('pagehide');
+        expect(events).toContain('beforeunload');
+    });
+
+    it('runs the cleanup when the page is torn down (idempotent across both events)', () => {
+        const cleanup = vi.fn();
+        onPageTeardown(cleanup);
+        window.dispatchEvent(new Event('beforeunload'));
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        window.dispatchEvent(new Event('pagehide'));
+        expect(cleanup).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/app/util/onPageTeardown.ts
+++ b/src/app/util/onPageTeardown.ts
@@ -1,0 +1,12 @@
+/**
+ * Run `cleanup` when the page is being torn down. Registers BOTH `pagehide`
+ * (fires on navigation away + bfcache eviction — the reliable modern hook) and
+ * `beforeunload` (classic unload), so page-lifetime singletons (e.g. the
+ * dependency / first-run panels and their polling intervals) get a chance to
+ * release. `cleanup` may run more than once (both events can fire), so it MUST
+ * be idempotent. (#36)
+ */
+export function onPageTeardown(cleanup: () => void): void {
+    window.addEventListener('pagehide', cleanup);
+    window.addEventListener('beforeunload', cleanup);
+}


### PR DESCRIPTION
Follow-up to #394, closing the two caveats it flagged:

- **#36** — `DependencyPanel`/`FirstRunBanner` `destroy()` now has a caller: `index.ts` captures the singletons and releases them via a new `onPageTeardown()` helper (registers `pagehide` + `beforeunload`). Their polling intervals no longer run into bfcache/unload.
- **#34** — `refreshDeviceTable` is async (awaits the once-per-refresh label fetch), so rapid WS messages could interleave two diff passes over the same DOM. Added a coalescing guard: an in-flight refresh collapses further requests into a single re-run (at most one extra pass, capturing the latest descriptors).

Full TDD — `onPageTeardown.test.ts` (registers on both events + fires), `BaseDeviceTrackerCoalesce.test.ts` (3 rapid refreshes → exactly 2 passes).

**Gates:** `tsc --noEmit` clean · `vitest` **1204 pass / 0 fail**.

`release:none`.
