### PR TITLE
refactor(css): centralize accent color into --accent-color / --accent-rgb tokens

### DIFF
--- a/src/style/__tests__/design-tokens.test.ts
+++ b/src/style/__tests__/design-tokens.test.ts
@@ -1,0 +1,68 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Vitest runs with cwd = repo root (npm --prefix / vitest root), so resolve the
+// stylesheet dir from there. These are structural guards for the design-token
+// system: they fail if a hardcoded color literal is re-introduced or a token
+// stops being defined in both themes.
+const STYLE_DIR = path.resolve('src', 'style');
+const CSS_FILES = [
+    'app.css',
+    'home.css',
+    'modal.css',
+    'listfiles.css',
+    'devicelist.css',
+    'dependencies.css',
+    'ws-scrcpy.css',
+];
+// Consumers must not hardcode token literals; the canonical definitions live in
+// app.css, so it is exempt from the no-literal checks.
+const CONSUMER_CSS_FILES = CSS_FILES.filter((f) => f !== 'app.css');
+
+function readStyle(name: string): string {
+    return fs.readFileSync(path.join(STYLE_DIR, name), 'utf8');
+}
+
+/** The dark theme block in app.css spans from the dark selector to the light selector. */
+function darkBlock(appCss: string): string {
+    return appCss.slice(appCss.indexOf('[data-theme="dark"]'), appCss.indexOf('[data-theme="light"]'));
+}
+/** The light theme block onward (only the light block defines tokens after this point). */
+function lightBlock(appCss: string): string {
+    return appCss.slice(appCss.indexOf('[data-theme="light"]'));
+}
+
+describe('accent design token', () => {
+    it('defines --accent-color in both dark and light themes', () => {
+        const appCss = readStyle('app.css');
+        expect(darkBlock(appCss)).toMatch(/--accent-color\s*:/);
+        expect(lightBlock(appCss)).toMatch(/--accent-color\s*:/);
+    });
+
+    it('defines --accent-rgb in both dark and light themes', () => {
+        const appCss = readStyle('app.css');
+        expect(darkBlock(appCss)).toMatch(/--accent-rgb\s*:/);
+        expect(lightBlock(appCss)).toMatch(/--accent-rgb\s*:/);
+    });
+
+    it('has no hardcoded #5b9aff accent literal in any stylesheet', () => {
+        for (const file of CONSUMER_CSS_FILES) {
+            expect(readStyle(file), `${file} should use var(--accent-color)`).not.toMatch(/#5b9aff/i);
+        }
+    });
+
+    it('has no hardcoded rgba(91, 154, 255, …) accent literal', () => {
+        for (const file of CONSUMER_CSS_FILES) {
+            expect(readStyle(file), `${file} should use rgba(var(--accent-rgb), …)`).not.toMatch(
+                /rgba\(\s*91\s*,\s*154\s*,\s*255/,
+            );
+        }
+    });
+
+    it('no longer references the undefined --accent alias (consolidated to --accent-color)', () => {
+        for (const file of CONSUMER_CSS_FILES) {
+            expect(readStyle(file), `${file} should use var(--accent-color)`).not.toMatch(/var\(\s*--accent\s*,/);
+        }
+    });
+});

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -35,6 +35,8 @@
     --button-border-color: #444444;
     --progress-background-color: rgba(50, 100, 255, 0.2);
     --progress-background-error-color: rgba(255, 50, 50, 0.2);
+    --accent-color: #5b9aff;
+    --accent-rgb: 91, 154, 255;
 }
 
 /* Light theme */
@@ -66,6 +68,8 @@
     --button-border-color: #c0c6cc;
     --progress-background-color: rgba(50, 100, 255, 0.2);
     --progress-background-error-color: rgba(255, 50, 50, 0.2);
+    --accent-color: #5b9aff;
+    --accent-rgb: 91, 154, 255;
 }
 
 html {

--- a/src/style/dependencies.css
+++ b/src/style/dependencies.css
@@ -55,10 +55,10 @@
 /* Buttons */
 .dep-btn {
     padding: 0.3rem 0.75rem;
-    border: 0.5px solid #5b9aff;
+    border: 0.5px solid var(--accent-color);
     border-radius: 6px;
     background: transparent;
-    color: #5b9aff;
+    color: var(--accent-color);
     font-family: var(--font-mono);
     font-size: var(--font-size);
     cursor: pointer;

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -336,10 +336,10 @@ body.list #device_list_menu {
    (with gray cell borders) without an outer blue border around it. */
 #devices .device-list div.desc-block .action-button,
 #devices .device-list div.desc-block a {
-    border: 0.5px solid #5b9aff;
+    border: 0.5px solid var(--accent-color);
     border-radius: 6px;
     background-color: transparent;
-    color: #5b9aff;
+    color: var(--accent-color);
     text-decoration: none;
     padding: 0.15rem 0.5rem;
     font-family: var(--font-mono);
@@ -424,7 +424,7 @@ body.list #device_list_menu {
 
 #devices .device-name-input:focus {
     outline: none;
-    border-color: var(--accent-color, #5b9aff);
+    border-color: var(--accent-color);
 }
 
 a.link-stream .kind-icon {

--- a/src/style/home.css
+++ b/src/style/home.css
@@ -183,7 +183,7 @@
 
 .discovery-name-input:focus {
     outline: none;
-    border-color: var(--accent-color, #5b9aff);
+    border-color: var(--accent-color);
 }
 
 .discovery-name-input::placeholder {
@@ -222,7 +222,7 @@
 
 .discovery-manual-form input[type="text"]:focus {
     outline: none;
-    border-color: var(--accent-color, #5b9aff);
+    border-color: var(--accent-color);
 }
 
 .discovery-manual-form input[type="text"]::placeholder {
@@ -383,8 +383,8 @@
 }
 
 .update-button-container.state-downloading {
-    color: #5b9aff; /* deep blue — matches .settings-btn-primary */
-    border-color: #5b9aff;
+    color: var(--accent-color); /* deep blue — matches .settings-btn-primary */
+    border-color: var(--accent-color);
 }
 
 .update-button-container.state-downloading:hover {

--- a/src/style/listfiles.css
+++ b/src/style/listfiles.css
@@ -71,7 +71,7 @@
 }
 
 .list-files-breadcrumb-segment {
-    background: rgba(91, 154, 255, 0.15);
+    background: rgba(var(--accent-rgb), 0.15);
     padding: 2px 8px;
     border-radius: 4px;
     cursor: pointer;
@@ -80,7 +80,7 @@
 }
 
 .list-files-breadcrumb-segment:hover {
-    background: rgba(91, 154, 255, 0.3);
+    background: rgba(var(--accent-rgb), 0.3);
 }
 
 .list-files-breadcrumb-current {
@@ -113,7 +113,7 @@
 
 .list-files-filter input:focus {
     outline: none;
-    border-color: #5b9aff;
+    border-color: var(--accent-color);
 }
 
 [data-theme="light"] .list-files-filter input {
@@ -176,7 +176,7 @@
 .list-files-header-check {
     width: 16px;
     height: 16px;
-    accent-color: #5b9aff;
+    accent-color: var(--accent-color);
 }
 
 .list-files-sort-arrow {
@@ -213,7 +213,7 @@
 }
 
 .list-files-row.selected {
-    background: rgba(91, 154, 255, 0.08);
+    background: rgba(var(--accent-rgb), 0.08);
 }
 
 .list-files-row.directory {
@@ -223,7 +223,7 @@
 .list-files-row-check {
     width: 16px;
     height: 16px;
-    accent-color: #5b9aff;
+    accent-color: var(--accent-color);
     flex-shrink: 0;
 }
 
@@ -288,11 +288,11 @@
 }
 
 .list-files-action-download {
-    color: #5b9aff;
+    color: var(--accent-color);
 }
 
 .list-files-action-download:hover {
-    background: rgba(91, 154, 255, 0.15);
+    background: rgba(var(--accent-rgb), 0.15);
 }
 
 .list-files-action-delete {
@@ -309,7 +309,7 @@
     left: 0;
     top: 0;
     height: 100%;
-    background: rgba(91, 154, 255, 0.1);
+    background: rgba(var(--accent-rgb), 0.1);
     transition: width 0.2s ease;
     pointer-events: none;
 }
@@ -342,7 +342,7 @@
     border: 0.5px solid var(--text-color, #ddd);
     border-radius: 4px;
     background: transparent;
-    color: #5b9aff;
+    color: var(--accent-color);
     padding: 4px 12px;
     cursor: pointer;
     font-family: var(--font-mono);
@@ -350,7 +350,7 @@
 }
 
 .list-files-footer-btn:hover:not(:disabled) {
-    background: rgba(91, 154, 255, 0.1);
+    background: rgba(var(--accent-rgb), 0.1);
 }
 
 .list-files-footer-btn:disabled {
@@ -375,13 +375,13 @@
 .list-files-dropzone {
     position: absolute;
     inset: 0;
-    background: rgba(91, 154, 255, 0.1);
-    border: 3px dashed #5b9aff;
+    background: rgba(var(--accent-rgb), 0.1);
+    border: 3px dashed var(--accent-color);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 18px;
-    color: #5b9aff;
+    color: var(--accent-color);
     z-index: 10;
     pointer-events: none;
 }
@@ -421,12 +421,12 @@
 }
 
 .list-files-size-option:hover {
-    border-color: rgba(91, 154, 255, 0.5);
+    border-color: rgba(var(--accent-rgb), 0.5);
 }
 
 .list-files-size-option.selected {
-    border-color: #5b9aff;
-    background: rgba(91, 154, 255, 0.1);
+    border-color: var(--accent-color);
+    background: rgba(var(--accent-rgb), 0.1);
 }
 
 .list-files-size-option .size-label {

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -243,7 +243,7 @@ dialog.modal .modal-controls input:not([type="checkbox"]) {
 dialog.modal .modal-controls select:focus,
 dialog.modal .modal-controls input:focus {
     outline: none;
-    border-color: #5b9aff;
+    border-color: var(--accent-color);
 }
 
 dialog.modal .modal-controls input:disabled,
@@ -267,7 +267,7 @@ dialog.modal .modal-controls input[type="range"] {
     grid-column: controls;
     width: 100%;
     cursor: pointer;
-    accent-color: #5b9aff;
+    accent-color: var(--accent-color);
 }
 
 /* ── Advanced toggle ── */
@@ -361,7 +361,7 @@ dialog.modal .modal-advanced input[type="checkbox"] {
     width: 16px;
     height: 16px;
     cursor: pointer;
-    accent-color: #5b9aff;
+    accent-color: var(--accent-color);
 }
 
 [data-theme="light"] dialog.modal .modal-advanced select,
@@ -389,7 +389,7 @@ dialog.modal .modal-settings button {
     border: 0.5px solid var(--text-color, #ddd);
     border-radius: 6px;
     background: transparent;
-    color: #5b9aff;
+    color: var(--accent-color);
     padding: 6px 16px;
     cursor: pointer;
     white-space: nowrap;
@@ -439,7 +439,7 @@ dialog.modal .connect-btn {
     border: 0.5px solid var(--text-color, #ddd);
     border-radius: 6px;
     background: transparent;
-    color: #5b9aff;
+    color: var(--accent-color);
     padding: 6px 20px;
     cursor: pointer;
     white-space: nowrap;
@@ -655,7 +655,7 @@ dialog.settings-modal .settings-control .settings-radio-label {
  * radio is never `disabled` (Chromium desaturates accent-color on :disabled),
  * so this dot renders at full saturation in both the active and locked state. */
 dialog.settings-modal .settings-control .settings-radio-label input[type="radio"] {
-    accent-color: #5b9aff;
+    accent-color: var(--accent-color);
 }
 
 /*
@@ -701,7 +701,7 @@ dialog.settings-modal .settings-input {
 
 dialog.settings-modal .settings-input:focus {
     outline: none;
-    border-color: #5b9aff;
+    border-color: var(--accent-color);
 }
 
 [data-theme="light"] dialog.settings-modal .settings-input {
@@ -725,8 +725,8 @@ dialog.modal .settings-btn:disabled {
 }
 
 dialog.modal .settings-btn-primary {
-    color: #5b9aff;
-    border-color: #5b9aff;
+    color: var(--accent-color);
+    border-color: var(--accent-color);
 }
 
 dialog.modal .settings-btn-danger {
@@ -798,7 +798,7 @@ dialog.service-operation-modal .modal-body {
     width: 32px;
     height: 32px;
     border: 3px solid var(--border-muted, rgba(255, 255, 255, 0.2));
-    border-top-color: var(--accent, #5b9aff);
+    border-top-color: var(--accent-color);
     border-radius: 50%;
     margin: 0 auto 1rem;
     animation: service-op-spin 0.8s linear infinite;


### PR DESCRIPTION
Security review finding 60 (plus the accent-token part of finding 59).

The accent blue `#5b9aff` was hardcoded 25+ times — plus `rgba(91, 154, 255, …)` forms — across `modal`/`home`/`devicelist`/`listfiles`/`dependencies` CSS, and three sites referenced **undefined** tokens (`--accent-color` / `--accent`) that silently fell back to the literal (so "theming" was a no-op there).

## What changed
- Define `--accent-color` and `--accent-rgb` in `app.css` for both themes. **Identical values in both** — this is pure centralization, no visual change. (A nicer light-theme accent is a possible future enhancement; deliberately out of scope here to keep it behavior-preserving.)
- Replace every `#5b9aff` with `var(--accent-color)`, every `rgba(91, 154, 255, a)` with `rgba(var(--accent-rgb), a)`, and consolidate the stray `--accent` alias to `--accent-color`.

## Tests
New `src/style/__tests__/design-tokens.test.ts` — structural guards that fail if the tokens stop being defined in both themes or if any consumer stylesheet reintroduces the literal. (CSS can't be unit-tested for computed style here, so these text-structural assertions are the regression net.) Full suite 1217 pass, `tsc` clean, biome 0 errors.

`release:none`.