### PR TITLE
refactor(css): centralize modal divider + border-muted into theme tokens

### DIFF
--- a/src/style/__tests__/design-tokens.test.ts
+++ b/src/style/__tests__/design-tokens.test.ts
@@ -102,3 +102,38 @@ describe('status color tokens (danger / success)', () => {
         }
     });
 });
+
+describe('divider / border-muted tokens', () => {
+    it('defines --modal-divider and --border-muted in both themes', () => {
+        const appCss = readStyle('app.css');
+        expect(darkBlock(appCss)).toMatch(/--modal-divider\s*:/);
+        expect(lightBlock(appCss)).toMatch(/--modal-divider\s*:/);
+        expect(darkBlock(appCss)).toMatch(/--border-muted\s*:/);
+        expect(lightBlock(appCss)).toMatch(/--border-muted\s*:/);
+    });
+
+    it('has no hardcoded rgba(255,255,255,0.08) divider literal in consumers', () => {
+        for (const file of CONSUMER_CSS_FILES) {
+            expect(readStyle(file), `${file}: rgba(255,255,255,0.08)`).not.toMatch(
+                /rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*0\.08\s*\)/,
+            );
+        }
+    });
+
+    it('removed the now-redundant light-theme divider overrides in modal + listfiles', () => {
+        // The --modal-divider token switches per theme, so the explicit
+        // [data-theme="light"] border-color overrides (rgba(0,0,0,0.08)) are gone.
+        // (first-run-banner.css uses rgba(0,0,0,0.08) as a background, not a divider — excluded.)
+        for (const file of ['modal.css', 'listfiles.css']) {
+            expect(readStyle(file), `${file}: leftover rgba(0,0,0,0.08) divider override`).not.toMatch(
+                /rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\.08\s*\)/,
+            );
+        }
+    });
+
+    it('no longer references the --border-muted fallback literal', () => {
+        for (const file of CONSUMER_CSS_FILES) {
+            expect(readStyle(file), `${file}: var(--border-muted, …)`).not.toMatch(/var\(\s*--border-muted\s*,/);
+        }
+    });
+});

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -39,6 +39,8 @@
     --accent-rgb: 91, 154, 255;
     --danger-rgb: 240, 108, 117;
     --success-rgb: 74, 222, 128;
+    --modal-divider: rgba(255, 255, 255, 0.08);
+    --border-muted: rgba(255, 255, 255, 0.2);
 }
 
 /* Light theme */
@@ -74,6 +76,8 @@
     --accent-rgb: 91, 154, 255;
     --danger-rgb: 185, 28, 28;
     --success-rgb: 21, 128, 61;
+    --modal-divider: rgba(0, 0, 0, 0.08);
+    --border-muted: rgba(0, 0, 0, 0.2);
 }
 
 html {

--- a/src/style/listfiles.css
+++ b/src/style/listfiles.css
@@ -60,14 +60,10 @@
     display: flex;
     align-items: center;
     padding: 6px 12px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid var(--modal-divider);
     gap: 4px;
     overflow-x: auto;
     flex-shrink: 0;
-}
-
-[data-theme="light"] .list-files-breadcrumbs {
-    border-bottom-color: rgba(0, 0, 0, 0.08);
 }
 
 .list-files-breadcrumb-segment {
@@ -129,7 +125,7 @@
     display: flex;
     align-items: center;
     padding: 6px 12px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid var(--modal-divider);
     font-size: 11px;
     color: rgba(255, 255, 255, 0.4);
     flex-shrink: 0;
@@ -141,7 +137,6 @@
 }
 
 [data-theme="light"] .list-files-header {
-    border-bottom-color: rgba(0, 0, 0, 0.08);
     color: rgba(0, 0, 0, 0.4);
     background: rgb(245, 248, 252);
 }
@@ -323,14 +318,10 @@
     display: flex;
     align-items: center;
     padding: 8px 12px;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: 1px solid var(--modal-divider);
     flex-shrink: 0;
     gap: 8px;
     font-size: 12px;
-}
-
-[data-theme="light"] .list-files-footer {
-    border-top-color: rgba(0, 0, 0, 0.08);
 }
 
 .list-files-footer-actions {

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -130,12 +130,8 @@ dialog.modal .modal-header {
     align-items: center;
     justify-content: space-between;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid var(--modal-divider);
     flex-shrink: 0;
-}
-
-[data-theme="light"] dialog.modal .modal-header {
-    border-bottom-color: rgba(0, 0, 0, 0.08);
 }
 
 dialog.modal .modal-title {
@@ -190,12 +186,8 @@ dialog.modal .modal-footer {
     align-items: center;
     justify-content: space-between;
     padding: 0.75rem 1rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: 1px solid var(--modal-divider);
     flex-shrink: 0;
-}
-
-[data-theme="light"] dialog.modal .modal-footer {
-    border-top-color: rgba(0, 0, 0, 0.08);
 }
 
 /* ── Controls grid (used by ConfigureScrcpy) ── */
@@ -273,13 +265,9 @@ dialog.modal .modal-controls input[type="range"] {
 /* ── Advanced toggle ── */
 dialog.modal .modal-advanced-separator {
     grid-column: 1 / -1;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: 1px solid var(--modal-divider);
     margin-top: 0.5rem;
     padding-top: 0.5rem;
-}
-
-[data-theme="light"] dialog.modal .modal-advanced-separator {
-    border-top-color: rgba(0, 0, 0, 0.08);
 }
 
 dialog.modal .modal-advanced-toggle {
@@ -378,11 +366,7 @@ dialog.modal .modal-settings {
     justify-content: center;
     margin-top: 1rem;
     padding-top: 0.75rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-[data-theme="light"] dialog.modal .modal-settings {
-    border-top-color: rgba(0, 0, 0, 0.08);
+    border-top: 1px solid var(--modal-divider);
 }
 
 dialog.modal .modal-settings button {
@@ -464,12 +448,8 @@ dialog.modal .shell-warning {
     padding: 4px 1rem;
     font-size: 11px;
     color: var(--danger-color);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid var(--modal-divider);
     flex-shrink: 0;
-}
-
-[data-theme="light"] dialog.modal .shell-warning {
-    border-bottom-color: rgba(0, 0, 0, 0.08);
 }
 
 dialog.modal.shell-modal .modal-body {
@@ -546,11 +526,7 @@ dialog.settings-modal .modal-frame {
 
 dialog.settings-modal .settings-section {
     padding: 0.75rem 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-[data-theme="light"] dialog.settings-modal .settings-section {
-    border-bottom-color: rgba(0, 0, 0, 0.08);
+    border-bottom: 1px solid var(--modal-divider);
 }
 
 dialog.settings-modal .settings-section:last-child {
@@ -797,7 +773,7 @@ dialog.service-operation-modal .modal-body {
 .service-operation-spinner {
     width: 32px;
     height: 32px;
-    border: 3px solid var(--border-muted, rgba(255, 255, 255, 0.2));
+    border: 3px solid var(--border-muted);
     border-top-color: var(--accent-color);
     border-radius: 50%;
     margin: 0 auto 1rem;


### PR DESCRIPTION
Security review finding 65 (plus the `--modal-divider`/`--border-muted` part of finding 59 — this **completes finding 59**: all four originally-undefined tokens are now resolved).

The 1px modal/list divider `rgba(255, 255, 255, 0.08)` was hardcoded ~9 times, each with a mirrored `[data-theme="light"]` `rgba(0,0,0,0.08)` override beside it, and the service-operation spinner referenced an **undefined** `--border-muted` (fell back to a literal that didn't adapt to light theme).

## What changed
- Define `--modal-divider` and `--border-muted` in `app.css`, both themes.
- Replace the dark divider literal with `var(--modal-divider)` and **delete the now-redundant `[data-theme="light"]` border-color overrides** — the token switches per theme. One override (`.list-files-header`) also set color/background, so only its border line was removed.
- Point the spinner border at `var(--border-muted)` (drops the fallback; it now adapts to light theme too).

Behavior-preserving for the dividers (identical values); the only visible delta is the light-theme spinner border, which now uses the light muted value instead of the dark one.

## Tests
`design-tokens.test.ts` gains divider cases: tokens defined in both themes, no `rgba(255,255,255,0.08)` divider literal in consumers, and the light-theme overrides removed from modal/listfiles. Suite 1225 pass, `tsc` clean, biome 0 errors.

`release:none`.