### PR TITLE
fix(a11y): restore keyboard focus indicator, add embed lang, drop !important war

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Several browser-side leaks are now cleaned up on teardown.** The device-tracker reconnect timer, the dependency-panel and first-run-banner polling intervals (released on page unload), a per-file-browser `hashchange` listener, a keep-alive channel handler, and the player's stats animation-frame loop are all cancelled or removed when their owner is destroyed instead of lingering; the shared pointer-id map also releases mouse entries on mouse-up.
 - **The in-app-update wait server is more robust.** A failed socket clone now drops that one connection instead of panicking the process, its redirect JSON is properly escaped, and its port probe advances past a permanent bind error instead of retrying a dead port until timeout.
 - **Status tints now follow the active theme.** Several red/green tinted backgrounds (file-row selection, delete-hover, the apply-update hover) were hardcoded to their dark-theme channel values and showed a slightly off shade in light mode; they now resolve through the danger/success design tokens and adapt to the theme.
+- **Keyboard focus is visible again, and the embed page declares its language.** A global `:focus { outline: none }` had removed the keyboard focus indicator across the whole app; it is replaced by a `:focus-visible` outline (shown on keyboard navigation, not mouse clicks), so keyboard users can see where they are. The embedded stream page (`embed.html`) now sets `<html lang>` for assistive technology.
 
 ### Security
 

--- a/public/embed.html
+++ b/public/embed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <title>ws-scrcpy-web stream</title>

--- a/src/style/__tests__/css-a11y.test.ts
+++ b/src/style/__tests__/css-a11y.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// cwd = repo root under vitest; resolve repo-relative paths from there.
+const read = (rel: string): string => fs.readFileSync(path.resolve(...rel.split('/')), 'utf8');
+
+describe('focus accessibility (WCAG 2.4.7)', () => {
+    it('does not blanket-remove focus outlines globally', () => {
+        // A bare `:focus { outline: none }` strips the keyboard focus indicator
+        // from every element that lacks its own. Components may still opt out via
+        // a more specific selector (e.g. inputs that swap to a border highlight).
+        expect(read('src/style/app.css')).not.toMatch(/(^|})\s*:focus\s*\{[^}]*outline\s*:\s*none/);
+    });
+
+    it('provides a global :focus-visible outline', () => {
+        expect(read('src/style/app.css')).toMatch(/:focus-visible\s*\{[^}]*outline\s*:/);
+    });
+});
+
+describe('document language (WCAG 3.1.1)', () => {
+    it('embed.html declares a document language', () => {
+        expect(read('public/embed.html')).toMatch(/<html[^>]*\blang=/i);
+    });
+});
+
+describe('cascade hygiene (no !important war)', () => {
+    it('home.css uses specificity, not !important, for the discovery buttons', () => {
+        // Match the declaration form (`… !important;` / `… !important}`) so a
+        // comment that merely mentions the word doesn't trip the guard.
+        expect(read('src/style/home.css')).not.toMatch(/!important\s*[;}]/);
+    });
+});

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -116,8 +116,12 @@ body.stream {
     padding: 5px;
 }
 
-:focus {
-    outline: none;
+/* Keyboard focus indicator (WCAG 2.4.7). Inputs that swap to a border highlight
+   opt out via their own more-specific :focus rule; everything else shows this
+   outline on keyboard navigation only (not on mouse click). */
+:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
 }
 
 .wait {

--- a/src/style/home.css
+++ b/src/style/home.css
@@ -278,30 +278,28 @@
     color: var(--success-color);
 }
 
-.dep-ok-btn {
-    background: #1a3a1a !important;
-    border-color: #2a5a2a !important;
-    color: var(--success-color) !important;
+/* Discovery action buttons recolor the .dep-btn base (blue) to success-green /
+   danger-red. Qualified with the base class so they win by specificity rather
+   than !important. (The unreferenced .dep-ok-btn rule that lived here was dead
+   CSS and was removed.) */
+.dep-btn.discovery-connect-btn {
+    border-color: var(--success-color);
+    color: var(--success-color);
+    background: transparent;
 }
 
-.discovery-connect-btn {
-    border-color: var(--success-color) !important;
-    color: var(--success-color) !important;
-    background: transparent !important;
+.dep-btn.discovery-connect-btn:hover:not(:disabled) {
+    background: var(--success-hover-bg);
 }
 
-.discovery-connect-btn:hover:not(:disabled) {
-    background: var(--success-hover-bg) !important;
+.dep-btn.discovery-dismiss-btn {
+    border-color: var(--danger-color);
+    color: var(--danger-color);
+    background: transparent;
 }
 
-.discovery-dismiss-btn {
-    border-color: var(--danger-color) !important;
-    color: var(--danger-color) !important;
-    background: transparent !important;
-}
-
-.discovery-dismiss-btn:hover:not(:disabled) {
-    background: var(--danger-hover-bg) !important;
+.dep-btn.discovery-dismiss-btn:hover:not(:disabled) {
+    background: var(--danger-hover-bg);
 }
 
 /* ── Update button (top-right, third from edge) ──


### PR DESCRIPTION
Security review findings 62, 66, and 63.

- **62 (WCAG 2.4.7):** a global `:focus { outline: none }` stripped the keyboard focus indicator from every element app-wide. Replaced with a `:focus-visible` outline (keyboard-only — not shown on mouse click; inputs that swap to a border highlight still opt out via their own more-specific `:focus` rule).
- **66 (WCAG 3.1.1):** `embed.html` now declares `<html lang="en">` (the other three HTML entry points already did — verified).
- **63:** the network-discovery connect/dismiss buttons fought the `.dep-btn` base palette with 11 `!important` flags; they now win by **specificity** (`.dep-btn.discovery-*`). The `.dep-ok-btn` rule sharing that block was unreferenced dead CSS and was removed.

## Tests
New `src/style/__tests__/css-a11y.test.ts`: no blanket `:focus{outline:none}`, a `:focus-visible` outline exists, `embed.html` has `lang`, and home.css carries no `!important` declarations. Suite 1229 pass, `tsc` clean, biome 0 errors (warnings 457 → 446).

`release:none`.