### PR TITLE
refactor(css): de-duplicate stream theme tokens (ws-scrcpy.css owns them)

### DIFF
--- a/src/style/__tests__/design-tokens.test.ts
+++ b/src/style/__tests__/design-tokens.test.ts
@@ -137,3 +137,24 @@ describe('divider / border-muted tokens', () => {
         }
     });
 });
+
+describe('theme-token ownership (no app/ws-scrcpy duplication)', () => {
+    // The stream/toolbar tokens must live in ws-scrcpy.css because embed.html
+    // loads it standalone (without app.css). app.css imports ws-scrcpy.css, so it
+    // must NOT redefine them — that was the duplication finding 64 flagged.
+    const STREAM_TOKENS = ['--control-buttons-bg-color', '--svg-button-fill', '--svg-checkbox-bg-color'];
+
+    it('defines the stream tokens in ws-scrcpy.css', () => {
+        const ws = readStyle('ws-scrcpy.css');
+        for (const t of STREAM_TOKENS) {
+            expect(ws, `${t} should be defined in ws-scrcpy.css`).toMatch(new RegExp(`${t}\\s*:`));
+        }
+    });
+
+    it('does not duplicate the stream tokens in app.css', () => {
+        const appCss = readStyle('app.css');
+        for (const t of STREAM_TOKENS) {
+            expect(appCss, `${t} duplicated in app.css`).not.toMatch(new RegExp(`${t}\\s*:`));
+        }
+    });
+});

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -14,7 +14,6 @@
     --text-shadow-color: hsl(218, 17%, 18%);
     --header-bg-color: #333333;
     --controls-bg-color: rgba(45, 55, 65, 0.8);
-    --control-buttons-bg-color: #2d3741;
     --text-color: #e0e0e0;
     --text-color-light: #a8a8a8;
     --success-color: #4ade80;
@@ -27,8 +26,6 @@
     --link-color-light: hsl(218, 63%, 50%);
     --link-color_visited: hsl(267, 31%, 47%);
     --link-color_visited-light: hsl(267, 31%, 27%);
-    --svg-checkbox-bg-color: #10b981;
-    --svg-button-fill: #ffffff;
     --kill-button-hover-color: #f06c75;
     --url-color: #888888;
     --button-text-color: hsl(214, 82%, 76%);
@@ -51,7 +48,6 @@
     --text-shadow-color: hsl(218, 67%, 95%);
     --header-bg-color: #f8f9fa;
     --controls-bg-color: rgba(248, 249, 250, 0.8);
-    --control-buttons-bg-color: #f8f9fa;
     --text-color: #212529;
     --text-color-light: #495057;
     --success-color: #15803d;
@@ -64,8 +60,6 @@
     --link-color-light: hsl(218, 85%, 73%);
     --link-color_visited: hsl(271, 68%, 32%);
     --link-color_visited-light: hsl(271, 68%, 72%);
-    --svg-checkbox-bg-color: #198754;
-    --svg-button-fill: #495057;
     --kill-button-hover-color: #dc3545;
     --url-color: #6c757d;
     --button-text-color: #0d6efd;


### PR DESCRIPTION
Security review finding 64.

Three stream/toolbar tokens (`--control-buttons-bg-color`, `--svg-button-fill`, `--svg-checkbox-bg-color`) were defined **identically** in both `app.css` and `ws-scrcpy.css`. `ws-scrcpy.css` is loaded standalone by `embed.html` (no app.css), so it must keep them; `app.css` imports `ws-scrcpy.css`, so its copies were pure duplicates.

## What changed
- Remove the three tokens from `app.css` dark + light blocks. `ws-scrcpy.css` is now their single source; the home page still gets them via the existing `@import "./ws-scrcpy.css"`.

I chose this over introducing a new shared partial: a partial would have to host (or awkwardly split around) `ws-scrcpy.css`'s embed-specific `prefers-color-scheme` auto-detection, and would ripple the token tests. Consolidating ownership to the file that already must own them (for the standalone embed load) is the smaller, behavior-preserving change — identical values, same selectors, so the cascade winner is unchanged.

## Tests
`design-tokens.test.ts` asserts the stream tokens are defined in `ws-scrcpy.css` and not duplicated in `app.css`. Suite 1231 pass, `tsc` clean, biome 0 errors.

`release:none`.