### PR TITLE
fix(player): unify NALU start-code scanner + fix tail off-by-one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The in-app-update wait server is more robust.** A failed socket clone now drops that one connection instead of panicking the process, its redirect JSON is properly escaped, and its port probe advances past a permanent bind error instead of retrying a dead port until timeout.
 - **Status tints now follow the active theme.** Several red/green tinted backgrounds (file-row selection, delete-hover, the apply-update hover) were hardcoded to their dark-theme channel values and showed a slightly off shade in light mode; they now resolve through the danger/success design tokens and adapt to the theme.
 - **Keyboard focus is visible again, and the embed page declares its language.** A global `:focus { outline: none }` had removed the keyboard focus indicator across the whole app; it is replaced by a `:focus-visible` outline (shown on keyboard navigation, not mouse clicks), so keyboard users can see where they are. The embedded stream page (`embed.html`) now sets `<html lang>` for assistive technology.
+- **The video config parser no longer misses a NAL unit at the very end of a packet.** The H.264/H.265 Annex B start-code scanner stopped four bytes short of the buffer end, so a parameter-set NAL unit whose start code landed in the final bytes could be missed; the scan bound is corrected (and the three duplicated scanners unified into one).
 
 ### Security
 

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -8,6 +8,7 @@ import { BaseCanvasBasedPlayer } from './BaseCanvasBasedPlayer';
 import { BasePlayer } from './BasePlayer';
 import { parseSPS, stripEmulationPrevention } from './h264-utils';
 import { HEVC_NAL_TYPE, hevcNalType, parseHevcSPS } from './h265-utils';
+import { findFirstNaluOffset, findNaluByHeader } from './naluScanner';
 import { buildDecoderConfig } from './webCodecsConfig';
 
 function toHex(value: number) {
@@ -179,23 +180,7 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
 
     /** Find offset of NALU with given type in Annex B stream. Returns -1 if not found. */
     private findNaluOffset(data: Uint8Array, naluType: number): number {
-        for (let i = 0; i < data.length - 4; i++) {
-            // Look for start code 00 00 00 01 or 00 00 01
-            if (data[i] === 0 && data[i + 1] === 0) {
-                let offset: number;
-                if (data[i + 2] === 1) {
-                    offset = i + 3;
-                } else if (data[i + 2] === 0 && data[i + 3] === 1) {
-                    offset = i + 4;
-                } else {
-                    continue;
-                }
-                if (offset < data.length && (data[offset]! & 0x1f) === naluType) {
-                    return offset;
-                }
-            }
-        }
-        return -1;
+        return findNaluByHeader(data, (b) => (b & 0x1f) === naluType);
     }
 
     private parseConfig(data: Uint8Array): { codec: string; width?: number; height?: number } | null {
@@ -243,32 +228,11 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     }
 
     private findStartCode(data: Uint8Array): number {
-        for (let i = 0; i < data.length - 4; i++) {
-            if (data[i] === 0 && data[i + 1] === 0) {
-                if (data[i + 2] === 1) return i + 3;
-                if (data[i + 2] === 0 && data[i + 3] === 1) return i + 4;
-            }
-        }
-        return -1;
+        return findFirstNaluOffset(data);
     }
 
     private findHevcNalu(data: Uint8Array, nalType: number): number {
-        for (let i = 0; i < data.length - 4; i++) {
-            if (data[i] === 0 && data[i + 1] === 0) {
-                let offset: number;
-                if (data[i + 2] === 1) {
-                    offset = i + 3;
-                } else if (data[i + 2] === 0 && data[i + 3] === 1) {
-                    offset = i + 4;
-                } else {
-                    continue;
-                }
-                if (offset < data.length && hevcNalType(data[offset]!) === nalType) {
-                    return offset;
-                }
-            }
-        }
-        return -1;
+        return findNaluByHeader(data, (b) => hevcNalType(b) === nalType);
     }
 
     /** Set fallback dimensions from stream metadata (used by AV1 which doesn't include dimensions in config). */

--- a/src/app/player/__tests__/naluScanner.test.ts
+++ b/src/app/player/__tests__/naluScanner.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { findFirstNaluOffset, findNaluByHeader } from '../naluScanner';
+
+describe('findNaluByHeader', () => {
+    it('finds a NAL unit after a 4-byte start code', () => {
+        const data = new Uint8Array([0, 0, 0, 1, 0x67, 0xab]);
+        expect(findNaluByHeader(data, (b) => (b & 0x1f) === 7)).toBe(4);
+    });
+
+    it('finds a NAL unit after a 3-byte start code', () => {
+        const data = new Uint8Array([0, 0, 1, 0x67, 0xab]);
+        expect(findNaluByHeader(data, (b) => (b & 0x1f) === 7)).toBe(3);
+    });
+
+    it('finds a 3-byte start code whose payload byte is the final byte (tail off-by-one regression)', () => {
+        // Only start code begins at i = length-4 (= 3). The old `i < length - 4`
+        // bound stopped at i < 3 and missed it, returning -1.
+        const data = new Uint8Array([0xff, 0xff, 0xff, 0, 0, 1, 0x67]);
+        expect(findNaluByHeader(data, (b) => (b & 0x1f) === 7)).toBe(6);
+    });
+
+    it('returns -1 when no matching NAL unit is present', () => {
+        const data = new Uint8Array([0, 0, 1, 0x41, 0xab]);
+        expect(findNaluByHeader(data, (b) => (b & 0x1f) === 7)).toBe(-1);
+    });
+
+    it('returns -1 for a start code with no payload byte after it', () => {
+        const data = new Uint8Array([0xff, 0, 0, 1]);
+        expect(findNaluByHeader(data, () => true)).toBe(-1);
+    });
+});
+
+describe('findFirstNaluOffset', () => {
+    it('returns the offset past the first start code of any NAL type', () => {
+        expect(findFirstNaluOffset(new Uint8Array([0, 0, 0, 1, 0x67]))).toBe(4);
+        expect(findFirstNaluOffset(new Uint8Array([0xff, 0, 0, 1, 0x41]))).toBe(4);
+    });
+
+    it('returns -1 when there is no start code', () => {
+        expect(findFirstNaluOffset(new Uint8Array([1, 2, 3, 4, 5]))).toBe(-1);
+    });
+});

--- a/src/app/player/naluScanner.ts
+++ b/src/app/player/naluScanner.ts
@@ -1,0 +1,36 @@
+// Shared Annex B (H.264/H.265) NAL-unit start-code scanner. Previously three
+// near-identical copies lived in WebCodecsPlayer (findNaluOffset / findStartCode
+// / findHevcNalu), each with the same off-by-one loop bound.
+
+/**
+ * Scan an Annex B byte stream for the first NAL unit whose header byte satisfies
+ * `match`. Returns the offset of the header byte (just past the start code), or
+ * -1 if none is found.
+ */
+export function findNaluByHeader(data: Uint8Array, match: (headerByte: number) => boolean): number {
+    // `i + 3 <= length` (not the old `i < length - 4`) so a 3-byte start code in
+    // the final bytes isn't missed; the `offset < length` check below still
+    // rejects a start code with no payload byte after it.
+    for (let i = 0; i + 3 <= data.length; i++) {
+        if (data[i] !== 0 || data[i + 1] !== 0) {
+            continue;
+        }
+        let offset: number;
+        if (data[i + 2] === 1) {
+            offset = i + 3;
+        } else if (data[i + 2] === 0 && data[i + 3] === 1) {
+            offset = i + 4;
+        } else {
+            continue;
+        }
+        if (offset < data.length && match(data[offset]!)) {
+            return offset;
+        }
+    }
+    return -1;
+}
+
+/** Offset just past the first Annex B start code (any NAL type), or -1. */
+export function findFirstNaluOffset(data: Uint8Array): number {
+    return findNaluByHeader(data, () => true);
+}


### PR DESCRIPTION
Security review finding 70.

`WebCodecsPlayer` had **three** near-identical Annex B start-code scanners (`findNaluOffset` / `findStartCode` / `findHevcNalu`), each looping `i < length - 4`. That bound stops four bytes early, so a start code beginning in the final bytes (e.g. a 3-byte `00 00 01` at `length-4` with a one-byte payload) is **never found**.

## What changed
- New `src/app/player/naluScanner.ts`: `findNaluByHeader(data, match)` + `findFirstNaluOffset(data)`, looping `i + 3 <= length`. The `offset < length` payload guard still rejects a start code with nothing after it.
- The three player methods are now thin wrappers over the shared scanner (dedup).

## Tests
New `__tests__/naluScanner.test.ts` (7 cases). The tail-start-code regression **fails on the old `i < length - 4` bound and passes on `i + 3 <= length`** (verified: implemented the old bound first, watched it fail, then fixed). Suite 1245 pass, `tsc` clean, biome 0 errors.

`release:none`.