### PR TITLE
refactor(filebrowser): extract shared ADB sync-reply parsers

### DIFF
--- a/src/app/googDevice/client/FileListingClient.ts
+++ b/src/app/googDevice/client/FileListingClient.ts
@@ -13,6 +13,7 @@ import { html } from '../../ui/HtmlTag';
 import { Entry } from '../Entry';
 import { AdbkitFilePushStream } from '../filePush/AdbkitFilePushStream';
 import FilePushHandler, { type DragAndPushListener, type PushUpdateParams } from '../filePush/FilePushHandler';
+import { parseDataChunk, parseDentReply, parseFailReply, parseStatReply, readSyncReplyCode } from './adbSyncReply';
 import { buildFslsInitData } from './multiplexConnection';
 
 const TAG = '[FileListing]';
@@ -409,17 +410,10 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
 
     protected handleReply(channel: Multiplexer, e: MessageEvent): void {
         const data = new Uint8Array(e.data);
-        const reply = new TextDecoder('ascii').decode(data.subarray(0, 4));
+        const reply = readSyncReplyCode(data);
         switch (reply) {
             case Protocol.DENT: {
-                const stat = data.subarray(4);
-                const statView = new DataView(stat.buffer, stat.byteOffset);
-                const mode = statView.getUint32(0, true);
-                const size = statView.getUint32(4, true);
-                const mtime = statView.getUint32(8, true);
-                const namelen = statView.getUint32(12, true);
-                const name = new TextDecoder().decode(stat.subarray(16, 16 + namelen));
-                this.addEntry(new Entry(name, mode, size, mtime));
+                this.addEntry(parseDentReply(data));
                 return;
             }
             case Protocol.DONE:
@@ -430,11 +424,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
                 if (!download) {
                     return;
                 }
-                const stat = data.subarray(4);
-                const statView = new DataView(stat.buffer, stat.byteOffset);
-                const mode = statView.getUint32(0, true);
-                const size = statView.getUint32(4, true);
-                const mtime = statView.getUint32(8, true);
+                const { mode, size, mtime } = parseStatReply(data);
                 const nameString = basename(download.path);
                 if (mode === 0) {
                     console.error(this.name, `no entity "${download.path}"`);
@@ -456,9 +446,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
                 break;
             }
             case Protocol.FAIL: {
-                const dataView = new DataView(data.buffer, data.byteOffset);
-                const length = dataView.getUint32(4, true);
-                const message = new TextDecoder().decode(data.subarray(8, 8 + length));
+                const message = parseFailReply(data);
                 console.error(TAG, `FAIL: ${message}`);
                 return;
             }
@@ -467,8 +455,9 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
                 if (!download) {
                     return;
                 }
-                download.chunks.push(data.subarray(4));
-                download.receivedBytes += data.length - 4;
+                const chunk = parseDataChunk(data);
+                download.chunks.push(chunk);
+                download.receivedBytes += chunk.length;
                 if (download.anchor) {
                     let progressElement = download.progressEl;
                     if (!progressElement) {

--- a/src/app/googDevice/client/ListFilesModal.ts
+++ b/src/app/googDevice/client/ListFilesModal.ts
@@ -9,6 +9,7 @@ import { debugLog } from '../../util/debugLog';
 import { Entry } from '../Entry';
 import { AdbkitFilePushStream } from '../filePush/AdbkitFilePushStream';
 import FilePushHandler, { type DragAndPushListener, type PushUpdateParams } from '../filePush/FilePushHandler';
+import { parseDataChunk, parseDentReply, parseFailReply, parseStatReply, readSyncReplyCode } from './adbSyncReply';
 import { createFileIconForEntry } from './FileIconUtils';
 import { attachFsChannelKeepAlive } from './fsChannelKeepAlive';
 import { buildFslsInitData, buildMultiplexUrl } from './multiplexConnection';
@@ -632,21 +633,14 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
 
     private handleReply(channel: Multiplexer, e: MessageEvent): void {
         const data = new Uint8Array(e.data);
-        const reply = new TextDecoder('ascii').decode(data.subarray(0, 4));
+        const reply = readSyncReplyCode(data);
         debugLog(TAG, 'handleReply:', reply, 'dataLen:', data.length);
 
         switch (reply) {
             case Protocol.DENT: {
-                const stat = data.subarray(4);
-                const statView = new DataView(stat.buffer, stat.byteOffset);
-                const mode = statView.getUint32(0, true);
-                const size = statView.getUint32(4, true);
-                const mtime = statView.getUint32(8, true);
-                const namelen = statView.getUint32(12, true);
-                const name = new TextDecoder().decode(stat.subarray(16, 16 + namelen));
-                const entry = new Entry(name, mode, size, mtime);
+                const entry = parseDentReply(data);
                 // Skip '.' and '..'
-                if (name !== '.' && name !== '..') {
+                if (entry.name !== '.' && entry.name !== '..') {
                     this.pendingEntries.push(entry);
                 }
                 return;
@@ -679,11 +673,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
                 const download = this.downloads.get(channel);
                 if (!download) return;
 
-                const stat = data.subarray(4);
-                const statView = new DataView(stat.buffer, stat.byteOffset);
-                const mode = statView.getUint32(0, true);
-                const size = statView.getUint32(4, true);
-                const mtime = statView.getUint32(8, true);
+                const { mode, size, mtime } = parseStatReply(data);
                 const nameString = basename(download.path);
 
                 if (mode === 0) {
@@ -710,9 +700,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
                 break;
             }
             case Protocol.FAIL: {
-                const dataView = new DataView(data.buffer, data.byteOffset);
-                const length = dataView.getUint32(4, true);
-                const message = new TextDecoder().decode(data.subarray(8, 8 + length));
+                const message = parseFailReply(data);
                 console.error(TAG, `FAIL: ${message}`);
                 return;
             }
@@ -720,8 +708,9 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
                 const download = this.downloads.get(channel);
                 if (!download) return;
 
-                download.chunks.push(data.subarray(4));
-                download.receivedBytes += data.length - 4;
+                const chunk = parseDataChunk(data);
+                download.chunks.push(chunk);
+                download.receivedBytes += chunk.length;
 
                 // Update progress bar in the file row
                 if (download.entry) {

--- a/src/app/googDevice/client/__tests__/adbSyncReply.test.ts
+++ b/src/app/googDevice/client/__tests__/adbSyncReply.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { Entry } from '../../Entry';
+import { parseDataChunk, parseDentReply, parseFailReply, parseStatReply, readSyncReplyCode } from '../adbSyncReply';
+
+function u32le(n: number): number[] {
+    return [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff];
+}
+function buildReply(code: string, body: number[]): Uint8Array {
+    const codeBytes = [...new TextEncoder().encode(code)];
+    return new Uint8Array([...codeBytes, ...body]);
+}
+
+describe('readSyncReplyCode', () => {
+    it('reads the 4-byte ascii reply code', () => {
+        expect(readSyncReplyCode(buildReply('DENT', [0, 0]))).toBe('DENT');
+        expect(readSyncReplyCode(buildReply('FAIL', []))).toBe('FAIL');
+    });
+});
+
+describe('parseDentReply', () => {
+    it('extracts a directory entry (name, size, type) from the DENT body', () => {
+        const name = 'file.txt';
+        const data = buildReply('DENT', [
+            ...u32le(0o100644), // mode: regular file
+            ...u32le(1234), // size
+            ...u32le(99), // mtime
+            ...u32le(name.length), // namelen
+            ...new TextEncoder().encode(name),
+        ]);
+        const entry = parseDentReply(data);
+        expect(entry).toBeInstanceOf(Entry);
+        expect(entry.name).toBe(name);
+        expect(entry.size).toBe(1234);
+        expect(entry.isFile()).toBe(true);
+        expect(entry.isDirectory()).toBe(false);
+    });
+});
+
+describe('parseStatReply', () => {
+    it('extracts mode/size/mtime from the STAT body', () => {
+        const data = buildReply('STAT', [...u32le(0o40755), ...u32le(4096), ...u32le(42)]);
+        expect(parseStatReply(data)).toEqual({ mode: 0o40755, size: 4096, mtime: 42 });
+    });
+});
+
+describe('parseFailReply', () => {
+    it('extracts the length-prefixed failure message', () => {
+        const msg = 'permission denied';
+        const data = buildReply('FAIL', [...u32le(msg.length), ...new TextEncoder().encode(msg)]);
+        expect(parseFailReply(data)).toBe(msg);
+    });
+});
+
+describe('parseDataChunk', () => {
+    it('returns the payload after the 4-byte code', () => {
+        expect([...parseDataChunk(buildReply('DATA', [1, 2, 3, 4]))]).toEqual([1, 2, 3, 4]);
+    });
+});

--- a/src/app/googDevice/client/adbSyncReply.ts
+++ b/src/app/googDevice/client/adbSyncReply.ts
@@ -1,0 +1,47 @@
+import { Entry } from '../Entry';
+
+// View-agnostic parsers for the ADB sync-protocol replies. FileListingClient and
+// ListFilesModal both implement the file browser over the same wire protocol;
+// the reply byte-parsing below was byte-identical in both (their dispatch and
+// view rendering legitimately differ and stay in each class). These pure helpers
+// remove that duplication and are unit-tested in isolation.
+
+/** The 4-byte ascii reply code at the head of a sync reply (DENT/STAT/DATA/DONE/FAIL). */
+export function readSyncReplyCode(data: Uint8Array): string {
+    return new TextDecoder('ascii').decode(data.subarray(0, 4));
+}
+
+/** Parse a DENT (directory entry) reply body into an Entry. */
+export function parseDentReply(data: Uint8Array): Entry {
+    const stat = data.subarray(4);
+    const view = new DataView(stat.buffer, stat.byteOffset);
+    const mode = view.getUint32(0, true);
+    const size = view.getUint32(4, true);
+    const mtime = view.getUint32(8, true);
+    const namelen = view.getUint32(12, true);
+    const name = new TextDecoder().decode(stat.subarray(16, 16 + namelen));
+    return new Entry(name, mode, size, mtime);
+}
+
+/** Parse a STAT reply body into its mode/size/mtime fields. */
+export function parseStatReply(data: Uint8Array): { mode: number; size: number; mtime: number } {
+    const stat = data.subarray(4);
+    const view = new DataView(stat.buffer, stat.byteOffset);
+    return {
+        mode: view.getUint32(0, true),
+        size: view.getUint32(4, true),
+        mtime: view.getUint32(8, true),
+    };
+}
+
+/** Parse a FAIL reply into its length-prefixed message string. */
+export function parseFailReply(data: Uint8Array): string {
+    const view = new DataView(data.buffer, data.byteOffset);
+    const length = view.getUint32(4, true);
+    return new TextDecoder().decode(data.subarray(8, 8 + length));
+}
+
+/** The payload bytes of a DATA reply (everything after the 4-byte code). */
+export function parseDataChunk(data: Uint8Array): Uint8Array {
+    return data.subarray(4);
+}


### PR DESCRIPTION
Security review finding 68, scoped (per discussion) to the **view-agnostic reply parsers** — the genuinely-duplicated part.

`FileListingClient` and `ListFilesModal` implement the file browser over the same ADB sync protocol. Their reply **byte-parsing** (DENT/STAT/FAIL/DATA + the 4-byte reply code) was byte-identical; their **dispatch and view rendering legitimately differ** (live table + `location.hash` vs. batched modal render with `pendingEntries`) and stay in each class.

## What changed
- New `src/app/googDevice/client/adbSyncReply.ts`: `readSyncReplyCode`, `parseDentReply` (→ `Entry`), `parseStatReply` (→ `{mode,size,mtime}`), `parseFailReply` (→ message), `parseDataChunk`.
- Both `handleReply` methods now call the shared parsers; their control flow and view code are unchanged.

A full "view-agnostic `AdbSyncSession`" (channel + download + dispatch behind a callback interface) was considered, but the two classes' dispatch/listing models diverge enough that the parser extraction captures the real duplication at far lower risk.

## Tests
New `__tests__/adbSyncReply.test.ts` (5 cases) covering each parser's byte layout. Suite 1250 pass, `tsc` clean, biome 0 errors.

`release:none`.