### PR TITLE
refactor(client): naming/dead-code nits + narrow file-push interface

### DIFF
--- a/src/app/Util.ts
+++ b/src/app/Util.ts
@@ -129,9 +129,6 @@ export default class Util {
         } catch (error: any) {}
 
         return (Util.supportsPassiveValue = supportsPassive);
-
-        // Use our detect's results. passive applied if supported, capture will be false either way.
-        // elem.addEventListener('touchstart', fn, supportsPassive ? { passive: true } : false);
     }
 
     static setImmediate(fn: () => any): void {

--- a/src/app/googDevice/KeyInputHandler.ts
+++ b/src/app/googDevice/KeyInputHandler.ts
@@ -15,7 +15,7 @@ export class KeyInputHandler {
         if (!keyCode) {
             return;
         }
-        let action: typeof KeyEvent.ACTION_DOWN | typeof KeyEvent.ACTION_DOWN;
+        let action: typeof KeyEvent.ACTION_DOWN | typeof KeyEvent.ACTION_UP;
         let repeatCount = 0;
         if (keyboardEvent.type === 'keydown') {
             action = KeyEvent.ACTION_DOWN;

--- a/src/app/googDevice/Stats.ts
+++ b/src/app/googDevice/Stats.ts
@@ -59,7 +59,7 @@ export class Stats {
     public isFIFO(): boolean {
         return this.checkModeProperty(Stats.S_IFIFO);
     }
-    public isisSocket(): boolean {
+    public isSocket(): boolean {
         return this.checkModeProperty(Stats.S_IFSOCK);
     }
     public isSymbolicLink(): boolean {

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -134,7 +134,6 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
 
     private updateLink(params: {
         url: string;
-        name: string;
         fullName: string;
         udid: string;
         deviceKind?: 'phone' | 'tablet' | 'tv' | undefined;
@@ -314,7 +313,6 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
 
         // Auto-select best interface: prefer wifi/direct IP, fallback to proxy
         let selectedInterfaceUrl = '';
-        let selectedInterfaceName = '';
         if (isActive) {
             const wifiInterface = device.interfaces.find((i) => i.name === device['wifi.interface']);
             const firstInterface = device.interfaces[0];
@@ -327,11 +325,9 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                     port: SERVER_PORT,
                 };
                 selectedInterfaceUrl = DeviceTracker.createUrl(params).toString();
-                selectedInterfaceName = bestInterface.name;
             }
             if (!selectedInterfaceUrl) {
                 selectedInterfaceUrl = DeviceTracker.createUrl(this.params, device.udid).toString();
-                selectedInterfaceName = 'proxy';
             }
         }
 
@@ -409,7 +405,6 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         if (DeviceTracker.CREATE_DIRECT_LINKS && isActive && selectedInterfaceUrl) {
             this.updateLink({
                 url: selectedInterfaceUrl,
-                name: selectedInterfaceName,
                 fullName,
                 udid: device.udid,
                 deviceKind: device.deviceKind,

--- a/src/app/googDevice/client/ListFilesModal.ts
+++ b/src/app/googDevice/client/ListFilesModal.ts
@@ -459,7 +459,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
             this.fsChannel.addEventListener('open', () => {
                 debugLog(TAG, 'FSLS channel opened, readyState:', this.fsChannel?.readyState);
                 // Set up upload handler (needs the FSLS channel for AdbkitFilePushStream)
-                const pushStream = new AdbkitFilePushStream(this.fsChannel!, this as any);
+                const pushStream = new AdbkitFilePushStream(this.fsChannel!, this);
                 this.filePushHandler = new FilePushHandler(this.bodyEl, pushStream);
                 this.filePushHandler.addEventListener(this);
 

--- a/src/app/googDevice/filePush/AdbkitFilePushStream.ts
+++ b/src/app/googDevice/filePush/AdbkitFilePushStream.ts
@@ -3,16 +3,24 @@ import type { Multiplexer } from '../../../packages/multiplexer/Multiplexer';
 import { BinaryReader } from '../../BinaryReader';
 import { CommandControlMessage, FilePushState } from '../../controlMessage/CommandControlMessage';
 import { join } from '../../pathUtils';
-import type { FileListingClient } from '../client/FileListingClient';
 import FilePushHandler from './FilePushHandler';
 import { FilePushResponseStatus } from './FilePushResponseStatus';
 import { FilePushStream } from './FilePushStream';
+
+/**
+ * Minimal contract AdbkitFilePushStream needs from its host — just the current
+ * remote directory to resolve upload paths against. Both FileListingClient and
+ * ListFilesModal satisfy it structurally, so neither needs an `as any`. (#87)
+ */
+export interface FilePushTarget {
+    getPath(): string;
+}
 
 export class AdbkitFilePushStream extends FilePushStream {
     private channels: Map<number, Multiplexer> = new Map();
     constructor(
         private readonly socket: Multiplexer,
-        private readonly fileListingClient: FileListingClient,
+        private readonly fileListingClient: FilePushTarget,
     ) {
         super();
     }
@@ -61,13 +69,15 @@ export class AdbkitFilePushStream extends FilePushStream {
         const channel = this.socket.createChannel(new TextEncoder().encode(Protocol.SEND));
         const onMessage = (event: MessageEvent): void => {
             const reader = new BinaryReader(new Uint8Array(event.data as ArrayBuffer));
-            const id = reader.readInt16BE();
+            // Distinct from the outer `id` param (the push-request id): this is the
+            // device's response id. Renamed to avoid shadowing the parameter. (#84)
+            const responseId = reader.readInt16BE();
             const code = reader.readInt8();
             if (code === FilePushResponseStatus.NEW_PUSH_ID) {
-                this.channels.set(id, channel);
-                pushId = id;
+                this.channels.set(responseId, channel);
+                pushId = responseId;
             }
-            this.emit('response', { id, code });
+            this.emit('response', { id: responseId, code });
         };
         const onClose = (event: CloseEvent): void => {
             if (!event.wasClean) {


### PR DESCRIPTION
## What

MINOR-tier code-review mop-up (items 81, 83, 84, 85, 86, 87) — client naming / dead-code / typing nits, no behavior change.

- **85** — `Stats.isisSocket()` → `isSocket()` (the method had no callers).
- **86** — `KeyInputHandler` typed `action` as `ACTION_DOWN | ACTION_DOWN`; corrected the duplicate to `ACTION_DOWN | ACTION_UP` (the keyup branch assigns `ACTION_UP`). Both constants are `number`, so it's a clarity fix, not behavior.
- **84** — `AdbkitFilePushStream.sendEventNew`: the inner device-response `id` shadowed the `id` param; renamed to `responseId`. (The finding's "unused `value`/`type`" half was a false positive — both are used in `FilePushHandler`, so no change there.)
- **87** — narrowed `AdbkitFilePushStream`'s host param from `FileListingClient` to a minimal `FilePushTarget { getPath(): string }` (the only method it calls), so `ListFilesModal` drops its `this as any`. `FileListingClient` still satisfies it structurally.
- **83** — `DeviceTracker.updateLink` took an unused `name` param; removed it and the now-dead `selectedInterfaceName` that was computed only to feed it.
- **81** — removed the unreachable comment after the `return` in `Util.supportsPassive`.

## Gates

`tsc --noEmit` clean · vitest **1261 passed** · biome lint **0 errors**. Pure nits → no CHANGELOG entry.