### PR TITLE
refactor(launcher): de-duplicate Windows helpers + harden sentinel/HOME fallback

### DIFF
--- a/launcher/src/elevated_runner.rs
+++ b/launcher/src/elevated_runner.rs
@@ -479,7 +479,7 @@ impl CapturedOutput {
 pub(crate) fn silent_command(exe: impl AsRef<std::ffi::OsStr>) -> Command {
     use std::os::windows::process::CommandExt;
     let mut cmd = Command::new(exe);
-    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    cmd.creation_flags(crate::win_util::CREATE_NO_WINDOW);
     cmd
 }
 

--- a/launcher/src/install_acl.rs
+++ b/launcher/src/install_acl.rs
@@ -23,8 +23,7 @@
 // grant either; first launch under beta.7 catches them).
 
 use anyhow::{Context, Result, bail};
-use std::ffi::OsStr;
-use std::os::windows::ffi::OsStrExt;
+use crate::win_util::to_wide;
 use std::path::Path;
 
 use windows::Win32::Foundation::CloseHandle;
@@ -32,15 +31,20 @@ use windows::Win32::System::Threading::{GetExitCodeProcess, INFINITE, WaitForSin
 use windows::Win32::UI::Shell::{SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW};
 use windows::core::PCWSTR;
 
-const SENTINEL_FILE_NAME: &str = ".ws-scrcpy-write-test";
+const SENTINEL_PREFIX: &str = ".ws-scrcpy-write-test";
 const ACL_SID_AUTH_USERS: &str = "*S-1-5-11";
 
-/// Test whether the running user can write to `path`. Creates and deletes
-/// a sentinel file. Velopack uses a similar test internally
-/// (`<root>/.velopack_dir_test`) — we use a distinct filename so concurrent
-/// self-tests don't race.
+/// Monotonic suffix so concurrent `is_writable` calls — even within one process
+/// — never collide on the sentinel filename. (#97)
+static SENTINEL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Test whether the running user can write to `path`. Creates and deletes a
+/// sentinel file whose name is unique per call (pid + a monotonic counter), so
+/// two instances (or threads) probing the same path can't delete each other's
+/// sentinel mid-test and misreport writability. (#97)
 pub fn is_writable(path: &Path) -> bool {
-    let test_path = path.join(SENTINEL_FILE_NAME);
+    let seq = SENTINEL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let test_path = path.join(format!("{SENTINEL_PREFIX}-{}-{seq}", std::process::id()));
     match std::fs::write(&test_path, b"") {
         Ok(()) => {
             let _ = std::fs::remove_file(&test_path);
@@ -135,13 +139,6 @@ fn run_icacls_elevated(install_root: &Path) -> Result<i32> {
     }
 }
 
-fn to_wide(s: &str) -> Vec<u16> {
-    OsStr::new(s)
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,8 +154,11 @@ mod tests {
     fn is_writable_does_not_leave_sentinel_behind() {
         let dir = tempdir().unwrap();
         is_writable(dir.path());
-        let sentinel = dir.path().join(SENTINEL_FILE_NAME);
-        assert!(!sentinel.exists(), "sentinel file should be cleaned up");
+        let leftover = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| e.file_name().to_string_lossy().starts_with(SENTINEL_PREFIX));
+        assert!(!leftover, "sentinel file should be cleaned up");
     }
 
     #[test]

--- a/launcher/src/linux_app_uninstall.rs
+++ b/launcher/src/linux_app_uninstall.rs
@@ -143,7 +143,7 @@ pub fn app_uninstall_commands(
 
     // 2b. tray autostart entry — defensive: pre-beta.45 installs wrote it. Always
     //     attempted; HOME-relative (resolved like unit_path).
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+    let home = crate::linux_service::home_dir();
     user_owned.push(vec![
         rm.clone(),
         "-f".into(),

--- a/launcher/src/linux_service.rs
+++ b/launcher/src/linux_service.rs
@@ -22,10 +22,22 @@ pub(crate) fn scope_prefix(scope: Scope) -> Vec<String> {
     }
 }
 
+/// Resolve the invoking user's HOME for building user-scope (`$HOME/.config`)
+/// paths. Logs when HOME is unset rather than silently assuming `/root`: the
+/// fallback only applies when HOME is absent (typically running as root, where
+/// `/root` is in fact correct), so it stays a last resort but is no longer
+/// invisible. (#98)
+pub fn home_dir() -> String {
+    std::env::var("HOME").unwrap_or_else(|_| {
+        log::error("HOME unset; falling back to /root for user-scope path resolution");
+        "/root".to_string()
+    })
+}
+
 pub fn unit_path(scope: Scope, name: &str) -> PathBuf {
     match scope {
         Scope::User => {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+            let home = home_dir();
             PathBuf::from(home)
                 .join(".config/systemd/user")
                 .join(format!("{name}.service"))

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -30,6 +30,8 @@ mod system_service_cli;
 #[cfg(windows)]
 mod user_session_spawn;
 #[cfg(windows)]
+mod win_util;
+#[cfg(windows)]
 mod windows_app_uninstall;
 
 fn main() {

--- a/launcher/src/operation_server.rs
+++ b/launcher/src/operation_server.rs
@@ -567,10 +567,10 @@ fn run() -> i32 {
             #[cfg(windows)]
             {
                 use std::os::windows::process::CommandExt;
-                const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
+                use crate::win_util::CREATE_NO_WINDOW;
                 let _ = std::process::Command::new(r"C:\Windows\System32\taskkill.exe")
                     .args(["/F", "/IM", "ws-scrcpy-web-tray.exe", "/T"])
-                    .creation_flags(CREATE_NO_WINDOW_FLAG)
+                    .creation_flags(CREATE_NO_WINDOW)
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())
@@ -612,11 +612,10 @@ fn run() -> i32 {
             {
                 let launcher_path = current_dir.join("ws-scrcpy-web-launcher.exe");
                 use std::os::windows::process::CommandExt;
-                const DETACHED_PROCESS: u32 = 0x00000008;
-                const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
+                use crate::win_util::{CREATE_NO_WINDOW, DETACHED_PROCESS};
                 match std::process::Command::new(&launcher_path)
                     .current_dir(&install_root)
-                    .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW_FLAG)
+                    .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())

--- a/launcher/src/single_instance.rs
+++ b/launcher/src/single_instance.rs
@@ -38,14 +38,7 @@
 #[cfg(windows)]
 mod imp {
     use anyhow::Result;
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
-
-    /// Convert a Rust string to a null-terminated UTF-16 buffer suitable
-    /// for the W-suffixed Win32 APIs.
-    fn to_wide(s: &str) -> Vec<u16> {
-        OsStr::new(s).encode_wide().chain(std::iter::once(0)).collect()
-    }
+    use crate::win_util::to_wide;
 
     /// Returns true when the current process has an elevated token (i.e.
     /// "Run as administrator" was used). Internally queries the process

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -21,11 +21,8 @@ const NODE_BIN: &str = "node.exe";
 #[cfg(not(windows))]
 const NODE_BIN: &str = "node";
 
-// CREATE_NO_WINDOW = 0x08000000. Defined here as a literal so we don't need
-// to thread the windows crate through pure-logic functions / tests on
-// non-Windows hosts (when those happen — e.g., CI matrix expansion).
 #[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+use crate::win_util::CREATE_NO_WINDOW;
 
 /// Pure resolution: given an optional DEPS_PATH and an exe directory,
 /// return the Node binary path or an error.

--- a/launcher/src/tray_supervisor.rs
+++ b/launcher/src/tray_supervisor.rs
@@ -306,8 +306,7 @@ fn ensure_tray_in_current_session(tray_exe: &Path) -> EnsureOutcome {
     // opens its own console window (CREATE_NO_WINDOW). Tray binary is
     // windows-subsystem so it'd be windowless either way, but the flags
     // also break the parent-process exit kill-chain for cleaner detach.
-    const DETACHED_PROCESS: u32 = 0x00000008;
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    use crate::win_util::{CREATE_NO_WINDOW, DETACHED_PROCESS};
     match std::process::Command::new(tray_exe)
         .arg("--launcher-spawn")
         .stdin(Stdio::null())

--- a/launcher/src/uac_requester.rs
+++ b/launcher/src/uac_requester.rs
@@ -125,14 +125,7 @@ fn request_uac_impl(_command: &str, _args_path: &str, _result_path: &str) -> i32
 }
 
 #[cfg(windows)]
-fn to_wide(s: &str) -> Vec<u16> {
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
-    OsStr::new(s)
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect()
-}
+use crate::win_util::to_wide;
 
 #[cfg(test)]
 mod tests {

--- a/launcher/src/win_util.rs
+++ b/launcher/src/win_util.rs
@@ -1,0 +1,21 @@
+//! Shared Windows-only helpers: UTF-16 widening for the W-suffixed Win32 APIs
+//! and the process-creation flags used across the spawn / elevation paths.
+//! Plain `u32` constants (not the `windows` crate's) so pure-logic modules can
+//! reference them without threading the crate through on non-Windows hosts.
+//! (#95, #96)
+
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+
+/// Suppress the child's console window (`CREATE_NO_WINDOW`).
+pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Detach the child from this process's console and parent-exit kill-chain
+/// (`DETACHED_PROCESS`).
+pub const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+/// Convert a Rust string to a null-terminated UTF-16 buffer for the W-suffixed
+/// Win32 APIs.
+pub fn to_wide(s: &str) -> Vec<u16> {
+    OsStr::new(s).encode_wide().chain(std::iter::once(0)).collect()
+}

--- a/launcher/src/windows_app_uninstall.rs
+++ b/launcher/src/windows_app_uninstall.rs
@@ -321,8 +321,7 @@ fn run_bootstrap(a: &UninstallArgs) -> i32 {
     // CREATE_NO_WINDOW gives no console window, and null stdio severs inherited
     // handles. The cleaner MUST outlive our std::process::exit(0) below; the
     // uninstall helper also runs outside any kill-on-job-close job.
-    const DETACHED_PROCESS: u32 = 0x0000_0008;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    use crate::win_util::{CREATE_NO_WINDOW, DETACHED_PROCESS};
 
     let pid = std::process::id();
 


### PR DESCRIPTION
## What

MINOR-tier code-review mop-up (items 95, 96, 97, 98; 99 closed as acceptable) — Rust launcher dedup + hardening.

- **95 / 96** — new `win_util` module owns the shared `to_wide()` UTF-16 helper and the `CREATE_NO_WINDOW` / `DETACHED_PROCESS` process-creation flags. The three duplicate `to_wide` definitions and the ~6 duplicate const definitions (including an inline `0x08000000` literal) now reference it.
- **97** — `install_acl::is_writable` builds a per-call sentinel filename (pid + a monotonic counter) instead of the fixed `.ws-scrcpy-write-test`, so two instances (or threads) probing the same path can no longer delete each other's sentinel mid-test.
- **98** — `linux_service::home_dir()` logs when `HOME` is unset rather than silently defaulting to `/root` (the fallback only applies when HOME is absent — typically running as root, where `/root` is correct — so it stays a last resort, now visible). `unit_path` and the uninstall autostart-removal both use it.
- **99** — the three bounded one-shot busy-poll helpers (`wait_port` / `verify_up` / `wait_for_pid_exit`, 12–60s timeouts) are left as-is: bounded startup/upgrade/shutdown helpers, not hot loops. Closed as acceptable, no change.

## Verification

`cargo clippy --all-targets -- -D warnings` + `cargo test` green on Windows (141 launcher tests). The Linux-cfg item-98 code is compiled, clippy'd, and tested by this repo's CI on `ubuntu-latest` (a local Windows→Linux cross-check needs a cross-gcc this dev box lacks). Pure refactor / internal hardening → no CHANGELOG entry.