### PR TITLE
fix(build): scope Cargo.toml version regex, sync dist package.json, harden extract

### DIFF
--- a/scripts/__tests__/package-linux.test.mjs
+++ b/scripts/__tests__/package-linux.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parseCargoWorkspaceVersion } from '../package-linux.mjs';
+
+describe('parseCargoWorkspaceVersion', () => {
+    it('reads version from the [workspace.package] section', () => {
+        const toml = '[workspace]\nmembers = ["a"]\n\n[workspace.package]\nversion = "1.2.3"\nedition = "2021"\n';
+        expect(parseCargoWorkspaceVersion(toml)).toBe('1.2.3');
+    });
+
+    it('does not grab a version= from an earlier section by position (#102)', () => {
+        const toml = '[package]\nversion = "9.9.9"\n\n[workspace.package]\nversion = "1.2.3"\n';
+        expect(parseCargoWorkspaceVersion(toml)).toBe('1.2.3');
+    });
+
+    it('finds version when it is not the first key in the section', () => {
+        const toml = '[workspace.package]\nedition = "2021"\nversion = "4.5.6"\n';
+        expect(parseCargoWorkspaceVersion(toml)).toBe('4.5.6');
+    });
+
+    it('returns null when there is no [workspace.package] version', () => {
+        expect(parseCargoWorkspaceVersion('[workspace]\nmembers = []\n')).toBeNull();
+    });
+});

--- a/scripts/fetch-node.mjs
+++ b/scripts/fetch-node.mjs
@@ -106,7 +106,7 @@ function extract(archivePath, outDir) {
         execFileSync(WINDOWS_TAR, ['-xf', archivePath, '-C', outDir], { stdio: 'inherit' });
     } else {
         log(`extracting via tar`);
-        execFileSync('tar', ['-xf', archivePath, '-C', outDir], { stdio: 'inherit' });
+        execFileSync('tar', ['-xf', archivePath, '-C', outDir, '--no-same-owner'], { stdio: 'inherit' });
     }
 }
 

--- a/scripts/package-linux.mjs
+++ b/scripts/package-linux.mjs
@@ -28,7 +28,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -63,14 +63,24 @@ function readVersion() {
             err(`failed to parse package.json: ${e.message}`);
         }
     }
-    // Fallback: parse Cargo.toml workspace.package.version naively.
+    // Fallback: parse Cargo.toml's [workspace.package] version.
     const cargoPath = join(REPO_ROOT, 'Cargo.toml');
     if (existsSync(cargoPath)) {
-        const text = readFileSync(cargoPath, 'utf8');
-        const m = text.match(/^\s*version\s*=\s*"([^"]+)"/m);
-        if (m) return m[1];
+        const v = parseCargoWorkspaceVersion(readFileSync(cargoPath, 'utf8'));
+        if (v) return v;
     }
     throw new Error('Could not resolve a version from package.json or Cargo.toml');
+}
+
+/**
+ * Extract `version` from the `[workspace.package]` section of a Cargo.toml.
+ * Scoped to that section — not the first line-start `version =` anywhere — so a
+ * `version =` in an earlier section can't be grabbed by position. Returns null
+ * if absent. (#102)
+ */
+export function parseCargoWorkspaceVersion(tomlText) {
+    const m = tomlText.match(/\[workspace\.package\][^[]*?\bversion\s*=\s*"([^"]+)"/);
+    return m ? m[1] : null;
 }
 
 /** Verify `vpk` is callable on PATH. Returns true / false. */
@@ -167,9 +177,13 @@ function main() {
     log('AppImage packaging + runtime swap complete. Output under Releases/linux/.');
 }
 
-try {
-    main();
-} catch (e) {
-    err(`unexpected error: ${e.message}`);
-    process.exit(1);
+// Only run when invoked directly (`node scripts/package-linux.mjs`), not when
+// imported (e.g. by the unit test for parseCargoWorkspaceVersion). (#102)
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        main();
+    } catch (e) {
+        err(`unexpected error: ${e.message}`);
+        process.exit(1);
+    }
 }

--- a/webpack/ws-scrcpy-web.common.ts
+++ b/webpack/ws-scrcpy-web.common.ts
@@ -11,9 +11,8 @@ const buildConfigDefinePlugin = new webpack.DefinePlugin({
     '__PATHNAME__': JSON.stringify('/'),
 });
 
-const pkgVersion: string = JSON.parse(
-    readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf-8'),
-).version;
+const rootPkg = JSON.parse(readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf-8'));
+const pkgVersion: string = rootPkg.version;
 
 const versionDefinePlugin = new webpack.DefinePlugin({
     '__WSSCRCPY_VERSION__': JSON.stringify(pkgVersion),
@@ -31,11 +30,11 @@ class GenerateDistPackageJsonPlugin {
                 () => {
                     const pkg = {
                         name: 'ws-scrcpy-web',
-                        version: '1.0.0',
+                        version: pkgVersion,
                         scripts: { start: 'node index.js' },
                         dependencies: {
-                            'node-pty': '^0.10.1',
-                            'ws': '^8.18.0',
+                            'node-pty': rootPkg.optionalDependencies?.['node-pty'] ?? rootPkg.dependencies?.['node-pty'],
+                            'ws': rootPkg.dependencies?.ws,
                         },
                     };
                     const content = JSON.stringify(pkg, null, 2);


### PR DESCRIPTION
## What

MINOR-tier code-review mop-up (items 100, 101, 102) — build-script fixes.

- **102** — `package-linux.mjs` extracts the version from Cargo.toml's `[workspace.package]` section explicitly (new exported `parseCargoWorkspaceVersion`) rather than the first line-start `version =` by position (fragile if an earlier section ever carried one). Its top-level `main()` now runs only when invoked directly, so the module is import-safe for the unit test.
- **101** — the inline webpack plugin that emits `dist/package.json` used a hardcoded `version: "1.0.0"` and stale `node-pty`/`ws` ranges; it now derives both from the real root `package.json`.
- **100** — `fetch-node.mjs` adds `--no-same-owner` to the Linux `tar` extract (defense in depth; the archive is already SHA-256-pinned). `fetch-servy.mjs` is Windows-only (bsdtar), so the Unix-ownership flag does not apply there.

⚠️ **Flag (local-dependencies rule):** `fetch-node.mjs` resolves `tar` by bare name on Linux (PATH lookup). Left as-is — build-time script, `tar` is a base system utility — but surfacing it per the rule; say the word to resolve it to an absolute path.

## Tests

New `scripts/__tests__/package-linux.test.mjs` for `parseCargoWorkspaceVersion`.

## Gates

`tsc --noEmit` clean · vitest **1278 passed** · biome lint **0 errors**. (`webpack/` TS + the `dist/package.json` emit are additionally exercised by CI's `npm run build`.) Build-script changes → no CHANGELOG entry.