### PR TITLE
docs(smoke): beta.66 a11y/theming + perf/security smoke coverage

### DIFF
--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -1,13 +1,13 @@
 # ws-scrcpy-web — Smoke Run-Sheet
 
-> **Smoke target: `v0.1.30-beta.64`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.66`** — bump this one line each release; everything below is version-agnostic.
 
 Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
 [`smoke-full.md`](./smoke-full.md) by **app state** — the order you actually run them; that doc
 stays the module-organized reference. Wherever a row shows a version, expect the **smoke-target version** (top of this doc),
 which carries the beta.48 port-discovery fix plus the Server-section UX (batch #15).
 
-**Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.40 artifact / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot)
+**Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.40 artifact / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot) · 🌐 browser-only (no device or install state)
 
 ## Before each run — reset to a clean slate
 
@@ -52,6 +52,20 @@ Boxes start unticked — this is a fresh pass.
 | ☐ **10.1** `[B]` Status API | Browse `/api/service/status` | JSON with correct `platform`, `supported`, `status` |
 | ☐ **10.3** `[L]` Logs clean | Tail `~/.local/share/WsScrcpyWeb/logs` | No error spam; teardown logs on stop |
 | ☐ **12.2** `[B]` Stop-exit gating | Settings → Server (service installed) | Button **greyed** + neutral note; clicking fires **no** shutdown POST; re-enables after uninstall |
+
+## #7A — Browser UX & accessibility 🌐 *(app running; no device needed)*
+
+> Browser-only checks — run any time the app is up (right after #7 is convenient). No device or service state required. Repeat the visual rows in **both** light and dark themes. These cover beta.66's accessibility/theming work plus the user-visible security behaviors.
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| ☐ **16.1** `[B]` Theme switch | Toggle the home-page theme light ↔ dark; open a modal + the stream view in each | Whole UI recolors live; nothing stuck at the other theme; persists across reload |
+| ☐ **16.2** `[B]` Keyboard focus ring | **Tab** through controls, then **click** with the mouse | 2px accent `:focus-visible` outline on keyboard focus; **not** on a mouse click (old global `:focus{outline:none}` gone) |
+| ☐ **16.3** `[B]` Reduced motion | OS "reduce motion" on → reload → trigger modals/spinners/transitions | Animations collapse to near-instant (`prefers-reduced-motion`); off → normal animation returns |
+| ☐ **16.4** `[B]` Light-mode status tints | In **light** theme: select a file row, hover delete, (update run) hover apply-update | Tints are proper light shades via danger/success tokens — not off-shade dark values |
+| ☐ **16.5** `[B]` Embed page lang | Open `embed.html`; inspect `<html>` | `<html lang>` set (a11y), matching the app shell |
+| ☐ **10.4** `[B]` Token / reload-on-restart | Restart the server (web-port save, or stop & relaunch); also `curl /api/service/status` with no cookie | Open tab must **reload** to reconnect (new per-instance token each boot, `SameSite=Strict` `HttpOnly` cookie); cookie-less curl **rejected**; normal browser use unchanged |
+| ☐ **10.5** `[B]` 404 + security headers | `curl -I` a missing path and `/`; load a deep in-app route + refresh | Missing asset / unknown API → **404** (not the shell); in-app route still serves shell; responses carry `nosniff` + `X-Frame-Options: SAMEORIGIN` |
 
 ## #8 — User-service uninstall → local mode
 
@@ -117,12 +131,14 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 |---|---|---|
 | ☐ **7.1** `[B]` Wireless connect | Scan/connect → device `ip:port` | adb connects; card appears within ~5s |
 | ☐ **7.2** `[B]` Subnet scan | Scan-network modal → subnet | Devices listed; bad/empty subnets handled (no hang) |
-| ☐ **8.1** `[B]` Video stream | Device → stream/config → connect | Live video renders; no decode errors |
+| ☐ **7.4** `[B]` Device list in place *(beta.66)* | Connect / rename / disconnect a few devices | Rows diff in place (no whole-list flicker); labels load once per refresh, not once per row |
+| ☐ **8.1** `[B]` Video stream | Device → stream/config → connect; resize window | Live video renders; no decode errors; **video cell keeps correct aspect** (no stretch/overflow), rescales on resize (beta.66 #106) |
 | ☐ **8.2** `[B]` Control | Click/scroll/type + on-screen device buttons | Input reaches the device; nav works |
 | ☐ **8.3** `[B]` Audio | Enable audio (Android 11+) | Plays; codec/source toggle works |
 | ☐ **8.4** `[B]` Codec/encoder | Change display/codec/encoder/fps/bitrate → reconnect | Applies; persists per-device |
+| ☐ **8.5** `[B]` H.265 decode *(#41)* | Set codec **H.265/HEVC** → connect; repeat **H.264** | Both decode + render in-browser (WebCodecs); no decode errors |
 | ☐ **9.1** `[B]` Shell modal | Run `getprop ro.product.model` + a couple commands | Terminal works; clean close, no orphaned adb shell |
-| ☐ **9.2** `[B]` File listing/transfer | Browse, change icon size, push/pull | Loads; icon-size persists; transfers succeed |
+| ☐ **9.2** `[B]` File listing/transfer | Browse, change icon size, push/pull (console open) | Loads; icon-size persists; transfers succeed; **console quiet** unless `ws-scrcpy-web-debug` localStorage flag set (beta.66) |
 | ☐ **9.3** `[B]` Device actions | Sleep/wake + power/nav on the card | Buttons reflect state; actions take effect |
 
 ## #14 — Windows pass 🪟 *(clean Win11 snapshot, accounts Admin/User1/User2, the MSI)*

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -1,10 +1,10 @@
 # ws-scrcpy-web — Full Smoke Test
 
-> **Smoke target: `v0.1.30-beta.64`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.66`** — bump this one line each release; everything below is version-agnostic.
 
 All-encompassing manual smoke, grouped by function and tagged by platform (`[Win]` / `[Linux]` / `[Both]`). Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
 
-> **Consolidated 2026-06-06.** This doc absorbs the three former per-feature checklists — Linux service-mode (`beta.37`), stop-server-&-exit (`beta.39`), and the Windows multi-user / MSI pass (`v0.1.25-beta.3`) — so it is the **single gate for `0.1.30` final** (the first true Windows + Linux release). It covers every shipped feature to date: install/first-run, Linux layout & SELinux, multi-user & single-instance, service mode (incl. the beta.45–48 stable-ExecStart + install hand-off + post-install port-discovery fix), lifecycle, updates (local / machine-wide / user- & system-service), devices, streaming, adb, logs, Velopack 1.2.0, stop-server-&-exit, settings prompts, and the **Linux Server-section UX** (install-for-all-users, start-menu icon, in-app complete uninstall — Module 14).
+> **Consolidated 2026-06-06.** This doc absorbs the three former per-feature checklists — Linux service-mode (`beta.37`), stop-server-&-exit (`beta.39`), and the Windows multi-user / MSI pass (`v0.1.25-beta.3`) — so it is the **single gate for `0.1.30` final** (the first true Windows + Linux release). It covers every shipped feature to date: install/first-run, Linux layout & SELinux, multi-user & single-instance, service mode (incl. the beta.45–48 stable-ExecStart + install hand-off + post-install port-discovery fix), lifecycle, updates (local / machine-wide / user- & system-service), devices, streaming, adb, logs, Velopack 1.2.0, stop-server-&-exit, settings prompts, and the **Linux Server-section UX** (install-for-all-users, start-menu icon, in-app complete uninstall — Module 14), plus the security/quality hardening and **accessibility & theming** (Module 16) shipped in beta.66.
 
 ## Pre-flight
 
@@ -124,22 +124,24 @@ Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact).
 | **7.1** `[Both]` Wireless connect | Home → "scan/connect" → enter device `ip:port` (or scan a subnet). | adb connects; device card appears in "connected devices" within ~5s. |
 | **7.2** `[Both]` Scan subnet | Open the scan-network modal; run a subnet scan. | Reachable devices listed; selecting one connects; bad/empty subnets handled gracefully (no hang). |
 | **7.3** `[Win]` USB device | Plug a USB device (authorize the RSA prompt on device). | Appears in connected devices; survives a home-page reload. |
+| **7.4** `[Both]` Device list updates in place *(beta.66 perf)* | With the app open, connect / rename / disconnect a few devices and watch the "connected devices" list. | Rows update **in place** — diffed by device id, not torn down and rebuilt on every server message (no whole-list flicker); device labels load **once per refresh**, not once per row (no per-row request storm that grows with device count); add / remove / rename reflects within ~1s. |
 
 ## Module 8 — scrcpy streaming
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **8.1** `[Both]` Video stream | Click a device → open the stream/config modal → connect. | Live video renders smoothly; no decode errors in console. |
+| **8.1** `[Both]` Video stream | Click a device → open the stream/config modal → connect; then resize the browser window. | Live video renders smoothly; no decode errors in console. **The video cell fills its area with the correct aspect ratio** — no stretch, squish, or overflow — and **rescales on window resize while keeping aspect** (beta.66 #106: `.video` is grid-auto-sized and the device resolution is exposed via the `--video-width` / `--video-height` custom props, replacing the old inline `width/height` + `auto !important`). |
 | **8.2** `[Both]` Control | In the stream, click/scroll/type and use the on-screen device buttons. | Touch + key input reaches the device; navigation works. |
 | **8.3** `[Both]` Audio | Enable audio in the stream settings (Android 11+). | Audio plays; codec/source toggle works. |
 | **8.4** `[Both]` Codec/encoder settings | In the config modal, change display/codec/encoder/fps/bitrate → reconnect. | Settings apply; stream restarts with the new params; persisted per-device on next open. |
+| **8.5** `[Both]` H.265 (HEVC) decode *(#41)* | In the config modal set the **video codec to H.265 / HEVC** → connect; then repeat with **H.264**. | **Both** codecs decode and render in-browser (WebCodecs) — live frames, no decode errors in the console. Confirms the real-browser H.265 decode owed since the "configure the decoder once with its parameter sets" change (the keyframe-backlog drop now also covers H.265/AV1, not H.264 only); H.264 is the baseline. |
 
 ## Module 9 — adb in modals
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | **9.1** `[Both]` Shell modal | Device → "shell" → run `getprop ro.product.model`, a couple of commands. | Interactive terminal works; output correct; closing the modal ends the session cleanly (no orphaned adb shell). |
-| **9.2** `[Both]` File listing/transfer | Device → file-list modal → browse, change icon size, push/pull a file. | Listing loads; icon-size pref persists; transfers succeed. |
+| **9.2** `[Both]` File listing/transfer *(+ quiet console, beta.66)* | Device → file-list modal → browse, change icon size, push/pull a file — with the browser console open. | Listing loads; icon-size pref persists; transfers succeed. **The console stays quiet** — the per-message / per-chunk file-listing protocol traces are now gated behind a debug flag. Verify the gate: `localStorage.setItem('ws-scrcpy-web-debug','true')` → reopen the modal → the `[ListFiles]` traces reappear; `localStorage.removeItem('ws-scrcpy-web-debug')` → silent again. |
 | **9.3** `[Both]` Device actions | Use sleep/wake (and any power/nav actions) on the device card. | Buttons reflect state (green/red), actions take effect. |
 
 ## Module 10 — Logs & sanity
@@ -149,6 +151,8 @@ Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact).
 | **10.1** `[Both]` Service status API | Browse `http://localhost:<port>/api/service/status`. | JSON with correct `platform`, `supported`, `status`. |
 | **10.2** `[Win]` Logs clean | Tail `C:\ProgramData\WsScrcpyWeb\logs\{launcher,ws-scrcpy-web}.log` during normal use (canonical logs). `server.log` / `service.log` are thin crash-catchers — normal lines live in the canonical files; a `.1` backup may appear; all files are tail-able. | No `ERR` / `Error:` except known cosmetic node-pty AttachConsole noise. |
 | **10.3** `[Linux]` Logs clean | Tail `launcher.log` + `ws-scrcpy-web.log` under `~/.local/share/.../logs` (or `/var/lib/.../logs` for system) — these are the canonical logs. `server.log` / `service.log` are thin crash-catchers; a `.1` backup may appear; all files are tail-able. | No error spam; teardown logs present on stop. |
+| **10.4** `[Both]` Per-instance token / reload-on-restart *(beta.66 security)* | With the app open in a tab, **restart the server** (change the web port → save, or stop & relaunch the app). Then, separately, `curl http://localhost:<port>/api/service/status` with no cookie. | After a restart the **already-open tab must be reloaded** to reconnect — the server mints a **new per-instance token** on each boot and hands it to the page as a `SameSite=Strict; HttpOnly` cookie, so the stale tab's socket/API calls are rejected until it reloads (then it works normally). A non-browser `curl` that never loaded the page (no cookie) is **rejected** on the sensitive API surface. Normal browser use is unchanged. |
+| **10.5** `[Both]` 404 + security headers *(beta.66 security)* | `curl -I http://localhost:<port>/no-such-asset.js` ; `curl -I http://localhost:<port>/` ; then load a deep in-app route in the browser and refresh it. | A missing **asset / unknown API path → `404`** (no longer the HTML shell with `200`); an **in-app route navigation still falls back to the shell**. Every static response carries **`X-Content-Type-Options: nosniff`** and **`X-Frame-Options: SAMEORIGIN`** (the documented same-origin embed still works). |
 
 ## Module 11 — Velopack 1.2.0 / item-31
 
@@ -210,6 +214,20 @@ In-app **uninstall** now works on Windows (parity with Linux), and "stop server 
 
 ---
 
+## Module 16 — Accessibility & theming
+
+beta.66's security/quality pass restored the keyboard focus indicator, added a reduced-motion mode, and finished theming a few hardcoded tints. All browser-only — **no device or install state needed**; run with the app open, and repeat the visual rows in both themes.
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **16.1** `[Both]` Light/dark theme switch | Toggle the theme (the home-page theme control) light ↔ dark; open a couple of modals and the stream view in each. | The whole UI recolors live — backgrounds, text, borders, buttons — with no element stuck at the other theme's colors; the choice persists across a reload. |
+| **16.2** `[Both]` Keyboard focus ring *(WCAG 2.4.7)* | **Tab** through the home page and a modal's controls with the keyboard; then **click** controls with the mouse. | A clear **focus outline** (2px, accent color) appears on the **keyboard**-focused control (`:focus-visible`); it does **not** appear on a plain mouse click. Regression guard: the old global `:focus { outline: none }` that hid focus everywhere is gone. |
+| **16.3** `[Both]` Reduced motion *(WCAG 2.3.3)* | Turn on the OS "reduce motion" setting (GNOME: Settings → Accessibility; Windows: Settings → Accessibility → Visual effects → Animation effects **off**), reload the app, then trigger animated UI (open modals, spinners, transitions). | Animations and transitions collapse to **near-instant** — no meaningful slides / fades / spins (the global `prefers-reduced-motion: reduce` reset). Turn the setting back off → normal animation returns. |
+| **16.4** `[Both]` Light-mode status tints | In **light** theme: select a file row, hover the delete control, and (on a beta.40→latest update run) hover the apply-update control. | The selection / delete-hover / apply-update tints render as proper light-theme shades — they now resolve through the danger / success design tokens, **not** the slightly-off dark-theme channel values they were previously hardcoded to. |
+| **16.5** `[Both]` Embed page language | Open `embed.html` (the embeddable stream page); view source / inspect the `<html>` element. | `<html>` has a **`lang`** attribute set (assistive-tech hint), matching the main app shell. |
+
+---
+
 ## Global pass criteria
 
 | Criterion | Holds when |
@@ -221,5 +239,6 @@ In-app **uninstall** now works on Windows (parity with Linux), and "stop server 
 | **Clean shutdown** | "stop server & exit" tears down adb (+ Win tray) with no orphans; gated off in service mode. |
 | **Data preserved** | User config/deps/logs survive uninstall + reinstall. |
 | **Core flow** | Scan → connect → stream (video + control) → shell works on both platforms. |
+| **Accessible UI** | Keyboard focus is always visible (`:focus-visible`); reduce-motion is honoured; both light + dark themes render fully with no hardcoded off-theme tints. |
 
 **If a `[Linux]` SELinux/lifecycle row (Modules 2, 4, 5, the service-mode update rows 6.5/6.6, or the Module 14 uninstall-cascade rows 14.4–14.7) or the core-flow criterion fails:** stop, run `capture-logs.sh <id>` (`.ps1` on Windows) for the evidence bundle, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker. **Module 11 (no-libfuse2)** is the gate for closing item 31, not a 0.1.30-stable blocker on its own — a failure there means keep the libfuse2 gate, don't remove it.

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -1,10 +1,10 @@
 # ws-scrcpy-web — Smoke Test Runbook (plain-English)
 
-> **Smoke target: `v0.1.30-beta.64`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.66`** — bump this one line each release; everything below is version-agnostic.
 
 **What this is.** A step-by-step manual test pass for the **ws-scrcpy-web** app. Completing it is the agreed gate before cutting the **0.1.30 final** release — the "prove it really installs, updates, and streams on Windows + Linux" check. You run it by hand on your test VMs plus a real Android device; it can't be automated from a chat.
 
-**Source of truth.** This is the plain-English twin of `docs/smoke-tests/smoke-full.md` in the repo. Same 76 tests, jargon spelled out, laid out as fixed-width tables you can keep open and tick through. If the two ever disagree, **the repo doc wins** — tell me and I'll re-sync this one.
+**Source of truth.** This is the plain-English twin of `docs/smoke-tests/smoke-full.md` in the repo. The same tests as the repo doc, jargon spelled out, laid out as fixed-width tables you can keep open and tick through. If the two ever disagree, **the repo doc wins** — tell me and I'll re-sync this one.
 
 ## How to use this runbook
 
@@ -371,17 +371,21 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 7.1 Connect over     │ Both │ Home > "scan/connect" > type │ adb connects; the device card shows under        │ [ ]  │
-│ Wi-Fi                │      │ the device ip:port (or scan  │ "connected devices" within ~5s.                  │      │
-│                      │      │ a subnet).                   │                                                  │      │
+│ Wi-Fi                │      │ the device ip:port (or scan a│ "connected devices" within ~5s.                  │      │
+│                      │      │ subnet).                     │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 7.2 Scan a subnet    │ Both │ Open the scan-network dialog │ Reachable devices are listed; picking one        │ [ ]  │
 │                      │      │ and scan a subnet.           │ connects; a bad/empty subnet is handled          │      │
 │                      │      │                              │ gracefully (no hang).                            │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 7.3 USB device       │ Win  │ Plug in a USB Android        │ It appears under connected devices and survives  │ [ ]  │
-│ (Windows)            │      │ device; approve the "allow   │ a page reload.                                   │      │
-│                      │      │ debugging" prompt on the     │                                                  │      │
-│                      │      │ phone.                       │                                                  │      │
+│ 7.3 USB device       │ Win  │ Plug in a USB Android device;│ It appears under connected devices and survives a│ [ ]  │
+│ (Windows)            │      │ approve the "allow debugging"│ page reload.                                     │      │
+│                      │      │ prompt on the phone.         │                                                  │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 7.4 List updates in  │ Both │ Connect, rename, and         │ Rows update in place (diffed by device id) — no  │ [ ]  │
+│ place                │      │ disconnect a few devices;    │ whole-list flicker; labels load once per refresh,│      │
+│                      │      │ watch the connected-devices  │ not once per row; changes show within ~1s.       │      │
+│                      │      │ list.                        │ (beta.66 perf)                                   │      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
@@ -393,19 +397,25 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 8.1 Video            │ Both │ Click a device > open the    │ Live video plays smoothly; no decode errors in   │ [ ]  │
-│                      │      │ stream dialog > connect.     │ the browser console.                             │      │
+│                      │      │ stream dialog > connect; then│ the console. The video cell fills its area with  │      │
+│                      │      │ resize the window.           │ the correct aspect ratio (no stretch/overflow)   │      │
+│                      │      │                              │ and rescales on resize keeping aspect. (beta.66  │      │
+│                      │      │                              │ #106)                                            │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 8.2 Control          │ Both │ In the stream,               │ Your touches and keystrokes reach the device;    │ [ ]  │
-│                      │      │ click/scroll/type and use    │ navigation works.                                │      │
-│                      │      │ the on-screen buttons.       │                                                  │      │
+│                      │      │ click/scroll/type and use the│ navigation works.                                │      │
+│                      │      │ on-screen buttons.           │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 8.3 Audio            │ Both │ Turn on audio in the stream  │ Audio plays; the codec/source toggles work.      │ [ ]  │
-│                      │      │ settings (needs Android      │                                                  │      │
-│                      │      │ 11+).                        │                                                  │      │
+│                      │      │ settings (needs Android 11+).│                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 8.4 Quality settings │ Both │ Change                       │ Changes take effect; the stream restarts with    │ [ ]  │
-│                      │      │ display/codec/encoder/fps/bi │ them; they're remembered per-device next time.   │      │
-│                      │      │ trate, then reconnect.       │                                                  │      │
+│                      │      │ display/codec/encoder/fps/bit│ them; they're remembered per-device next time.   │      │
+│                      │      │ rate, then reconnect.        │                                                  │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 8.5 H.265 (HEVC)     │ Both │ Set the video codec to       │ Both codecs decode and render in-browser         │ [ ]  │
+│ decode               │      │ H.265/HEVC, connect; then    │ (WebCodecs) — live frames, no decode errors.     │      │
+│                      │      │ repeat with H.264.           │ Confirms the owed real-browser H.265 check. (#41)│      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
@@ -421,8 +431,11 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │ a couple commands.           │ shell).                                          │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 9.2 Files            │ Both │ Device > file-list dialog >  │ The listing loads; the icon-size choice sticks;  │ [ ]  │
-│                      │      │ browse, change the icon      │ transfers work.                                  │      │
-│                      │      │ size, push and pull a file.  │                                                  │      │
+│                      │      │ browse, change the icon size,│ transfers work. The console stays quiet —        │      │
+│                      │      │ push and pull a file — with  │ file-listing protocol traces are gated behind the│      │
+│                      │      │ the browser console open.    │ 'ws-scrcpy-web-debug' localStorage flag (set it  │      │
+│                      │      │                              │ to 'true' to see the [ListFiles] traces).        │      │
+│                      │      │                              │ (beta.66)                                        │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 9.3 Device buttons   │ Both │ Use sleep/wake and any       │ Buttons show the right state (green/red); the    │ [ ]  │
 │                      │      │ power/nav buttons on the     │ actions actually happen on the device.           │      │
@@ -437,20 +450,32 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 10.1 Status endpoint │ Both │ Open                         │ Returns JSON with the right platform, supported, │ [ ]  │
-│                      │      │ http://localhost:<port>/api/ │ and status fields.                               │      │
-│                      │      │ service/status in a browser. │                                                  │      │
+│                      │      │ http://localhost:<port>/api/s│ and status fields.                               │      │
+│                      │      │ ervice/status in a browser.  │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 10.2 Windows logs    │ Win  │ Tail launcher.log +          │ No ERR / Error: lines, apart from the known      │ [ ]  │
 │ clean                │      │ ws-scrcpy-web.log under      │ harmless node-pty "AttachConsole" noise.         │      │
-│                      │      │ ProgramData\WsScrcpyWeb\logs │ server.log / service.log are thin crash-catchers │      │
-│                      │      │ during use (canonical logs). │ — normal lines live in the canonical files; a    │      │
-│                      │      │                              │ .1 backup may appear; all files are tail-able.   │      │
+│                      │      │ ProgramData\WsScrcpyWeb\logs │ server.log / service.log are thin crash-catchers;│      │
+│                      │      │ during use (canonical logs). │ a .1 backup may appear; all files are tail-able. │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 10.3 Linux logs      │ Lin  │ Tail launcher.log +          │ No error spam; shutdown messages appear when you │ [ ]  │
-│ clean                │      │ ws-scrcpy-web.log under      │ stop the app. server.log / service.log are thin  │      │
-│                      │      │ ~/.local/share/.../logs (or  │ crash-catchers; a .1 backup may appear; all      │      │
-│                      │      │ /var/lib/.../logs for        │ files are tail-able.                             │      │
-│                      │      │ system installs).            │                                                  │      │
+│ 10.3 Linux logs clean│ Lin  │ Tail launcher.log +          │ No error spam; shutdown messages appear when you │ [ ]  │
+│                      │      │ ws-scrcpy-web.log under      │ stop the app. server.log / service.log are thin  │      │
+│                      │      │ ~/.local/share/.../logs (or  │ crash-catchers; a .1 backup may appear; all files│      │
+│                      │      │ /var/lib/.../logs for system │ are tail-able.                                   │      │
+│                      │      │ installs).                   │                                                  │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 10.4 Token /         │ Both │ With the app open, restart   │ After a restart the open tab must be reloaded to │ [ ]  │
+│ reload-on-restart    │      │ the server (change web port >│ reconnect — a new per-instance token is minted   │      │
+│                      │      │ save, or stop & relaunch).   │ each boot (SameSite=Strict, HttpOnly cookie). A  │      │
+│                      │      │ Separately, curl             │ cookie-less curl is rejected on the sensitive    │      │
+│                      │      │ /api/service/status with no  │ API. Normal browser use is unchanged. (beta.66   │      │
+│                      │      │ cookie.                      │ security)                                        │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 10.5 404 + security  │ Both │ curl -I a missing asset path │ A missing asset / unknown API path returns 404   │ [ ]  │
+│ headers              │      │ and /, then load a deep      │ (not the HTML shell); an in-app route still      │      │
+│                      │      │ in-app route in the browser  │ serves the shell. Static responses carry         │      │
+│                      │      │ and refresh.                 │ X-Content-Type-Options: nosniff and              │      │
+│                      │      │                              │ X-Frame-Options: SAMEORIGIN. (beta.66 security)  │      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
@@ -627,6 +652,41 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 
 ---
 
+### Module 16 — Accessibility & theming
+*Keyboard focus, reduced motion, and theming — all in the browser. No device or install state needed; run with the app open and repeat the visual rows in both themes.*
+
+```text
+┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
+│ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 16.1 Theme switch    │ Both │ Toggle the home-page theme   │ The whole UI recolors live (backgrounds, text,   │ [ ]  │
+│                      │      │ control light <-> dark; open │ borders, buttons); nothing stuck at the other    │      │
+│                      │      │ modals + the stream view in  │ theme; the choice persists across a reload.      │      │
+│                      │      │ each.                        │                                                  │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 16.2 Keyboard focus  │ Both │ Tab through the home page and│ A clear 2px accent focus outline shows on the    │ [ ]  │
+│ ring                 │      │ a dialog's controls with the │ keyboard-focused control (:focus-visible), but   │      │
+│                      │      │ keyboard; then click controls│ NOT on a plain mouse click. (WCAG 2.4.7)         │      │
+│                      │      │ with the mouse.              │                                                  │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 16.3 Reduced motion  │ Both │ Turn on the OS "reduce       │ Animations and transitions collapse to           │ [ ]  │
+│                      │      │ motion" setting, reload the  │ near-instant; turn the setting off and normal    │      │
+│                      │      │ app, then trigger animated UI│ animation returns. (WCAG 2.3.3)                  │      │
+│                      │      │ (modals, spinners,           │                                                  │      │
+│                      │      │ transitions).                │                                                  │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 16.4 Light-mode tints│ Both │ In light theme: select a file│ The selection / delete-hover / apply-update tints│ [ ]  │
+│                      │      │ row, hover the delete        │ are proper light-theme shades (via the           │      │
+│                      │      │ control, and (on an update   │ danger/success tokens), not slightly-off dark    │      │
+│                      │      │ run) hover apply-update.     │ values.                                          │      │
+├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
+│ 16.5 Embed page      │ Both │ Open embed.html (the         │ <html> has a lang attribute set (assistive-tech  │ [ ]  │
+│ language             │      │ embeddable stream page);     │ hint), matching the main app shell.              │      │
+│                      │      │ view-source / inspect the    │                                                  │      │
+│                      │      │ <html> element.              │                                                  │      │
+└──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
+```
+
 ## Global pass criteria
 
 ```text
@@ -651,11 +711,14 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ├──────────────────────┼────────────────────────────────────────────────────────────────┼──────┤
 │ Data preserved       │ Your config/deps/logs survive an uninstall + reinstall.        │ [ ]  │
 ├──────────────────────┼────────────────────────────────────────────────────────────────┼──────┤
-│ Core flow            │ scan > connect > stream (video + control) > shell works on     │ [ ]  │
-│                      │ both Windows and Linux.                                        │      │
+│ Core flow            │ scan > connect > stream (video + control) > shell works on both│ [ ]  │
+│                      │ Windows and Linux.                                             │      │
+├──────────────────────┼────────────────────────────────────────────────────────────────┼──────┤
+│ Accessible UI        │ Keyboard focus stays visible (:focus-visible); reduce-motion is│ [ ]  │
+│                      │ honoured; both themes render fully with no off-theme tints.    │      │
 └──────────────────────┴────────────────────────────────────────────────────────────────┴──────┘
 ```
 
 **If any Linux SELinux/lifecycle test (Modules 2, 4, 5, the service-update rows 6.5/6.6) — or the core-flow criterion — fails:** stop, **run `capture-logs.sh <id>` (Pre-flight F; `.ps1` on Windows)** for the evidence bundle, and report it before promoting 0.1.30 to stable. Cosmetic/polish failures: note and triage later. **Module 11 (no-libfuse2)** is optional — a failure there just means keep the libfuse2 code; it doesn't block 0.1.30.
 
-*Plain-English companion to [`smoke-full.md`](./smoke-full.md), the canonical machine-precise checklist. Same 76 tests with the jargon spelled out; if the two ever diverge, the full doc wins.*
+*Plain-English companion to [`smoke-full.md`](./smoke-full.md), the canonical machine-precise checklist. The same tests as the repo doc, with the jargon spelled out; if the two ever diverge, the full doc wins.*


### PR DESCRIPTION
Cuts **v0.1.30-beta.66** (via the `release:beta` auto-release) so the accumulated security-review work since beta.65 — all merged `release:none` — can be smoke-tested, and brings the three smoke docs current for that pass.

### Smoke-doc updates (all three docs, consistent row IDs)
- **New Module 16 — Accessibility & theming**: light/dark theme switch, `:focus-visible` keyboard focus ring, `prefers-reduced-motion`, light-mode status tints, `embed.html` `<html lang>`.
- **Module 7**: `7.4` device list updates in place (row diffing; labels fetched once per refresh).
- **Module 8**: `8.1` now checks the `.video` cell sizing/aspect via the `--video-width`/`--video-height` custom props (#106); new `8.5` real-browser H.265/HEVC decode (#41).
- **Module 9**: `9.2` checks file-listing console traces are gated behind the `ws-scrcpy-web-debug` flag.
- **Module 10**: `10.4` per-instance-token reload-on-restart; `10.5` 404 + `nosniff`/`X-Frame-Options`.
- Bumped the smoke-target line to beta.66; regrouped the new rows into the checklist (new `#7A` browser-only batch) and the runbook (tables regenerated, global criteria + Accessible UI).

No version bump in this PR — auto-release **Mode 1** owns promoting `[Unreleased]` → `[0.1.30-beta.66]` and tagging.