### PR TITLE
fix(build): pin tar to an absolute system path in fetch-node (Local-Deps #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The build-time Node-bootstrap extraction resolves `tar` by an absolute system path instead of via `PATH`.** The script that unpacks the bundled Node runtime (used in CI and air-gapped installs) invoked `tar` by bare name on Linux/macOS, which the OS resolves through `$PATH`; it now resolves to a canonical absolute location (`/usr/bin/tar`, falling back to `/bin/tar`) and fails fast if it isn't found — matching the Windows build's absolute `tar.exe` path and closing a PATH-hijack surface during the build. Build-time only; no change to the shipped app.
+
 ## [0.1.30-beta.66] - 2026-06-17
 
 ### Changed

--- a/scripts/fetch-node.mjs
+++ b/scripts/fetch-node.mjs
@@ -31,6 +31,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolvePosixTar } from './posix-tar.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -105,8 +106,11 @@ function extract(archivePath, outDir) {
         log(`extracting via ${WINDOWS_TAR}`);
         execFileSync(WINDOWS_TAR, ['-xf', archivePath, '-C', outDir], { stdio: 'inherit' });
     } else {
-        log(`extracting via tar`);
-        execFileSync('tar', ['-xf', archivePath, '-C', outDir, '--no-same-owner'], { stdio: 'inherit' });
+        // Absolute canonical tar, never the bare name (which $PATH would
+        // resolve) — Local-Dependencies-Only, mirrors WINDOWS_TAR above.
+        const tarBin = resolvePosixTar();
+        log(`extracting via ${tarBin}`);
+        execFileSync(tarBin, ['-xf', archivePath, '-C', outDir, '--no-same-owner'], { stdio: 'inherit' });
     }
 }
 

--- a/scripts/posix-tar.mjs
+++ b/scripts/posix-tar.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// scripts/posix-tar.mjs
+//
+// Resolve `tar` to an absolute, canonical system path on Linux/macOS instead of
+// the bare name `tar` (which the OS would resolve via $PATH). Mirrors the
+// Windows `C:\Windows\System32\tar.exe` pin the build scripts already use, and
+// the app's "OS helpers resolve to absolute system paths, never PATH" policy
+// (Local-Dependencies-Only). Build-time only — used by the extract in
+// fetch-node.mjs.
+
+import * as fs from 'node:fs';
+
+// Canonical locations for the system `tar`. /usr/bin/tar is GNU tar on Linux
+// and bsdtar on macOS (both read the .tar.xz we extract); /bin/tar covers the
+// distros that still place it there. Absolute paths only — no $PATH, no env var.
+export const POSIX_TAR_CANDIDATES = ['/usr/bin/tar', '/bin/tar'];
+
+/**
+ * First existing canonical `tar`. Throws (with NO $PATH fallback) if tar is at
+ * none of the known absolute locations, so a build never silently shells out to
+ * a PATH-resolved binary.
+ * @param {(p: string) => boolean} [existsSync] - injected for testing.
+ * @returns {string} absolute path to tar
+ */
+export function resolvePosixTar(existsSync = fs.existsSync) {
+    for (const candidate of POSIX_TAR_CANDIDATES) {
+        if (existsSync(candidate)) {
+            return candidate;
+        }
+    }
+    throw new Error(
+        `tar not found at a canonical system path (${POSIX_TAR_CANDIDATES.join(', ')}). ` +
+            'Install tar via your package manager.',
+    );
+}

--- a/scripts/posix-tar.test.mjs
+++ b/scripts/posix-tar.test.mjs
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { POSIX_TAR_CANDIDATES, resolvePosixTar } from './posix-tar.mjs';
+
+// `existsSync` is injected so these run on any host (incl. Windows CI) without
+// touching the real filesystem or the real tar.
+describe('resolvePosixTar', () => {
+    it('returns /usr/bin/tar when it exists (preferred candidate)', () => {
+        expect(resolvePosixTar((p) => p === '/usr/bin/tar')).toBe('/usr/bin/tar');
+    });
+
+    it('falls back to /bin/tar when /usr/bin/tar is absent', () => {
+        expect(resolvePosixTar((p) => p === '/bin/tar')).toBe('/bin/tar');
+    });
+
+    it('prefers /usr/bin/tar over /bin/tar when both exist', () => {
+        expect(resolvePosixTar(() => true)).toBe('/usr/bin/tar');
+    });
+
+    it('throws (no $PATH fallback) when tar is at no canonical path', () => {
+        expect(() => resolvePosixTar(() => false)).toThrow(/canonical system path/);
+    });
+
+    it('lists only absolute canonical paths — never a bare name resolved via $PATH', () => {
+        expect(POSIX_TAR_CANDIDATES.length).toBeGreaterThan(0);
+        for (const candidate of POSIX_TAR_CANDIDATES) {
+            expect(candidate.startsWith('/')).toBe(true);
+        }
+    });
+});


### PR DESCRIPTION
Closes the security-review **#100 bare-`tar`-on-Linux** call (decision: **Option A — pin the absolute path**).

`scripts/fetch-node.mjs` extracted the bundled Node runtime on Linux/macOS via `execFileSync('tar', …)` — **`tar` by bare name**, resolved through `$PATH`, unlike the Windows branch's absolute `WINDOWS_TAR` (`C:\Windows\System32\tar.exe`). That's the Local-Dependencies-Only surface the review flagged; PR #415 added `--no-same-owner` but left the bare name.

### Change
- **New `scripts/posix-tar.mjs`** — `resolvePosixTar()` returns the first existing canonical absolute path (`/usr/bin/tar` → `/bin/tar`) and **throws with no `$PATH` fallback** if none is found, so a build can never silently shell out to a PATH-resolved `tar`. Mirrors the absolute `WINDOWS_TAR` pin.
- **`fetch-node.mjs`** now calls `resolvePosixTar()` for the extract.
- **`scripts/posix-tar.test.mjs`** — 5 tests (TDD; `existsSync` injected, so they run on any host incl. Windows CI).
- CHANGELOG `[Unreleased]` Security note.

### Verification
- TDD red → green; full suite **1286 passed** (was 1281 + 5 new). `scripts/` is outside tsconfig/biome scope, so vitest is the relevant gate.
- Build-time only; **no runtime change**. The Linux extract path itself is exercised by the release ubuntu build leg (same pattern as the verified Windows branch).

`release:none` — rides the next labeled beta.