### PR TITLE
fix(client): graceful modal connect errors, WCAG-AA light accent, marker-doc row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The light theme's accent color now meets WCAG AA contrast.** The accent blue used for focus outlines and accent text was `#5b9aff` in both themes, which only reaches about 3.8:1 against the light theme's white background — below the 4.5:1 minimum. Light mode now uses a darker blue (`#0969da`, ~5.2:1), matching its existing info color; dark mode is unchanged.
+
+### Fixed
+
+- **Opening the file browser or shell against a device with a malformed address no longer aborts with an uncaught error.** Both modals built their WebSocket URL without catching the validation error `buildMultiplexUrl` throws on an invalid hostname or port, so a malformed device address threw past the modal-open path. They now show a brief "connection failed" message and close, matching how the stream modal already handles connection errors.
+
 ### Security
 
 - **The build-time Node-bootstrap extraction resolves `tar` by an absolute system path instead of via `PATH`.** The script that unpacks the bundled Node runtime (used in CI and air-gapped installs) invoked `tar` by bare name on Linux/macOS, which the OS resolves through `$PATH`; it now resolves to a canonical absolute location (`/usr/bin/tar`, falling back to `/bin/tar`) and fails fast if it isn't found — matching the Windows build's absolute `tar.exe` path and closing a PATH-hijack surface during the build. Build-time only; no change to the shipped app.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1790,6 +1790,7 @@ The upgrade-server's wind-down probe detects when the new Node process is ready:
 | Marker file | Written by | Read by | Purpose |
 |-------------|-----------|---------|---------|
 | `control/apply-update-pending` | Node (UpdateService) | `post-stop` handler | (Windows) tells the post-stop step to run the Velopack apply |
+| `control/apply-update-verify.json` | Node (UpdateService) | `operation_server.rs` | (Windows local-mode) SHA256 manifest the operation-server verifies before applying a downloaded nupkg update |
 | `control/local-appimage` | Node (install) | `linux_service.rs` | (Linux) home AppImage path, used to relaunch local mode after a user-scope service uninstall |
 | `.restart` | Node (DependencyManager) | Launcher supervisor | Triggers a Node respawn after dep updates |
 

--- a/src/app/googDevice/client/ListFilesModal.ts
+++ b/src/app/googDevice/client/ListFilesModal.ts
@@ -415,6 +415,22 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
         return buildMultiplexUrl({ hostname, port, secure, pathname });
     }
 
+    // buildMultiplexUrl throws on a malformed device hostname/port; show a
+    // friendly inline message and close instead of letting the throw abort the
+    // modal open with an uncaught error. Mirrors ConnectModal's onError UI.
+    private showConnectError(err: unknown): void {
+        console.error('[ListFilesModal]', err);
+        const errorEl = document.createElement('div');
+        errorEl.className = 'list-files-modal-error';
+        errorEl.textContent = `connection failed: ${err instanceof Error ? err.message : String(err)}`;
+        errorEl.style.cssText =
+            'padding: 24px; color: #f06c75; font-family: monospace; font-size: 14px; text-align: center;';
+        this.bodyEl.innerHTML = '';
+        this.bodyEl.appendChild(errorEl);
+        // Close after 4s (long enough to read, short enough not to feel stuck).
+        setTimeout(() => this.close(), 4000);
+    }
+
     // The FSLS channel — a sub-multiplexer on the shared WebSocket multiplexer.
     // ManagerClient creates this via createChannel(getChannelInitData()).
     // loadDirectory creates command sub-channels on THIS channel, not on the root multiplexer.
@@ -426,7 +442,12 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
     private detachFsChannelKeepAlive?: (() => void) | undefined;
 
     private connectAndLoad(): void {
-        this.wsUrl = this.buildWebSocketUrl();
+        try {
+            this.wsUrl = this.buildWebSocketUrl();
+        } catch (err) {
+            this.showConnectError(err);
+            return;
+        }
 
         // Get or create the shared root multiplexer (same pattern as ManagerClient/ShellModal)
         let mux = ManagerClient.sockets.get(this.wsUrl);

--- a/src/app/googDevice/client/ShellModal.ts
+++ b/src/app/googDevice/client/ShellModal.ts
@@ -115,8 +115,30 @@ export class ShellModal extends Modal {
         return buildMultiplexUrl({ hostname, port, secure, pathname });
     }
 
+    // buildMultiplexUrl throws on a malformed device hostname/port; show a
+    // friendly inline message and close instead of letting the throw abort the
+    // modal open with an uncaught error. Mirrors ConnectModal's onError UI.
+    private showConnectError(err: unknown): void {
+        console.error('[ShellModal]', err);
+        const errorEl = document.createElement('div');
+        errorEl.className = 'shell-modal-error';
+        errorEl.textContent = `connection failed: ${err instanceof Error ? err.message : String(err)}`;
+        errorEl.style.cssText =
+            'padding: 24px; color: #f06c75; font-family: monospace; font-size: 14px; text-align: center;';
+        this.bodyEl.innerHTML = '';
+        this.bodyEl.appendChild(errorEl);
+        // Close after 4s (long enough to read, short enough not to feel stuck).
+        setTimeout(() => this.close(), 4000);
+    }
+
     private connect(terminalContainer: HTMLElement): void {
-        const url = this.buildWebSocketUrl();
+        let url: string;
+        try {
+            url = this.buildWebSocketUrl();
+        } catch (err) {
+            this.showConnectError(err);
+            return;
+        }
 
         // Get or create a multiplexer for this URL
         let multiplexer = ManagerClient.sockets.get(url);

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -66,8 +66,11 @@
     --button-border-color: #c0c6cc;
     --progress-background-color: rgba(50, 100, 255, 0.2);
     --progress-background-error-color: rgba(255, 50, 50, 0.2);
-    --accent-color: #5b9aff;
-    --accent-rgb: 91, 154, 255;
+    /* Darker than the dark-theme accent so it clears WCAG AA contrast (at least
+     * 4.5:1) as a focus ring / accent text color on the light background —
+     * #0969da is ~5.2:1 on white; reuses the light --info-color blue. */
+    --accent-color: #0969da;
+    --accent-rgb: 9, 105, 218;
     --danger-rgb: 185, 28, 28;
     --success-rgb: 21, 128, 61;
     --modal-divider: rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
Bundles three low-risk post-ship residuals from the security-review follow-ups (todo item 56 b/c/e). All `release:none` — none warrant their own beta; rides the next beta.67 cut.

## Changes

**56c — graceful modal connect errors.** `ListFilesModal.connectAndLoad` and `ShellModal.connect` called `buildWebSocketUrl()` with no try/catch, so the validation error `buildMultiplexUrl` throws on a malformed hostname/port propagated past the modal-open path with no user-visible message. Both now catch it and show a brief inline "connection failed" notice before closing — the same pattern `ConnectModal` already uses for stream errors. Only reachable with a malformed/hostile device address; real LAN devices never hit it.

**56b — light-theme accent contrast.** `--accent-color` was `#5b9aff` in both themes, ~3.8:1 on the light theme's white background — below WCAG AA (4.5:1) for the focus ring and accent text. Light mode now uses `#0969da` (~5.2:1), reusing its existing info-color blue; dark mode unchanged.

**56e — docs.** Adds the `control/apply-update-verify.json` row to TECHNICAL_GUIDE §22.3's marker-file table (Windows local-mode nupkg verification).

## Verification

- `npm run lint` → 0 errors (448 pre-existing warnings unchanged — the separate item-56a backlog)
- `tsc --noEmit` → clean
- `vitest run` → 132 files, 1286 tests pass