### PR TITLE
feat(security): optional allowedHosts escape-hatch for domain/reverse-proxy deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Optional `allowedHosts` config for reverse-proxy / domain deployments.** By default the server accepts only `localhost` and IP-literal `Host` headers (a DNS-rebinding defense), which blocks serving it on a domain name behind a TLS-terminating reverse proxy. A new server-only `allowedHosts` array in `config.json` opts specific domains in (e.g. `{ "allowedHosts": ["devices.example.com"] }`). It is read once at startup and is deliberately not exposed or mutable through the `/api/config` surface. See `SECURITY.md` and TECHNICAL_GUIDE §24.
+
 ### Changed
 
 - **The light theme's accent color now meets WCAG AA contrast.** The accent blue used for focus outlines and accent text was `#5b9aff` in both themes, which only reaches about 3.8:1 against the light theme's white background — below the 4.5:1 minimum. Light mode now uses a darker blue (`#0969da`, ~5.2:1), matching its existing info color; dark mode is unchanged.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,18 @@ A few advanced switches are only available via environment variables:
 | `VELOPACK_FEED_URL` | Force the Velopack auto-updater to use a custom feed URL (mostly useful for the local update-flow sandbox test). |
 | `ADB_PATH` | Override the path to the ADB executable (rarely needed; the dependency manager handles ADB by default). |
 
+### Access control
+
+ws-scrcpy-web has **no login** — anyone who can reach the port can control connected devices, so run it only on a trusted local/LAN network. The server blocks cross-site (CSRF) and DNS-rebinding attacks with a Host allowlist, an Origin check, and a per-launch token cookie; by default it accepts only `localhost` and IP-literal hosts.
+
+To serve it on a domain name behind a TLS-terminating reverse proxy, add the domain(s) to a server-only `allowedHosts` array in `config.json` (read at startup, never exposed via the in-app API), and make sure the proxy forwards the original `Host` header:
+
+```json
+{ "allowedHosts": ["devices.example.com"] }
+```
+
+See [`SECURITY.md`](SECURITY.md) and `docs/TECHNICAL_GUIDE.md` §24 for the full access-control model.
+
 ## Logging
 
 The server logs all output to `ws-scrcpy-web.log`. Every line includes an ISO 8601 timestamp and a module tag (e.g., `[ScrcpyConnection]`, `[Server]`). The log file rotates at 10 MB (per write), keeping one backup (`.log.1`). In dev (`npm start`, no launcher) console output is preserved in the terminal; under the launcher the console echo is suppressed and `ws-scrcpy-web.log` is the single source of truth.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,4 +38,20 @@ Out of scope:
 - Issues requiring physical access to a host already running the server
 - Self-XSS or similar issues requiring the victim to paste attacker-controlled code into devtools
 
+## Access Control Model
+
+ws-scrcpy-web exposes an **unauthenticated** control surface intended for a trusted local or LAN network — anyone who can reach the port can drive connected devices. There is no built-in user login yet. The server does defend that surface against cross-network and cross-site attackers with three layers (see `docs/TECHNICAL_GUIDE.md` §24 for the implementation):
+
+- **Host allowlist** — the `Host` header must be `localhost`, an IP literal, or a configured `allowedHosts` entry. Bare domains are rejected (DNS-rebinding defense).
+- **Origin match** — for the API / WebSocket surface, a present `Origin` must be same-origin (CSRF defense).
+- **Per-instance token** — a random per-launch `HttpOnly; SameSite=Strict` cookie gates the API and the WebSocket upgrade, so a non-browser client that never loaded the page is refused.
+
+**Serving on a domain / behind a reverse proxy.** Because the default rejects domain `Host` headers, a TLS-terminating reverse proxy on a domain name must be opted in via the server-only `allowedHosts` array in `config.json`:
+
+```json
+{ "allowedHosts": ["devices.example.com"] }
+```
+
+`allowedHosts` is read only at startup and is **not** exposed or mutable through `/api/config`. The proxy must forward the original `Host` header (not rewrite it to `localhost`), or the Origin check will reject requests. List only domains you control, and leave it empty for local/LAN-only use.
+
 Thanks for helping keep the project safe.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -33,6 +33,7 @@ This document covers the internal architecture of ws-scrcpy-web -- a browser-bas
 21. [Tray Helper](#21-tray-helper)
 22. [In-App Updater (Velopack)](#22-in-app-updater-velopack)
 23. [First-Run Modal Gating](#23-first-run-modal-gating)
+24. [Access Control & Request Gating](#24-access-control--request-gating)
 
 ---
 
@@ -1889,3 +1890,38 @@ This design means the state survives port changes, browser cache clears, and mac
 | `src/app/client/ServiceFirstRunModal.ts` | Service-instance first-run info modal |
 | `src/app/client/PortChangeModal.ts` | Port-changed notification modal |
 | `src/app/client/SettingsModal.ts` | "Reset welcome prompts" button |
+
+---
+
+## 24. Access Control & Request Gating
+
+ws-scrcpy-web serves an **unauthenticated** API + WebSocket surface (anyone who can reach the port can drive connected devices). It is designed for a trusted local/LAN network — there is no user login (an opt-in auth subsystem is a separate, future workstream). The server defends that surface against *cross-network* and *cross-site* attackers with three layers, evaluated in order in `src/server/security/requestGate.ts`:
+
+1. **Host allowlist (DNS-rebinding defense)** — `originGuard.isHostAllowed`. The `Host` header's hostname must be `localhost`, an IP literal (e.g. `192.168.1.5`, `[::1]`), or an operator-configured `allowedHosts` entry. A bare domain name is rejected, because DNS-rebinding attacks require a domain the attacker can re-point at a loopback/LAN address. This check is **universal** — it applies even to document / static-asset requests, so a rebound page never loads.
+2. **Origin match (CSRF defense)** — `originGuard.isRequestAllowed`. For the sensitive surface (`/api/*` and any state-changing method), a present `Origin` header must equal the request's own origin (`http(s)://<host>`). A *missing* Origin is allowed here (non-browser clients and top-level navigations omit it); the token layer closes that gap.
+3. **Per-instance token** — `instanceToken.ts`. A 256-bit random token is minted once per server launch and handed to the browser as an `HttpOnly; SameSite=Strict` cookie when it loads a document. Every `/api/*` call (except the launcher's `GET /api/config` discovery probe) and every WebSocket upgrade must present it, compared in constant time. A non-browser LAN client that never loaded the page has no token and is refused.
+
+### 24.1 `allowedHosts` — serving on a domain / behind a reverse proxy
+
+By default only `localhost` + IP literals pass layer 1, so terminating TLS at a reverse proxy and serving on a domain name (`https://devices.example.com`) is blocked. Rather than weaken the default, add the domain(s) to the server-only `allowedHosts` array in `config.json`:
+
+```json
+{
+  "webPort": 8000,
+  "allowedHosts": ["devices.example.com"]
+}
+```
+
+- `allowedHosts` is read **once at boot** (`Config.allowedHosts` → `originGuard.setAllowedHosts`) and is **server-only**: it is deliberately absent from `AppConfig`, so it can never be read or changed through the frontend-facing `GET` / `PATCH /api/config` surface. Entries are trimmed, lowercased, and matched against the `Host` hostname (port stripped).
+- The reverse proxy **must forward the original `Host` header** (the domain), not rewrite it to the upstream `localhost` — otherwise layer 2's Origin match fails (browser `Origin: https://devices.example.com` vs upstream `Host: localhost`).
+- Only list domains you control. Every entry widens the rebinding surface by exactly that name, so keep the list tight; leave it empty (the default) for local/LAN-only use.
+
+### 24.2 Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/server/security/originGuard.ts` | Host allowlist (`isHostAllowed`, `setAllowedHosts`) + Origin match (`isRequestAllowed`) |
+| `src/server/security/requestGate.ts` | Composes the three layers for HTTP (`evaluateHttpRequest`) and WS (`evaluateWsConnection`) |
+| `src/server/security/instanceToken.ts` | Per-launch token mint, cookie build, constant-time validation |
+| `src/server/Config.ts` | Reads + sanitizes `allowedHosts` from config.json (`sanitizeAllowedHosts`, `Config.allowedHosts`) |
+| `src/server/index.ts` | Applies `allowedHosts` at boot via `setAllowedHosts(config.allowedHosts)` |

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -50,6 +50,12 @@ export interface FlatConfig {
     updateCheckIntervalMinutes?: number;
     channel?: 'stable' | 'beta';
     githubOwner?: string;
+
+    // Security: extra Host header hostnames accepted beyond localhost / IP
+    // literals (reverse-proxy / domain deployments). Server-only and read at
+    // boot — deliberately NOT part of AppConfig, so it is never exposed or
+    // mutable via the frontend-facing GET/PATCH /api/config surface.
+    allowedHosts?: string[];
 }
 
 /**
@@ -342,6 +348,29 @@ function sanitizeAppConfig(raw: FlatConfig, warn: (msg: string) => void): AppCon
     return out;
 }
 
+/**
+ * Validate the optional `allowedHosts` escape-hatch from config.json into a
+ * clean string[]. Non-arrays and non-string / blank entries are dropped with a
+ * warning rather than throwing (Contract 1: do not throw on load). Hostnames
+ * are trimmed + lowercased so they compare directly against the parsed Host.
+ */
+export function sanitizeAllowedHosts(raw: unknown, warn: (msg: string) => void): string[] {
+    if (raw === undefined) return [];
+    if (!Array.isArray(raw)) {
+        warn('config.json: allowedHosts must be an array of hostname strings; ignoring');
+        return [];
+    }
+    const out: string[] = [];
+    for (const entry of raw) {
+        if (typeof entry !== 'string' || entry.trim().length === 0) {
+            warn(`config.json: allowedHosts entry ${JSON.stringify(entry)} is not a non-empty string; skipping`);
+            continue;
+        }
+        out.push(entry.trim().toLowerCase());
+    }
+    return out;
+}
+
 export class Config {
     private static instance?: Config | undefined;
 
@@ -475,6 +504,8 @@ export class Config {
                 fileConfig.scanProgressInterval ||
                 DEFAULT_SCAN_PROGRESS_INTERVAL;
 
+            const allowedHosts = sanitizeAllowedHosts(fileConfig.allowedHosts, warn);
+
             this.instance = new Config(
                 servers,
                 adbPath,
@@ -486,6 +517,7 @@ export class Config {
                 appConfig,
                 configFilePath,
                 dataRoot,
+                allowedHosts,
             );
         }
         return this.instance;
@@ -507,6 +539,7 @@ export class Config {
         appConfig: AppConfig,
         configFilePath: string,
         private readonly _dataRoot: string | null = null,
+        private readonly _allowedHosts: string[] = [],
     ) {
         this._appConfig = appConfig;
         this._configFilePath = configFilePath;
@@ -537,6 +570,15 @@ export class Config {
      */
     public get dataRoot(): string | null {
         return this._dataRoot;
+    }
+
+    /**
+     * Operator-configured extra Host hostnames (config.json `allowedHosts`)
+     * accepted beyond localhost / IP literals. Read once at boot and applied to
+     * the security layer via setAllowedHosts(); never frontend-mutable.
+     */
+    public get allowedHosts(): string[] {
+        return this._allowedHosts;
     }
 
     /**

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,7 @@ import { NetworkScanner } from './network/NetworkScanner';
 import { consumeSuppressBrowserMarker, openBrowser, shouldAutoOpenBrowser } from './openBrowser';
 import { findAvailablePort, webPortOverride } from './PortPicker';
 import { ScrcpyConnection } from './ScrcpyConnection';
+import { setAllowedHosts } from './security/originGuard';
 import { makeProductionCoreDeps, parseSystemServiceArgs, runSystemServiceCli } from './service/systemServiceCli';
 import { HttpServer } from './services/HttpServer';
 import type { Service, ServiceClass } from './services/Service';
@@ -80,6 +81,12 @@ if (__ssArgs) {
     const runningServices: Service[] = [];
 
     const config = Config.getInstance();
+
+    // Apply the operator-configured Host allowlist to the security layer before
+    // any server starts accepting requests. Empty by default (localhost + IP
+    // literals only); a config.json `allowedHosts` opts a domain/reverse-proxy
+    // deployment in. See docs/SECURITY.md.
+    setAllowedHosts(config.allowedHosts);
 
     // Detect port collision: walk forward from the configured webPort until a free
     // port is found (range = configured..+99). On shift, persist the new port and

--- a/src/server/security/originGuard.test.ts
+++ b/src/server/security/originGuard.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { isHostAllowed, isRequestAllowed, requiresOriginCheck } from './originGuard';
+import { afterEach, describe, expect, it } from 'vitest';
+import { isHostAllowed, isRequestAllowed, requiresOriginCheck, setAllowedHosts } from './originGuard';
 
 describe('originGuard.isRequestAllowed', () => {
     describe('Host allowlist (DNS-rebinding defense)', () => {
@@ -84,6 +84,59 @@ describe('originGuard.isHostAllowed', () => {
         expect(isHostAllowed('myserver.local')).toBe(false);
         expect(isHostAllowed(undefined)).toBe(false);
         expect(isHostAllowed('bad host!!')).toBe(false);
+    });
+});
+
+describe('originGuard.setAllowedHosts (configurable escape-hatch)', () => {
+    // setAllowedHosts mutates module-level state; restore the default
+    // (localhost + IP only) after every test so the rest of the suite — and
+    // re-runs — see pristine state.
+    afterEach(() => {
+        setAllowedHosts([]);
+    });
+
+    it('accepts a configured domain Host that would otherwise be rejected', () => {
+        expect(isHostAllowed('app.example.com')).toBe(false);
+        setAllowedHosts(['app.example.com']);
+        expect(isHostAllowed('app.example.com')).toBe(true);
+    });
+
+    it('strips the port when matching a configured domain Host', () => {
+        setAllowedHosts(['app.example.com']);
+        expect(isHostAllowed('app.example.com:8443')).toBe(true);
+    });
+
+    it('matches configured hosts case-insensitively', () => {
+        setAllowedHosts(['App.Example.COM']);
+        expect(isHostAllowed('app.example.com')).toBe(true);
+    });
+
+    it('still rejects domains that are not in the configured list', () => {
+        setAllowedHosts(['app.example.com']);
+        expect(isHostAllowed('evil.com')).toBe(false);
+    });
+
+    it('still allows localhost and IP literals when a list is configured', () => {
+        setAllowedHosts(['app.example.com']);
+        expect(isHostAllowed('localhost:8000')).toBe(true);
+        expect(isHostAllowed('192.168.1.5:8000')).toBe(true);
+    });
+
+    it('lets a same-origin request to a configured domain pass end-to-end', () => {
+        setAllowedHosts(['app.example.com']);
+        expect(isRequestAllowed('https://app.example.com', 'app.example.com').allowed).toBe(true);
+    });
+
+    it('restores the default localhost+IP-only policy when set to an empty list', () => {
+        setAllowedHosts(['app.example.com']);
+        setAllowedHosts([]);
+        expect(isHostAllowed('app.example.com')).toBe(false);
+    });
+
+    it('ignores blank/whitespace entries', () => {
+        setAllowedHosts(['  ', '', 'app.example.com']);
+        expect(isHostAllowed('app.example.com')).toBe(true);
+        expect(isHostAllowed('   ')).toBe(false);
     });
 });
 

--- a/src/server/security/originGuard.ts
+++ b/src/server/security/originGuard.ts
@@ -39,14 +39,33 @@ function hostnameOf(host: string): string | null {
     }
 }
 
+// Additional Host hostnames accepted beyond localhost / IP literals, populated
+// once at server boot from config (`allowedHosts`). Empty by default so the
+// localhost+IP-only DNS-rebinding defense is unchanged unless an operator opts
+// in (e.g. to serve the app behind a reverse proxy on a domain name).
+let configuredAllowedHosts: ReadonlySet<string> = new Set();
+
 /**
- * A Host is allowed only if its hostname is `localhost` or an IP literal.
+ * Register extra Host hostnames that isHostAllowed() accepts on top of
+ * localhost / IP literals — the opt-in escape-hatch for reverse-proxy / domain
+ * deployments. Called once during startup from `Config.allowedHosts`. Entries
+ * are trimmed, lowercased, and de-duplicated; an empty array restores the
+ * default localhost+IP-only policy.
+ */
+export function setAllowedHosts(hosts: readonly string[]): void {
+    configuredAllowedHosts = new Set(hosts.map((h) => h.trim().toLowerCase()).filter((h) => h.length > 0));
+}
+
+/**
+ * A Host is allowed if its hostname is `localhost`, an IP literal, or one of the
+ * operator-configured `allowedHosts` (see setAllowedHosts).
  *
  * A DNS-rebinding attack requires a *domain name* (so the attacker can later
  * point it at a loopback/LAN address). Rejecting any Host that is neither
  * `localhost` nor a raw IP blocks rebinding without having to enumerate the
  * machine's own addresses, and still allows legitimate access by IP over the
- * LAN (e.g. http://192.168.1.5:8000).
+ * LAN (e.g. http://192.168.1.5:8000). A domain deployment must explicitly opt
+ * in via `allowedHosts` rather than the default accepting any domain.
  */
 export function isHostAllowed(host: string | undefined): boolean {
     if (!host) {
@@ -56,7 +75,10 @@ export function isHostAllowed(host: string | undefined): boolean {
     if (!hostname) {
         return false;
     }
-    return hostname === 'localhost' || isIP(hostname) !== 0;
+    if (hostname === 'localhost' || isIP(hostname) !== 0) {
+        return true;
+    }
+    return configuredAllowedHosts.has(hostname);
 }
 
 /**


### PR DESCRIPTION
Implements todo item 56(d) — the conditional "if domain deployment is wanted" escape-hatch, full feature. `release:none`; rides the next beta.67 cut.

## Why

The Host allowlist (`originGuard.isHostAllowed`) accepts only `localhost` and IP literals — a DNS-rebinding defense — so it rejects a domain `Host` header. That blocks serving the app on a domain name behind a TLS-terminating reverse proxy (`https://devices.example.com`), even though local + LAN-IP + same-origin embed work fine.

## What

- **`allowedHosts` config (opt-in, server-only).** A new `string[]` field in `config.json`. When set, those hostnames pass the Host allowlist on top of localhost/IP. Read **once at boot** (`Config.allowedHosts` → `originGuard.setAllowedHosts`); entries trimmed/lowercased/de-duped; matched against the parsed Host (port stripped).
- **Kept off the frontend surface.** `allowedHosts` lives in `FlatConfig`, deliberately **not** in `AppConfig`/`APP_CONFIG_DEFAULTS`, so it's absent from `KNOWN_CONFIG_KEYS` and can never be read or mutated via `GET`/`PATCH /api/config`. The default (empty) preserves the localhost+IP-only posture exactly.
- **Docs.** New TECHNICAL_GUIDE §24 (the three-layer model: Host allowlist + Origin match + per-instance token, with file map), an Access Control Model section in `SECURITY.md`, and a README access-control note. All call out the reverse-proxy `Host`-forwarding requirement.

## Design note

`isHostAllowed` consults module-level state set once at boot (mirroring `instanceToken.ts`) rather than threading a new parameter through `requestGate` → `HttpServer`/`WebSocketServer`. This contains the change to `originGuard.ts` + one boot call. Allowing the domain in layer 1 is sufficient — the Origin check (layer 2) naturally passes for a same-origin domain request.

## Verification

- 8 new `originGuard` tests (configured-host accept, port-strip, case-insensitivity, non-listed reject, localhost/IP still allowed, end-to-end `isRequestAllowed`, empty-list reset, blank-entry filtering) with `afterEach` state reset.
- `tsc --noEmit` → clean · `npm run lint` → 0 errors · `vitest run` → 132 files, **1294** tests pass.