### PR TITLE
refactor: remove the libfuse2 first-run gate (Velopack 1.2.0 type-2 runtime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The light theme's accent color now meets WCAG AA contrast.** The accent blue used for focus outlines and accent text was `#5b9aff` in both themes, which only reaches about 3.8:1 against the light theme's white background — below the 4.5:1 minimum. Light mode now uses a darker blue (`#0969da`, ~5.2:1), matching its existing info color; dark mode is unchanged.
 
+### Removed
+
+- **Removed the libfuse2 first-run gate.** The Linux in-app updater previously required host `libfuse2` to mount the downloaded update AppImage and showed an "install libfuse2" prompt in Settings → Updates when it was missing. Velopack 1.2.0's bundled type-2 runtime embeds FUSE, so the update mount no longer needs host libfuse2. Removed the gate end to end: `isLibfuse2Installed` / `ensureLibfuse2` (`SystemdClient.ts`), the `/api/updates/install-libfuse2` endpoint and `libfuse2Installed` status field (`UpdatesApi.ts`, `UpdateEvents.ts`), the Settings prompt (`SettingsModal.ts`), and the README instructions. The AppImage already launches without libfuse2 via the build-time type-2 runtime swap.
+
 ### Fixed
 
 - **Opening the file browser or shell against a device with a malformed address no longer aborts with an uncaught error.** Both modals built their WebSocket URL without catching the validation error `buildMultiplexUrl` throws on an invalid hostname or port, so a malformed device address threw past the modal-open path. They now show a brief "connection failed" message and close, matching how the stream modal already handles connection errors.

--- a/README.md
+++ b/README.md
@@ -287,17 +287,9 @@ AppImage signing is currently under evaluation; releases ship **unsigned** for n
 
 The bundled `node-pty` native binary is built against glibc. Musl-based distros (Alpine and similar) are not supported. Run on glibc-based distros: Ubuntu, Debian, Fedora, Arch, openSUSE, etc. — anything that ships glibc 2.31+ should work.
 
-#### libfuse2 (only for in-app updates)
+#### libfuse2 — not required
 
-**The AppImage no longer needs libfuse2 to launch.** Our packaging swaps in the static [type-2 AppImage runtime](https://github.com/AppImage/type2-runtime) (it statically links libfuse), so the AppImage starts on any glibc-based distro — including fresh Ubuntu 24+, Fedora 40+, and Arch installs that no longer ship libfuse2 by default. Just `chmod +x` and run.
-
-The **in-app updater** is the one remaining piece that still needs host `libfuse2`: it mounts the downloaded update AppImage to extract the new build. If Settings → Updates shows a libfuse2 warning, click **install libfuse2** to invoke `pkexec <pkg-manager> install` for your distro (auto-detected: `dnf`, `apt-get`, or `yum`). Or install manually:
-
-- **Debian/Ubuntu**: `sudo apt-get install libfuse2`
-- **Fedora/RHEL**: `sudo dnf install fuse-libs`
-- **Arch**: `sudo pacman -S fuse2`
-
-> This updater-side dependency is slated for removal: Velopack 1.1.1 (now bundled) ships its own type-2 runtime, so once it's verified on a no-libfuse2 distro the gate goes away entirely.
+The AppImage needs no host `libfuse2`. Packaging swaps in the static [type-2 AppImage runtime](https://github.com/AppImage/type2-runtime) (libfuse is statically linked), and the in-app updater uses Velopack's bundled type-2 runtime for the update mount — so the app both **launches** and **self-updates** on any glibc-based distro, including fresh Ubuntu 24+, Fedora 40+, and Arch installs that no longer ship libfuse2. Just `chmod +x` and run.
 
 #### Tray icon
 

--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -122,7 +122,7 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | ☐ **11.1** `[L]` No-libfuse2 launch | Run the smoke-target AppImage on a host without `libfuse2` | Launches (type-2 FUSE embedded); no "dlopen libfuse" error |
-| ☐ **11.2** `[L]` No-libfuse2 update | In-app update from that host | Succeeds → **clears item 31 step 3** (then remove the 5 gate files) |
+| ☐ **11.2** `[L]` No-libfuse2 update | In-app update from that host | Succeeds — regression check that the type-2 runtime self-updates with no host libfuse2 (gate code already removed) |
 | ☐ **11.3** `[L]` Locator-fix watch | During 6.3 / 6.4 / 6.6 apply + relaunch | No Velopack locator root-path regression (velopack#921) |
 
 ## #13 — Devices / scrcpy / adb 📱 *(needs a real Android device, Wireless debugging)*

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -161,7 +161,7 @@ Velopack is at 1.2.0 (bumped in beta.44). These rows close out item 31 (the libf
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | **11.1** `[Linux]` No-libfuse2 launch | On a minimal distro/container **without** `libfuse2` installed, run the smoke-target AppImage. | Launches (type-2 runtime has FUSE embedded); **no** `libfuse.so.2` / "dlopen libfuse" error. |
-| **11.2** `[Linux]` No-libfuse2 in-app update | From that no-libfuse2 host, run an in-app update (6.x flow). | Update succeeds → **clears item 31 step 3**; then the 5 libfuse2 gate files can be removed (`SystemdClient.ts`, `UpdatesApi.ts`, `UpdateEvents.ts`, `SettingsModal.ts`, README section). |
+| **11.2** `[Linux]` No-libfuse2 in-app update | From that no-libfuse2 host, run an in-app update (6.x flow). | Update succeeds. The libfuse2 gate code is already removed (`SystemdClient.ts`, `UpdatesApi.ts`, `UpdateEvents.ts`, `SettingsModal.ts`, README); this row is the regression check that the type-2 runtime self-updates with no host libfuse2. |
 | **11.3** `[Linux]` Locator fix watch (velopack#921) | During **6.3 / 6.4 / 6.6** apply + relaunch on the machine-wide `/opt` install. | Apply + relaunch land correctly; no Velopack locator root-path regression (the 1.2.0 fix targets exactly this path). |
 | **11.4** `[Win]` PerMachine intact | After the 1.5 MSI install, check the install location. | Installed PerMachine to `C:\Program Files\WsScrcpyWeb\` (vpk 1.2.0 `--msi --instLocation PerMachine` unchanged). |
 

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -746,56 +746,6 @@ export class SettingsModal extends Modal {
             return;
         }
 
-        // Linux libfuse2 gate — required for AppImage updates via Velopack.
-        if (s.libfuse2Installed === false) {
-            const versionNote = document.createElement('p');
-            versionNote.className = 'settings-stub-note';
-            versionNote.style.gridColumn = '1 / -1';
-            versionNote.textContent = `current: v${s.currentVersion}`;
-            this.updatesBody.appendChild(versionNote);
-
-            const warning = document.createElement('p');
-            warning.style.cssText = 'grid-column: 1 / -1; color: var(--error-color, #ff6b6b); margin: 4px 0;';
-            warning.textContent = 'libfuse2 is required for in-app updates but is not installed.';
-            this.updatesBody.appendChild(warning);
-
-            const installBtn = document.createElement('button');
-            installBtn.type = 'button';
-            installBtn.className = 'settings-btn settings-btn-primary';
-            installBtn.textContent = 'install libfuse2';
-            installBtn.addEventListener('click', () => {
-                installBtn.disabled = true;
-                installBtn.textContent = 'installing...';
-                fetch('/api/updates/install-libfuse2', { method: 'POST' })
-                    .then(async (r) => {
-                        const data = (await r.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
-                        if (r.ok && data?.ok) {
-                            void this.refreshUpdates();
-                        } else {
-                            warning.textContent = data?.error ?? 'install failed';
-                            installBtn.disabled = false;
-                            installBtn.textContent = 'install libfuse2';
-                        }
-                    })
-                    .catch(() => {
-                        warning.textContent = "couldn't reach server";
-                        installBtn.disabled = false;
-                        installBtn.textContent = 'install libfuse2';
-                    });
-            });
-            const btnRow = document.createElement('div');
-            btnRow.style.cssText = 'grid-column: 1 / -1; display: flex; justify-content: flex-start;';
-            btnRow.appendChild(installBtn);
-            this.updatesBody.appendChild(btnRow);
-
-            const hint = document.createElement('p');
-            hint.style.cssText =
-                'grid-column: 1 / -1; color: var(--text-color-light); font-size: 12px; margin: 4px 0 0;';
-            hint.textContent = 'or install manually (e.g. "sudo dnf install fuse-libs") and restart the app.';
-            this.updatesBody.appendChild(hint);
-            return;
-        }
-
         // Row 1: auto-download checkbox.
         const autoCheckbox = document.createElement('input');
         autoCheckbox.type = 'checkbox';

--- a/src/common/UpdateEvents.ts
+++ b/src/common/UpdateEvents.ts
@@ -35,8 +35,6 @@ export interface UpdatesStatusResponse {
     errorMessage?: string;
     /** Last successful check timestamp (ISO string). */
     lastCheckedAt?: string;
-    /** Linux only: whether libfuse2 is installed (required for AppImage updates). */
-    libfuse2Installed?: boolean;
     /** Mirrored from config.json for UI convenience. */
     autoUpdate: boolean;
     channel: UpdateChannel;

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -10,7 +10,6 @@ import type {
 } from '../../common/UpdateEvents';
 import { Config } from '../Config';
 import { Logger } from '../Logger';
-import { ensureLibfuse2, isLibfuse2Installed } from '../service/SystemdClient';
 import type { UpdateService } from '../UpdateService';
 import { readJsonBody } from './utils';
 
@@ -57,9 +56,6 @@ export class UpdatesApi {
             if (req.method === 'PATCH' && url === '/api/updates/config') {
                 return await this.handleConfig(req, res);
             }
-            if (req.method === 'POST' && url === '/api/updates/install-libfuse2') {
-                return await this.handleInstallLibfuse2(res);
-            }
 
             res.writeHead(404);
             res.end(JSON.stringify({ error: 'Not found' }));
@@ -89,9 +85,6 @@ export class UpdatesApi {
             githubOwner: cfg.githubOwner,
             updateCheckIntervalMinutes: cfg.updateCheckIntervalMinutes,
         };
-        if (process.platform !== 'win32') {
-            out.libfuse2Installed = await isLibfuse2Installed();
-        }
         if (s.availableVersion !== undefined) out.availableVersion = s.availableVersion;
         if (s.progress !== undefined) out.progress = s.progress;
         if (s.errorMessage !== undefined) out.errorMessage = s.errorMessage;
@@ -221,28 +214,6 @@ export class UpdatesApi {
 
         res.writeHead(200);
         res.end(JSON.stringify(await this.buildStatusResponse()));
-        return true;
-    }
-
-    private async handleInstallLibfuse2(res: ServerResponse): Promise<boolean> {
-        if (process.platform === 'win32') {
-            res.writeHead(400);
-            res.end(JSON.stringify({ ok: false, error: 'libfuse2 is Linux-only' }));
-            return true;
-        }
-        if (await isLibfuse2Installed()) {
-            res.writeHead(200);
-            res.end(JSON.stringify({ ok: true, alreadyInstalled: true }));
-            return true;
-        }
-        try {
-            await ensureLibfuse2();
-            res.writeHead(200);
-            res.end(JSON.stringify({ ok: true }));
-        } catch (err) {
-            res.writeHead(500);
-            res.end(JSON.stringify({ ok: false, error: (err as Error).message }));
-        }
         return true;
     }
 }

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -168,57 +168,6 @@ export async function runPkexec(shellCmd: string, label: string): Promise<string
     }
 }
 
-/**
- * Check if libfuse2 is available (required for Velopack AppImage updates).
- * If missing, return the package-manager install command for the detected
- * distro family (deb or rpm). Returns null if already present.
- */
-export async function isLibfuse2Installed(): Promise<boolean> {
-    try {
-        const { stdout } = await execFileAsync(resolveSystemTool('ldconfig'), ['-p'], {
-            encoding: 'utf8',
-        });
-        return stdout.includes('libfuse.so.2');
-    } catch {
-        return false;
-    }
-}
-
-async function libfuse2InstallCmd(): Promise<string | null> {
-    try {
-        const { stdout } = await execFileAsync(resolveSystemTool('ldconfig'), ['-p'], {
-            encoding: 'utf8',
-        });
-        if (stdout.includes('libfuse.so.2')) return null;
-    } catch {
-        // ldconfig not found or failed — assume libfuse2 is missing.
-    }
-
-    if (await fileExists('/usr/bin/dnf')) {
-        return 'dnf install -y fuse-libs';
-    }
-    if (await fileExists('/usr/bin/apt-get')) {
-        return 'apt-get install -y libfuse2';
-    }
-    if (await fileExists('/usr/bin/yum')) {
-        return 'yum install -y fuse-libs';
-    }
-    log.warn('libfuse2 missing but cannot detect package manager (no dnf, apt-get, or yum)');
-    return null;
-}
-
-/**
- * Ensure libfuse2 is installed (required for Velopack AppImage updates).
- * Uses pkexec for graphical privilege escalation if installation is needed.
- */
-export async function ensureLibfuse2(): Promise<void> {
-    const cmd = await libfuse2InstallCmd();
-    if (!cmd) return;
-    log.info(`libfuse2 not found; installing via: ${cmd}`);
-    await runPkexec(cmd, 'install libfuse2');
-    log.info('libfuse2 installed successfully');
-}
-
 async function runSystemctl(args: string[], label: string): Promise<string> {
     try {
         const { bin, args: a } = systemctlArgv(args);

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -510,7 +510,7 @@ dialog.list-files-modal .modal-body {
 
 /* ── Settings modal ── */
 /* Wider than the base modal: the Settings modal has accreted enough sections
-   (service scope, updates, App-section, libfuse2 gate) that long info/error text
+   (service scope, updates, App-section) that long info/error text
    wrapped into many lines and pushed the content past max-height -> a vertical
    scrollbar. The extra horizontal room lets that text breathe (fewer wrapped
    lines -> shorter content). Scoped to .settings-modal so the small confirm


### PR DESCRIPTION
Implements todo item 57. Velopack 1.2.0 (type-2 runtime, FUSE embedded) is pinned, so the Linux in-app updater no longer needs host `libfuse2` to mount the downloaded update AppImage. Removes the first-run gate end to end. `release:none`; rides the next beta.67 cut.

## Removed
- `isLibfuse2Installed` / `libfuse2InstallCmd` / `ensureLibfuse2` — `src/server/service/SystemdClient.ts`
- the `POST /api/updates/install-libfuse2` endpoint + `handleInstallLibfuse2` + the `libfuse2Installed` status field — `src/server/api/UpdatesApi.ts`, `src/common/UpdateEvents.ts`
- the Settings → Updates "install libfuse2" gate UI — `src/app/client/SettingsModal.ts`
- the README "libfuse2 (only for in-app updates)" instructions; a now-stale `modal.css` comment reference

## Kept (intentional — unrelated to the gate)
The **build-time** type-2 runtime swap (`scripts/swap-appimage-runtime.mjs`, `package-linux.mjs`) stays — that is what lets the AppImage *launch* without libfuse2, and it is still in force. The README now states the app both launches and self-updates with no host libfuse2.

## Docs
Smoke 11.2 (checklist + full) reworded from "then remove the gate files" to a regression check, since the code is now removed. The smoke-runbook box-table parenthetical was left as-is (alignment-sensitive); its rows remain valid.

## Verification
- `tsc --noEmit` clean · `npm run lint` 0 errors · `vitest run` 132 files / **1294** tests pass
- grep confirms **zero** `libfuse2` references remain in `src/`
- No tests referenced the gate (verified before removal)
- Net **−136 lines**