### PR TITLE
chore(lint): clean up Biome warnings (fix the fixable, disable 3 config-conflicting rules)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,7 +27,7 @@
                 "noStaticOnlyClass": "off",
                 "noThisInStatic": "off",
                 "useOptionalChain": "warn",
-                "useLiteralKeys": "warn",
+                "useLiteralKeys": "off",
                 "noUselessConstructor": "warn",
                 "noArguments": "warn"
             },
@@ -35,7 +35,7 @@
                 "noNonNullAssertion": "off",
                 "useDefaultParameterLast": "off",
                 "noParameterAssign": "off",
-                "useNodejsImportProtocol": "warn",
+                "useNodejsImportProtocol": "off",
                 "useTemplate": "warn",
                 "noUnusedTemplateLiteral": "warn",
                 "noUselessElse": "warn",
@@ -48,7 +48,7 @@
                 "noConstantCondition": "warn"
             },
             "performance": {
-                "noDelete": "warn"
+                "noDelete": "off"
             }
         }
     },

--- a/src/app/Util.ts
+++ b/src/app/Util.ts
@@ -31,7 +31,7 @@ export default class Util {
         // host_port as before) while neutralising HTML-dangerous characters in
         // any id/name derived from the udid (defence in depth alongside the
         // html`` quote-escaping).
-        return 'udid_' + udid.replace(/[^A-Za-z0-9_-]/g, '_');
+        return `udid_${udid.replace(/[^A-Za-z0-9_-]/g, '_')}`;
     }
 
     public static parse(params: URLSearchParams, name: string, required?: boolean): string | null {
@@ -61,7 +61,7 @@ export default class Util {
             return 0;
         }
         const int = Number.parseInt(value, 10);
-        if (isNaN(int)) {
+        if (Number.isNaN(int)) {
             return 0;
         }
         return int;
@@ -100,7 +100,7 @@ export default class Util {
             input = input[input.length - 1] ?? '';
         }
         const int = Number.parseInt(input, 10);
-        if (isNaN(int)) {
+        if (Number.isNaN(int)) {
             return undefined;
         }
         return int;
@@ -126,7 +126,7 @@ export default class Util {
             window.addEventListener('testPassive', null, opts);
             // @ts-expect-error
             window.removeEventListener('testPassive', null, opts);
-        } catch (error: any) {}
+        } catch (_error: any) {}
 
         return (Util.supportsPassiveValue = supportsPassive);
     }

--- a/src/app/VideoSettings.ts
+++ b/src/app/VideoSettings.ts
@@ -41,7 +41,7 @@ export default class VideoSettings {
             this.iFrameInterval = data.iFrameInterval;
             this.sendFrameMeta = data.sendFrameMeta || false;
             this.lockedVideoOrientation = data.lockedVideoOrientation || -1;
-            if (typeof data.displayId === 'number' && !isNaN(data.displayId) && data.displayId >= 0) {
+            if (typeof data.displayId === 'number' && !Number.isNaN(data.displayId) && data.displayId >= 0) {
                 this.displayId = data.displayId;
             }
             if (data.codecOptions) {

--- a/src/app/audio/AudioPlayer.ts
+++ b/src/app/audio/AudioPlayer.ts
@@ -118,7 +118,7 @@ export class AudioPlayer {
             return;
         }
 
-        if (!this.decoder || this.decoder.state !== 'configured') return;
+        if (this.decoder?.state !== 'configured') return;
 
         this.decoder.decode(
             new EncodedAudioChunk({

--- a/src/app/client/DependencyPanel.ts
+++ b/src/app/client/DependencyPanel.ts
@@ -236,7 +236,7 @@ export class DependencyPanel {
                 const tooltip =
                     'In-app updates require an installed build. ' +
                     'In dev mode, populate dependencies/ via scripts/fetch-node.mjs.';
-                return `<button class="dep-btn dep-update" disabled title="${tooltip}">` + 'update (dev)</button>';
+                return `<button class="dep-btn dep-update" disabled title="${tooltip}">update (dev)</button>`;
             }
             return `<button class="dep-btn dep-update" data-update="${escapeHtml(dep.name)}">update</button>`;
         }

--- a/src/app/client/NetworkDiscoveryPanel.ts
+++ b/src/app/client/NetworkDiscoveryPanel.ts
@@ -93,7 +93,7 @@ export class NetworkDiscoveryPanel {
         try {
             const res = await fetch('/api/devices/scan/subnet');
             const detected = await res.json();
-            if (detected && detected.cidr) {
+            if (detected?.cidr) {
                 gateway = { cidr: detected.cidr, hostCount: detected.hostCount };
             }
         } catch {

--- a/src/app/client/PortChangeModal.ts
+++ b/src/app/client/PortChangeModal.ts
@@ -110,7 +110,7 @@ export class PortChangeModal extends Modal {
         // (global) dismissal. Checking it supersedes — and disables — the
         // per-port box. Committing it goes through a confirmation (see dismiss).
         const globalLabel = document.createElement('label');
-        globalLabel.style.cssText = dontShowLabel.style.cssText + ' margin-top: 8px;';
+        globalLabel.style.cssText = `${dontShowLabel.style.cssText} margin-top: 8px;`;
         const globalCheckbox = document.createElement('input');
         globalCheckbox.type = 'checkbox';
         globalLabel.appendChild(globalCheckbox);

--- a/src/app/googDevice/client/ConfigureScrcpy.ts
+++ b/src/app/googDevice/client/ConfigureScrcpy.ts
@@ -461,7 +461,7 @@ export class ConfigureScrcpy extends Modal {
             const displayId = this.getNumberValueFromInput('displayId');
             const codecOptions = this.getStringValueFromInput('codecOptions') || undefined;
             let bounds: Size | undefined;
-            if (!isNaN(maxWidth) && !isNaN(maxHeight) && maxWidth && maxHeight) {
+            if (!Number.isNaN(maxWidth) && !Number.isNaN(maxHeight) && maxWidth && maxHeight) {
                 bounds = new Size(maxWidth, maxHeight);
             }
             const encoderName = this.getValueFromSelect('encoderName') || undefined;

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -485,7 +485,7 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         DeviceTracker.instancesByUrl.delete(this.url.toString());
         if (!DeviceTracker.instancesByUrl.size) {
             const holder = document.getElementById(BaseDeviceTracker.HOLDER_ELEMENT_ID);
-            if (holder && holder.parentElement) {
+            if (holder?.parentElement) {
                 holder.parentElement.removeChild(holder);
             }
         }

--- a/src/app/googDevice/client/FileListingClient.ts
+++ b/src/app/googDevice/client/FileListingClient.ts
@@ -171,7 +171,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
                     let anchor: HTMLElement | undefined;
                     if (entryIdString) {
                         const entryId = Number.parseInt(entryIdString, 10);
-                        if (!isNaN(entryId) && this.entries[entryId]) {
+                        if (!Number.isNaN(entryId) && this.entries[entryId]) {
                             entry = this.entries[entryId];
                             anchor = e.target;
                         }
@@ -215,7 +215,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
 
     private findOrCreateEntryRow(fileName: string): HTMLElement {
         const existing = this.rowsByName.get(fileName);
-        if (existing && existing.isConnected) {
+        if (existing?.isConnected) {
             return existing;
         }
         return this.addRow(true, fileName, 'file');
@@ -224,7 +224,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
     public onFilePushUpdate(data: PushUpdateParams): void {
         const { fileName, progress, error, message, finished } = data;
         let upload = this.uploads.get(fileName);
-        if (!upload || !upload.anchor.isConnected) {
+        if (!upload?.anchor.isConnected) {
             const row = this.findOrCreateEntryRow(fileName);
             const anchor = row.getElementsByTagName('a')[0]!;
             const progressEl = this.appendProgressElement(anchor);
@@ -572,7 +572,7 @@ export class FileListingClient extends ManagerClient<ParamsFileListing, never> i
             this.cleanProgress(el);
         }
         let name: string;
-        if (download.entry && download.entry.isFile()) {
+        if (download.entry?.isFile()) {
             name = download.entry.name;
         } else {
             // we always should have `download.entry` and never be here

--- a/src/app/googDevice/client/ListFilesModal.ts
+++ b/src/app/googDevice/client/ListFilesModal.ts
@@ -668,7 +668,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
             }
             case Protocol.DONE: {
                 const download = this.downloads.get(channel);
-                if (download && download.entry && download.entry.isFile()) {
+                if (download?.entry?.isFile()) {
                     // File download complete
                     this.finishFileDownload(channel);
                 } else {
@@ -881,7 +881,7 @@ export class ListFilesModal extends Modal implements DragAndPushListener {
             } else {
                 seg.className = 'list-files-breadcrumb-segment';
                 seg.textContent = part;
-                const targetPath = '/' + parts.slice(0, i + 1).join('/');
+                const targetPath = `/${parts.slice(0, i + 1).join('/')}`;
                 seg.addEventListener('click', () => this.loadDirectory(targetPath));
             }
             this.breadcrumbBar!.appendChild(seg);

--- a/src/app/interactionHandler/InteractionHandler.ts
+++ b/src/app/interactionHandler/InteractionHandler.ts
@@ -463,7 +463,7 @@ export abstract class InteractionHandler {
         const logPrefix = `${TAG}[formatTouchEvent]`;
         const messages: TouchControlMessage[] = [];
         const touches = e.changedTouches;
-        if (touches && touches.length) {
+        if (touches?.length) {
             for (let i = 0, l = touches.length; i < l; i++) {
                 const touch = touches[i]!;
                 const pointerId = InteractionHandler.getPointerId(e.type, touch.identifier);

--- a/src/app/player/BaseCanvasBasedPlayer.ts
+++ b/src/app/player/BaseCanvasBasedPlayer.ts
@@ -30,7 +30,7 @@ export abstract class BaseCanvasBasedPlayer extends BasePlayer {
         while (!gl && index++ < validContextNames.length) {
             try {
                 gl = testCanvas.getContext(validContextNames[index]!);
-            } catch (error: any) {
+            } catch (_error: any) {
                 gl = null;
             }
         }

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -146,7 +146,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
                     if (boundsHeight > scaledHeight) {
                         boundsHeight = scaledHeight;
                     }
-                    if (boundsHeight == h) {
+                    if (boundsHeight === h) {
                         scaledWidth = w;
                     } else {
                         scaledWidth = (boundsHeight * w) / h;
@@ -228,7 +228,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
         }
         try {
             parsedValue = JSON.parse(saved);
-        } catch (error: any) {
+        } catch (_error: any) {
             console.error(`[${this.name}]`, 'Failed to parse', saved);
         }
         return parsedValue;
@@ -260,11 +260,18 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
         } = parsed;
 
         // REMOVE `frameRate`
-        const maxFps = isNaN(parsed.maxFps) ? parsed.frameRate : parsed.maxFps;
+        // parsed.* come from JSON.parse and may be undefined / strings; wrap in
+        // Number() so Number.isNaN replicates the old isNaN coercion (undefined -> NaN
+        // -> fall back to the preferred default), which a bare Number.isNaN would not.
+        const maxFps = Number.isNaN(Number(parsed.maxFps)) ? parsed.frameRate : parsed.maxFps;
         // REMOVE `maxSize`
         let bounds: Size | null = null;
-        if (typeof parsed.bounds !== 'object' || isNaN(parsed.bounds.width) || isNaN(parsed.bounds.height)) {
-            if (!isNaN(parsed.maxSize)) {
+        if (
+            typeof parsed.bounds !== 'object' ||
+            Number.isNaN(Number(parsed.bounds.width)) ||
+            Number.isNaN(Number(parsed.bounds.height))
+        ) {
+            if (!Number.isNaN(Number(parsed.maxSize))) {
                 bounds = new Size(parsed.maxSize, parsed.maxSize);
             }
         } else {
@@ -273,12 +280,12 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
         return new VideoSettings({
             displayId: typeof displayId === 'number' ? displayId : 0,
             crop: crop ? new Rect(crop.left, crop.top, crop.right, crop.bottom) : preferred.crop,
-            bitrate: !isNaN(bitrate) ? bitrate : preferred.bitrate,
+            bitrate: !Number.isNaN(Number(bitrate)) ? bitrate : preferred.bitrate,
             bounds: bounds !== null ? bounds : preferred.bounds,
-            maxFps: !isNaN(maxFps) ? maxFps : preferred.maxFps,
-            iFrameInterval: !isNaN(iFrameInterval) ? iFrameInterval : preferred.iFrameInterval,
+            maxFps: !Number.isNaN(Number(maxFps)) ? maxFps : preferred.maxFps,
+            iFrameInterval: !Number.isNaN(Number(iFrameInterval)) ? iFrameInterval : preferred.iFrameInterval,
             sendFrameMeta: typeof sendFrameMeta === 'boolean' ? sendFrameMeta : preferred.sendFrameMeta,
-            lockedVideoOrientation: !isNaN(lockedVideoOrientation)
+            lockedVideoOrientation: !Number.isNaN(Number(lockedVideoOrientation))
                 ? lockedVideoOrientation
                 : preferred.lockedVideoOrientation,
             codecOptions,

--- a/src/packages/multiplexer/Message.ts
+++ b/src/packages/multiplexer/Message.ts
@@ -47,7 +47,7 @@ export class Message {
     public toCloseEvent(): CloseEvent {
         let code: number | undefined;
         let reason: string | undefined;
-        if (this.data && this.data.byteLength) {
+        if (this.data?.byteLength) {
             const view = new DataView(this.data);
             code = view.getUint16(0, true);
             if (this.data.byteLength > 6) {

--- a/src/server/AdbClient.ts
+++ b/src/server/AdbClient.ts
@@ -68,7 +68,7 @@ export function parseMdnsOutput(output: string): MdnsDevice[] {
         if (colonIdx === -1) continue;
         const address = addressPort.substring(0, colonIdx);
         const port = parseInt(addressPort.substring(colonIdx + 1), 10);
-        if (isNaN(port)) continue;
+        if (Number.isNaN(port)) continue;
         results.push({ name: name.trim(), service: service.trim(), address, port });
     }
     return results;

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -721,7 +721,6 @@ export class Config {
             if (!r.ok) {
                 throw new ConfigValidationError(r.error, key as string);
             }
-            // biome-ignore lint/suspicious/noExplicitAny: index assignment with verified-typed value
             (merged as any)[key] = r.value;
         }
         const restartRequired = merged.webPort !== this._appConfig.webPort;
@@ -739,7 +738,7 @@ export class Config {
      * with 2-space indent and trailing newline (Contract 1).
      */
     public saveToDisk(): void {
-        const out = JSON.stringify(this._appConfig, null, 2) + '\n';
+        const out = `${JSON.stringify(this._appConfig, null, 2)}\n`;
         const dir = path.dirname(this._configFilePath);
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -1,12 +1,7 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFile } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import os from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import path from 'path';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { promisify } from 'util';
 import { Logger } from './Logger';
 import { loadManifest } from './NodePtyResolver';

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -1,16 +1,9 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFile } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import os from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import path from 'path';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { Writable } from 'stream';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { pipeline } from 'stream/promises';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { promisify } from 'util';
 import type { DependencyInfo, UpdateResult } from '../common/DependencyTypes';
 import { compareVersions, DependencyStatus } from '../common/DependencyTypes';

--- a/src/server/DeviceLabelStore.ts
+++ b/src/server/DeviceLabelStore.ts
@@ -51,7 +51,7 @@ export class DeviceLabelStore {
 
     private save(): void {
         try {
-            fs.writeFileSync(this.filePath, JSON.stringify(this.labels, null, 2) + '\n');
+            fs.writeFileSync(this.filePath, `${JSON.stringify(this.labels, null, 2)}\n`);
         } catch {
             // If we can't write, don't crash the server
         }

--- a/src/server/DeviceProbe.ts
+++ b/src/server/DeviceProbe.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import path from 'path';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type WS from 'ws';
 import { ACTION } from '../common/Action';
 import { DEVICE_SERVER_PATH, SERVER_PACKAGE } from '../common/Constants';

--- a/src/server/FrameReader.ts
+++ b/src/server/FrameReader.ts
@@ -1,5 +1,4 @@
 // src/server/FrameReader.ts
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type net from 'net';
 
 // scrcpy v4 wire-protocol constants. v4 added a "session packet flag" at

--- a/src/server/Logger.ts
+++ b/src/server/Logger.ts
@@ -67,7 +67,7 @@ function timestamp(): string {
 function writeToFile(line: string): void {
     rotateIfNeeded(LOG_FILE, MAX_LOG_SIZE);
     try {
-        fs.appendFileSync(LOG_FILE, line + '\n');
+        fs.appendFileSync(LOG_FILE, `${line}\n`);
     } catch {
         // If we can't write to the log file, don't crash the server
     }

--- a/src/server/NodePtyResolver.ts
+++ b/src/server/NodePtyResolver.ts
@@ -1,8 +1,5 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as crypto from 'crypto';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 import { Logger } from './Logger';
 import { detectLibc, type LibcFlavor } from './libcDetect';
@@ -272,7 +269,7 @@ export async function downloadAndOverlayPtyNode(version: string, host: HostInfo,
         // contents onto the existing build/Release/. We DON'T blow away
         // build/Release because it may contain platform-specific helper
         // files (winpty-agent.exe on Windows, etc.) we want to keep.
-        const stagingDir = path.join(packageDir, '.staging-' + Date.now());
+        const stagingDir = path.join(packageDir, `.staging-${Date.now()}`);
         fs.mkdirSync(stagingDir, { recursive: true });
         const tarPath = path.join(stagingDir, `${key}.tar.gz`);
         fs.writeFileSync(tarPath, Buffer.from(await tarRes.arrayBuffer()));
@@ -328,14 +325,12 @@ function loadFromDataRoot(packageDir: string): typeof import('node-pty') | null 
         // survives bundling untouched. createRequire's argument is a
         // marker path inside packageDir; the require it returns then
         // resolves 'node-pty' against packageDir's node_modules tree.
-        // biome-ignore lint/suspicious/noExplicitAny: process.getBuiltinModule is loosely typed
         const builtinModule = (process as any).getBuiltinModule('module') as {
             createRequire(filename: string): NodeJS.Require;
         };
         const marker = path.join(packageDir, '_resolver-marker.js');
         const r = builtinModule.createRequire(marker);
         const pty = r('node-pty') as typeof import('node-pty');
-        // biome-ignore lint/suspicious/noExplicitAny: runtime shape check on an untyped import
         if (typeof (pty as any).spawn !== 'function') {
             return null;
         }

--- a/src/server/PortPicker.ts
+++ b/src/server/PortPicker.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as net from 'net';
 
 /**

--- a/src/server/ScrcpyConnection.ts
+++ b/src/server/ScrcpyConnection.ts
@@ -1,8 +1,5 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import crypto from 'crypto';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import net from 'net';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import path from 'path';
 import type WS from 'ws';
 import { ACTION } from '../common/Action';

--- a/src/server/UpdateService.ts
+++ b/src/server/UpdateService.ts
@@ -1,10 +1,6 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFile, spawn } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { promisify } from 'util';
 import { type UpdateInfo, UpdateManager, type UpdateOptions, type VelopackLocatorConfig } from 'velopack';
 import type { UpdateChannel } from '../common/ConfigEvents';
@@ -730,7 +726,7 @@ export class UpdateService {
             try {
                 const content = await fs.promises.readFile(portFilePath, 'utf8');
                 const port = parseInt(content.trim(), 10);
-                if (!isNaN(port) && port > 0 && port <= 65535) {
+                if (!Number.isNaN(port) && port > 0 && port <= 65535) {
                     return port;
                 }
             } catch {

--- a/src/server/Utils.ts
+++ b/src/server/Utils.ts
@@ -39,12 +39,12 @@ export class Utils {
             encodeURI(`${proto}://${os.hostname()}:${port}${pathname}`),
             encodeURI(`${proto}://localhost:${port}${pathname}`),
         ];
-        log.info('Listening on:\n\t' + nameList.join(' '));
+        log.info(`Listening on:\n\t${nameList.join(' ')}`);
         if (ipv4List.length) {
-            log.info('\t' + ipv4List.join(' '));
+            log.info(`\t${ipv4List.join(' ')}`);
         }
         if (ipv6List.length) {
-            log.info('\t' + ipv6List.join(' '));
+            log.info(`\t${ipv6List.join(' ')}`);
         }
     }
 }

--- a/src/server/__tests__/PortPicker.test.ts
+++ b/src/server/__tests__/PortPicker.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as net from 'net';
 import { afterEach, describe, expect, it } from 'vitest';
 import { findAvailablePort, webPortOverride } from '../PortPicker';

--- a/src/server/__tests__/ServerShutdownApi.test.ts
+++ b/src/server/__tests__/ServerShutdownApi.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { describe, expect, it, vi } from 'vitest';
 import { ServerShutdownApi } from '../api/ServerShutdownApi';

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -1,5 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
-
 import * as fs from 'fs';
 import type { IncomingMessage, ServerResponse } from 'http';
 import * as os from 'os';

--- a/src/server/__tests__/UpdateService.test.ts
+++ b/src/server/__tests__/UpdateService.test.ts
@@ -1,10 +1,6 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as child_process from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as os from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 import type { UpdateInfo, UpdateOptions, VelopackAsset } from 'velopack';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -545,7 +541,6 @@ describe('UpdateService', () => {
             },
         });
         // Replace mgr after init so we can inspect progress live.
-        // biome-ignore lint/suspicious/noExplicitAny: test reaches into private field intentionally
         (svc as any).mgr = liveMgr;
         await svc.checkForUpdates();
         expect(progresses).toEqual([0, 42, 100]);

--- a/src/server/__tests__/UpdatesApi.test.ts
+++ b/src/server/__tests__/UpdatesApi.test.ts
@@ -1,11 +1,6 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
-
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
 import type { IncomingMessage, ServerResponse } from 'http';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as os from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdatesApi } from '../api/UpdatesApi';

--- a/src/server/__tests__/capabilitiesApi.test.ts
+++ b/src/server/__tests__/capabilitiesApi.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CapabilitiesApi } from '../api/CapabilitiesApi';

--- a/src/server/__tests__/dependencyApi.retryInstall.test.ts
+++ b/src/server/__tests__/dependencyApi.retryInstall.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { EventEmitter } from 'events';
 import { describe, expect, it, vi } from 'vitest';
 import { DependencyStatus } from '../../common/DependencyTypes';
@@ -27,7 +26,6 @@ function makeMockRes() {
     (res.end as ReturnType<typeof vi.fn>).mockImplementation((body: string) => {
         res.body = body;
     });
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
     return res as any;
 }
 

--- a/src/server/__tests__/dependencyApi.update.test.ts
+++ b/src/server/__tests__/dependencyApi.update.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { EventEmitter } from 'events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DependencyApi } from '../api/DependencyApi';
@@ -26,12 +25,10 @@ function makeMockRes() {
     (res.end as ReturnType<typeof vi.fn>).mockImplementation((body: string) => {
         res.body = body;
     });
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
     return res as any;
 }
 
 function makeReq(method: string, url: string) {
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
     return { method, url } as any;
 }
 

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -156,7 +156,6 @@ describe('DependencyManager.installNodejs rollback', () => {
         platform: 'win32' | 'linux',
     ): Promise<void> {
         // installNodejs is private — invoke via a typed cast for the test only.
-        // biome-ignore lint/suspicious/noExplicitAny: invoke private method
         await (mgr as any).installNodejs(downloadPath, version, installTmp, platform);
     }
 
@@ -170,7 +169,6 @@ describe('DependencyManager.installNodejs rollback', () => {
         const extractTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsscrcpy-extract-'));
 
         // Mock extractZip to throw
-        // biome-ignore lint/suspicious/noExplicitAny: private method spy
         vi.spyOn(mgr as any, 'extractZip').mockRejectedValue(new Error('mock extract fail'));
 
         await expect(callInstallNodejs(mgr, '/fake/download.zip', '24.15.0', extractTmp, 'win32')).rejects.toThrow(
@@ -198,10 +196,8 @@ describe('DependencyManager.installNodejs rollback', () => {
         fs.writeFileSync(path.join(archiveRoot, 'node.exe'), 'NEW-NODE-BYTES');
 
         // extractZip mock succeeds (no-op — the layout is pre-populated).
-        // biome-ignore lint/suspicious/noExplicitAny: private method spy
         vi.spyOn(mgr as any, 'extractZip').mockResolvedValue(undefined);
         // copyDirContents mock throws partway.
-        // biome-ignore lint/suspicious/noExplicitAny: private method spy
         vi.spyOn(mgr as any, 'copyDirContents').mockImplementation(() => {
             throw new Error('mock copy fail');
         });
@@ -231,7 +227,6 @@ describe('DependencyManager.installNodejs rollback', () => {
         fs.writeFileSync(path.join(archiveRoot, 'node.exe'), 'NEW-NODE-BYTES');
         fs.writeFileSync(path.join(archiveRoot, 'npm.cmd'), 'NPM-CMD-BYTES');
 
-        // biome-ignore lint/suspicious/noExplicitAny: private method spy
         vi.spyOn(mgr as any, 'extractZip').mockResolvedValue(undefined);
         // Don't mock copyDirContents — let it run for real on the pre-populated archive.
 

--- a/src/server/__tests__/gracefulShutdown.adb.test.ts
+++ b/src/server/__tests__/gracefulShutdown.adb.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as child_process from 'child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { reapStrayAdbOnWindows } from '../shutdownHelpers';

--- a/src/server/__tests__/nodePtyResolver.integration.test.ts
+++ b/src/server/__tests__/nodePtyResolver.integration.test.ts
@@ -1,8 +1,5 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as os from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -63,7 +60,6 @@ describe('NodePtyResolver — integration (seed → dataRoot)', () => {
 
         expect(handle.reason).toBeUndefined();
         expect(handle.available).toBe(true);
-        // biome-ignore lint/suspicious/noExplicitAny: runtime shape probe
         expect(typeof (handle.pty as any).spawn).toBe('function');
 
         // Verify staging actually happened in dataRoot (not in install

--- a/src/server/__tests__/nodePtyResolver.test.ts
+++ b/src/server/__tests__/nodePtyResolver.test.ts
@@ -1,8 +1,5 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as os from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {

--- a/src/server/__tests__/openBrowser.test.ts
+++ b/src/server/__tests__/openBrowser.test.ts
@@ -1,8 +1,5 @@
-// biome-ignore lint/style/useNodejsImportProtocol: match the non-prefixed app-code import style
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: match the non-prefixed app-code import style
 import { tmpdir } from 'os';
-// biome-ignore lint/style/useNodejsImportProtocol: match the non-prefixed app-code import style
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { consumeSuppressBrowserMarker, shouldAutoOpenBrowser } from '../openBrowser';

--- a/src/server/__tests__/setup-fixture.ts
+++ b/src/server/__tests__/setup-fixture.ts
@@ -1,10 +1,6 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFileSync } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as crypto from 'crypto';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 
 /**

--- a/src/server/api/CapabilitiesApi.ts
+++ b/src/server/api/CapabilitiesApi.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { getNodePty } from '../NodePtyResolver';
 

--- a/src/server/api/ConfigApi.ts
+++ b/src/server/api/ConfigApi.ts
@@ -1,5 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
-
 import * as fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { AppConfigEnvelope, AppConfigPatchResponse } from '../../common/ConfigEvents';

--- a/src/server/api/DependencyApi.ts
+++ b/src/server/api/DependencyApi.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { DependencyStatus } from '../../common/DependencyTypes';
 import type { DependencyManager } from '../DependencyManager';

--- a/src/server/api/DeviceDiscoveryApi.ts
+++ b/src/server/api/DeviceDiscoveryApi.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { AdbClient, parseSerialFromMdnsName } from '../AdbClient';
 import { Config } from '../Config';

--- a/src/server/api/ServerShutdownApi.ts
+++ b/src/server/api/ServerShutdownApi.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { Logger } from '../Logger';
 

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -1,5 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
-
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/src/server/api/UpdatesApi.ts
+++ b/src/server/api/UpdatesApi.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { UpdateChannel } from '../../common/ConfigEvents';
 import { VALID_CHANNELS } from '../../common/ConfigEvents';

--- a/src/server/api/WhoamiApi.ts
+++ b/src/server/api/WhoamiApi.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 import { getAppVersion } from '../appVersion';
 import { Config } from '../Config';

--- a/src/server/api/utils.ts
+++ b/src/server/api/utils.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import type { IncomingMessage, ServerResponse } from 'http';
 
 /**

--- a/src/server/appVersion.ts
+++ b/src/server/appVersion.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 
 /**

--- a/src/server/downloadToFile.ts
+++ b/src/server/downloadToFile.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
 
 export type FetchFn = typeof fetch;

--- a/src/server/ensureScrcpyServerPushed.ts
+++ b/src/server/ensureScrcpyServerPushed.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { statSync } from 'fs';
 import { DEVICE_SERVER_PATH } from '../common/Constants';
 import type { AdbClient } from './AdbClient';

--- a/src/server/goog-device/Device.ts
+++ b/src/server/goog-device/Device.ts
@@ -166,7 +166,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 return output
                     .split(' ')
                     .map((pid) => Number.parseInt(pid, 10))
-                    .filter((num) => !isNaN(num));
+                    .filter((num) => !Number.isNaN(num));
             })
             .catch(() => {
                 return [];
@@ -183,7 +183,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 .filter((item) => item.length);
             if (cols[cols.length - 1] === processName) {
                 const pid = Number.parseInt(cols[1]!, 10);
-                if (!isNaN(pid)) {
+                if (!Number.isNaN(pid)) {
                     list.push(pid);
                 }
             }

--- a/src/server/goog-device/filePush/FilePushReader.ts
+++ b/src/server/goog-device/filePush/FilePushReader.ts
@@ -129,7 +129,7 @@ export class FilePushReader {
                     return;
                 }
                 const { chunk } = command;
-                if (!chunk || !chunk.length) {
+                if (!chunk?.length) {
                     this.closeWithError(FilePushResponseStatus.ERROR_INCORRECT_SIZE);
                     return;
                 }

--- a/src/server/goog-device/mw/RemoteShell.ts
+++ b/src/server/goog-device/mw/RemoteShell.ts
@@ -150,7 +150,8 @@ export class RemoteShell extends Mw {
             if (!this.term) {
                 return;
             }
-            return this.term.write(event.data as string);
+            this.term.write(event.data as string);
+            return;
         }
         let data;
         try {

--- a/src/server/goog-device/services/ControlCenter.ts
+++ b/src/server/goog-device/services/ControlCenter.ts
@@ -162,7 +162,7 @@ export class ControlCenter extends BaseControlCenter<GoogDeviceDescriptor> imple
         this.stopTracking();
     }
 
-    public async runCommand(command: ControlCenterCommand): Promise<void> {
+    public async runCommand(command: ControlCenterCommand): Promise<string | undefined> {
         const udid = command.getUdid();
         const device = this.getDevice(udid);
         if (!device) {

--- a/src/server/libcDetect.ts
+++ b/src/server/libcDetect.ts
@@ -1,6 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
-
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 

--- a/src/server/openBrowser.ts
+++ b/src/server/openBrowser.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { spawn } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { rmSync, statSync } from 'fs';
 import { Logger } from './Logger';
 

--- a/src/server/scrcpyEncoderList.ts
+++ b/src/server/scrcpyEncoderList.ts
@@ -24,9 +24,7 @@ export function parseScrcpyEncoderList(output: string): ScrcpyEncoders {
     const videoRegex = /--video-encoder=(\S+)/g;
     const audioRegex = /--audio-encoder=(\S+)/g;
     let m: RegExpExecArray | null;
-    // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
     while ((m = videoRegex.exec(output)) !== null) videoEncoders.push(m[1]!);
-    // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
     while ((m = audioRegex.exec(output)) !== null) audioEncoders.push(m[1]!);
     return { videoEncoders, audioEncoders };
 }

--- a/src/server/scrcpyServerVersion.ts
+++ b/src/server/scrcpyServerVersion.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as fs from 'fs';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as path from 'path';
 import { SERVER_VERSION } from '../common/Constants';
 

--- a/src/server/service/elevatedRunner.ts
+++ b/src/server/service/elevatedRunner.ts
@@ -32,7 +32,6 @@
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import { Logger } from '../Logger';

--- a/src/server/service/resumeToken.ts
+++ b/src/server/service/resumeToken.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import * as crypto from 'crypto';
 
 /**

--- a/src/server/service/systemServiceCli.ts
+++ b/src/server/service/systemServiceCli.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals
 import { execFile } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals
 import * as fs from 'fs';
 import { WS_SCRCPY_SERVICE_DESCRIPTION, WS_SCRCPY_SERVICE_NAME } from '../../common/ServiceEvents';
 import { Config } from '../Config';
@@ -69,12 +67,12 @@ export function assertSafeRootDir(path: string, lstat: CoreDeps['lstat']): void 
 
 export async function installSystemService(opts: { port: number }, d: CoreDeps): Promise<void> {
     assertRoot(d.getuid);
-    const mkdir = d.tool('mkdir'),
-        cp = d.tool('cp'),
-        chmod = d.tool('chmod'),
-        systemctl = d.tool('systemctl');
-    const semanage = d.sbinTool('semanage'),
-        restorecon = d.sbinTool('restorecon');
+    const mkdir = d.tool('mkdir');
+    const cp = d.tool('cp');
+    const chmod = d.tool('chmod');
+    const systemctl = d.tool('systemctl');
+    const semanage = d.sbinTool('semanage');
+    const restorecon = d.sbinTool('restorecon');
 
     await d.run([mkdir, '-p', STAGED_SYSTEM_DIR]);
     await d.run([mkdir, '-p', SYSTEM_STATE_DIR]);
@@ -93,7 +91,7 @@ export async function installSystemService(opts: { port: number }, d: CoreDeps):
     await d.run([restorecon, '-R', SYSTEM_STATE_DIR]);
 
     const seed = buildSystemSeedConfig(opts.port);
-    d.writeFile(`${SYSTEM_STATE_DIR}/config.json`, JSON.stringify(seed, null, 2) + '\n', { mode: 0o644 });
+    d.writeFile(`${SYSTEM_STATE_DIR}/config.json`, `${JSON.stringify(seed, null, 2)}\n`, { mode: 0o644 });
     const envVars = {
         ...buildServiceUnitEnv('linux', 'system', STAGED_SYSTEM_DEPS_DIR),
         WS_SCRCPY_WEB_PORT: String(opts.port),
@@ -121,10 +119,10 @@ export async function uninstallSystemService(
     d: CoreDeps & { removeFile: (p: string) => void },
 ): Promise<void> {
     assertRoot(d.getuid);
-    const systemctl = d.tool('systemctl'),
-        rm = d.tool('rm'),
-        semanage = d.sbinTool('semanage'),
-        restorecon = d.sbinTool('restorecon');
+    const systemctl = d.tool('systemctl');
+    const rm = d.tool('rm');
+    const semanage = d.sbinTool('semanage');
+    const restorecon = d.sbinTool('restorecon');
     await d.run([systemctl, 'disable', '--now', `${WS_SCRCPY_SERVICE_NAME}.service`]).catch(() => undefined);
     d.removeFile(UNIT_PATH);
     await d.run([systemctl, 'daemon-reload']);
@@ -254,7 +252,7 @@ export function makeProductionCoreDeps(): CliDeps {
         sbinTool: (t) => resolveSystemTool(t),
         defaultPort: () => Config.getInstance().getAppConfig().webPort,
         log: (s) => {
-            process.stdout.write(s + '\n');
+            process.stdout.write(`${s}\n`);
         },
     };
 }

--- a/src/server/services/BaseControlCenter.ts
+++ b/src/server/services/BaseControlCenter.ts
@@ -9,5 +9,5 @@ export abstract class BaseControlCenter<T> extends TypedEmitter<ControlCenterEve
     abstract getId(): string;
     abstract getName(): string;
     abstract getDevices(): T[];
-    abstract runCommand(command: ControlCenterCommand): Promise<string | void>;
+    abstract runCommand(command: ControlCenterCommand): Promise<string | undefined>;
 }

--- a/src/server/shutdownHelpers.ts
+++ b/src/server/shutdownHelpers.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { execFile } from 'child_process';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);

--- a/src/server/verifySha256.ts
+++ b/src/server/verifySha256.ts
@@ -1,6 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { createHash } from 'crypto';
-// biome-ignore lint/style/useNodejsImportProtocol: webpack externals don't support node: prefix
 import { createReadStream } from 'fs';
 
 /** Stream-hash `filePath` (sha256) and return the lowercase hex digest. */

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -88,10 +88,12 @@ html {
     *,
     *::before,
     *::after {
+        /* biome-ignore-start lint/complexity/noImportantStyles: WCAG prefers-reduced-motion global reset — !important is the idiomatic override (#103) */
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
+        /* biome-ignore-end lint/complexity/noImportantStyles: end reduced-motion reset */
     }
 }
 

--- a/src/style/devicelist.css
+++ b/src/style/devicelist.css
@@ -50,6 +50,7 @@ body.list #device_list_menu {
     display: none;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional source order; reordering would change the cascade */
 #device_list_menu {
     display: block;
     position: absolute;
@@ -334,6 +335,7 @@ body.list #device_list_menu {
 /* Action buttons and links styled as buttons. Blue border moved here
    from .desc-block so the parent .desc-block can act as a grid cell
    (with gray cell borders) without an outer blue border around it. */
+/* biome-ignore-start lint/style/noDescendingSpecificity: intentional source order; reordering would change the cascade */
 #devices .device-list div.desc-block .action-button,
 #devices .device-list div.desc-block a {
     border: 0.5px solid var(--accent-color);
@@ -347,6 +349,7 @@ body.list #device_list_menu {
     cursor: pointer;
     display: inline-block;
 }
+/* biome-ignore-end lint/style/noDescendingSpecificity: end desc-block action selectors */
 
 #devices .device-list div.desc-block .action-button:hover,
 #devices .device-list div.desc-block a:hover {
@@ -379,6 +382,7 @@ body.list #device_list_menu {
 /* Device name row — inline label editor */
 #devices .device-name-cell {
     position: relative;
+    /* biome-ignore lint/complexity/noImportantStyles: targeted override of the row's base padding for the inline name-editor affordance */
     padding-right: 28px !important;
 }
 

--- a/src/style/listfiles.css
+++ b/src/style/listfiles.css
@@ -264,6 +264,7 @@
     visibility: visible;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional source order; reordering would change the cascade */
 .list-files-action-btn {
     background: transparent;
     border: none;
@@ -276,6 +277,7 @@
     justify-content: center;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional source order; reordering would change the cascade */
 .list-files-action-btn svg {
     width: var(--file-icon-size, 24px);
     height: var(--file-icon-size, 24px);

--- a/src/style/ws-scrcpy.css
+++ b/src/style/ws-scrcpy.css
@@ -141,6 +141,7 @@ body[data-embed-entry] .device-view {
     opacity: 1;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional source order; reordering would change the cascade */
 .control-button > svg {
     fill: var(--svg-button-fill);
     width: 100%;


### PR DESCRIPTION
Implements todo item 56(a). **The item's premise was wrong:** `noExplicitAny` is already `off`, so this was never a "typing pass." Empirically, **333 of the 448 warnings** came from two rules that structurally conflict with the project's own configuration, plus a third with the same issue. Per the agreed approach: **disable the config-conflicting rules, fix everything else.** `release:none`; rides beta.67.

## Rules disabled in `biome.json` (with rationale)

| Rule | Why it can't be "fixed" |
|------|--------------------------|
| `complexity/useLiteralKeys` (242) | tsconfig sets `noPropertyAccessFromIndexSignature` → bracket access is *required* for index-signature props; tests also bracket-access private members. The autofix breaks `tsc` (verified). |
| `style/useNodejsImportProtocol` (91) | webpack bundles `server/` + `common/` and its loader rejects the `node:` scheme (`UnhandledSchemeError` — verified with `npm run build`). Node-builtin imports must stay bare. |
| `performance/noDelete` (34) | 32/34 sites legitimately need `delete`: `delete process.env[X]` cleanup (`=undefined` sets the literal string `"undefined"`) and map-key removal. |

## Fixed (the genuinely-fixable ~115)

- Mechanical: `useTemplate`, `useSingleVarDeclarator`, `useOptionalChain`, `noConfusingVoidType`, `noUnusedVariables`, `noDoubleEquals`, `noVoidTypeReturn`.
- `noGlobalIsNan` → `Number.isNaN`. **BasePlayer's** `isNaN` calls validate `JSON.parse` output whose fields may be `undefined`; a bare `Number.isNaN(undefined)` is `false` (skips the fallback) where `isNaN(undefined)` is `true`. Wrapped those in `Number(x)` to preserve the exact coercion/fallback. Other sites take `parseInt`/typeof-guarded numbers — safe.
- Widened `ControlCenter.runCommand` to `Promise<string | undefined>` to match the `noConfusingVoidType` change to `BaseControlCenter`.

## Suppressions

- Removed ~60 now-redundant `biome-ignore` comments (the `useNodejsImportProtocol` ones, plus dead `noExplicitAny`/`noAssignInExpressions` suppressions).
- Added **justified** `biome-ignore`s only where a fix would change rendering: `noImportantStyles` on the WCAG `prefers-reduced-motion` reset (idiomatic `!important`) + one targeted override, and `noDescendingSpecificity` on selector source-order (reordering risks cascade regressions).

## Verification

- `npm run lint` → **0 errors, 0 warnings** (was 448)
- `tsc --noEmit` → clean
- `npm run build` (webpack) → **succeeds**
- `vitest run` → **1294/1294 pass**
- Net **−84 lines** across 72 files