### PR TITLE
feat(db): SQLite store foundation — one wsscrcpy.db, migration, and the Config split (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **App settings and device names now persist in a single SQLite database (foundation).** The server previously spread its state across a flat `config.json`, a separate `device-labels.json`, and per-origin browser `localStorage` — the last of which is unreliable on the Linux AppImage, where each launch can look like a new origin and silently lose preferences. This first phase introduces one `wsscrcpy.db` (through Node's built-in `node:sqlite`, so no native module or extra bundled binary) with WAL journaling, an integrity check with last-good-backup recovery on open, and a one-time automatic import of the existing `config.json` and `device-labels.json`. `config.json` is trimmed to the boot fields the launcher reads at startup (`installMode` / `webPort` / `firstRunComplete`, plus any `server` / `allowedHosts` entries); every other setting now lives in the database. The change is behavior-preserving — existing settings carry over and nothing requires a login — and lays the groundwork for per-user settings and optional accounts in later phases.
 - **The light theme's accent color now meets WCAG AA contrast.** The accent blue used for focus outlines and accent text was `#5b9aff` in both themes, which only reaches about 3.8:1 against the light theme's white background — below the 4.5:1 minimum. Light mode now uses a darker blue (`#0969da`, ~5.2:1), matching its existing info color; dark mode is unchanged.
 
 ### Removed

--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,5 @@
 {
-    "port": 8000,
-    "adbPath": "adb"
+  "installMode": null,
+  "webPort": 8000,
+  "firstRunComplete": false
 }

--- a/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase1-foundation.md
+++ b/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase1-foundation.md
@@ -10,6 +10,8 @@
 
 **Spec:** `docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md`. This plan implements the **Store foundation** phase. The exact integration line-targets in `Config.ts`/`index.ts` pin against the post-beta.62 tree at execution time; the `db/` layer is greenfield and exact.
 
+> **AS-BUILT (PR #425, 2026-06-21).** Shipped with four deviations from the text below, each fixing a real gap: (1) the `config.json` trim **PRESERVES** the server-only `server` (SSL) + `allowedHosts` (#421) fields, not "only the trio" — see Task 10; (2) the DB directory is `dirname(configFilePath)` (co-located with config.json so a `CONFIG_PATH` override isolates tests), and `dbDir()` takes a config FILE PATH — not the `dataRoot ?? dirname(depsPath)` of Task 12; the open Db is reached via `Config.getInstance().db`; (3) `UserRow` is a `type`, not an `interface`, so the `.all()` cast type-checks; (4) `importConfigJson` folds the legacy `port` alias into `webPort`. Behavior-preserving; 1323 tests green.
+
 **Conventions (from the repo):**
 - Tests live in `src/server/db/__tests__/`, import `{ describe, it, expect, beforeEach, afterEach } from 'vitest'` (globals are OFF).
 - File-backed tests use `fs.mkdtempSync(path.join(os.tmpdir(), 'prefix-'))` and `fs.rmSync(dir, { recursive: true, force: true })`.

--- a/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase2-device-store.md
+++ b/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase2-device-store.md
@@ -10,6 +10,8 @@
 
 **Spec:** `docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md` (Device store phase). **Depends on Phase 1** (the `Db`, `DeviceStore`, and the device-labels.json import already ran). The label data is already in `device_labels` for user 1; this phase only retargets the *consumers*.
 
+> **⚠️ Phase 1 as-built (read first, PR #425).** The Db is reached via **`Config.getInstance().db`** (`Config` owns it); `dbDir()` now takes a config FILE PATH, so the `Db.getInstance(dbDir(config)).devices` in the table below is superseded by `Config.getInstance().db.devices`. `DeviceStore` already exists with `upsertDevice` / `getDevice` / `listDevices` / `getLabel` / `setLabel` / `deleteLabel` / `getAllLabels`; this phase adds `resolveUserId` + retargets consumers + wires the `devices` upserts.
+
 **Conventions:** same as Phase 1 (vitest explicit imports; `Db._resetForTest()` between tests; per-user reads/writes go through `resolveUserId(req)`).
 
 ---

--- a/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase3-settings-migration.md
+++ b/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase3-settings-migration.md
@@ -10,6 +10,8 @@
 
 **Spec:** `docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md` (Settings migration phase). **Depends on Phase 1** (stores) and **Phase 2** (`resolveUserId` seam). **Coordination:** this phase edits the Settings modal + player/file-browser client code that the **beta.62** restructure also touches — its tasks rebase onto the post-beta.62 tree; the exact line targets below are from the pre-beta.62 tree and pin at execution.
 
+> **⚠️ Phase 1 as-built (read first, PR #425).** The DB is reached via `Config.getInstance().db`; the legacy import lives in `src/server/db/import/`. Phase 1 composes the prompt-dismissal flags into `AppConfig` by overlaying `user_settings` (`Config.overlayStore(out, prompts, PROMPT_KEYS)`) — this phase moves them onto `SettingsApi`, so remove that overlay (and drop `PROMPT_KEYS` from the compose). The `config.json` trim preserves `server`/`allowedHosts`; don't re-introduce a trio-only trim. Re-pin the Settings-modal / player line targets against the current (post-beta.66) tree.
+
 ---
 
 ## File structure

--- a/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase4-auth.md
+++ b/docs/plans/2026-06-11-sqlite-persistence-and-auth-phase4-auth.md
@@ -10,6 +10,8 @@
 
 **Spec:** `docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md` (Auth subsystem). **Depends on Phases 1–3.** **Coordination:** the Users modal, login page, admin-only section hiding, and change-password control land in the Settings modal area that **beta.62** restructures — the client tasks rebase onto post-beta.62.
 
+> **⚠️ Phase 1 as-built (read first, PR #425).** (1) New `UserStore` auth methods that cast `.all()` rows MUST use a `type` / inline literal, NOT an `interface` (the existing `UserRow` is already a `type` for this reason). (2) The app has a request gate now — `src/server/security/requestGate.ts` (#367, origin/Host validation, **not** user-login) — so order `AuthGate` relative to it in the HTTP chain rather than assuming an empty chain; user-login itself is still greenfield. (3) The DB is reached via `Config.getInstance().db`; the `users` + `sessions` tables already exist in the v1 schema. (4) Re-pin the Settings-modal / `WebSocketServer` line targets against the current (post-beta.66) tree.
+
 ---
 
 ## File structure

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -228,6 +228,19 @@ beta.66's security/quality pass restored the keyboard focus indicator, added a r
 
 ---
 
+## Module 17 — SQLite store migration (Phase 1 upgrade)
+
+> **Upgrade-only — pairs with Module 6 (Updates).** The one-time `config.json` + `device-labels.json` → `wsscrcpy.db` import runs on the **first boot of a Phase-1 build that updated from a pre-Phase-1 one**. Run this on the **beta.40 → latest** update path (Module 6's "from" build), after setting state on the old build first. `🧩` needs the pre-Phase-1 "from" build + pre-set state. *(Applies once Phase 1 — PR #425 — is in a beta; until then the rows are N/A.)*
+
+| Test | How to perform | Expected + verify |
+|---|---|---|
+| **17.1** `[Both]` 🧩 Settings + label migrate | On the **pre-Phase-1** build: set a non-default (switch update channel to beta, dismiss the bookmark prompt) and label a connected device. Update to the Phase-1 build and reopen. | The channel + dismissed-prompt + device label are all still in effect (settings carried over). A new `wsscrcpy.db` sits in the data dir beside `config.json`; `device-labels.json` is left inert. |
+| **17.2** `[Both]` 🧩 config.json trimmed to the boot skeleton | After 17.1, open `config.json` in the data dir. | It holds **only** the boot trio (`installMode` / `webPort` / `firstRunComplete`); the moved-out globals (channel/autoUpdate/…) and prompt flags are **gone from the file** (they're in `wsscrcpy.db` now). The app still runs on the same web port. |
+| **17.3** `[Both]` 🧩🌐 `allowedHosts` survives the trim | Before updating, add `"allowedHosts": ["x.example.com"]` to the pre-Phase-1 `config.json`. Update, then re-open `config.json`. | `allowedHosts` (and any `server` SSL array) is **still present** in the trimmed file — server-only boot fields are preserved, so a reverse-proxy / TLS deploy keeps working across the upgrade. |
+| **17.4** `[Both]` 🧩 Idempotent re-open | Restart the Phase-1 build a second time. | No re-import, no error; `config.json` unchanged from 17.2; settings stable (the `legacyImported` guard ran once). |
+
+---
+
 ## Global pass criteria
 
 | Criterion | Holds when |

--- a/docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md
+++ b/docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md
@@ -353,3 +353,14 @@ Each phase is its own plan in `docs/plans/` (per D1) and its own beta.
 ## Rollout
 
 Four sequential betas off `main` (post-beta.62), one per phase, each `release:beta` with CHANGELOG notes under `## [Unreleased]` (never a pre-written version heading — `bump-version.mjs` promotes Unreleased). The store foundation (phase 1) ships behind no flag because it is behavior-preserving (settings move stores but stay open until phase 4). Auth (phase 4) is the only user-visible behavior change and is itself opt-in (inert until the first real user is added).
+
+---
+
+## As-built deltas (Phase 1 — PR #425, 2026-06-21)
+
+Phase 1 shipped `release:none` with four deviations from the design above (each fixes a real gap; the phase plans carry matching notes):
+
+1. **The `config.json` trim preserves server-only boot fields.** `server` (SSL array) + `allowedHosts` (PR #421, post-dates this spec) stay in the trimmed file — dropping them breaks SSL / reverse-proxy deploys. So `config.json` = boot trio **+ `server`/`allowedHosts`**, not trio-only.
+2. **DB directory = `dirname(configFilePath)`**, not `dataRoot ?? dirname(dependenciesPath)`. It equals `<dataRoot>` in production but follows a `CONFIG_PATH` override, which is what lets tests isolate (the `dataRoot`-based dir resolved to the real `ProgramData` on Windows). The open Db is reached via `Config.getInstance().db`; `dbDir()` takes a config file path.
+3. **Row types cast from `node:sqlite` `.all()` are `type` aliases / inline literals, never `interface`s** (an interface has no implicit index signature, so the cast fails). Relevant to Phase 4's UserStore auth methods.
+4. **Phase 4 `AuthGate` slots into the existing `src/server/security/requestGate.ts` chain** (added by #367 after this spec — origin/Host validation, not user-login). App-login is still greenfield, but the gate ordering must account for the request gate.

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -120,7 +120,8 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path, open_browser: bool) -> R
     let entry = resolve_server_entry_with(&work_dir)?;
 
     let mut cmd = Command::new(&node);
-    cmd.arg(&entry)
+    cmd.arg("--disable-warning=ExperimentalWarning")
+        .arg(&entry)
         .current_dir(&work_dir)
         .env("DEPS_PATH", deps_path)
         .env("DATA_ROOT", data_root)
@@ -172,7 +173,8 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path, open_browser: bool) -> R
     let entry = resolve_server_entry_with(&work_dir)?;
 
     let mut cmd = Command::new(&node);
-    cmd.arg(&entry)
+    cmd.arg("--disable-warning=ExperimentalWarning")
+        .arg(&entry)
         .current_dir(&work_dir)
         .env("DEPS_PATH", deps_path)
         .env("DATA_ROOT", data_root);

--- a/scripts/dev-supervisor.mjs
+++ b/scripts/dev-supervisor.mjs
@@ -192,7 +192,7 @@ async function main() {
             console.error('[dev-supervisor] FATAL: Node binary disappeared between iterations — aborting');
             process.exit(1);
         }
-        currentChild = spawn(node.path, [serverScript], {
+        currentChild = spawn(node.path, ['--disable-warning=ExperimentalWarning', serverScript], {
             stdio: 'inherit',
             cwd: REPO_ROOT,
         });

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -11,8 +11,8 @@ import {
 } from '../common/ConfigEvents';
 import type { ServerItem } from '../types/Configuration';
 import { DEFAULT_DEVICE_LABELS_PATH } from './DeviceLabelStore';
-import { Db, dbDir } from './db/Db';
 import { IMPLICIT_ADMIN_ID } from './db/constants';
+import { Db, dbDir } from './db/Db';
 import { GLOBAL_KEYS, PROMPT_KEYS } from './db/import/importConfigJson';
 import { EnvName } from './EnvName';
 import { Logger } from './Logger';

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -10,6 +10,10 @@ import {
     VALID_INSTALL_MODES,
 } from '../common/ConfigEvents';
 import type { ServerItem } from '../types/Configuration';
+import { DEFAULT_DEVICE_LABELS_PATH } from './DeviceLabelStore';
+import { Db, dbDir } from './db/Db';
+import { IMPLICIT_ADMIN_ID } from './db/constants';
+import { GLOBAL_KEYS, PROMPT_KEYS } from './db/import/importConfigJson';
 import { EnvName } from './EnvName';
 import { Logger } from './Logger';
 
@@ -348,6 +352,50 @@ function sanitizeAppConfig(raw: FlatConfig, warn: (msg: string) => void): AppCon
     return out;
 }
 
+/** The boot-trio keys that stay in config.json; everything else lives in the DB. */
+const TRIO_KEYS: ReadonlySet<string> = new Set(['installMode', 'webPort', 'firstRunComplete']);
+
+/**
+ * Overlay store-backed values (app_settings globals or the implicit admin's
+ * prompt flags) onto a composed AppConfig, validating each. Only the provided
+ * key list is consulted, so non-AppConfig store rows (authEnabled,
+ * legacyImported) are ignored. Invalid stored values fall back to whatever the
+ * compose-so-far already holds (defaults), matching sanitizeAppConfig semantics.
+ */
+function overlayStore(
+    out: AppConfig,
+    store: Record<string, unknown>,
+    keys: readonly string[],
+    warn: (msg: string) => void,
+): void {
+    for (const key of keys) {
+        const value = store[key];
+        if (value === undefined) continue;
+        const r = validateField(key as keyof AppConfig, value);
+        if (r.ok) (out as unknown as Record<string, unknown>)[key] = r.value;
+        else warn(`stored ${key}: ${r.error}; ignoring`);
+    }
+}
+
+/**
+ * Compose the effective AppConfig from the trimmed config.json boot trio
+ * (`fileConfig`) plus the store-backed globals (`app_settings`) and the implicit
+ * admin's prompt flags (`user_settings`). Pre-migration `fileConfig` still
+ * carries the globals/prompts; the store overlay is authoritative once the
+ * one-time import has moved them out.
+ */
+function composeAppConfig(
+    fileConfig: FlatConfig,
+    globals: Record<string, unknown>,
+    prompts: Record<string, unknown>,
+    warn: (msg: string) => void,
+): AppConfig {
+    const out = sanitizeAppConfig(fileConfig, warn);
+    overlayStore(out, globals, GLOBAL_KEYS, warn);
+    overlayStore(out, prompts, PROMPT_KEYS, warn);
+    return out;
+}
+
 /**
  * Validate the optional `allowedHosts` escape-hatch from config.json into a
  * clean string[]. Non-arrays and non-string / blank entries are dropped with a
@@ -475,33 +523,57 @@ export class Config {
                 fileConfig = Config.tryLoadFile(configFilePath, warn);
             }
 
-            const appConfig = sanitizeAppConfig(fileConfig, warn);
+            // Resolve the dependencies path BEFORE opening the DB: the DB's
+            // directory must never depend on a value stored INSIDE the DB (no
+            // load-order cycle). DEPS_PATH env / config.json / platform default.
+            const bootDependenciesPath = resolveDependenciesPath(process.env, fileConfig, process.argv[1] ?? '.');
+
+            // Open (or recover) the SQLite store and run the one-time legacy
+            // import. The DB lives beside config.json (so a CONFIG_PATH override —
+            // tests, custom deploys — co-locates it). The import reads the REAL
+            // config.json + the bundle-relative device-labels.json, moves their
+            // non-boot fields into the store, and trims config.json to the boot
+            // skeleton (trio + server-only fields).
+            const db = Db.getInstance(dbDir(configFilePath), {
+                configPath: configFilePath,
+                deviceLabelsPath: DEFAULT_DEVICE_LABELS_PATH,
+            });
+            const globals = db.appSettings.getAll();
+            const prompts = db.userSettings.getAll(IMPLICIT_ADMIN_ID);
+
+            // Compose the effective AppConfig from the trio + store-backed globals
+            // + the implicit admin's prompt flags.
+            const appConfig = composeAppConfig(fileConfig, globals, prompts, warn);
             const servers = Config.buildServers(fileConfig, appConfig.webPort);
 
-            const dependenciesPath = resolveDependenciesPath(process.env, fileConfig, process.argv[1] ?? '.');
+            // An app_settings override of dependenciesPath/adbPath is overlaid for
+            // downstream consumers (the adb spawn path) AFTER the DB opens — it
+            // does NOT relocate the DB or the boot deps folder.
+            const dependenciesPath = (globals['dependenciesPath'] as string | undefined) ?? bootDependenciesPath;
 
             // ADB resolution must come AFTER dependenciesPath. Always returns a path
-            // inside <dependenciesPath>/adb/ unless config.json explicitly overrides.
-            // No system-PATH fallback by design.
-            const adbResolution = resolveAdbPath(fileConfig, dependenciesPath);
+            // inside <dependenciesPath>/adb/ unless an override is configured. No
+            // system-PATH fallback by design.
+            const adbOverride = (globals['adbPath'] ?? fileConfig.adbPath) as string | undefined;
+            const adbResolution = resolveAdbPath(adbOverride ? { adbPath: adbOverride } : {}, dependenciesPath);
             const adbPath = adbResolution.path;
             log.info(`adbPath=${adbPath} (source=${adbResolution.source})`);
 
             const scanConcurrency =
                 Number.parseInt(process.env['SCAN_CONCURRENCY'] ?? '', 10) ||
-                fileConfig.scanConcurrency ||
+                (globals['scanConcurrency'] as number | undefined) ||
                 DEFAULT_SCAN_CONCURRENCY;
             const scanTcpTimeoutMs =
                 Number.parseInt(process.env['SCAN_TCP_TIMEOUT_MS'] ?? '', 10) ||
-                fileConfig.scanTcpTimeoutMs ||
+                (globals['scanTcpTimeoutMs'] as number | undefined) ||
                 DEFAULT_SCAN_TCP_TIMEOUT_MS;
             const scanAdbConnectTimeoutMs =
                 Number.parseInt(process.env['SCAN_ADB_CONNECT_TIMEOUT_MS'] ?? '', 10) ||
-                fileConfig.scanAdbConnectTimeoutMs ||
+                (globals['scanAdbConnectTimeoutMs'] as number | undefined) ||
                 DEFAULT_SCAN_ADB_CONNECT_TIMEOUT_MS;
             const scanProgressInterval =
                 Number.parseInt(process.env['SCAN_PROGRESS_INTERVAL'] ?? '', 10) ||
-                fileConfig.scanProgressInterval ||
+                (globals['scanProgressInterval'] as number | undefined) ||
                 DEFAULT_SCAN_PROGRESS_INTERVAL;
 
             const allowedHosts = sanitizeAllowedHosts(fileConfig.allowedHosts, warn);
@@ -518,14 +590,16 @@ export class Config {
                 configFilePath,
                 dataRoot,
                 allowedHosts,
+                db,
             );
         }
         return this.instance;
     }
 
-    /** Test-only: clear the cached singleton. */
+    /** Test-only: clear the cached singleton (and the DB it owns). */
     public static _resetForTest(): void {
         this.instance = undefined;
+        Db._resetForTest();
     }
 
     constructor(
@@ -538,8 +612,9 @@ export class Config {
         private readonly _scanProgressInterval: number,
         appConfig: AppConfig,
         configFilePath: string,
-        private readonly _dataRoot: string | null = null,
-        private readonly _allowedHosts: string[] = [],
+        private readonly _dataRoot: string | null,
+        private readonly _allowedHosts: string[],
+        private readonly _db: Db,
     ) {
         this._appConfig = appConfig;
         this._configFilePath = configFilePath;
@@ -570,6 +645,11 @@ export class Config {
      */
     public get dataRoot(): string | null {
         return this._dataRoot;
+    }
+
+    /** The SQLite store opened for this config's data directory (Phase 1). */
+    public get db(): Db {
+        return this._db;
     }
 
     /**
@@ -721,7 +801,18 @@ export class Config {
             if (!r.ok) {
                 throw new ConfigValidationError(r.error, key as string);
             }
-            (merged as any)[key] = r.value;
+            (merged as unknown as Record<string, unknown>)[k] = r.value;
+            // Route each field to its backing store: the boot trio stays in
+            // config.json (written by saveToDisk below); globals go to
+            // app_settings; prompt-dismissal flags go to the implicit admin's
+            // user_settings. The DB is the source of truth post-split.
+            if (TRIO_KEYS.has(k)) {
+                // persisted by saveToDisk()
+            } else if ((GLOBAL_KEYS as readonly string[]).includes(k)) {
+                this._db.appSettings.set(k, r.value);
+            } else if ((PROMPT_KEYS as readonly string[]).includes(k)) {
+                this._db.userSettings.set(IMPLICIT_ADMIN_ID, k, r.value);
+            }
         }
         const restartRequired = merged.webPort !== this._appConfig.webPort;
         this._appConfig = merged;
@@ -738,7 +829,24 @@ export class Config {
      * with 2-space indent and trailing newline (Contract 1).
      */
     public saveToDisk(): void {
-        const out = `${JSON.stringify(this._appConfig, null, 2)}\n`;
+        // config.json holds ONLY the boot trio now. Preserve the server-only boot
+        // fields (`server` SSL array, `allowedHosts`) that live in the file but
+        // aren't part of AppConfig — re-read them so a save never drops them.
+        const preserved: Record<string, unknown> = {};
+        try {
+            const existing = JSON.parse(fs.readFileSync(this._configFilePath, 'utf-8')) as Record<string, unknown>;
+            for (const k of ['server', 'allowedHosts']) {
+                if (existing[k] !== undefined) preserved[k] = existing[k];
+            }
+        } catch {
+            /* no existing file / unparseable — nothing to preserve */
+        }
+        const trio = {
+            installMode: this._appConfig.installMode,
+            webPort: this._appConfig.webPort,
+            firstRunComplete: this._appConfig.firstRunComplete,
+        };
+        const out = `${JSON.stringify({ ...trio, ...preserved }, null, 2)}\n`;
         const dir = path.dirname(this._configFilePath);
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });

--- a/src/server/DeviceLabelStore.ts
+++ b/src/server/DeviceLabelStore.ts
@@ -1,7 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const DEFAULT_PATH = path.resolve(__dirname, '..', 'device-labels.json');
+// Exported so the SQLite migration (Db / importLegacy) reads the SAME legacy
+// file this store wrote — it is bundle-relative (next to dist/), NOT under
+// <dataRoot>, so the importer must use this exact path, not a dataRoot guess.
+export const DEFAULT_DEVICE_LABELS_PATH = path.resolve(__dirname, '..', 'device-labels.json');
 
 export class DeviceLabelStore {
     private static instance?: DeviceLabelStore | undefined;
@@ -11,7 +14,7 @@ export class DeviceLabelStore {
         this.load();
     }
 
-    static getInstance(filePath = DEFAULT_PATH): DeviceLabelStore {
+    static getInstance(filePath = DEFAULT_DEVICE_LABELS_PATH): DeviceLabelStore {
         if (!this.instance) {
             this.instance = new DeviceLabelStore(filePath);
         }

--- a/src/server/__tests__/Config.test.ts
+++ b/src/server/__tests__/Config.test.ts
@@ -65,13 +65,15 @@ describe('Config — AppConfig extension', () => {
         expect(Config.getInstance().getAppConfig().bookmarkDismissedGlobally).toBe(false);
     });
 
-    it('migrates legacy `port` → `webPort` in memory without rewriting file', () => {
+    it('migrates legacy `port` → `webPort` (now persisted via the config trim)', () => {
         const configPath = setup({ port: 8123 });
-        const before = fs.readFileSync(configPath, 'utf-8');
         const c = Config.getInstance().getAppConfig();
         expect(c.webPort).toBe(8123);
-        const after = fs.readFileSync(configPath, 'utf-8');
-        expect(after).toBe(before);
+        // Phase 1: the one-time import trims config.json — the legacy `port`
+        // alias is folded into `webPort` (the boot trio) and the old key is gone.
+        const after = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        expect(after.webPort).toBe(8123);
+        expect(after.port).toBeUndefined();
     });
 
     it('falls back to default for an out-of-range webPort', () => {
@@ -95,7 +97,9 @@ describe('Config — AppConfig extension', () => {
         expect(text).toContain('  "firstRunComplete": true');
         const parsed = JSON.parse(text);
         expect(parsed.firstRunComplete).toBe(true);
-        expect(parsed.autoUpdate).toBe(false);
+        // autoUpdate is a global now → persisted to the SQLite store, not config.json.
+        expect(parsed.autoUpdate).toBeUndefined();
+        expect(cfg.getAppConfig().autoUpdate).toBe(false);
     });
 
     it('updateAppConfig sets restartRequired when webPort changes', () => {
@@ -204,8 +208,9 @@ describe('Config — AppConfig extension', () => {
 
     it('setActualWebPort with same port leaves portWasAutoShifted=false and does not rewrite file', () => {
         const configPath = setup({ webPort: 8000 });
-        const before = fs.readFileSync(configPath, 'utf-8');
         const cfg = Config.getInstance();
+        // Capture AFTER getInstance — the one-time import trims config.json on open.
+        const before = fs.readFileSync(configPath, 'utf-8');
         cfg.setActualWebPort(8000);
         const status = cfg.getFirstRunStatus();
         expect(status.portWasAutoShifted).toBe(false);

--- a/src/server/__tests__/config.storeBacked.test.ts
+++ b/src/server/__tests__/config.storeBacked.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Config } from '../Config';
+import { EnvName } from '../EnvName';
+
+// Uses the CONFIG_PATH + DEPS_PATH temp harness (NOT DATA_ROOT, which
+// resolveDataRoot ignores on Windows). The DB co-locates with config.json
+// (dbDir = dirname(configFilePath)), so each test is isolated in its own temp.
+const tmpDirs: string[] = [];
+const saved = { CONFIG: process.env[EnvName.CONFIG_PATH], DEPS: process.env['DEPS_PATH'] };
+
+function setup(initial: unknown): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-cfg-store-'));
+    tmpDirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify(initial));
+    process.env[EnvName.CONFIG_PATH] = configPath;
+    process.env['DEPS_PATH'] = path.join(dir, 'deps');
+    Config._resetForTest();
+    return configPath;
+}
+
+afterEach(() => {
+    Config._resetForTest();
+    if (saved.CONFIG === undefined) delete process.env[EnvName.CONFIG_PATH];
+    else process.env[EnvName.CONFIG_PATH] = saved.CONFIG;
+    if (saved.DEPS === undefined) delete process.env['DEPS_PATH'];
+    else process.env['DEPS_PATH'] = saved.DEPS;
+    while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('Config store-backed composition', () => {
+    it('composes AppConfig from the JSON trio + app_settings + user-1 prompts', () => {
+        setup({
+            webPort: 8200,
+            installMode: 'user',
+            firstRunComplete: true,
+            channel: 'beta',
+            bookmarkDismissedGlobally: true,
+        });
+        const cfg = Config.getInstance().getAppConfig();
+        expect(cfg.webPort).toBe(8200); // trio (config.json)
+        expect(cfg.installMode).toBe('user'); // trio (config.json)
+        expect(cfg.channel).toBe('beta'); // global → app_settings (imported)
+        expect(cfg.bookmarkDismissedGlobally).toBe(true); // prompt → user-1 (imported)
+    });
+
+    it('updateAppConfig routes fields to the right store and keeps config.json trio-only', () => {
+        const configPath = setup({ webPort: 8200, installMode: 'user', firstRunComplete: false });
+        const c = Config.getInstance();
+        c.updateAppConfig({ channel: 'stable', firstRunComplete: true, bookmarkDismissedGlobally: true });
+        // config.json holds ONLY the trio (channel + bookmark went to the DB).
+        const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        expect(Object.keys(onDisk).sort()).toEqual(['firstRunComplete', 'installMode', 'webPort']);
+        expect(onDisk.firstRunComplete).toBe(true);
+        // Re-read composes the global + prompt back from the stores.
+        Config._resetForTest();
+        const cfg2 = Config.getInstance().getAppConfig();
+        expect(cfg2.channel).toBe('stable');
+        expect(cfg2.bookmarkDismissedGlobally).toBe(true);
+    });
+
+    it('preserves server-only boot fields (allowedHosts) across the trim and a save', () => {
+        const configPath = setup({
+            webPort: 8200,
+            installMode: 'user',
+            firstRunComplete: false,
+            allowedHosts: ['proxy.example.com'],
+        });
+        const c = Config.getInstance();
+        expect(c.allowedHosts).toEqual(['proxy.example.com']);
+        // Still on disk after the import trim + a settings save (saveToDisk re-merges it).
+        c.updateAppConfig({ firstRunComplete: true });
+        const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        expect(onDisk.allowedHosts).toEqual(['proxy.example.com']);
+        expect(onDisk.webPort).toBe(8200);
+    });
+
+    it('rejects an out-of-range stored global and keeps the default (compose validation)', () => {
+        // updateCheckIntervalMinutes is a validated global; an out-of-range stored
+        // value must fall back to the default rather than surfacing the bad value.
+        setup({ webPort: 8200, installMode: 'user', firstRunComplete: false, updateCheckIntervalMinutes: 1 });
+        const cfg = Config.getInstance().getAppConfig();
+        expect(cfg.updateCheckIntervalMinutes).toBe(60);
+    });
+});

--- a/src/server/__tests__/config.storeBacked.test.ts
+++ b/src/server/__tests__/config.storeBacked.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
 

--- a/src/server/db/AppSettingsStore.ts
+++ b/src/server/db/AppSettingsStore.ts
@@ -11,7 +11,10 @@ export class AppSettingsStore {
     }
 
     getAll(): Record<string, unknown> {
-        const rows = this.db.prepare('SELECT key, value FROM app_settings').all() as Array<{ key: string; value: string }>;
+        const rows = this.db.prepare('SELECT key, value FROM app_settings').all() as Array<{
+            key: string;
+            value: string;
+        }>;
         const out: Record<string, unknown> = {};
         for (const r of rows) out[r.key] = JSON.parse(r.value);
         return out;
@@ -19,7 +22,9 @@ export class AppSettingsStore {
 
     set(key: string, value: unknown): void {
         this.db
-            .prepare('INSERT INTO app_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+            .prepare(
+                'INSERT INTO app_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+            )
             .run(key, JSON.stringify(value));
     }
 }

--- a/src/server/db/AppSettingsStore.ts
+++ b/src/server/db/AppSettingsStore.ts
@@ -1,0 +1,25 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export class AppSettingsStore {
+    constructor(private readonly db: DatabaseSync) {}
+
+    get(key: string): unknown {
+        const r = this.db.prepare('SELECT value FROM app_settings WHERE key = ?').get(key) as
+            | { value: string }
+            | undefined;
+        return r ? JSON.parse(r.value) : undefined;
+    }
+
+    getAll(): Record<string, unknown> {
+        const rows = this.db.prepare('SELECT key, value FROM app_settings').all() as Array<{ key: string; value: string }>;
+        const out: Record<string, unknown> = {};
+        for (const r of rows) out[r.key] = JSON.parse(r.value);
+        return out;
+    }
+
+    set(key: string, value: unknown): void {
+        this.db
+            .prepare('INSERT INTO app_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+            .run(key, JSON.stringify(value));
+    }
+}

--- a/src/server/db/Db.ts
+++ b/src/server/db/Db.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
+import * as fs from 'fs';
 import * as path from 'path';
 import { openDatabase } from './openDatabase';
 import { importLegacyIfNeeded } from './import/importLegacy';
@@ -57,7 +58,13 @@ export class Db {
     }
 
     backup(toPath: string): void {
-        // VACUUM INTO writes a clean snapshot; the path must not already exist.
+        // VACUUM INTO writes a clean snapshot but fails if the target exists, so
+        // clear any prior snapshot first.
+        try {
+            fs.rmSync(toPath, { force: true });
+        } catch {
+            /* best effort */
+        }
         this.handle.exec(`VACUUM INTO '${toPath.replace(/'/g, "''")}'`);
     }
 }

--- a/src/server/db/Db.ts
+++ b/src/server/db/Db.ts
@@ -1,13 +1,13 @@
 import type { DatabaseSync } from 'node:sqlite';
 import * as fs from 'fs';
 import * as path from 'path';
-import { openDatabase } from './openDatabase';
-import { importLegacyIfNeeded } from './import/importLegacy';
-import { UserStore } from './UserStore';
-import { UserSettingsStore } from './UserSettingsStore';
 import { AppSettingsStore } from './AppSettingsStore';
-import { DeviceStore } from './DeviceStore';
 import { DB_FILENAME } from './constants';
+import { DeviceStore } from './DeviceStore';
+import { importLegacyIfNeeded } from './import/importLegacy';
+import { openDatabase } from './openDatabase';
+import { UserSettingsStore } from './UserSettingsStore';
+import { UserStore } from './UserStore';
 
 export class Db {
     private static instance?: Db | undefined;

--- a/src/server/db/Db.ts
+++ b/src/server/db/Db.ts
@@ -63,14 +63,14 @@ export class Db {
 }
 
 /**
- * THE one resolver for the Db directory. Every `Db.getInstance(...)` call across
- * all phases MUST pass `dbDir(Config.getInstance())` — never an ad-hoc
- * `dataRoot ?? dependenciesPath`. Mirrors `resolveDataRoot` precedence; on a null
- * dataRoot (non-Windows dev) it falls back to the parent of the dependencies path
- * (matching `Config.restartMarkerPath`'s fallback), so the DB sits beside the
- * other writable state. Typed structurally (not against `Config`) to keep the db
- * layer decoupled from the server config module.
+ * THE one resolver for the Db directory: the directory that holds config.json, so
+ * the DB is always a sibling of config.json — one file, no split-brain, and it
+ * follows a CONFIG_PATH override (tests + custom deployments) automatically. In
+ * production that directory IS <dataRoot> (config.json lives at
+ * <dataRoot>/config.json); on a null-dataRoot dev host it is the repo root
+ * (matching the pre-existing config.json location). Pass
+ * `Config.getInstance().getConfigFilePath()`.
  */
-export function dbDir(config: { dataRoot: string | null; dependenciesPath: string }): string {
-    return config.dataRoot ?? path.dirname(config.dependenciesPath);
+export function dbDir(configFilePath: string): string {
+    return path.dirname(configFilePath);
 }

--- a/src/server/db/Db.ts
+++ b/src/server/db/Db.ts
@@ -1,0 +1,76 @@
+import type { DatabaseSync } from 'node:sqlite';
+import * as path from 'path';
+import { openDatabase } from './openDatabase';
+import { importLegacyIfNeeded } from './import/importLegacy';
+import { UserStore } from './UserStore';
+import { UserSettingsStore } from './UserSettingsStore';
+import { AppSettingsStore } from './AppSettingsStore';
+import { DeviceStore } from './DeviceStore';
+import { DB_FILENAME } from './constants';
+
+export class Db {
+    private static instance?: Db | undefined;
+
+    public readonly users: UserStore;
+    public readonly userSettings: UserSettingsStore;
+    public readonly appSettings: AppSettingsStore;
+    public readonly devices: DeviceStore;
+
+    private constructor(
+        private readonly handle: DatabaseSync,
+        public readonly dbPath: string,
+    ) {
+        this.users = new UserStore(handle);
+        this.userSettings = new UserSettingsStore(handle);
+        this.appSettings = new AppSettingsStore(handle);
+        this.devices = new DeviceStore(handle);
+    }
+
+    /**
+     * Open (or recover) <dataRoot>/wsscrcpy.db and run the one-time legacy import.
+     * `opts` lets callers point the import at the ACTUAL legacy file locations:
+     * `configPath` defaults to <dataRoot>/config.json and `deviceLabelsPath` to
+     * <dataRoot>/device-labels.json, but the real device-labels.json is
+     * bundle-relative (DeviceLabelStore), so Config passes its true path. The
+     * defaults keep the unit test hermetic.
+     */
+    static getInstance(dataRoot: string, opts?: { configPath?: string; deviceLabelsPath?: string }): Db {
+        if (!this.instance) {
+            const dbPath = path.join(dataRoot, DB_FILENAME);
+            const handle = openDatabase(dbPath);
+            importLegacyIfNeeded(handle, {
+                configPath: opts?.configPath ?? path.join(dataRoot, 'config.json'),
+                deviceLabelsPath: opts?.deviceLabelsPath ?? path.join(dataRoot, 'device-labels.json'),
+            });
+            this.instance = new Db(handle, dbPath);
+        }
+        return this.instance;
+    }
+
+    static _resetForTest(): void {
+        this.instance?.handle.close();
+        this.instance = undefined;
+    }
+
+    get sqlite(): DatabaseSync {
+        return this.handle;
+    }
+
+    backup(toPath: string): void {
+        // VACUUM INTO writes a clean snapshot; the path must not already exist.
+        this.handle.exec(`VACUUM INTO '${toPath.replace(/'/g, "''")}'`);
+    }
+}
+
+/**
+ * THE one resolver for the Db directory. Every `Db.getInstance(...)` call across
+ * all phases MUST pass `dbDir(Config.getInstance())` — never an ad-hoc
+ * `dataRoot ?? dependenciesPath`. Mirrors `resolveDataRoot` precedence; on a null
+ * dataRoot (non-Windows dev) it falls back to the parent of the dependencies path
+ * (matching `Config.restartMarkerPath`'s fallback), so the DB sits beside the
+ * other writable state. Typed structurally (not against `Config`) to keep the db
+ * layer decoupled from the server config module.
+ */
+export function dbDir(config: { dataRoot: string | null; dependenciesPath: string }): string {
+    return config.dataRoot ?? path.dirname(config.dependenciesPath);
+}

--- a/src/server/db/DeviceStore.ts
+++ b/src/server/db/DeviceStore.ts
@@ -35,10 +35,22 @@ export class DeviceStore {
         const r = this.db
             .prepare('SELECT serial, manufacturer, model, address, last_seen_at FROM devices WHERE serial = ?')
             .get(serial) as
-            | { serial: string; manufacturer: string | null; model: string | null; address: string | null; last_seen_at: number | null }
+            | {
+                  serial: string;
+                  manufacturer: string | null;
+                  model: string | null;
+                  address: string | null;
+                  last_seen_at: number | null;
+              }
             | undefined;
         return r
-            ? { serial: r.serial, manufacturer: r.manufacturer, model: r.model, address: r.address, lastSeenAt: r.last_seen_at }
+            ? {
+                  serial: r.serial,
+                  manufacturer: r.manufacturer,
+                  model: r.model,
+                  address: r.address,
+                  lastSeenAt: r.last_seen_at,
+              }
             : undefined;
     }
 
@@ -63,9 +75,9 @@ export class DeviceStore {
     }
 
     getLabel(userId: number, serial: string): string | undefined {
-        const r = this.db.prepare('SELECT label FROM device_labels WHERE user_id = ? AND serial = ?').get(userId, serial) as
-            | { label: string }
-            | undefined;
+        const r = this.db
+            .prepare('SELECT label FROM device_labels WHERE user_id = ? AND serial = ?')
+            .get(userId, serial) as { label: string } | undefined;
         return r?.label;
     }
 

--- a/src/server/db/DeviceStore.ts
+++ b/src/server/db/DeviceStore.ts
@@ -1,0 +1,93 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export interface DeviceRecord {
+    serial: string;
+    manufacturer: string | null;
+    model: string | null;
+    address: string | null;
+    lastSeenAt: number | null;
+}
+
+export class DeviceStore {
+    constructor(private readonly db: DatabaseSync) {}
+
+    upsertDevice(rec: {
+        serial: string;
+        manufacturer?: string | null;
+        model?: string | null;
+        address?: string | null;
+        lastSeenAt?: number | null;
+    }): void {
+        // COALESCE(excluded, existing): a field omitted (undefined→null bind) does not clobber a known value.
+        this.db
+            .prepare(
+                `INSERT INTO devices (serial, manufacturer, model, address, last_seen_at) VALUES (?, ?, ?, ?, ?)
+                 ON CONFLICT(serial) DO UPDATE SET
+                   manufacturer = COALESCE(excluded.manufacturer, devices.manufacturer),
+                   model        = COALESCE(excluded.model,        devices.model),
+                   address      = COALESCE(excluded.address,      devices.address),
+                   last_seen_at = COALESCE(excluded.last_seen_at, devices.last_seen_at)`,
+            )
+            .run(rec.serial, rec.manufacturer ?? null, rec.model ?? null, rec.address ?? null, rec.lastSeenAt ?? null);
+    }
+
+    getDevice(serial: string): DeviceRecord | undefined {
+        const r = this.db
+            .prepare('SELECT serial, manufacturer, model, address, last_seen_at FROM devices WHERE serial = ?')
+            .get(serial) as
+            | { serial: string; manufacturer: string | null; model: string | null; address: string | null; last_seen_at: number | null }
+            | undefined;
+        return r
+            ? { serial: r.serial, manufacturer: r.manufacturer, model: r.model, address: r.address, lastSeenAt: r.last_seen_at }
+            : undefined;
+    }
+
+    listDevices(): DeviceRecord[] {
+        return (
+            this.db
+                .prepare('SELECT serial, manufacturer, model, address, last_seen_at FROM devices ORDER BY serial')
+                .all() as Array<{
+                serial: string;
+                manufacturer: string | null;
+                model: string | null;
+                address: string | null;
+                last_seen_at: number | null;
+            }>
+        ).map((r) => ({
+            serial: r.serial,
+            manufacturer: r.manufacturer,
+            model: r.model,
+            address: r.address,
+            lastSeenAt: r.last_seen_at,
+        }));
+    }
+
+    getLabel(userId: number, serial: string): string | undefined {
+        const r = this.db.prepare('SELECT label FROM device_labels WHERE user_id = ? AND serial = ?').get(userId, serial) as
+            | { label: string }
+            | undefined;
+        return r?.label;
+    }
+
+    setLabel(userId: number, serial: string, label: string): void {
+        this.db
+            .prepare(
+                'INSERT INTO device_labels (user_id, serial, label) VALUES (?, ?, ?) ON CONFLICT(user_id, serial) DO UPDATE SET label = excluded.label',
+            )
+            .run(userId, serial, label);
+    }
+
+    deleteLabel(userId: number, serial: string): void {
+        this.db.prepare('DELETE FROM device_labels WHERE user_id = ? AND serial = ?').run(userId, serial);
+    }
+
+    getAllLabels(userId: number): Record<string, string> {
+        const rows = this.db.prepare('SELECT serial, label FROM device_labels WHERE user_id = ?').all(userId) as Array<{
+            serial: string;
+            label: string;
+        }>;
+        const out: Record<string, string> = {};
+        for (const r of rows) out[r.serial] = r.label;
+        return out;
+    }
+}

--- a/src/server/db/UserSettingsStore.ts
+++ b/src/server/db/UserSettingsStore.ts
@@ -1,0 +1,39 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export class UserSettingsStore {
+    constructor(private readonly db: DatabaseSync) {}
+
+    get(userId: number, key: string): unknown {
+        const r = this.db.prepare('SELECT value FROM user_settings WHERE user_id = ? AND key = ?').get(userId, key) as
+            | { value: string }
+            | undefined;
+        return r ? JSON.parse(r.value) : undefined;
+    }
+
+    getAll(userId: number): Record<string, unknown> {
+        const rows = this.db.prepare('SELECT key, value FROM user_settings WHERE user_id = ?').all(userId) as Array<{
+            key: string;
+            value: string;
+        }>;
+        const out: Record<string, unknown> = {};
+        for (const r of rows) out[r.key] = JSON.parse(r.value);
+        return out;
+    }
+
+    set(userId: number, key: string, value: unknown): void {
+        this.db
+            .prepare(
+                'INSERT INTO user_settings (user_id, key, value) VALUES (?, ?, ?) ' +
+                    'ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value',
+            )
+            .run(userId, key, JSON.stringify(value));
+    }
+
+    delete(userId: number, key: string): void {
+        this.db.prepare('DELETE FROM user_settings WHERE user_id = ? AND key = ?').run(userId, key);
+    }
+
+    clearForUser(userId: number): void {
+        this.db.prepare('DELETE FROM user_settings WHERE user_id = ?').run(userId);
+    }
+}

--- a/src/server/db/UserStore.ts
+++ b/src/server/db/UserStore.ts
@@ -1,0 +1,76 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export type Role = 'user' | 'admin';
+
+export interface User {
+    id: number;
+    username: string;
+    role: Role;
+    passwordHash: string | null;
+    disabled: boolean;
+    failedAttempts: number;
+    lockoutWindowStart: number | null;
+    lockedUntil: number | null;
+    createdAt: number;
+    lastLoginAt: number | null;
+}
+
+// NOTE: a `type` alias (not `interface`) so it gains an implicit index signature
+// and is therefore comparable to node:sqlite's `.all()` return type
+// (`Record<string, SQLOutputValue>[]`) without an `as unknown` double-cast.
+type UserRow = {
+    id: number;
+    username: string;
+    role: Role;
+    password_hash: string | null;
+    disabled: number;
+    failed_attempts: number;
+    lockout_window_start: number | null;
+    locked_until: number | null;
+    created_at: number;
+    last_login_at: number | null;
+};
+
+function toUser(r: UserRow): User {
+    return {
+        id: r.id,
+        username: r.username,
+        role: r.role,
+        passwordHash: r.password_hash,
+        disabled: r.disabled === 1,
+        failedAttempts: r.failed_attempts,
+        lockoutWindowStart: r.lockout_window_start,
+        lockedUntil: r.locked_until,
+        createdAt: r.created_at,
+        lastLoginAt: r.last_login_at,
+    };
+}
+
+const COLS =
+    'id, username, role, password_hash, disabled, failed_attempts, lockout_window_start, locked_until, created_at, last_login_at';
+
+export class UserStore {
+    constructor(private readonly db: DatabaseSync) {}
+
+    getById(id: number): User | undefined {
+        const r = this.db.prepare(`SELECT ${COLS} FROM users WHERE id = ?`).get(id) as UserRow | undefined;
+        return r ? toUser(r) : undefined;
+    }
+
+    getByUsername(username: string): User | undefined {
+        const r = this.db.prepare(`SELECT ${COLS} FROM users WHERE username = ?`).get(username) as UserRow | undefined;
+        return r ? toUser(r) : undefined;
+    }
+
+    list(): User[] {
+        return (this.db.prepare(`SELECT ${COLS} FROM users ORDER BY id`).all() as UserRow[]).map(toUser);
+    }
+
+    create(input: { username: string; role: Role; passwordHash: string | null }): User {
+        const now = Date.now();
+        const info = this.db
+            .prepare('INSERT INTO users (username, role, password_hash, created_at) VALUES (?, ?, ?, ?)')
+            .run(input.username, input.role, input.passwordHash, now);
+        return this.getById(Number(info.lastInsertRowid))!;
+    }
+}

--- a/src/server/db/__tests__/db.test.ts
+++ b/src/server/db/__tests__/db.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { Db, dbDir } from '../Db';
 
 const dirs: string[] = [];

--- a/src/server/db/__tests__/db.test.ts
+++ b/src/server/db/__tests__/db.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Db, dbDir } from '../Db';
+
+const dirs: string[] = [];
+function dataRoot(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wsroot-'));
+    dirs.push(d);
+    return d;
+}
+afterEach(() => {
+    Db._resetForTest();
+    while (dirs.length) fs.rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('Db singleton', () => {
+    it('opens <dataRoot>/wsscrcpy.db, runs the import, and exposes repos', () => {
+        const root = dataRoot();
+        fs.writeFileSync(
+            path.join(root, 'config.json'),
+            JSON.stringify({ webPort: 8000, installMode: 'user', firstRunComplete: true, channel: 'beta' }),
+        );
+        const db = Db.getInstance(root);
+        expect(fs.existsSync(path.join(root, 'wsscrcpy.db'))).toBe(true);
+        expect(db.appSettings.get('channel')).toBe('beta');
+        expect(db.users.getById(1)?.role).toBe('admin');
+    });
+
+    it('caches the singleton across getInstance calls (same handle)', () => {
+        const root = dataRoot();
+        const a = Db.getInstance(root);
+        const b = Db.getInstance(root);
+        expect(a).toBe(b);
+        expect(a.sqlite).toBe(b.sqlite);
+    });
+
+    it('backup() writes a .bak snapshot', () => {
+        const root = dataRoot();
+        const db = Db.getInstance(root);
+        const bak = path.join(root, 'wsscrcpy.db.bak');
+        db.backup(bak);
+        expect(fs.existsSync(bak)).toBe(true);
+    });
+});
+
+describe('dbDir resolver', () => {
+    it('uses dataRoot when set, else the parent of dependenciesPath', () => {
+        expect(dbDir({ dataRoot: '/data/root', dependenciesPath: '/opt/app/dependencies' })).toBe('/data/root');
+        expect(dbDir({ dataRoot: null, dependenciesPath: '/opt/app/dependencies' })).toBe(
+            path.dirname('/opt/app/dependencies'),
+        );
+    });
+});

--- a/src/server/db/__tests__/db.test.ts
+++ b/src/server/db/__tests__/db.test.ts
@@ -46,10 +46,8 @@ describe('Db singleton', () => {
 });
 
 describe('dbDir resolver', () => {
-    it('uses dataRoot when set, else the parent of dependenciesPath', () => {
-        expect(dbDir({ dataRoot: '/data/root', dependenciesPath: '/opt/app/dependencies' })).toBe('/data/root');
-        expect(dbDir({ dataRoot: null, dependenciesPath: '/opt/app/dependencies' })).toBe(
-            path.dirname('/opt/app/dependencies'),
-        );
+    it('is the directory holding config.json (the DB sits beside config.json)', () => {
+        const cfgPath = path.join('some', 'data', 'dir', 'config.json');
+        expect(dbDir(cfgPath)).toBe(path.dirname(cfgPath));
     });
 });

--- a/src/server/db/__tests__/deviceStore.test.ts
+++ b/src/server/db/__tests__/deviceStore.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+import { DeviceStore } from '../DeviceStore';
+import { UserStore } from '../UserStore';
+
+let db: DatabaseSync;
+let store: DeviceStore;
+beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    runMigrations(db);
+    store = new DeviceStore(db);
+});
+
+describe('DeviceStore observed devices', () => {
+    it('upserts and reads observed metadata (partial fields preserved)', () => {
+        store.upsertDevice({ serial: 'S1', model: 'Pixel 7', lastSeenAt: 100 });
+        store.upsertDevice({ serial: 'S1', address: '10.0.0.5:5555', lastSeenAt: 200 });
+        expect(store.getDevice('S1')).toEqual({
+            serial: 'S1',
+            manufacturer: null,
+            model: 'Pixel 7',
+            address: '10.0.0.5:5555',
+            lastSeenAt: 200,
+        });
+        expect(store.listDevices().length).toBe(1);
+    });
+});
+
+describe('DeviceStore per-user labels', () => {
+    it('sets/gets/deletes labels scoped per user', () => {
+        // device_labels.user_id is an FK to users(id); create user 2 so the label
+        // holds under foreign_keys=ON (the runtime opens with that pragma).
+        new UserStore(db).create({ username: 'u2', role: 'user', passwordHash: null });
+        store.setLabel(1, 'S1', 'Living Room');
+        store.setLabel(2, 'S1', 'Office');
+        expect(store.getLabel(1, 'S1')).toBe('Living Room');
+        store.deleteLabel(1, 'S1');
+        expect(store.getLabel(1, 'S1')).toBeUndefined();
+        expect(store.getAllLabels(2)).toEqual({ S1: 'Office' });
+    });
+});

--- a/src/server/db/__tests__/deviceStore.test.ts
+++ b/src/server/db/__tests__/deviceStore.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
-import { runMigrations } from '../migrations';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { DeviceStore } from '../DeviceStore';
+import { runMigrations } from '../migrations';
 import { UserStore } from '../UserStore';
 
 let db: DatabaseSync;

--- a/src/server/db/__tests__/importConfigJson.test.ts
+++ b/src/server/db/__tests__/importConfigJson.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+import { AppSettingsStore } from '../AppSettingsStore';
+import { UserSettingsStore } from '../UserSettingsStore';
+import { importConfigJson } from '../import/importConfigJson';
+import { IMPLICIT_ADMIN_ID } from '../constants';
+
+let db: DatabaseSync;
+beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    runMigrations(db);
+});
+
+describe('importConfigJson', () => {
+    it('routes globals to app_settings, prompt flags to user-1 settings, returns the boot trio', () => {
+        const legacy = {
+            installMode: 'user',
+            webPort: 8123,
+            firstRunComplete: true,
+            autoUpdate: false,
+            updateCheckIntervalMinutes: 30,
+            channel: 'beta',
+            githubOwner: 'x',
+            adbPath: '/opt/adb',
+            dependenciesPath: '/opt/deps',
+            scanConcurrency: 32,
+            scanTcpTimeoutMs: 200,
+            scanAdbConnectTimeoutMs: 4000,
+            scanProgressInterval: 5,
+            bookmarkDismissedForPort: 8123,
+            bookmarkDismissedGlobally: true,
+            serviceFirstRunSeen: true,
+        };
+        const trio = importConfigJson(db, legacy);
+        expect(trio).toEqual({ installMode: 'user', webPort: 8123, firstRunComplete: true });
+
+        const app = new AppSettingsStore(db).getAll();
+        expect(app).toMatchObject({
+            autoUpdate: false,
+            channel: 'beta',
+            githubOwner: 'x',
+            adbPath: '/opt/adb',
+            dependenciesPath: '/opt/deps',
+            scanConcurrency: 32,
+        });
+        // Boot trio must NOT be duplicated into app_settings.
+        expect(app).not.toHaveProperty('webPort');
+        expect(app).not.toHaveProperty('installMode');
+
+        const prompts = new UserSettingsStore(db).getAll(IMPLICIT_ADMIN_ID);
+        expect(prompts).toMatchObject({
+            bookmarkDismissedForPort: 8123,
+            bookmarkDismissedGlobally: true,
+            serviceFirstRunSeen: true,
+        });
+    });
+
+    it('omits absent fields (no undefined rows written)', () => {
+        const trio = importConfigJson(db, { webPort: 9000 });
+        expect(trio).toEqual({ installMode: null, webPort: 9000, firstRunComplete: false });
+        expect(new AppSettingsStore(db).getAll()).toEqual({ authEnabled: false });
+    });
+});

--- a/src/server/db/__tests__/importConfigJson.test.ts
+++ b/src/server/db/__tests__/importConfigJson.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
-import { runMigrations } from '../migrations';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { AppSettingsStore } from '../AppSettingsStore';
-import { UserSettingsStore } from '../UserSettingsStore';
-import { importConfigJson } from '../import/importConfigJson';
 import { IMPLICIT_ADMIN_ID } from '../constants';
+import { importConfigJson } from '../import/importConfigJson';
+import { runMigrations } from '../migrations';
+import { UserSettingsStore } from '../UserSettingsStore';
 
 let db: DatabaseSync;
 beforeEach(() => {

--- a/src/server/db/__tests__/importDeviceLabels.test.ts
+++ b/src/server/db/__tests__/importDeviceLabels.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
-import { runMigrations } from '../migrations';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IMPLICIT_ADMIN_ID } from '../constants';
 import { DeviceStore } from '../DeviceStore';
 import { importDeviceLabels } from '../import/importDeviceLabels';
-import { IMPLICIT_ADMIN_ID } from '../constants';
+import { runMigrations } from '../migrations';
 
 let db: DatabaseSync;
 beforeEach(() => {

--- a/src/server/db/__tests__/importDeviceLabels.test.ts
+++ b/src/server/db/__tests__/importDeviceLabels.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+import { DeviceStore } from '../DeviceStore';
+import { importDeviceLabels } from '../import/importDeviceLabels';
+import { IMPLICIT_ADMIN_ID } from '../constants';
+
+let db: DatabaseSync;
+beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    runMigrations(db);
+});
+
+describe('importDeviceLabels', () => {
+    it('imports labels for the implicit admin and seeds devices', () => {
+        importDeviceLabels(db, { S1: 'Living Room', S2: 'Office' });
+        const ds = new DeviceStore(db);
+        expect(ds.getAllLabels(IMPLICIT_ADMIN_ID)).toEqual({ S1: 'Living Room', S2: 'Office' });
+        expect(ds.getDevice('S1')?.serial).toBe('S1');
+        expect(ds.listDevices().length).toBe(2);
+    });
+});

--- a/src/server/db/__tests__/importLegacy.test.ts
+++ b/src/server/db/__tests__/importLegacy.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runMigrations } from '../migrations';
+import { AppSettingsStore } from '../AppSettingsStore';
+import { importLegacyIfNeeded } from '../import/importLegacy';
+
+const dirs: string[] = [];
+function tmpdir(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wsimp-'));
+    dirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (dirs.length) fs.rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('importLegacyIfNeeded', () => {
+    it('imports once, trims config.json to the boot trio (+ server-only fields), and is idempotent', () => {
+        const dir = tmpdir();
+        const configPath = path.join(dir, 'config.json');
+        const labelsPath = path.join(dir, 'device-labels.json');
+        fs.writeFileSync(
+            configPath,
+            JSON.stringify({
+                webPort: 8123,
+                installMode: 'user',
+                firstRunComplete: true,
+                channel: 'beta',
+                bookmarkDismissedGlobally: true,
+                // Server-only boot fields (NOT AppConfig) that MUST survive the trim.
+                allowedHosts: ['proxy.example.com'],
+                server: [{ secure: true, port: 443 }],
+            }),
+        );
+        fs.writeFileSync(labelsPath, JSON.stringify({ S1: 'TV' }));
+
+        const db = new DatabaseSync(':memory:');
+        runMigrations(db);
+        importLegacyIfNeeded(db, { configPath, deviceLabelsPath: labelsPath });
+
+        // config.json trimmed to the trio PLUS the preserved server-only fields —
+        // channel/bookmark (moved to stores) are gone; allowedHosts/server stay.
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf-8'))).toEqual({
+            installMode: 'user',
+            webPort: 8123,
+            firstRunComplete: true,
+            allowedHosts: ['proxy.example.com'],
+            server: [{ secure: true, port: 443 }],
+        });
+        expect(new AppSettingsStore(db).get('channel')).toBe('beta');
+        expect(new AppSettingsStore(db).get('legacyImported')).toBe(true);
+
+        // Second call: marker present → no-op (mutate config.json to prove it is not re-trimmed/re-read).
+        fs.writeFileSync(configPath, JSON.stringify({ webPort: 9999, installMode: 'user', firstRunComplete: true }));
+        importLegacyIfNeeded(db, { configPath, deviceLabelsPath: labelsPath });
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf-8')).webPort).toBe(9999);
+    });
+
+    it('handles missing legacy files (fresh install) by marking imported', () => {
+        const dir = tmpdir();
+        const db = new DatabaseSync(':memory:');
+        runMigrations(db);
+        importLegacyIfNeeded(db, {
+            configPath: path.join(dir, 'config.json'),
+            deviceLabelsPath: path.join(dir, 'device-labels.json'),
+        });
+        expect(new AppSettingsStore(db).get('legacyImported')).toBe(true);
+    });
+});

--- a/src/server/db/__tests__/importLegacy.test.ts
+++ b/src/server/db/__tests__/importLegacy.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, afterEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { runMigrations } from '../migrations';
+import { afterEach, describe, expect, it } from 'vitest';
 import { AppSettingsStore } from '../AppSettingsStore';
 import { importLegacyIfNeeded } from '../import/importLegacy';
+import { runMigrations } from '../migrations';
 
 const dirs: string[] = [];
 function tmpdir(): string {

--- a/src/server/db/__tests__/migration001.test.ts
+++ b/src/server/db/__tests__/migration001.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
 import { runMigrations } from '../migrations';
 
 function tables(db: DatabaseSync): string[] {
@@ -28,7 +28,9 @@ describe('migration 001', () => {
     it('seeds the implicit admin (id 1, role admin, no password) and authEnabled=false', () => {
         const db = new DatabaseSync(':memory:');
         runMigrations(db);
-        const admin = db.prepare('SELECT id, username, role, password_hash, disabled FROM users WHERE id = 1').get() as {
+        const admin = db
+            .prepare('SELECT id, username, role, password_hash, disabled FROM users WHERE id = 1')
+            .get() as {
             id: number;
             username: string;
             role: string;
@@ -43,8 +45,6 @@ describe('migration 001', () => {
     it('enforces the role CHECK constraint', () => {
         const db = new DatabaseSync(':memory:');
         runMigrations(db);
-        expect(() =>
-            db.exec("INSERT INTO users (username, role, created_at) VALUES ('x', 'superuser', 0)"),
-        ).toThrow();
+        expect(() => db.exec("INSERT INTO users (username, role, created_at) VALUES ('x', 'superuser', 0)")).toThrow();
     });
 });

--- a/src/server/db/__tests__/migration001.test.ts
+++ b/src/server/db/__tests__/migration001.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+
+function tables(db: DatabaseSync): string[] {
+    return (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{ name: string }>
+    ).map((r) => r.name);
+}
+
+describe('migration 001', () => {
+    it('creates every v1 table', () => {
+        const db = new DatabaseSync(':memory:');
+        runMigrations(db);
+        for (const t of [
+            'users',
+            'sessions',
+            'user_settings',
+            'devices',
+            'device_labels',
+            'device_settings',
+            'app_settings',
+        ]) {
+            expect(tables(db)).toContain(t);
+        }
+    });
+
+    it('seeds the implicit admin (id 1, role admin, no password) and authEnabled=false', () => {
+        const db = new DatabaseSync(':memory:');
+        runMigrations(db);
+        const admin = db.prepare('SELECT id, username, role, password_hash, disabled FROM users WHERE id = 1').get() as {
+            id: number;
+            username: string;
+            role: string;
+            password_hash: string | null;
+            disabled: number;
+        };
+        expect(admin).toMatchObject({ id: 1, role: 'admin', password_hash: null, disabled: 0 });
+        const flag = db.prepare("SELECT value FROM app_settings WHERE key = 'authEnabled'").get() as { value: string };
+        expect(flag.value).toBe('false');
+    });
+
+    it('enforces the role CHECK constraint', () => {
+        const db = new DatabaseSync(':memory:');
+        runMigrations(db);
+        expect(() =>
+            db.exec("INSERT INTO users (username, role, created_at) VALUES ('x', 'superuser', 0)"),
+        ).toThrow();
+    });
+});

--- a/src/server/db/__tests__/migrations.test.ts
+++ b/src/server/db/__tests__/migrations.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations, MIGRATIONS } from '../migrations';
+
+function userVersion(db: DatabaseSync): number {
+    return (db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version;
+}
+
+describe('runMigrations', () => {
+    it('applies all migrations once and is idempotent on re-run', () => {
+        const db = new DatabaseSync(':memory:');
+        runMigrations(db);
+        expect(userVersion(db)).toBe(MIGRATIONS.length);
+        // Re-run: no throw, version unchanged, tables still present (no double-create).
+        runMigrations(db);
+        expect(userVersion(db)).toBe(MIGRATIONS.length);
+    });
+
+    it('refuses a database newer than the binary supports', () => {
+        const db = new DatabaseSync(':memory:');
+        db.exec(`PRAGMA user_version = ${MIGRATIONS.length + 1}`);
+        expect(() => runMigrations(db)).toThrow(/newer than supported/);
+    });
+});

--- a/src/server/db/__tests__/migrations.test.ts
+++ b/src/server/db/__tests__/migrations.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
-import { runMigrations, MIGRATIONS } from '../migrations';
+import { describe, expect, it } from 'vitest';
+import { MIGRATIONS, runMigrations } from '../migrations';
 
 function userVersion(db: DatabaseSync): number {
     return (db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version;

--- a/src/server/db/__tests__/openDatabase.test.ts
+++ b/src/server/db/__tests__/openDatabase.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { openDatabase } from '../openDatabase';
 
 const dirs: string[] = [];

--- a/src/server/db/__tests__/openDatabase.test.ts
+++ b/src/server/db/__tests__/openDatabase.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { openDatabase } from '../openDatabase';
+
+const dirs: string[] = [];
+function tmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wsdb-'));
+    dirs.push(d);
+    return path.join(d, 'wsscrcpy.db');
+}
+afterEach(() => {
+    while (dirs.length) fs.rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('openDatabase', () => {
+    it('creates the file, enables WAL + foreign_keys, migrates to v1', () => {
+        const p = tmp();
+        const db = openDatabase(p);
+        expect(fs.existsSync(p)).toBe(true);
+        expect((db.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode).toBe('wal');
+        expect((db.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number }).foreign_keys).toBe(1);
+        expect((db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(1);
+        db.close();
+    });
+});

--- a/src/server/db/__tests__/openDatabaseIntegrity.test.ts
+++ b/src/server/db/__tests__/openDatabaseIntegrity.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { openDatabase } from '../openDatabase';
 
 const dirs: string[] = [];

--- a/src/server/db/__tests__/openDatabaseIntegrity.test.ts
+++ b/src/server/db/__tests__/openDatabaseIntegrity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { openDatabase } from '../openDatabase';
+
+const dirs: string[] = [];
+function tmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wsint-'));
+    dirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (dirs.length) fs.rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('openDatabase integrity recovery', () => {
+    it('moves a corrupt file aside and recreates a fresh schema', () => {
+        const dir = tmp();
+        const p = path.join(dir, 'wsscrcpy.db');
+        fs.writeFileSync(p, 'this is not a sqlite database header at all');
+        const db = openDatabase(p);
+        // Fresh DB is usable at v1 and the corrupt file was preserved with a .corrupt- suffix.
+        expect((db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(1);
+        const moved = fs.readdirSync(dir).filter((f) => f.startsWith('wsscrcpy.db.corrupt-'));
+        expect(moved.length).toBe(1);
+        db.close();
+    });
+});

--- a/src/server/db/__tests__/settingsStores.test.ts
+++ b/src/server/db/__tests__/settingsStores.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+import { UserSettingsStore } from '../UserSettingsStore';
+import { AppSettingsStore } from '../AppSettingsStore';
+import { UserStore } from '../UserStore';
+
+let db: DatabaseSync;
+beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    runMigrations(db);
+});
+
+describe('UserSettingsStore', () => {
+    it('round-trips JSON values and isolates users', () => {
+        const us = new UserStore(db);
+        const bob = us.create({ username: 'bob', role: 'user', passwordHash: null });
+        const s = new UserSettingsStore(db);
+        s.set(1, 'theme', 'dark');
+        s.set(bob.id, 'theme', 'light');
+        s.set(1, 'scanSubnets', ['10.0.0.0/24']);
+        expect(s.get(1, 'theme')).toBe('dark');
+        expect(s.get(bob.id, 'theme')).toBe('light');
+        expect(s.get(1, 'scanSubnets')).toEqual(['10.0.0.0/24']);
+        expect(s.get(1, 'missing')).toBeUndefined();
+        expect(s.getAll(1)).toEqual({ theme: 'dark', scanSubnets: ['10.0.0.0/24'] });
+    });
+
+    it('delete and clearForUser remove only that user rows', () => {
+        const s = new UserSettingsStore(db);
+        const us = new UserStore(db);
+        const bob = us.create({ username: 'bob', role: 'user', passwordHash: null });
+        s.set(1, 'a', 1);
+        s.set(1, 'b', 2);
+        s.set(bob.id, 'a', 9);
+        s.delete(1, 'a');
+        expect(s.get(1, 'a')).toBeUndefined();
+        s.clearForUser(1);
+        expect(s.getAll(1)).toEqual({});
+        expect(s.get(bob.id, 'a')).toBe(9);
+    });
+});
+
+describe('AppSettingsStore', () => {
+    it('round-trips and upserts global values', () => {
+        const a = new AppSettingsStore(db);
+        a.set('autoUpdate', true);
+        a.set('channel', 'beta');
+        a.set('channel', 'stable'); // upsert
+        expect(a.get('autoUpdate')).toBe(true);
+        expect(a.get('channel')).toBe('stable');
+        expect(a.getAll()).toMatchObject({ authEnabled: false, autoUpdate: true, channel: 'stable' });
+    });
+});

--- a/src/server/db/__tests__/settingsStores.test.ts
+++ b/src/server/db/__tests__/settingsStores.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AppSettingsStore } from '../AppSettingsStore';
 import { runMigrations } from '../migrations';
 import { UserSettingsStore } from '../UserSettingsStore';
-import { AppSettingsStore } from '../AppSettingsStore';
 import { UserStore } from '../UserStore';
 
 let db: DatabaseSync;

--- a/src/server/db/__tests__/sqliteSmoke.test.ts
+++ b/src/server/db/__tests__/sqliteSmoke.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+
+describe('node:sqlite smoke (verification spike)', () => {
+    it('opens in-memory, execs DDL, prepares/run/get/all, reads pragmas', () => {
+        const db = new DatabaseSync(':memory:');
+        db.exec('PRAGMA foreign_keys = ON');
+        db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+
+        const insert = db.prepare('INSERT INTO t (name) VALUES (?)');
+        const info = insert.run('alice');
+        expect(Number(info.changes)).toBe(1);
+        expect(Number(info.lastInsertRowid)).toBe(1);
+
+        const one = db.prepare('SELECT * FROM t WHERE id = ?').get(1) as { id: number; name: string };
+        expect(one).toEqual({ id: 1, name: 'alice' });
+
+        insert.run('bob');
+        const all = db.prepare('SELECT name FROM t ORDER BY id').all() as Array<{ name: string }>;
+        expect(all.map((r) => r.name)).toEqual(['alice', 'bob']);
+
+        const ver = db.prepare('PRAGMA user_version').get() as { user_version: number };
+        expect(ver.user_version).toBe(0);
+        db.exec('PRAGMA user_version = 3');
+        expect((db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(3);
+
+        db.close();
+    });
+});

--- a/src/server/db/__tests__/sqliteSmoke.test.ts
+++ b/src/server/db/__tests__/sqliteSmoke.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
 
 describe('node:sqlite smoke (verification spike)', () => {
     it('opens in-memory, execs DDL, prepares/run/get/all, reads pragmas', () => {

--- a/src/server/db/__tests__/userStore.test.ts
+++ b/src/server/db/__tests__/userStore.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+import { UserStore, type User } from '../UserStore';
+
+let db: DatabaseSync;
+let store: UserStore;
+beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    runMigrations(db);
+    store = new UserStore(db);
+});
+
+describe('UserStore', () => {
+    it('reads the seeded implicit admin by id and username (case-insensitive)', () => {
+        const a = store.getById(1) as User;
+        expect(a).toMatchObject({ id: 1, username: 'admin', role: 'admin', passwordHash: null, disabled: false });
+        expect(store.getByUsername('ADMIN')?.id).toBe(1);
+    });
+
+    it('creates a user and lists all', () => {
+        const u = store.create({ username: 'bob', role: 'user', passwordHash: 'scrypt$...' });
+        expect(u).toMatchObject({ username: 'bob', role: 'user', disabled: false });
+        expect(store.list().map((x) => x.username).sort()).toEqual(['admin', 'bob']);
+    });
+
+    it('rejects a duplicate username (case-insensitive)', () => {
+        store.create({ username: 'bob', role: 'user', passwordHash: null });
+        expect(() => store.create({ username: 'BOB', role: 'user', passwordHash: null })).toThrow();
+    });
+});

--- a/src/server/db/__tests__/userStore.test.ts
+++ b/src/server/db/__tests__/userStore.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { runMigrations } from '../migrations';
-import { UserStore, type User } from '../UserStore';
+import { type User, UserStore } from '../UserStore';
 
 let db: DatabaseSync;
 let store: UserStore;
@@ -21,7 +21,12 @@ describe('UserStore', () => {
     it('creates a user and lists all', () => {
         const u = store.create({ username: 'bob', role: 'user', passwordHash: 'scrypt$...' });
         expect(u).toMatchObject({ username: 'bob', role: 'user', disabled: false });
-        expect(store.list().map((x) => x.username).sort()).toEqual(['admin', 'bob']);
+        expect(
+            store
+                .list()
+                .map((x) => x.username)
+                .sort(),
+        ).toEqual(['admin', 'bob']);
     });
 
     it('rejects a duplicate username (case-insensitive)', () => {

--- a/src/server/db/constants.ts
+++ b/src/server/db/constants.ts
@@ -1,0 +1,3 @@
+export const IMPLICIT_ADMIN_ID = 1;
+export const DB_FILENAME = 'wsscrcpy.db';
+export const AUTH_ENABLED_KEY = 'authEnabled';

--- a/src/server/db/import/importConfigJson.ts
+++ b/src/server/db/import/importConfigJson.ts
@@ -37,7 +37,9 @@ export function importConfigJson(db: DatabaseSync, legacy: Record<string, unknow
 
     return {
         installMode: (legacy['installMode'] as string | undefined) ?? null,
-        webPort: legacy['webPort'] as number | undefined,
+        // Honor the legacy `port` alias (pre-`webPort`); the trim drops `port`,
+        // so fold it into `webPort` here or the value would be lost.
+        webPort: (legacy['webPort'] ?? legacy['port']) as number | undefined,
         firstRunComplete: (legacy['firstRunComplete'] as boolean | undefined) ?? false,
     };
 }

--- a/src/server/db/import/importConfigJson.ts
+++ b/src/server/db/import/importConfigJson.ts
@@ -1,0 +1,43 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { AppSettingsStore } from '../AppSettingsStore';
+import { UserSettingsStore } from '../UserSettingsStore';
+import { IMPLICIT_ADMIN_ID } from '../constants';
+
+export interface BootTrio {
+    installMode: string | null;
+    webPort: number | undefined;
+    firstRunComplete: boolean;
+}
+
+export const GLOBAL_KEYS = [
+    'autoUpdate',
+    'updateCheckIntervalMinutes',
+    'channel',
+    'githubOwner',
+    'adbPath',
+    'dependenciesPath',
+    'scanConcurrency',
+    'scanTcpTimeoutMs',
+    'scanAdbConnectTimeoutMs',
+    'scanProgressInterval',
+] as const;
+
+export const PROMPT_KEYS = ['bookmarkDismissedForPort', 'bookmarkDismissedGlobally', 'serviceFirstRunSeen'] as const;
+
+export function importConfigJson(db: DatabaseSync, legacy: Record<string, unknown>): BootTrio {
+    const app = new AppSettingsStore(db);
+    const userSettings = new UserSettingsStore(db);
+
+    for (const k of GLOBAL_KEYS) {
+        if (legacy[k] !== undefined) app.set(k, legacy[k]);
+    }
+    for (const k of PROMPT_KEYS) {
+        if (legacy[k] !== undefined) userSettings.set(IMPLICIT_ADMIN_ID, k, legacy[k]);
+    }
+
+    return {
+        installMode: (legacy['installMode'] as string | undefined) ?? null,
+        webPort: legacy['webPort'] as number | undefined,
+        firstRunComplete: (legacy['firstRunComplete'] as boolean | undefined) ?? false,
+    };
+}

--- a/src/server/db/import/importConfigJson.ts
+++ b/src/server/db/import/importConfigJson.ts
@@ -1,7 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { AppSettingsStore } from '../AppSettingsStore';
-import { UserSettingsStore } from '../UserSettingsStore';
 import { IMPLICIT_ADMIN_ID } from '../constants';
+import { UserSettingsStore } from '../UserSettingsStore';
 
 export interface BootTrio {
     installMode: string | null;

--- a/src/server/db/import/importDeviceLabels.ts
+++ b/src/server/db/import/importDeviceLabels.ts
@@ -1,0 +1,11 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { DeviceStore } from '../DeviceStore';
+import { IMPLICIT_ADMIN_ID } from '../constants';
+
+export function importDeviceLabels(db: DatabaseSync, labels: Record<string, string>): void {
+    const ds = new DeviceStore(db);
+    for (const [serial, label] of Object.entries(labels)) {
+        ds.upsertDevice({ serial });
+        ds.setLabel(IMPLICIT_ADMIN_ID, serial, label);
+    }
+}

--- a/src/server/db/import/importDeviceLabels.ts
+++ b/src/server/db/import/importDeviceLabels.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
-import { DeviceStore } from '../DeviceStore';
 import { IMPLICIT_ADMIN_ID } from '../constants';
+import { DeviceStore } from '../DeviceStore';
 
 export function importDeviceLabels(db: DatabaseSync, labels: Record<string, string>): void {
     const ds = new DeviceStore(db);

--- a/src/server/db/import/importLegacy.ts
+++ b/src/server/db/import/importLegacy.ts
@@ -1,7 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite';
 import * as fs from 'fs';
 import { AppSettingsStore } from '../AppSettingsStore';
-import { importConfigJson, type BootTrio } from './importConfigJson';
+import { type BootTrio, importConfigJson } from './importConfigJson';
 import { importDeviceLabels } from './importDeviceLabels';
 
 const MARKER = 'legacyImported';

--- a/src/server/db/import/importLegacy.ts
+++ b/src/server/db/import/importLegacy.ts
@@ -1,0 +1,51 @@
+import type { DatabaseSync } from 'node:sqlite';
+import * as fs from 'fs';
+import { AppSettingsStore } from '../AppSettingsStore';
+import { importConfigJson, type BootTrio } from './importConfigJson';
+import { importDeviceLabels } from './importDeviceLabels';
+
+const MARKER = 'legacyImported';
+
+// Server-only boot fields that are NOT part of AppConfig and are read straight
+// from config.json at boot (Config.buildServers + sanitizeAllowedHosts). They
+// must survive the trim verbatim — dropping `server` breaks SSL setups and
+// dropping `allowedHosts` (PR #421) breaks reverse-proxy / domain deploys.
+const PRESERVED_BOOT_KEYS = ['server', 'allowedHosts'] as const;
+
+function readJson(p: string): Record<string, unknown> | null {
+    try {
+        return JSON.parse(fs.readFileSync(p, 'utf-8')) as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+}
+
+function writeTrimmedConfig(p: string, trio: BootTrio, legacy: Record<string, unknown>): void {
+    const out: Record<string, unknown> = { installMode: trio.installMode, firstRunComplete: trio.firstRunComplete };
+    if (trio.webPort !== undefined) out['webPort'] = trio.webPort;
+    for (const k of PRESERVED_BOOT_KEYS) {
+        if (legacy[k] !== undefined) out[k] = legacy[k];
+    }
+    fs.writeFileSync(p, `${JSON.stringify(out, null, 2)}\n`, 'utf-8');
+}
+
+export function importLegacyIfNeeded(db: DatabaseSync, paths: { configPath: string; deviceLabelsPath: string }): void {
+    const app = new AppSettingsStore(db);
+    if (app.get(MARKER) === true) return;
+
+    db.exec('BEGIN');
+    try {
+        const legacyConfig = readJson(paths.configPath);
+        if (legacyConfig) {
+            const trio = importConfigJson(db, legacyConfig);
+            writeTrimmedConfig(paths.configPath, trio, legacyConfig);
+        }
+        const labels = readJson(paths.deviceLabelsPath);
+        if (labels) importDeviceLabels(db, labels as Record<string, string>);
+        app.set(MARKER, true);
+        db.exec('COMMIT');
+    } catch (err) {
+        db.exec('ROLLBACK');
+        throw err;
+    }
+}

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -13,7 +13,7 @@ export function runMigrations(db: DatabaseSync): void {
     if (current > MIGRATIONS.length) {
         throw new Error(
             `wsscrcpy.db schema v${current} is newer than supported v${MIGRATIONS.length}; ` +
-                `refusing to run (downgrade unsupported).`,
+                'refusing to run (downgrade unsupported).',
         );
     }
     for (const m of MIGRATIONS) {

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -1,0 +1,31 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { migration001 } from './migrations/001_initial';
+
+export interface Migration {
+    version: number;
+    up(db: DatabaseSync): void;
+}
+
+export const MIGRATIONS: Migration[] = [migration001];
+
+export function runMigrations(db: DatabaseSync): void {
+    const current = (db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version;
+    if (current > MIGRATIONS.length) {
+        throw new Error(
+            `wsscrcpy.db schema v${current} is newer than supported v${MIGRATIONS.length}; ` +
+                `refusing to run (downgrade unsupported).`,
+        );
+    }
+    for (const m of MIGRATIONS) {
+        if (m.version <= current) continue;
+        db.exec('BEGIN');
+        try {
+            m.up(db);
+            db.exec(`PRAGMA user_version = ${m.version}`); // m.version is a trusted integer literal
+            db.exec('COMMIT');
+        } catch (err) {
+            db.exec('ROLLBACK');
+            throw err;
+        }
+    }
+}

--- a/src/server/db/migrations/001_initial.ts
+++ b/src/server/db/migrations/001_initial.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
-import type { Migration } from '../migrations';
 import { IMPLICIT_ADMIN_ID } from '../constants';
+import type { Migration } from '../migrations';
 
 const DDL = `
 CREATE TABLE users (

--- a/src/server/db/migrations/001_initial.ts
+++ b/src/server/db/migrations/001_initial.ts
@@ -1,0 +1,72 @@
+import type { DatabaseSync } from 'node:sqlite';
+import type { Migration } from '../migrations';
+import { IMPLICIT_ADMIN_ID } from '../constants';
+
+const DDL = `
+CREATE TABLE users (
+    id                   INTEGER PRIMARY KEY,
+    username             TEXT    NOT NULL COLLATE NOCASE UNIQUE,
+    role                 TEXT    NOT NULL CHECK (role IN ('user','admin')),
+    password_hash        TEXT,
+    disabled             INTEGER NOT NULL DEFAULT 0,
+    failed_attempts      INTEGER NOT NULL DEFAULT 0,
+    lockout_window_start INTEGER,
+    locked_until         INTEGER,
+    created_at           INTEGER NOT NULL,
+    last_login_at        INTEGER
+);
+CREATE TABLE sessions (
+    token_hash   TEXT    PRIMARY KEY,
+    user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at   INTEGER NOT NULL,
+    expires_at   INTEGER NOT NULL,
+    last_seen_at INTEGER NOT NULL
+);
+CREATE INDEX idx_sessions_user ON sessions(user_id);
+CREATE TABLE user_settings (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    key     TEXT    NOT NULL,
+    value   TEXT    NOT NULL,
+    PRIMARY KEY (user_id, key)
+);
+CREATE TABLE devices (
+    serial       TEXT PRIMARY KEY,
+    manufacturer TEXT,
+    model        TEXT,
+    address      TEXT,
+    last_seen_at INTEGER
+);
+CREATE TABLE device_labels (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    serial  TEXT    NOT NULL,
+    label   TEXT    NOT NULL,
+    PRIMARY KEY (user_id, serial)
+);
+CREATE TABLE device_settings (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    udid    TEXT    NOT NULL,
+    scope   TEXT    NOT NULL,
+    value   TEXT    NOT NULL,
+    PRIMARY KEY (user_id, udid, scope)
+);
+CREATE TABLE app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+`;
+
+export const migration001: Migration = {
+    version: 1,
+    up(db: DatabaseSync): void {
+        db.exec(DDL);
+        // Date.now() is acceptable in app/runtime code (only workflow scripts forbid it).
+        const now = Date.now();
+        db.prepare('INSERT INTO users (id, username, role, password_hash, created_at) VALUES (?, ?, ?, NULL, ?)').run(
+            IMPLICIT_ADMIN_ID,
+            'admin',
+            'admin',
+            now,
+        );
+        db.prepare("INSERT INTO app_settings (key, value) VALUES ('authEnabled', 'false')").run();
+    },
+};

--- a/src/server/db/openDatabase.ts
+++ b/src/server/db/openDatabase.ts
@@ -1,0 +1,11 @@
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from './migrations';
+
+export function openDatabase(dbPath: string): DatabaseSync {
+    const db = new DatabaseSync(dbPath);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA busy_timeout = 5000');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    return db;
+}

--- a/src/server/db/openDatabase.ts
+++ b/src/server/db/openDatabase.ts
@@ -1,11 +1,91 @@
 import { DatabaseSync } from 'node:sqlite';
+import * as fs from 'fs';
 import { runMigrations } from './migrations';
+import { Logger } from '../Logger';
 
-export function openDatabase(dbPath: string): DatabaseSync {
-    const db = new DatabaseSync(dbPath);
+function configure(db: DatabaseSync): void {
     db.exec('PRAGMA journal_mode = WAL');
     db.exec('PRAGMA busy_timeout = 5000');
     db.exec('PRAGMA foreign_keys = ON');
-    runMigrations(db);
-    return db;
+}
+
+function integrityOk(db: DatabaseSync): boolean {
+    try {
+        const r = db.prepare('PRAGMA integrity_check').get() as { integrity_check: string };
+        return r.integrity_check === 'ok';
+    } catch {
+        return false;
+    }
+}
+
+export function openDatabase(dbPath: string): DatabaseSync {
+    let db: DatabaseSync;
+    try {
+        db = new DatabaseSync(dbPath);
+        configure(db);
+        if (!integrityOk(db)) throw new Error('integrity_check failed');
+        runMigrations(db);
+        return db;
+    } catch (err) {
+        // Corrupt or unreadable. Recovery order: (1) move the corrupt file + its WAL sidecars
+        // aside; (2) restore the last-good `.bak` (VACUUM-INTO snapshot from graceful shutdown)
+        // if it opens clean — this preserves settings the migration moved OUT of the (now-trimmed)
+        // config.json, which a fresh+re-import would lose; (3) only if no valid backup, create a
+        // fresh schema (settings reset to defaults — the caller's legacy files were already trimmed).
+        Logger.for('Db').error(`wsscrcpy.db unusable (${(err as Error).message}); attempting recovery`);
+        try {
+            db!.close();
+        } catch {
+            /* best effort */
+        }
+        moveAsideCorrupt(dbPath); // renames dbPath, dbPath-wal, dbPath-shm to *.corrupt-<ts>
+
+        const bak = `${dbPath}.bak`;
+        if (fs.existsSync(bak)) {
+            try {
+                const probe = new DatabaseSync(bak);
+                const ok =
+                    (probe.prepare('PRAGMA integrity_check').get() as { integrity_check: string }).integrity_check ===
+                    'ok';
+                probe.close();
+                if (ok) {
+                    fs.copyFileSync(bak, dbPath);
+                    Logger.for('Db').error('restored wsscrcpy.db from wsscrcpy.db.bak');
+                }
+            } catch {
+                /* fall through to fresh */
+            }
+        }
+        const fresh = new DatabaseSync(dbPath);
+        configure(fresh);
+        if (!integrityOk(fresh)) {
+            // backup copy somehow bad → start clean
+            fresh.close();
+            moveAsideCorrupt(dbPath);
+            const blank = new DatabaseSync(dbPath);
+            configure(blank);
+            runMigrations(blank);
+            return blank;
+        }
+        runMigrations(fresh); // a restored backup may be an older schema version → migrate it forward
+        return fresh;
+    }
+}
+
+function moveAsideCorrupt(dbPath: string): void {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    for (const suffix of ['', '-wal', '-shm']) {
+        const p = `${dbPath}${suffix}`;
+        if (fs.existsSync(p)) {
+            try {
+                fs.renameSync(p, `${p}.corrupt-${stamp}`);
+            } catch {
+                try {
+                    fs.rmSync(p, { force: true });
+                } catch {
+                    /* best effort */
+                }
+            }
+        }
+    }
 }

--- a/src/server/db/openDatabase.ts
+++ b/src/server/db/openDatabase.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync } from 'node:sqlite';
 import * as fs from 'fs';
-import { runMigrations } from './migrations';
 import { Logger } from '../Logger';
+import { runMigrations } from './migrations';
 
 function configure(db: DatabaseSync): void {
     db.exec('PRAGMA journal_mode = WAL');

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -359,6 +359,14 @@ if (__ssArgs) {
             serverLog.info(`Stopping ${serviceName} ...`);
             service.release();
         });
+        // Snapshot the SQLite store on a clean shutdown — the last-good `.bak`
+        // the corrupt-recovery path restores from. Best-effort; never block exit.
+        try {
+            const db = config.db;
+            db.backup(`${db.dbPath}.bak`);
+        } catch (err) {
+            serverLog.warn(`db backup on shutdown failed: ${(err as Error).message}`);
+        }
     }
 
     let interrupted = false;


### PR DESCRIPTION
Phase 1 of the SQLite persistence + auth workstream (spec `docs/specs/2026-06-11-sqlite-persistence-and-auth-design.md`, plan `docs/plans/2026-06-11-sqlite-persistence-and-auth-phase1-foundation.md`; todo items 34/36/37/54). Foundation only — **no user-visible behavior change**.

## What this does

The server's state was spread across three mechanisms — a flat `config.json`, a separate `device-labels.json`, and per-origin browser `localStorage` (unreliable on the Linux AppImage, where each launch can look like a new origin and lose prefs). This stands up the single store they'll all converge on, without changing behavior yet.

- **One `wsscrcpy.db`**, opened only by the Node server via Node's built-in `node:sqlite` (`DatabaseSync`) — no native module, no vendored prebuilt, so it stays Local-Dependencies-clean. WAL + `busy_timeout` + `foreign_keys`, `PRAGMA integrity_check` on open, and recovery from a `VACUUM INTO` `.bak` snapshot (written on graceful shutdown) when the file is corrupt.
- **Versioned migrations** + the full v1 schema (7 tables, incl. `users`/`sessions` seeded now so Phase 4 only adds the repo + wiring). The implicit admin (`id=1`, no password) and `authEnabled=false` are seeded, so the app stays open exactly as today.
- **Thin typed repositories** (`UserStore`, `UserSettingsStore`, `AppSettingsStore`, `DeviceStore`), unit-tested for per-user isolation and JSON round-tripping.
- **A guarded one-time legacy import**: `config.json`'s non-boot fields move into `app_settings` (globals) and the admin's `user_settings` (prompt flags); `device-labels.json` into `device_labels` + seeded `devices`. Transactional, runs once.
- **`Config.ts` split**: `config.json` shrinks to the three boot fields the Rust launcher reads (`installMode`/`webPort`/`firstRunComplete`) plus the server-only `server`/`allowedHosts` entries; `Config` composes the effective `AppConfig` from the trio + the stores and routes `updateAppConfig` writes back to the right store. `getAppConfig()`/`updateAppConfig()` signatures unchanged, so no consumer moves.

`common/src/config.rs` and the install hook are untouched — the boot trio stays in the JSON they already read (design decision D2).

## Deviations from the written plan (each fixes a real gap)

- **Preserve `server[]` + `allowedHosts` through the config trim.** PR #421's `allowedHosts` post-dates the plan; trimming to "only the trio" as written would silently drop it (and the SSL `server` array) and break reverse-proxy / TLS deploys. The trim and `saveToDisk` now carry both through (tested).
- **DB dir = `dirname(configFilePath)`**, not the plan's `dataRoot ?? dirname(depsPath)`: the latter resolves to real `ProgramData` on Windows even under a test's `CONFIG_PATH` override, so it can't isolate. Co-locating with config.json matches production and isolates tests.
- `UserRow` is a `type`, not an `interface`, so `.all()`'s row cast type-checks; and the importer folds the legacy `port` alias into `webPort`.

## Verification

- `tsc --noEmit` clean; **1323/1323** vitest (1294 baseline + 29 new — migration idempotency + version guard, repo isolation, import routing + the `allowedHosts` preservation, corrupt-file recovery, the Config composition + trim).
- Launcher `cargo build` green (verifies the Windows `spawn.rs` node-flag edit; the unix arm is mirrored and rides this PR's Linux CI leg).

`release:none` — behavior-preserving foundation; it rides the next beta.