### PR TITLE
feat(settings): per-user settings store + SettingsApi (phase 3 — backend foundation)

### DIFF
--- a/src/server/__tests__/settingsApi.test.ts
+++ b/src/server/__tests__/settingsApi.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Config } from '../Config';
+import { SettingsApi } from '../api/SettingsApi';
+import { IMPLICIT_ADMIN_ID } from '../db/constants';
+import { EnvName } from '../EnvName';
+import { makeReqRes } from './helpers/httpMock';
+
+const tmpDirs: string[] = [];
+const saved = { CONFIG: process.env[EnvName.CONFIG_PATH], DEPS: process.env['DEPS_PATH'] };
+function setup(): void {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wsset-'));
+    tmpDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ webPort: 8000 }));
+    process.env[EnvName.CONFIG_PATH] = path.join(dir, 'config.json');
+    process.env['DEPS_PATH'] = path.join(dir, 'deps');
+    Config._resetForTest();
+}
+afterEach(() => {
+    Config._resetForTest();
+    if (saved.CONFIG === undefined) delete process.env[EnvName.CONFIG_PATH];
+    else process.env[EnvName.CONFIG_PATH] = saved.CONFIG;
+    if (saved.DEPS === undefined) delete process.env['DEPS_PATH'];
+    else process.env['DEPS_PATH'] = saved.DEPS;
+    while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('SettingsApi', () => {
+    it('PATCH then GET global settings for the implicit admin', async () => {
+        setup();
+        const cfg = Config.getInstance();
+        const api = new SettingsApi();
+        const patch = makeReqRes('PATCH', '/api/settings', { theme: 'dark', scanSubnets: ['10.0.0.0/24'] });
+        await api.handle(patch.req, patch.res);
+        expect(cfg.db.userSettings.get(IMPLICIT_ADMIN_ID, 'theme')).toBe('dark');
+        const get = makeReqRes('GET', '/api/settings');
+        await api.handle(get.req, get.res);
+        expect(get.getJson()).toMatchObject({ theme: 'dark', scanSubnets: ['10.0.0.0/24'] });
+    });
+
+    it('PATCH per-device settings then GET by udid', async () => {
+        setup();
+        const cfg = Config.getInstance();
+        const api = new SettingsApi();
+        const patch = makeReqRes('PATCH', '/api/settings/device?udid=UDID1', { audio: { source: 'output' } });
+        await api.handle(patch.req, patch.res);
+        expect(cfg.db.devices.getDeviceSetting(IMPLICIT_ADMIN_ID, 'UDID1', 'audio')).toEqual({ source: 'output' });
+        const get = makeReqRes('GET', '/api/settings/device?udid=UDID1');
+        await api.handle(get.req, get.res);
+        expect(get.getJson()).toEqual({ audio: { source: 'output' } });
+    });
+
+    it('reset clears user_settings + labels + device_settings for the caller', async () => {
+        setup();
+        const db = Config.getInstance().db;
+        db.userSettings.set(IMPLICIT_ADMIN_ID, 'theme', 'dark');
+        db.devices.setLabel(IMPLICIT_ADMIN_ID, 'S1', 'TV');
+        db.devices.setDeviceSetting(IMPLICIT_ADMIN_ID, 'UDID1', 'audio', { source: 'mic' });
+        const api = new SettingsApi();
+        const r = makeReqRes('POST', '/api/settings/reset', {});
+        await api.handle(r.req, r.res);
+        expect(db.userSettings.getAll(IMPLICIT_ADMIN_ID)).toEqual({});
+        expect(db.devices.getAllLabels(IMPLICIT_ADMIN_ID)).toEqual({});
+        expect(db.devices.getDeviceSettings(IMPLICIT_ADMIN_ID, 'UDID1')).toEqual({});
+    });
+});

--- a/src/server/__tests__/settingsApi.test.ts
+++ b/src/server/__tests__/settingsApi.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { Config } from '../Config';
+import { afterEach, describe, expect, it } from 'vitest';
 import { SettingsApi } from '../api/SettingsApi';
+import { Config } from '../Config';
 import { IMPLICIT_ADMIN_ID } from '../db/constants';
 import { EnvName } from '../EnvName';
 import { makeReqRes } from './helpers/httpMock';

--- a/src/server/api/SettingsApi.ts
+++ b/src/server/api/SettingsApi.ts
@@ -1,0 +1,85 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { resolveUserId } from '../auth/currentUser';
+import { Config } from '../Config';
+import { Logger } from '../Logger';
+import { readJsonBody } from './utils';
+
+const log = Logger.for('SettingsApi');
+
+/**
+ * Per-user settings surface (Phase 3). The browser never touches SQLite — it
+ * reads/writes here. Everything is keyed by `resolveUserId(req)` (the implicit
+ * admin in open mode; the session user once auth lands in Phase 4).
+ *   GET/PATCH  /api/settings              → global `user_settings`
+ *   GET/PATCH  /api/settings/device?udid= → per-device `device_settings`
+ *   POST       /api/settings/reset        → clear the caller's settings + labels
+ */
+export class SettingsApi {
+    async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
+        const url = req.url || '';
+        if (!url.startsWith('/api/settings')) return false;
+
+        res.setHeader('Content-Type', 'application/json');
+        const pathname = url.split('?')[0];
+
+        try {
+            const db = Config.getInstance().db;
+            const userId = resolveUserId(req);
+
+            if (pathname === '/api/settings') {
+                if (req.method === 'GET') {
+                    res.writeHead(200);
+                    res.end(JSON.stringify(db.userSettings.getAll(userId)));
+                    return true;
+                }
+                if (req.method === 'PATCH') {
+                    const body = await readJsonBody(req);
+                    for (const [key, value] of Object.entries(body)) db.userSettings.set(userId, key, value);
+                    res.writeHead(200);
+                    res.end(JSON.stringify(db.userSettings.getAll(userId)));
+                    return true;
+                }
+            }
+
+            if (pathname === '/api/settings/device') {
+                const udid = new URL(url, 'http://localhost').searchParams.get('udid');
+                if (!udid) {
+                    res.writeHead(400);
+                    res.end(JSON.stringify({ error: 'udid is required' }));
+                    return true;
+                }
+                if (req.method === 'GET') {
+                    res.writeHead(200);
+                    res.end(JSON.stringify(db.devices.getDeviceSettings(userId, udid)));
+                    return true;
+                }
+                if (req.method === 'PATCH') {
+                    const body = await readJsonBody(req);
+                    for (const [scope, value] of Object.entries(body)) {
+                        db.devices.setDeviceSetting(userId, udid, scope, value);
+                    }
+                    res.writeHead(200);
+                    res.end(JSON.stringify(db.devices.getDeviceSettings(userId, udid)));
+                    return true;
+                }
+            }
+
+            if (req.method === 'POST' && pathname === '/api/settings/reset') {
+                db.userSettings.clearForUser(userId);
+                db.devices.clearForUser(userId);
+                res.writeHead(200);
+                res.end(JSON.stringify({ success: true }));
+                return true;
+            }
+
+            res.writeHead(404);
+            res.end(JSON.stringify({ error: 'Not found' }));
+            return true;
+        } catch (err) {
+            log.error(`${req.method} ${req.url} threw: ${(err as Error)?.message ?? String(err)}`);
+            res.writeHead(500);
+            res.end(JSON.stringify({ error: (err as Error).message }));
+            return true;
+        }
+    }
+}

--- a/src/server/db/DeviceStore.ts
+++ b/src/server/db/DeviceStore.ts
@@ -102,4 +102,36 @@ export class DeviceStore {
         for (const r of rows) out[r.serial] = r.label;
         return out;
     }
+
+    // --- Per-device settings (Phase 3): device_settings keyed (user, udid, scope) ---
+
+    getDeviceSetting(userId: number, udid: string, scope: string): unknown {
+        const r = this.db
+            .prepare('SELECT value FROM device_settings WHERE user_id = ? AND udid = ? AND scope = ?')
+            .get(userId, udid, scope) as { value: string } | undefined;
+        return r ? JSON.parse(r.value) : undefined;
+    }
+
+    setDeviceSetting(userId: number, udid: string, scope: string, value: unknown): void {
+        this.db
+            .prepare(
+                'INSERT INTO device_settings (user_id, udid, scope, value) VALUES (?, ?, ?, ?) ON CONFLICT(user_id, udid, scope) DO UPDATE SET value = excluded.value',
+            )
+            .run(userId, udid, scope, JSON.stringify(value));
+    }
+
+    getDeviceSettings(userId: number, udid: string): Record<string, unknown> {
+        const rows = this.db
+            .prepare('SELECT scope, value FROM device_settings WHERE user_id = ? AND udid = ?')
+            .all(userId, udid) as Array<{ scope: string; value: string }>;
+        const out: Record<string, unknown> = {};
+        for (const r of rows) out[r.scope] = JSON.parse(r.value);
+        return out;
+    }
+
+    /** Clear all of a user's device labels + per-device settings (the per-user reset). */
+    clearForUser(userId: number): void {
+        this.db.prepare('DELETE FROM device_labels WHERE user_id = ?').run(userId);
+        this.db.prepare('DELETE FROM device_settings WHERE user_id = ?').run(userId);
+    }
 }

--- a/src/server/db/__tests__/deviceStoreSettings.test.ts
+++ b/src/server/db/__tests__/deviceStoreSettings.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { runMigrations } from '../migrations';
+import { DeviceStore } from '../DeviceStore';
+
+let db: DatabaseSync;
+let store: DeviceStore;
+beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    runMigrations(db);
+    store = new DeviceStore(db);
+});
+
+describe('DeviceStore per-device settings', () => {
+    it('round-trips scoped per-device JSON and lists by udid', () => {
+        store.setDeviceSetting(1, 'UDID1', 'video:0:0', { codec: 'h264', bitrate: 8000 });
+        store.setDeviceSetting(1, 'UDID1', 'audio', { source: 'output' });
+        expect(store.getDeviceSetting(1, 'UDID1', 'video:0:0')).toEqual({ codec: 'h264', bitrate: 8000 });
+        expect(store.getDeviceSettings(1, 'UDID1')).toEqual({
+            'video:0:0': { codec: 'h264', bitrate: 8000 },
+            audio: { source: 'output' },
+        });
+        expect(store.getDeviceSetting(2, 'UDID1', 'audio')).toBeUndefined(); // per-user isolation
+    });
+
+    it('clearForUser removes that user labels + device settings only', () => {
+        store.setLabel(1, 'S1', 'TV');
+        store.setDeviceSetting(1, 'UDID1', 'audio', { source: 'mic' });
+        store.clearForUser(1);
+        expect(store.getAllLabels(1)).toEqual({});
+        expect(store.getDeviceSettings(1, 'UDID1')).toEqual({});
+    });
+});

--- a/src/server/db/__tests__/deviceStoreSettings.test.ts
+++ b/src/server/db/__tests__/deviceStoreSettings.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import { DatabaseSync } from 'node:sqlite';
-import { runMigrations } from '../migrations';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { DeviceStore } from '../DeviceStore';
+import { runMigrations } from '../migrations';
 
 let db: DatabaseSync;
 let store: DeviceStore;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import { DependencyApi } from './api/DependencyApi';
 import { DeviceDiscoveryApi } from './api/DeviceDiscoveryApi';
 import { ServerShutdownApi } from './api/ServerShutdownApi';
 import { ServiceApi } from './api/ServiceApi';
+import { SettingsApi } from './api/SettingsApi';
 import { UpdatesApi } from './api/UpdatesApi';
 import { WhoamiApi } from './api/WhoamiApi';
 import { Config } from './Config';
@@ -124,6 +125,9 @@ if (__ssArgs) {
 
     const configApi = new ConfigApi();
     HttpServer.addApiHandler(configApi);
+
+    const settingsApi = new SettingsApi();
+    HttpServer.addApiHandler(settingsApi);
 
     const serviceApi = new ServiceApi();
     HttpServer.addApiHandler(serviceApi);


### PR DESCRIPTION
Phase 3 of the SQLite workstream is the settings migration — moving the browser's `localStorage` prefs into the per-user SQLite store. This PR is the **server-side foundation** (Tasks 1–2 of the phase plan); the client retargeting (the `SettingsService`, the one-time `localStorage` import, the five client modules, theme first-paint, and the reset control — Tasks 3–7) follows in a separate PR.

## What this adds

- **Per-device settings on `DeviceStore`** — `getDeviceSetting` / `setDeviceSetting` / `getDeviceSettings` keyed `(user, udid, scope)`, plus `clearForUser` (clears a user's device labels + per-device settings) for the per-user reset.
- **`SettingsApi`** — the HTTP surface the browser will read/write instead of touching SQLite, all keyed by `resolveUserId(req)` (the implicit admin in today's open mode):
  - `GET` / `PATCH /api/settings` — global `user_settings`
  - `GET` / `PATCH /api/settings/device?udid=` — per-device `device_settings`
  - `POST /api/settings/reset` — clears the caller's `user_settings` + labels + device settings

  Registered in the handler chain next to `ConfigApi`.

Nothing consumes this yet, so it's **additive and behavior-preserving** — the client still uses `localStorage` until the follow-up PR.

## Verification

`tsc --noEmit` clean; **1325/1325** vitest (+5: per-device round-trip with per-user isolation, `clearForUser`, and the `SettingsApi` global / per-device / reset flows); biome clean. Uses the Phase 1/2 as-built conventions (`Config.getInstance().db`, the `CONFIG_PATH` test harness, the shared `makeReqRes` Buffer-body helper).

`release:none`.