### PR TITLE
Phase 3 frontend follow-ups: theme first-load + settings-persistence doc sweep

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1832,10 +1832,10 @@ Windows and the Windows-service apply path are unchanged (Velopack `waitExitThen
 
 ### 23.1 Decision Flow
 
-On page load, `src/app/index.ts` fetches the config envelope from `GET /api/config` and evaluates:
+On page load, `src/app/index.ts` reads `installMode` + `firstRunComplete` from `GET /api/config` and the per-user prompt flags from the settings store (`SettingsService.loadGlobal()`), then evaluates:
 
 ```
-config.installMode is service AND config.serviceFirstRunSeen is false?
+installMode is service AND serviceFirstRunSeen (from settings) is false?
     → show ServiceFirstRunModal (section 23.3)
 config.firstRunComplete is false?
     → show WelcomeModal (section 23.2)
@@ -1859,20 +1859,22 @@ Shown on the first page load of a service-mode instance (after the service has b
 - The service runs at boot — this URL stays valid across reboots
 - The current port is the one to bookmark
 
-On dismissal, `serviceFirstRunSeen = true` is persisted to `config.json`.
+On dismissal, `serviceFirstRunSeen = true` is persisted to the per-user settings store (via `SettingsService.patchGlobal` → `SettingsApi`), not `config.json` — see §23.4.
 
-### 23.4 Config.json Persistence
+### 23.4 Persistence: config.json vs the per-user settings store
 
-The first-run and bookmark-dismissal flags are stored in `config.json` rather than localStorage:
+None of these flags live in browser `localStorage` (unreliable on the Linux AppImage, which can treat each launch as a different origin). As of the SQLite settings migration (PR #429), they split across two server-side homes:
 
-| Field | Default | Set by |
-|-------|---------|--------|
-| `firstRunComplete` | `false` | WelcomeModal dismissal |
-| `serviceFirstRunSeen` | `false` | ServiceFirstRunModal dismissal |
-| `bookmarkDismissedForPort` | `null` | PortChangeModal "got it" (stamps the current port) |
-| `bookmarkDismissedGlobally` | `false` | PortChangeModal "don't show again — ever" |
+| Field | Default | Home | Set by |
+|-------|---------|------|--------|
+| `firstRunComplete` | `false` | `config.json` (boot field) | WelcomeModal dismissal |
+| `serviceFirstRunSeen` | `false` | per-user settings store | ServiceFirstRunModal dismissal |
+| `bookmarkDismissedForPort` | `null` | per-user settings store | PortChangeModal "got it" (stamps the current port) |
+| `bookmarkDismissedGlobally` | `false` | per-user settings store | PortChangeModal "don't show again — ever" |
 
-This design means the state survives port changes, browser cache clears, and machine reboots (localStorage is unreliable on the Linux AppImage, which can treat each launch as a different origin). The **Settings → Server** panel includes a **"reset welcome and bookmark prompts"** button (`resetPromptsPayload()`) that clears all four fields at once — `firstRunComplete` and `serviceFirstRunSeen` back to `false`, `bookmarkDismissedForPort` to `null`, and `bookmarkDismissedGlobally` to `false` — re-triggering the first-run flow.
+`firstRunComplete` stays in `config.json` because the launcher reads it at boot, before the Node server (and the database) is up. The three prompt-dismissal flags are per-user UI state, so they moved onto the per-user SQLite settings store via `SettingsApi` — read with `SettingsService.loadGlobal()`, written with `patchGlobal`, served off `/api/settings` rather than the `/api/config` envelope. All other browser UI preferences (theme, file-browser icon size, network-scan subnets, per-device video/stream + audio) live in that same per-user store (`wsscrcpy.db`, served via `SettingsApi`) as of the Phase 3 frontend migration — `localStorage` is no longer used for any of them.
+
+The **Settings** modal's reset control — **"reset all my settings"** — now calls `SettingsService.reset()` (clearing the caller's entire `user_settings` + device labels + per-device settings, i.e. all of the prompt flags above plus theme/icon/subnets/audio/video) and also PATCHes `firstRunComplete = false` on `/api/config`, then reloads to re-trigger the first-run flow.
 
 ### 23.5 Port Change Modal
 

--- a/src/app/client/ThemeToggle.ts
+++ b/src/app/client/ThemeToggle.ts
@@ -26,16 +26,17 @@ export function shouldSeedTheme(hasStoredTheme: boolean, migrationDone: boolean)
 }
 
 /**
- * Applies the stored DB theme after the settings cache warms.
- * On first run (no stored theme AND migration complete), seeds the DB from
- * the OS reading already applied by initTheme's synchronous first paint.
+ * Applies the stored DB theme. Invoked from the boot sequence (`index.ts`
+ * onload) AFTER the localStorage→DB migration completes, so the migrated theme
+ * is already in the cache and applies on the FIRST post-upgrade load — not a
+ * load later. On a genuinely fresh install (migration complete, no stored
+ * theme), seeds the DB from the OS reading initTheme's first paint already set.
  *
- * The seed is gated on migration completion to avoid a race with the
- * localStorage→DB migration that runs later in window.onload: if migration is
- * still pending, it will write the user's saved theme, and the next load will
- * seed correctly if the install is genuinely fresh.
+ * The seed stays gated on `shouldSeedTheme` (migration-complete) as a
+ * defensive guard: even though this now runs post-migration, the gate ensures
+ * the OS-seed can never race the migration's own `theme` write.
  */
-async function applyStoredTheme(): Promise<void> {
+export async function applyStoredTheme(): Promise<void> {
     await settingsService.loadGlobal();
     const stored = settingsService.getGlobalCached()['theme'];
     if (stored === 'dark' || stored === 'light') {
@@ -44,14 +45,13 @@ async function applyStoredTheme(): Promise<void> {
         // Fresh install (migration complete, no stored theme): persist the OS reading.
         void settingsService.patchGlobal({ theme: getTheme() }).catch(() => {});
     }
-    // If migration is pending: do nothing — migration will write the user's theme.
 }
 
 export function initTheme(): void {
-    // Synchronous first paint from OS preference — no await, no flash-to-blank.
+    // Synchronous first paint from the OS preference — no await, no flash-to-blank.
+    // The stored (migrated) theme is applied later by applyStoredTheme(), invoked
+    // from the boot sequence AFTER the localStorage→DB migration runs in onload.
     setTheme(firstPaintTheme(window.matchMedia('(prefers-color-scheme: dark)').matches));
-    // Async: DB becomes authoritative once the cache is warm.
-    void applyStoredTheme();
 }
 
 export function createThemeToggle(): HTMLElement {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -10,7 +10,7 @@ import { FirstRunBanner } from './client/FirstRunBanner';
 import { HostTracker } from './client/HostTracker';
 import { NetworkDiscoveryPanel } from './client/NetworkDiscoveryPanel';
 import { createSettingsHeader } from './client/SettingsHeader';
-import { createThemeToggle, initTheme } from './client/ThemeToggle';
+import { applyStoredTheme, createThemeToggle, initTheme } from './client/ThemeToggle';
 import type { Tool } from './client/Tool';
 import { createUpdateButton } from './client/UpdateButton';
 import { WelcomeModal } from './client/WelcomeModal';
@@ -284,6 +284,10 @@ window.onload = async (): Promise<void> => {
             console.error('[boot] settings migration failed; will retry next load', e);
         }
         await settingsService.loadGlobal().catch(() => {}); // warm global cache (iconSize, scanSubnets)
+        // Apply the stored theme now that the migration has run, so an upgrading
+        // user's saved theme shows on THIS load rather than the next one.
+        // (initTheme already did the synchronous OS first paint at module-eval.)
+        await applyStoredTheme();
     }
 
     // WebCodecs player must be registered so ConnectModal can find it

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -283,11 +283,13 @@ window.onload = async (): Promise<void> => {
         } catch (e) {
             console.error('[boot] settings migration failed; will retry next load', e);
         }
-        await settingsService.loadGlobal().catch(() => {}); // warm global cache (iconSize, scanSubnets)
         // Apply the stored theme now that the migration has run, so an upgrading
-        // user's saved theme shows on THIS load rather than the next one.
-        // (initTheme already did the synchronous OS first paint at module-eval.)
-        await applyStoredTheme();
+        // user's saved theme shows on THIS load rather than the next one. (initTheme
+        // already did the synchronous OS first paint at module-eval.) applyStoredTheme
+        // awaits loadGlobal internally, which also warms the global cache (iconSize,
+        // scanSubnets) the settings modals read; the .catch keeps a boot-time
+        // /api/settings failure from rejecting onload.
+        await applyStoredTheme().catch((e) => console.error('[boot] applyStoredTheme failed', e));
     }
 
     // WebCodecs player must be registered so ConnectModal can find it


### PR DESCRIPTION
Two small `release:none` follow-ups to #429 (the Phase 3 frontend settings migration), tracked as TODO item 60 (d) + (e).

## 1. Theme applies on the first upgrade load (item 60d)

#429's whole-branch review caught a theme/migration write-race and fixed it by gating the OS-seed on the migration flag — but that left a cosmetic: an upgrading user whose saved theme differed from their OS preference saw the OS theme for that first session (their saved theme applied only on the *next* load).

This moves `applyStoredTheme()` out of `initTheme()` (which now does only the synchronous OS first-paint at module-eval) to run in the boot sequence **after** the localStorage→DB migration completes — so the migrated theme is in the cache and applies on the first load. The OS-seed stays gated on migration completion, so no race is re-introduced; and it's strictly better than the old fire-and-forget (now awaited, runs earlier). Also drops a now-redundant boot `loadGlobal()` call (`applyStoredTheme` warms the global cache itself).

## 2. Settings-persistence doc sweep (item 60e)

`docs/TECHNICAL_GUIDE.md` §23 still described the prompt-dismissal flags (`serviceFirstRunSeen`, `bookmarkDismissedForPort`, `bookmarkDismissedGlobally`) as living in `config.json` — but #429 moved all three onto the per-user SQLite settings store. Only `firstRunComplete` stays in `config.json` (the launcher reads it at boot, before the DB is up). Updated the §23.4 table + the §23.1/§23.3 source descriptions, and noted that all browser UI prefs now persist in that per-user store. Matches the #428 doc-sweep pattern (docs in a separate `release:none` PR, not bloating the code PR).

## Testing
- `tsc --noEmit` clean; full vitest suite green (1371); theme tests 27/27.
- The theme boot-ordering change was reviewed (confirmed `applyStoredTheme` runs post-migration, above the deep-link early-returns, awaited).

## Release
`release:none` — rides the next beta alongside #429.