### PR TITLE
docs: UI preferences persist in SQLite, not localStorage (wrap-up doc sweep)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -14,7 +14,7 @@ Everything you do with ws-scrcpy-web stays on your computer:
 - **scrcpy stream data** (video, audio, touch/keyboard input) -- bounces between the device, the local server, and your browser. Never leaves the LAN.
 - **Network device discovery** (mDNS + TCP port-5555 sweep) -- your machine talks to your local network only.
 - **Web UI** -- served from `localhost`. No third-party scripts, no analytics, no tracking pixels.
-- **localStorage preferences** -- theme choice (dark/light), per-device video/audio stream settings, file-browser icon size, and saved subnets for network scans. All `localStorage`, no cookies.
+- **UI preferences** -- theme choice (dark/light), per-device video/audio stream settings, file-browser icon size, and saved subnets for network scans -- persist **server-side in the app's local SQLite database** (`wsscrcpy.db`, in your data directory), written by the localhost server. They no longer use browser `localStorage` (which now holds only a one-time migration marker). No cookies.
 
 ## What leaves your machine
 
@@ -55,7 +55,7 @@ Release artifacts are currently unsigned, so there is no code-signing revocation
 - **No analytics.** We don't send page views, click events, or session times anywhere.
 - **No crash reporting.** We don't ship Sentry, Bugsnag, or anything similar. If we add this in the future, the change will be flagged in `CHANGELOG.md` and this file will be updated.
 - **No project-operated server.** There is no ws-scrcpy-web cloud account, no login, no sync. The app is local-only.
-- **No cookies.** The web UI stores only `localStorage` UI preferences (theme, stream/scan settings — see below). No cookies of any kind.
+- **No cookies.** UI preferences persist server-side in the local SQLite store (see below); the browser keeps only a one-time migration marker in `localStorage`. No cookies of any kind.
 
 ## Third-party operators
 
@@ -69,15 +69,11 @@ When traffic does leave your machine, it goes to one of these well-known operato
 | Velopack | Update SDK (the SDK runs locally; no data goes to Velopack itself) | https://velopack.io |
 | Genymobile (scrcpy) | Source of scrcpy-server binary, hosted on GitHub | See GitHub policy above |
 
-## Web UI cookies / localStorage
+## Web UI storage (no cookies)
 
-The browser side of the app uses `localStorage` only, no cookies. Stored keys are limited to:
+The browser side of the app uses no cookies. UI preferences — theme, per-device video/stream settings (codec, encoder, fps, bitrate), per-device audio settings, file-browser icon size, and saved network-scan subnets — persist **server-side in the app's local SQLite database** (`wsscrcpy.db`, in your data directory alongside `config.json` and `logs/`), written by the localhost server through its settings API. The database stays on your machine; nothing is transmitted off-device.
 
-- Theme preference (`ws-scrcpy-web-theme`: `dark` or `light`)
-- Per-device video/stream settings (codec, encoder, fps, bitrate; keyed per device/display)
-- Per-device audio settings (`ws-scrcpy-web:audio:<udid>`)
-- File-browser icon-size preference
-- Saved network-scan subnets (`ws-scrcpy-web:scan-subnets`)
+Browser `localStorage` now holds only a one-time migration marker (`ws-scrcpy-web:migrated-to-sqlite`, set after any legacy preferences are imported into the database) and, if you turn it on, a verbose-logging debug flag (`ws-scrcpy-web-debug`). No preferences, no identifiers.
 
 No third-party scripts. No fonts loaded from CDNs. No analytics SDKs. The browser bundle ships from your local server only.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Input flows back as mouse, UHID keyboard, i16-fixed-point scroll, and a D-pad/To
 - **Network device discovery** -- two-channel scan for ADB devices on the local network: mDNS advertisement for modern devices plus TCP port-5555 sweep for older devices that don't advertise. Configuration dialog auto-detects your gateway subnet and accepts additional subnets (CIDR, bare IP, or IP range); subnets persist across sessions. Streaming progress chip with cancel support; scan skips already-connected devices and dedupes mDNS+TCP hits. Manual-add fallback for single-IP cases.
 - **Device disconnect** -- disconnect network devices directly from the device card
 - **Sleep/wake toggle** -- turn devices on or off from the device card; state polled server-side and pushed via WebSocket so buttons stay in sync even when the device sleeps on a timer or via the physical remote
-- **Dark/light theme** -- toggle between dark (default) and light modes, preference saved to localStorage
+- **Dark/light theme** -- toggle between dark (default) and light modes; first paint follows your OS preference, then your saved choice applies (persisted per-user in the app's SQLite store)
 - **Responsive layout** -- centered page container scales from mobile to 4K (up to 5 device cards)
 - **In-app dependency updater** -- check and update Node.js, ADB, and scrcpy-server from the home page
 - **System tray helper** -- shows connection status, quick-open browser, mode-aware text (local vs. service); auto-spawns and auto-recovers via the launcher's supervisor

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1043,7 +1043,7 @@ The home page (`http://localhost:8000`) is a single-page view with three section
 
 **Page layout:** All content is wrapped in a centered `.page-container` with `max-width: 1800px` (fits up to 5 device cards on 4K monitors). Page structure is created in `src/app/index.ts` in fixed order before `HostTracker.start()` to prevent race conditions across browsers.
 
-**Theme toggle:** A sun/moon button in the top-right corner switches between dark (default) and light themes. Preference is saved to localStorage (`ws-scrcpy-web-theme`). Themes use `data-theme` attribute on `<html>` with CSS custom properties. Colors match the Control Menu project palette.
+**Theme toggle:** A sun/moon button in the top-right corner switches between dark (default) and light themes. First paint follows the OS `prefers-color-scheme`; once the settings cache warms (after the localStorage→SQLite migration runs in `onload`), the stored theme applies and the DB is authoritative. The preference persists per-user in the SQLite store via `SettingsApi` (`user_settings['theme']`), not localStorage. Themes use the `data-theme` attribute on `<html>` with CSS custom properties. Colors match the Control Menu project palette.
 
 **Components:**
 - `src/app/client/ThemeToggle.ts` -- theme initialization and toggle button
@@ -1119,7 +1119,7 @@ A two-channel discovery model: **mDNS** advertisement (modern devices) plus a **
 **User flow:**
 
 1. Click **scan network** -> `ScanNetworkModal` opens.
-2. Dialog shows the auto-detected gateway subnet plus any user-added subnets (restored from `localStorage`).
+2. Dialog shows the auto-detected gateway subnet plus any user-added subnets (restored from the per-user settings store via `SettingsService.loadGlobal()` → `scanSubnets`, not `localStorage`).
 3. User can add subnets via `AddSubnetModal` (CIDR, bare IP, or IP range), edit an existing row via the **✎** icon (opens `AddSubnetModal` in edit mode with the current value pre-filled), or remove via **×**.
 4. If the combined scan size exceeds 2,048 hosts, `LargeSubnetWarningModal` prompts for confirmation with a per-subnet breakdown.
 5. Scan streams over a WebSocket; hits render as cards under "Available Network Devices" with an optional name input and Connect button.


### PR DESCRIPTION
Wrap-up doc sweep catching drift that #429/#430 introduced but their doc passes missed: several user-facing docs still described the browser UI preferences as living in `localStorage`, but the Phase 3 frontend migration moved them server-side into the SQLite store (`wsscrcpy.db`).

Fixed:
- **PRIVACY.md** — the "Web UI cookies / localStorage" section + the two summary bullets listed theme / per-device video+audio / icon size / scan subnets as localStorage. They now persist server-side in the local SQLite DB (written by the localhost server, stays on-device); `localStorage` now holds only the one-time migration marker (+ optional `ws-scrcpy-web-debug` flag).
- **README.md** — the dark/light theme bullet ("preference saved to localStorage") now reflects OS-first-paint → DB-persisted-per-user.
- **docs/TECHNICAL_GUIDE.md** — the theme-toggle description (§14, "saved to localStorage") and the network-scan flow ("subnets restored from localStorage") now point at the per-user SQLite settings store via `SettingsApi`.

Docs only; no code change. `release:none`.