### PR TITLE
feat(auth): optional user accounts + login (client UI) — SQLite workstream Phase 4

### DIFF
--- a/src/app/client/AuthClient.ts
+++ b/src/app/client/AuthClient.ts
@@ -1,0 +1,80 @@
+async function ok(res: Response): Promise<Response> {
+    if (!res.ok) throw new Error(`auth request failed: HTTP ${res.status}`);
+    return res;
+}
+
+const JSON_HEADERS = { 'content-type': 'application/json' };
+
+export type Role = 'user' | 'admin';
+export interface MeResponse {
+    authEnabled: boolean;
+    user: { username: string; role: Role } | null;
+}
+export interface UserRow {
+    id: number;
+    username: string;
+    role: Role;
+    hasPassword: boolean;
+    disabled: boolean;
+    lockedUntil: number | null;
+    lastLogin: number | null;
+}
+
+class AuthClient {
+    async me(): Promise<MeResponse> {
+        const res = await ok(await fetch('/api/auth/me'));
+        return (await res.json()) as MeResponse;
+    }
+    async login(username: string, password: string): Promise<boolean> {
+        const res = await fetch('/api/auth/login', {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ username, password }),
+        });
+        return res.ok;
+    }
+    async logout(): Promise<void> {
+        await fetch('/api/auth/logout', { method: 'POST' });
+    }
+    async changePassword(currentPassword: string, newPassword: string): Promise<boolean> {
+        const res = await fetch('/api/auth/change-password', {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ currentPassword, newPassword }),
+        });
+        return res.ok;
+    }
+    async enableAuth(): Promise<Response> {
+        return fetch('/api/auth/enable', { method: 'POST' });
+    }
+    async disableAuth(): Promise<void> {
+        await ok(await fetch('/api/auth/disable', { method: 'POST' }));
+    }
+    async listUsers(): Promise<UserRow[]> {
+        const res = await ok(await fetch('/api/users'));
+        return ((await res.json()) as { users: UserRow[] }).users;
+    }
+    async createUser(input: { username: string; role: Role; password: string }): Promise<Response> {
+        return fetch('/api/users', { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(input) });
+    }
+    async lockdown(input: {
+        adminUsername: string;
+        adminPassword: string;
+        username: string;
+        role: Role;
+        password: string;
+    }): Promise<Response> {
+        return fetch('/api/users', { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(input) });
+    }
+    async patchUser(
+        id: number,
+        patch: { role?: Role; password?: string; disabled?: boolean; unlock?: boolean },
+    ): Promise<Response> {
+        return fetch(`/api/users/${id}`, { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify(patch) });
+    }
+    async deleteUser(id: number): Promise<Response> {
+        return fetch(`/api/users/${id}`, { method: 'DELETE' });
+    }
+}
+
+export const authClient = new AuthClient();

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -16,6 +16,7 @@ import { ServiceOperationModal } from './ServiceOperationModal';
 import { settingsService } from './SettingsService';
 import { UninstallConfirmModal } from './UninstallConfirmModal';
 import { runUpgradingHandoff } from './UpgradingOverlay';
+import { UsersModal } from './UsersModal';
 
 /**
  * Follow-up copy shown after a Linux service uninstall begins, by scope.
@@ -417,6 +418,7 @@ export function buildResetControl(opts: { reload: () => void }): {
  */
 export class SettingsModal extends Modal {
     private role: Role | null = null;
+    private authEnabled = false;
     private serviceSection!: HTMLElement;
     private webPortInput: HTMLInputElement | null = null;
     private webPortStatus: HTMLElement | null = null;
@@ -459,12 +461,16 @@ export class SettingsModal extends Modal {
         queueMicrotask(() => {
             void (async () => {
                 let role: Role | null = 'admin';
+                let authEnabled = false;
                 try {
-                    role = (await authClient.me()).user?.role ?? null;
+                    const me = await authClient.me();
+                    role = me.user?.role ?? null;
+                    authEnabled = me.authEnabled;
                 } catch {
                     role = 'admin';
                 }
                 this.role = role;
+                this.authEnabled = authEnabled;
                 this.fillBody(this.bodyEl);
                 if (canSeeSection(role, 'service')) void this.refreshService();
                 if (canSeeSection(role, 'updates')) void this.refreshUpdates();
@@ -485,6 +491,8 @@ export class SettingsModal extends Modal {
         // port row; there is no longer a separate "App" section.
         // Admin-only sections are gated on the current user's role (set before
         // fillBody is called). The server enforces the same set via requireAdmin.
+        // The "Users" section (manage users button + auth toggle) is admin-only.
+        if (canSeeSection(this.role, 'users')) container.appendChild(this.buildUsersSection());
         if (canSeeSection(this.role, 'updates')) container.appendChild(this.buildUpdatesSection());
         if (canSeeSection(this.role, 'service')) container.appendChild(this.buildServiceSection());
         container.appendChild(this.buildServerSection()); // always (contains the user-level reset row)
@@ -557,6 +565,81 @@ export class SettingsModal extends Modal {
         return { row, labelEl };
     }
 
+    // ── Users section (admin-only) ─────────────────────────────────────────
+    private buildUsersSection(): HTMLElement {
+        const { section, body } = this.buildSection('Users');
+
+        // 1. Manage users button — opens UsersModal (admin-only action).
+        const manageBtn = document.createElement('button');
+        manageBtn.type = 'button';
+        manageBtn.className = 'modal-button';
+        manageBtn.textContent = 'manage users';
+        manageBtn.addEventListener('click', () => {
+            new UsersModal();
+        });
+        body.appendChild(this.buildRow('user accounts', manageBtn));
+
+        // 2. Auth toggle — disable login (authEnabled=true) or enable login
+        //    (authEnabled=false). window.location.reload() on success.
+        const toggleStatus = document.createElement('p');
+        toggleStatus.className = 'settings-status';
+        toggleStatus.style.gridColumn = '1 / -1';
+        toggleStatus.hidden = true;
+
+        if (this.authEnabled) {
+            const disableBtn = document.createElement('button');
+            disableBtn.type = 'button';
+            disableBtn.className = 'modal-button';
+            disableBtn.textContent = 'disable login (return to open mode)';
+            disableBtn.addEventListener('click', () => {
+                disableBtn.disabled = true;
+                void (async () => {
+                    try {
+                        await authClient.disableAuth();
+                        window.location.reload();
+                    } catch {
+                        toggleStatus.textContent = 'failed to disable login — see server logs.';
+                        toggleStatus.hidden = false;
+                        disableBtn.disabled = false;
+                    }
+                })();
+            });
+            body.appendChild(this.buildRow('login', disableBtn));
+        } else {
+            const enableBtn = document.createElement('button');
+            enableBtn.type = 'button';
+            enableBtn.className = 'modal-button';
+            enableBtn.textContent = 'enable login';
+            enableBtn.addEventListener('click', () => {
+                enableBtn.disabled = true;
+                void (async () => {
+                    try {
+                        const res = await authClient.enableAuth();
+                        if (res.ok) {
+                            window.location.reload();
+                            return;
+                        }
+                        if (res.status === 409) {
+                            toggleStatus.textContent = 'Add a user with an admin password first (Users → manage users)';
+                        } else {
+                            toggleStatus.textContent = `failed to enable login (${res.status})`;
+                        }
+                        toggleStatus.hidden = false;
+                        enableBtn.disabled = false;
+                    } catch {
+                        toggleStatus.textContent = 'failed to enable login — could not reach server.';
+                        toggleStatus.hidden = false;
+                        enableBtn.disabled = false;
+                    }
+                })();
+            });
+            body.appendChild(this.buildRow('login', enableBtn));
+        }
+
+        body.appendChild(toggleStatus);
+        return section;
+    }
+
     // ── Server section ─────────────────────────────────────────────────────
     private buildServerSection(): HTMLElement {
         const { section, body } = this.buildSection('Server');
@@ -568,6 +651,123 @@ export class SettingsModal extends Modal {
         //    prefs are read fresh.
         const reset = buildResetControl({ reload: () => window.location.reload() });
         body.appendChild(this.buildRow('reset all my settings', reset.button));
+
+        // 1b. change password — user-level, only shown when auth is enabled
+        //     (in open mode there is no password to change). Reveals an inline
+        //     form with current + new password inputs, each with an eye toggle.
+        //     On save → authClient.changePassword(); on success collapse the form;
+        //     on failure show inline status. Never throws.
+        if (this.authEnabled) {
+            const cpStatus = document.createElement('p');
+            cpStatus.className = 'settings-status';
+            cpStatus.style.gridColumn = '1 / -1';
+            cpStatus.hidden = true;
+
+            const cpForm = document.createElement('div');
+            cpForm.style.cssText = 'display:none; flex-direction:column; gap:6px; margin-top:4px;';
+
+            // Current password row
+            const curRow = document.createElement('div');
+            curRow.style.cssText = 'display:flex; align-items:center; gap:4px;';
+            const curInput = document.createElement('input');
+            curInput.type = 'password';
+            curInput.placeholder = 'current password';
+            curInput.className = 'settings-input';
+            curInput.setAttribute('data-field', 'cp-current');
+            const curEye = document.createElement('button');
+            curEye.type = 'button';
+            curEye.className = 'modal-button';
+            curEye.textContent = '👁';
+            curEye.title = 'show/hide';
+            curEye.addEventListener('click', () => {
+                curInput.type = curInput.type === 'password' ? 'text' : 'password';
+            });
+            curRow.appendChild(curInput);
+            curRow.appendChild(curEye);
+            cpForm.appendChild(curRow);
+
+            // New password row
+            const newRow = document.createElement('div');
+            newRow.style.cssText = 'display:flex; align-items:center; gap:4px;';
+            const newInput = document.createElement('input');
+            newInput.type = 'password';
+            newInput.placeholder = 'new password';
+            newInput.className = 'settings-input';
+            newInput.setAttribute('data-field', 'cp-new');
+            const newEye = document.createElement('button');
+            newEye.type = 'button';
+            newEye.className = 'modal-button';
+            newEye.textContent = '👁';
+            newEye.title = 'show/hide';
+            newEye.addEventListener('click', () => {
+                newInput.type = newInput.type === 'password' ? 'text' : 'password';
+            });
+            newRow.appendChild(newInput);
+            newRow.appendChild(newEye);
+            cpForm.appendChild(newRow);
+
+            // Save / cancel
+            const cpBtnRow = document.createElement('div');
+            cpBtnRow.style.cssText = 'display:flex; gap:6px;';
+            const saveBtn = document.createElement('button');
+            saveBtn.type = 'button';
+            saveBtn.className = 'modal-button';
+            saveBtn.textContent = 'save';
+            saveBtn.addEventListener('click', () => {
+                void (async () => {
+                    saveBtn.disabled = true;
+                    cpStatus.textContent = 'saving…';
+                    cpStatus.hidden = false;
+                    try {
+                        const ok = await authClient.changePassword(curInput.value, newInput.value);
+                        if (ok) {
+                            cpStatus.textContent = 'password changed';
+                            cpForm.style.display = 'none';
+                            cpBtn.style.display = '';
+                            curInput.value = '';
+                            newInput.value = '';
+                        } else {
+                            cpStatus.textContent = 'current password incorrect';
+                        }
+                    } catch {
+                        cpStatus.textContent = 'could not reach server';
+                    }
+                    saveBtn.disabled = false;
+                })();
+            });
+            const cancelBtn = document.createElement('button');
+            cancelBtn.type = 'button';
+            cancelBtn.className = 'modal-button';
+            cancelBtn.textContent = 'cancel';
+            cancelBtn.addEventListener('click', () => {
+                cpForm.style.display = 'none';
+                cpBtn.style.display = '';
+                cpStatus.hidden = true;
+                curInput.value = '';
+                newInput.value = '';
+            });
+            cpBtnRow.appendChild(saveBtn);
+            cpBtnRow.appendChild(cancelBtn);
+            cpForm.appendChild(cpBtnRow);
+
+            // The trigger button (shown by default, hides when form is open)
+            const cpBtn = document.createElement('button');
+            cpBtn.type = 'button';
+            cpBtn.className = 'modal-button';
+            cpBtn.textContent = 'change password';
+            cpBtn.setAttribute('data-action', 'change-password');
+            cpBtn.addEventListener('click', () => {
+                cpBtn.style.display = 'none';
+                cpStatus.hidden = true;
+                cpForm.style.display = 'flex';
+            });
+
+            const cpControl = document.createDocumentFragment();
+            cpControl.appendChild(cpBtn);
+            cpControl.appendChild(cpForm);
+            body.appendChild(this.buildRow('password', cpControl));
+            body.appendChild(cpStatus);
+        }
 
         // 2–5 below are admin-only. Skip building + storing them entirely for
         //    non-admin users so no DOM or ref is created. The refresh methods

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -7,6 +7,8 @@ import type {
 import type { UpdatesConfigPatchRequest, UpdatesStatusResponse } from '../../common/UpdateEvents';
 import { Modal } from '../ui/Modal';
 import { AdminConfirmModal, type AdminConfirmOptions } from './AdminConfirmModal';
+import { authClient, type Role } from './AuthClient';
+import { canSeeSection } from './adminGate';
 import { ConfirmModal } from './ConfirmModal';
 import { pollServiceUninstalled } from './pollServiceUninstalled';
 import { ResetConfirmModal } from './ResetConfirmModal';
@@ -414,10 +416,11 @@ export function buildResetControl(opts: { reload: () => void }): {
  * "value column" across all rows.
  */
 export class SettingsModal extends Modal {
+    private role: Role | null = null;
     private serviceSection!: HTMLElement;
-    private webPortInput!: HTMLInputElement;
-    private webPortStatus!: HTMLElement;
-    private serverSaveBtn!: HTMLButtonElement;
+    private webPortInput: HTMLInputElement | null = null;
+    private webPortStatus: HTMLElement | null = null;
+    private serverSaveBtn: HTMLButtonElement | null = null;
     private currentWebPort: number | null = null;
     private serviceScopeSystemRadio: HTMLInputElement | null = null;
     private servicePlatform: 'win32' | 'linux' | null = null;
@@ -434,8 +437,8 @@ export class SettingsModal extends Modal {
     private uninstallButton: HTMLButtonElement | null = null;
 
     // ── Updates section state ─────────────────────────────────────────────
-    private updatesBody!: HTMLElement;
-    private updatesStatusEl!: HTMLElement;
+    private updatesBody: HTMLElement | null = null;
+    private updatesStatusEl: HTMLElement | null = null;
     private updatesAutoCheckbox: HTMLInputElement | null = null;
     private updatesIntervalInput: HTMLInputElement | null = null;
     private updatesChannelStableRadio: HTMLInputElement | null = null;
@@ -450,11 +453,23 @@ export class SettingsModal extends Modal {
         super({ title: 'Settings' });
         this.dialog.classList.add('settings-modal');
         // Defer body fill past class-field init phase (ES2022 useDefineForClassFields).
+        // Resolve the current user's role first so admin-only sections can be gated.
+        // Fail-open: on a me() error treat as admin (preserves today's full view;
+        // the server enforces 403 on admin endpoints regardless).
         queueMicrotask(() => {
-            this.fillBody(this.bodyEl);
-            void this.refreshServer();
-            void this.refreshService();
-            void this.refreshUpdates();
+            void (async () => {
+                let role: Role | null = 'admin';
+                try {
+                    role = (await authClient.me()).user?.role ?? null;
+                } catch {
+                    role = 'admin';
+                }
+                this.role = role;
+                this.fillBody(this.bodyEl);
+                if (canSeeSection(role, 'service')) void this.refreshService();
+                if (canSeeSection(role, 'updates')) void this.refreshUpdates();
+                void this.refreshServer(); // server section always present (has the user-level reset row)
+            })();
         });
     }
 
@@ -468,9 +483,11 @@ export class SettingsModal extends Modal {
         // former standalone "App" section (reset, install-for-all-users, stop &
         // exit, uninstall) was folded into "Server", which also keeps the web
         // port row; there is no longer a separate "App" section.
-        container.appendChild(this.buildUpdatesSection());
-        container.appendChild(this.buildServiceSection());
-        container.appendChild(this.buildServerSection());
+        // Admin-only sections are gated on the current user's role (set before
+        // fillBody is called). The server enforces the same set via requireAdmin.
+        if (canSeeSection(this.role, 'updates')) container.appendChild(this.buildUpdatesSection());
+        if (canSeeSection(this.role, 'service')) container.appendChild(this.buildServiceSection());
+        container.appendChild(this.buildServerSection()); // always (contains the user-level reset row)
     }
 
     // ── Layout primitives ──────────────────────────────────────────────────
@@ -544,90 +561,100 @@ export class SettingsModal extends Modal {
     private buildServerSection(): HTMLElement {
         const { section, body } = this.buildSection('Server');
 
-        // 1. reset all my settings — opens ResetConfirmModal, then clears all
-        //    user settings (theme, device names, per-device stream/audio prefs,
-        //    icon size, scan subnets, dismissed prompts) and reloads so
-        //    first-run re-triggers and all prefs are read fresh.
+        // 1. reset all my settings — user-level, always visible. Opens
+        //    ResetConfirmModal, then clears all user settings (theme, device
+        //    names, per-device stream/audio prefs, icon size, scan subnets,
+        //    dismissed prompts) and reloads so first-run re-triggers and all
+        //    prefs are read fresh.
         const reset = buildResetControl({ reload: () => window.location.reload() });
         body.appendChild(this.buildRow('reset all my settings', reset.button));
 
-        // 2. web port — number input with the SAVE button INLINE to its right
-        //    (same control cell). The status line below the row is EMPTY at rest
-        //    and only fills on save (saving → restarting/redirecting, "no change",
-        //    or an error) via setServerStatus / onSavePort.
-        this.webPortInput = document.createElement('input');
-        this.webPortInput.type = 'number';
-        this.webPortInput.min = '1024';
-        this.webPortInput.max = '65535';
-        this.webPortInput.className = 'settings-input';
-        this.webPortInput.style.maxWidth = '120px';
+        // 2–5 below are admin-only. Skip building + storing them entirely for
+        //    non-admin users so no DOM or ref is created. The refresh methods
+        //    (refreshServer, applyStopServerButtonState, applyAppSectionButtonsState)
+        //    are all null-safe on their stored refs — they guard with `if (this.x)`.
+        if (canSeeSection(this.role, 'webPort')) {
+            // 2. web port — number input with the SAVE button INLINE to its right
+            //    (same control cell). The status line below the row is EMPTY at rest
+            //    and only fills on save (saving → restarting/redirecting, "no change",
+            //    or an error) via setServerStatus / onSavePort.
+            this.webPortInput = document.createElement('input');
+            this.webPortInput.type = 'number';
+            this.webPortInput.min = '1024';
+            this.webPortInput.max = '65535';
+            this.webPortInput.className = 'settings-input';
+            this.webPortInput.style.maxWidth = '120px';
 
-        this.serverSaveBtn = document.createElement('button');
-        this.serverSaveBtn.type = 'button';
-        this.serverSaveBtn.className = 'settings-btn settings-btn-primary';
-        this.serverSaveBtn.textContent = 'save';
-        this.serverSaveBtn.style.marginLeft = '0.5rem';
-        this.serverSaveBtn.addEventListener('click', () => {
-            void this.onSavePort();
-        });
+            this.serverSaveBtn = document.createElement('button');
+            this.serverSaveBtn.type = 'button';
+            this.serverSaveBtn.className = 'settings-btn settings-btn-primary';
+            this.serverSaveBtn.textContent = 'save';
+            this.serverSaveBtn.style.marginLeft = '0.5rem';
+            this.serverSaveBtn.addEventListener('click', () => {
+                void this.onSavePort();
+            });
 
-        const portControl = document.createDocumentFragment();
-        portControl.appendChild(this.webPortInput);
-        portControl.appendChild(this.serverSaveBtn);
-        body.appendChild(this.buildRow('web port', portControl));
+            const portControl = document.createDocumentFragment();
+            portControl.appendChild(this.webPortInput);
+            portControl.appendChild(this.serverSaveBtn);
+            body.appendChild(this.buildRow('web port', portControl));
 
-        this.webPortStatus = document.createElement('p');
-        this.webPortStatus.className = 'settings-status';
-        this.webPortStatus.style.gridColumn = '1 / -1';
-        this.webPortStatus.hidden = true;
-        body.appendChild(this.webPortStatus);
+            this.webPortStatus = document.createElement('p');
+            this.webPortStatus.className = 'settings-status';
+            this.webPortStatus.style.gridColumn = '1 / -1';
+            this.webPortStatus.hidden = true;
+            body.appendChild(this.webPortStatus);
+        }
 
-        // 3. install for all users (Linux-only) — hidden until
-        //    applyAppSectionButtonsState reveals it on Linux. POSTs
-        //    /api/service/install-system-wide (pkexec → /opt → re-exec); the OS
-        //    pkexec dialog is the confirmation, so on success just reload.
-        const install = buildInstallAllUsersControl({ reload: () => window.location.reload() });
-        this.installAllUsersButton = install.button;
-        this.installAllUsersNote = install.note;
-        const installRow = this.buildRow('install for all users', install.button);
-        installRow.style.display = 'none';
-        this.installAllUsersRow = installRow;
-        body.appendChild(installRow);
-        body.appendChild(install.note);
+        if (canSeeSection(this.role, 'serverControls')) {
+            // 3. install for all users (Linux-only) — hidden until
+            //    applyAppSectionButtonsState reveals it on Linux. POSTs
+            //    /api/service/install-system-wide (pkexec → /opt → re-exec); the OS
+            //    pkexec dialog is the confirmation, so on success just reload.
+            const install = buildInstallAllUsersControl({ reload: () => window.location.reload() });
+            this.installAllUsersButton = install.button;
+            this.installAllUsersNote = install.note;
+            const installRow = this.buildRow('install for all users', install.button);
+            installRow.style.display = 'none';
+            this.installAllUsersRow = installRow;
+            body.appendChild(installRow);
+            body.appendChild(install.note);
 
-        // 4. stop the server and close the app — §27 graceful shutdown (exit 0,
-        //    the launcher supervisor will NOT restart it). Gated off in service
-        //    mode by applyStopServerButtonState once /api/service/status resolves.
-        const stopBtn = document.createElement('button');
-        stopBtn.type = 'button';
-        stopBtn.className = 'settings-btn settings-btn-primary';
-        stopBtn.textContent = 'stop server & exit';
-        stopBtn.addEventListener('click', () => void this.onStopServerExit(stopBtn));
-        this.stopServerButton = stopBtn;
-        body.appendChild(this.buildRow('stop the server and close the app', stopBtn));
+            // 4. stop the server and close the app — §27 graceful shutdown (exit 0,
+            //    the launcher supervisor will NOT restart it). Gated off in service
+            //    mode by applyStopServerButtonState once /api/service/status resolves.
+            const stopBtn = document.createElement('button');
+            stopBtn.type = 'button';
+            stopBtn.className = 'settings-btn settings-btn-primary';
+            stopBtn.textContent = 'stop server & exit';
+            stopBtn.addEventListener('click', () => void this.onStopServerExit(stopBtn));
+            this.stopServerButton = stopBtn;
+            body.appendChild(this.buildRow('stop the server and close the app', stopBtn));
 
-        const stopNote = document.createElement('p');
-        stopNote.className = 'settings-status';
-        stopNote.style.gridColumn = '1 / -1';
-        stopNote.hidden = true;
-        this.stopServerNote = stopNote;
-        body.appendChild(stopNote);
+            const stopNote = document.createElement('p');
+            stopNote.className = 'settings-status';
+            stopNote.style.gridColumn = '1 / -1';
+            stopNote.hidden = true;
+            this.stopServerNote = stopNote;
+            body.appendChild(stopNote);
 
-        // 5. uninstall ws-scrcpy-web (Linux + win32) — hidden until revealed.
-        //    Always enabled when shown (uninstalling is how you remove a
-        //    service). Opens UninstallConfirmModal; confirm POSTs
-        //    /api/service/uninstall-app { keep }.
-        const uninstall = buildUninstallControl({ onUninstalled: () => this.showUninstalledOverlay() });
-        this.uninstallButton = uninstall.button;
-        const uninstallRow = this.buildRow('uninstall ws-scrcpy-web', uninstall.button);
-        uninstallRow.style.display = 'none';
-        this.uninstallRow = uninstallRow;
-        body.appendChild(uninstallRow);
+            // 5. uninstall ws-scrcpy-web (Linux + win32) — hidden until revealed.
+            //    Always enabled when shown (uninstalling is how you remove a
+            //    service). Opens UninstallConfirmModal; confirm POSTs
+            //    /api/service/uninstall-app { keep }.
+            const uninstall = buildUninstallControl({ onUninstalled: () => this.showUninstalledOverlay() });
+            this.uninstallButton = uninstall.button;
+            const uninstallRow = this.buildRow('uninstall ws-scrcpy-web', uninstall.button);
+            uninstallRow.style.display = 'none';
+            this.uninstallRow = uninstallRow;
+            body.appendChild(uninstallRow);
+        }
 
         return section;
     }
 
     private async refreshServer(): Promise<void> {
+        if (!this.webPortInput) return; // web port row not built (non-admin)
         try {
             const r = await fetch('/api/config');
             if (!r.ok) {
@@ -646,6 +673,7 @@ export class SettingsModal extends Modal {
     }
 
     private async onSavePort(): Promise<void> {
+        if (!this.webPortInput || !this.serverSaveBtn) return; // not built (non-admin)
         const raw = this.webPortInput.value.trim();
         const port = Number.parseInt(raw, 10);
         if (!Number.isFinite(port) || port < 1024 || port > 65535) {
@@ -662,9 +690,10 @@ export class SettingsModal extends Modal {
         // serverSaveBtn. Captures `this` so the dispose also handles the
         // early-return inside the try (where the prior code had a manual
         // re-enable line that is now redundant — kept for symmetry, see below).
+        const saveBtn = this.serverSaveBtn;
         using _restoreBtn = {
             [Symbol.dispose]: (): void => {
-                this.serverSaveBtn.disabled = false;
+                saveBtn.disabled = false;
             },
         };
         try {
@@ -698,6 +727,7 @@ export class SettingsModal extends Modal {
     }
 
     private setServerStatus(msg: string, isError = false): void {
+        if (!this.webPortStatus) return; // web port row not built (non-admin)
         this.webPortStatus.textContent = msg;
         // The status line lives BELOW the web-port row and is empty at rest —
         // hide it when there is no message so it doesn't reserve a blank row.
@@ -735,6 +765,7 @@ export class SettingsModal extends Modal {
     }
 
     private renderUpdatesError(msg: string): void {
+        if (!this.updatesBody) return;
         this.updatesBody.replaceChildren();
         const retryBtn = document.createElement('button');
         retryBtn.type = 'button';
@@ -749,6 +780,7 @@ export class SettingsModal extends Modal {
     }
 
     private renderUpdatesSection(s: UpdatesStatusResponse): void {
+        if (!this.updatesBody) return;
         this.updatesBody.replaceChildren();
         this.updatesAutoCheckbox = null;
         this.updatesIntervalInput = null;

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -715,6 +715,11 @@ export class SettingsModal extends Modal {
             saveBtn.textContent = 'save';
             saveBtn.addEventListener('click', () => {
                 void (async () => {
+                    if (!curInput.value || !newInput.value) {
+                        cpStatus.textContent = 'enter your current and new password';
+                        cpStatus.hidden = false;
+                        return;
+                    }
                     saveBtn.disabled = true;
                     cpStatus.textContent = 'saving…';
                     cpStatus.hidden = false;
@@ -767,6 +772,32 @@ export class SettingsModal extends Modal {
             cpControl.appendChild(cpForm);
             body.appendChild(this.buildRow('password', cpControl));
             body.appendChild(cpStatus);
+
+            // Logout — user-level, only when authEnabled (you're only logged in when
+            // auth is enabled). Placed adjacent to change-password. Not admin-gated.
+            const logoutStatus = document.createElement('p');
+            logoutStatus.className = 'settings-status';
+            logoutStatus.style.gridColumn = '1 / -1';
+            logoutStatus.hidden = true;
+
+            const logoutBtn = document.createElement('button');
+            logoutBtn.type = 'button';
+            logoutBtn.className = 'modal-button';
+            logoutBtn.textContent = 'log out';
+            logoutBtn.setAttribute('data-action', 'logout');
+            logoutBtn.addEventListener('click', () => {
+                void (async () => {
+                    try {
+                        await authClient.logout();
+                    } catch {
+                        logoutStatus.textContent = 'logout request failed — reloading anyway.';
+                        logoutStatus.hidden = false;
+                    }
+                    window.location.reload();
+                })();
+            });
+            body.appendChild(this.buildRow('session', logoutBtn));
+            body.appendChild(logoutStatus);
         }
 
         // 2–5 below are admin-only. Skip building + storing them entirely for

--- a/src/app/client/UsersModal.ts
+++ b/src/app/client/UsersModal.ts
@@ -1,0 +1,469 @@
+import { Modal } from '../ui/Modal';
+import type { Role, UserRow } from './AuthClient';
+import { authClient } from './AuthClient';
+
+export class UsersModal extends Modal {
+    // NOTE: Do NOT store a ref to the body container in buildBody() — class field
+    // initializers (ES2022 useDefineForClassFields) run AFTER super() returns and
+    // would null any assignment made inside buildBody(). Use this.bodyEl directly.
+    private statusEl: HTMLElement | null = null;
+
+    constructor() {
+        super({ title: 'Users' });
+        this.dialog.classList.add('users-modal');
+        queueMicrotask(() => void this.refresh());
+    }
+
+    protected buildBody(_container: HTMLElement): void {
+        // Body content is rendered by refresh() via queueMicrotask in the constructor.
+    }
+
+    // -----------------------------------------------------------------------
+    // Main list view
+    // -----------------------------------------------------------------------
+
+    async refresh(): Promise<void> {
+        const me = await authClient.me().catch(() => ({ authEnabled: true, user: null }));
+        const users = await authClient.listUsers().catch(() => [] as UserRow[]);
+
+        const container = this.bodyEl;
+        container.replaceChildren();
+        this.statusEl = null;
+
+        // Shared inline status area (used by delete 409, etc.)
+        const statusDiv = document.createElement('div');
+        statusDiv.className = 'users-modal-status';
+        statusDiv.style.cssText = 'color: #e05555; font-size: 13px; margin-bottom: 8px; min-height: 1.4em;';
+        this.statusEl = statusDiv;
+        container.appendChild(statusDiv);
+
+        const list = document.createElement('ul');
+        list.style.cssText = 'list-style: none; margin: 0 0 16px; padding: 0;';
+
+        for (const u of users) {
+            const isLocked = u.lockedUntil != null && u.lockedUntil > Date.now();
+
+            const li = document.createElement('li');
+            li.style.cssText =
+                'margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid rgba(255,255,255,0.08);';
+
+            // Username + role + status
+            const infoRow = document.createElement('div');
+            infoRow.style.cssText = 'display: flex; align-items: center; gap: 10px; margin-bottom: 6px;';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.textContent = u.username;
+            nameSpan.style.fontWeight = 'bold';
+            infoRow.appendChild(nameSpan);
+
+            const roleSpan = document.createElement('span');
+            roleSpan.textContent = u.role;
+            roleSpan.style.cssText = 'font-size: 12px; opacity: 0.7;';
+            infoRow.appendChild(roleSpan);
+
+            if (u.disabled) {
+                const s = document.createElement('span');
+                s.textContent = 'disabled';
+                s.style.cssText = 'font-size: 12px; color: #e05555;';
+                infoRow.appendChild(s);
+            } else if (isLocked) {
+                const s = document.createElement('span');
+                s.textContent = 'locked';
+                s.style.cssText = 'font-size: 12px; color: #e0a455;';
+                infoRow.appendChild(s);
+            }
+
+            li.appendChild(infoRow);
+
+            // Controls row
+            const ctrlRow = document.createElement('div');
+            ctrlRow.style.cssText = 'display: flex; align-items: center; gap: 8px; flex-wrap: wrap;';
+
+            // Role select
+            const roleSelect = document.createElement('select');
+            roleSelect.className = 'modal-select';
+            for (const rv of ['user', 'admin'] as Role[]) {
+                const opt = document.createElement('option');
+                opt.value = rv;
+                opt.textContent = rv;
+                if (rv === u.role) opt.selected = true;
+                roleSelect.appendChild(opt);
+            }
+            roleSelect.addEventListener('change', () => {
+                void (async () => {
+                    const res = await authClient.patchUser(u.id, { role: roleSelect.value as Role });
+                    if (!res.ok) {
+                        this.showStatus(`Failed to change role (HTTP ${res.status})`);
+                    }
+                    await this.refresh();
+                })();
+            });
+            ctrlRow.appendChild(roleSelect);
+
+            // Disable checkbox
+            const disabledLabel = document.createElement('label');
+            disabledLabel.style.cssText =
+                'display: flex; align-items: center; gap: 4px; font-size: 13px; cursor: pointer;';
+            const disabledCb = document.createElement('input');
+            disabledCb.type = 'checkbox';
+            disabledCb.checked = u.disabled;
+            disabledCb.setAttribute('data-user-id', String(u.id));
+            disabledCb.addEventListener('change', () => {
+                void (async () => {
+                    const res = await authClient.patchUser(u.id, { disabled: disabledCb.checked });
+                    if (!res.ok) {
+                        this.showStatus(`Failed to update disabled state (HTTP ${res.status})`);
+                    }
+                    await this.refresh();
+                })();
+            });
+            disabledLabel.appendChild(disabledCb);
+            disabledLabel.appendChild(document.createTextNode('disable'));
+            ctrlRow.appendChild(disabledLabel);
+
+            // Unlock button (only if locked)
+            if (isLocked) {
+                const unlockBtn = document.createElement('button');
+                unlockBtn.type = 'button';
+                unlockBtn.className = 'modal-button';
+                unlockBtn.textContent = 'unlock';
+                unlockBtn.setAttribute('data-action', 'unlock');
+                unlockBtn.addEventListener('click', () => {
+                    void (async () => {
+                        const res = await authClient.patchUser(u.id, { unlock: true });
+                        if (!res.ok) {
+                            this.showStatus(`Failed to unlock (HTTP ${res.status})`);
+                        }
+                        await this.refresh();
+                    })();
+                });
+                ctrlRow.appendChild(unlockBtn);
+            }
+
+            // Reset password button + inline form
+            const pwContainer = document.createElement('span');
+            const resetBtn = document.createElement('button');
+            resetBtn.type = 'button';
+            resetBtn.className = 'modal-button';
+            resetBtn.textContent = 'reset password';
+            resetBtn.addEventListener('click', () => {
+                resetBtn.style.display = 'none';
+                pwContainer.appendChild(
+                    this.buildInlinePasswordReset(u.id, () => {
+                        resetBtn.style.display = '';
+                        pwContainer.replaceChildren(resetBtn);
+                    }),
+                );
+            });
+            pwContainer.appendChild(resetBtn);
+            ctrlRow.appendChild(pwContainer);
+
+            // Delete button
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.className = 'modal-button';
+            deleteBtn.textContent = 'delete';
+            deleteBtn.addEventListener('click', () => {
+                void (async () => {
+                    const res = await authClient.deleteUser(u.id);
+                    if (!res.ok) {
+                        this.showStatus(
+                            `Cannot delete: HTTP ${res.status}${res.status === 409 ? ' (last admin)' : ''}`,
+                        );
+                        return; // do NOT refresh — keep the inline error visible
+                    }
+                    await this.refresh();
+                })();
+            });
+            ctrlRow.appendChild(deleteBtn);
+
+            li.appendChild(ctrlRow);
+            list.appendChild(li);
+        }
+
+        container.appendChild(list);
+
+        // Add user button
+        const addBtn = document.createElement('button');
+        addBtn.type = 'button';
+        addBtn.className = 'modal-button modal-button-primary';
+        addBtn.textContent = 'Add user';
+        addBtn.addEventListener('click', () => void this.openAddUser(me.authEnabled));
+        container.appendChild(addBtn);
+    }
+
+    private showStatus(msg: string): void {
+        if (this.statusEl) this.statusEl.textContent = msg;
+    }
+
+    private buildInlinePasswordReset(userId: number, onCancel: () => void): HTMLElement {
+        const wrap = document.createElement('span');
+        wrap.style.cssText = 'display: inline-flex; align-items: center; gap: 4px;';
+
+        const pwInput = document.createElement('input');
+        pwInput.type = 'password';
+        pwInput.placeholder = 'new password';
+        pwInput.style.cssText = 'padding: 2px 6px; font-size: 13px;';
+
+        const eyeBtn = document.createElement('button');
+        eyeBtn.type = 'button';
+        eyeBtn.className = 'modal-button';
+        eyeBtn.textContent = '👁';
+        eyeBtn.title = 'Show/hide password';
+        eyeBtn.addEventListener('click', () => {
+            pwInput.type = pwInput.type === 'password' ? 'text' : 'password';
+        });
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.type = 'button';
+        confirmBtn.className = 'modal-button';
+        confirmBtn.textContent = 'confirm';
+        confirmBtn.addEventListener('click', () => {
+            void (async () => {
+                const res = await authClient.patchUser(userId, { password: pwInput.value });
+                if (!res.ok) {
+                    this.showStatus(`Failed to reset password (HTTP ${res.status})`);
+                    return;
+                }
+                onCancel();
+            })();
+        });
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'modal-button';
+        cancelBtn.textContent = 'cancel';
+        cancelBtn.addEventListener('click', onCancel);
+
+        wrap.appendChild(pwInput);
+        wrap.appendChild(eyeBtn);
+        wrap.appendChild(confirmBtn);
+        wrap.appendChild(cancelBtn);
+        return wrap;
+    }
+
+    // -----------------------------------------------------------------------
+    // Add user / lockdown flow
+    // -----------------------------------------------------------------------
+
+    async openAddUser(authEnabled: boolean): Promise<void> {
+        const container = this.bodyEl;
+        container.replaceChildren();
+
+        // Shared status
+        const statusDiv = document.createElement('div');
+        statusDiv.className = 'users-modal-status';
+        statusDiv.style.cssText = 'color: #e05555; font-size: 13px; margin-bottom: 8px; min-height: 1.4em;';
+        this.statusEl = statusDiv;
+        container.appendChild(statusDiv);
+
+        // -----------------------------------------------------------------------
+        // LOCKDOWN SECTION — only when authEnabled === false
+        // -----------------------------------------------------------------------
+        let adminUsernameInput: HTMLInputElement | null = null;
+        let adminPasswordInput: HTMLInputElement | null = null;
+
+        if (!authEnabled) {
+            const lockSection = document.createElement('div');
+            lockSection.className = 'lockdown-section';
+            lockSection.style.cssText =
+                'background: rgba(224,85,85,0.08); border-left: 3px solid #e05555; ' +
+                'padding: 10px 12px; margin-bottom: 16px; border-radius: 4px;';
+
+            const lockHeading = document.createElement('div');
+            lockHeading.textContent = 'Secure the admin account';
+            lockHeading.style.cssText = 'font-weight: bold; margin-bottom: 8px; color: #e05555;';
+            lockSection.appendChild(lockHeading);
+
+            const lockDesc = document.createElement('p');
+            lockDesc.textContent =
+                'Auth is currently disabled. Set an admin username and password — the app will require login after this.';
+            lockDesc.style.cssText = 'margin: 0 0 10px; font-size: 13px; opacity: 0.85;';
+            lockSection.appendChild(lockDesc);
+
+            // Admin username
+            const adminUserLabel = document.createElement('label');
+            adminUserLabel.style.cssText = 'display: block; margin-bottom: 6px; font-size: 13px;';
+            adminUserLabel.textContent = 'Admin username';
+            lockSection.appendChild(adminUserLabel);
+
+            adminUsernameInput = document.createElement('input');
+            adminUsernameInput.type = 'text';
+            adminUsernameInput.value = 'admin';
+            adminUsernameInput.required = true;
+            adminUsernameInput.style.cssText =
+                'display: block; width: 100%; margin-bottom: 10px; padding: 4px 8px; box-sizing: border-box;';
+            adminUsernameInput.setAttribute('data-field', 'admin-username');
+            lockSection.appendChild(adminUsernameInput);
+
+            // Admin password + eye toggle
+            const adminPwLabel = document.createElement('label');
+            adminPwLabel.style.cssText = 'display: block; margin-bottom: 4px; font-size: 13px;';
+            adminPwLabel.textContent = 'Admin password';
+            lockSection.appendChild(adminPwLabel);
+
+            const adminPwRow = document.createElement('div');
+            adminPwRow.style.cssText = 'display: flex; gap: 4px; margin-bottom: 10px;';
+
+            adminPasswordInput = document.createElement('input');
+            adminPasswordInput.type = 'password';
+            adminPasswordInput.required = true;
+            adminPasswordInput.style.cssText = 'flex: 1; padding: 4px 8px;';
+            adminPasswordInput.setAttribute('data-field', 'admin-password');
+
+            const adminEyeBtn = document.createElement('button');
+            adminEyeBtn.type = 'button';
+            adminEyeBtn.className = 'modal-button';
+            adminEyeBtn.textContent = '👁';
+            adminEyeBtn.title = 'Show/hide admin password';
+            adminEyeBtn.addEventListener('click', () => {
+                adminPasswordInput!.type = adminPasswordInput!.type === 'password' ? 'text' : 'password';
+            });
+
+            adminPwRow.appendChild(adminPasswordInput);
+            adminPwRow.appendChild(adminEyeBtn);
+            lockSection.appendChild(adminPwRow);
+
+            container.appendChild(lockSection);
+        }
+
+        // -----------------------------------------------------------------------
+        // NEW USER FIELDS
+        // -----------------------------------------------------------------------
+        const newUserSection = document.createElement('div');
+        newUserSection.className = 'new-user-section';
+
+        const newUserHeading = document.createElement('div');
+        newUserHeading.textContent = 'New user';
+        newUserHeading.style.cssText = 'font-weight: bold; margin-bottom: 8px;';
+        newUserSection.appendChild(newUserHeading);
+
+        // Username
+        const userLabel = document.createElement('label');
+        userLabel.style.cssText = 'display: block; margin-bottom: 4px; font-size: 13px;';
+        userLabel.textContent = 'Username';
+        newUserSection.appendChild(userLabel);
+
+        const usernameInput = document.createElement('input');
+        usernameInput.type = 'text';
+        usernameInput.required = true;
+        usernameInput.style.cssText =
+            'display: block; width: 100%; margin-bottom: 10px; padding: 4px 8px; box-sizing: border-box;';
+        newUserSection.appendChild(usernameInput);
+
+        // Role select
+        const roleLabel = document.createElement('label');
+        roleLabel.style.cssText = 'display: block; margin-bottom: 4px; font-size: 13px;';
+        roleLabel.textContent = 'Role';
+        newUserSection.appendChild(roleLabel);
+
+        const roleSelect = document.createElement('select');
+        roleSelect.className = 'modal-select';
+        roleSelect.style.cssText = 'display: block; margin-bottom: 10px;';
+        for (const rv of ['user', 'admin'] as Role[]) {
+            const opt = document.createElement('option');
+            opt.value = rv;
+            opt.textContent = rv;
+            roleSelect.appendChild(opt);
+        }
+        newUserSection.appendChild(roleSelect);
+
+        // Password + eye toggle
+        const pwLabel = document.createElement('label');
+        pwLabel.style.cssText = 'display: block; margin-bottom: 4px; font-size: 13px;';
+        pwLabel.textContent = 'Password';
+        newUserSection.appendChild(pwLabel);
+
+        const pwRow = document.createElement('div');
+        pwRow.style.cssText = 'display: flex; gap: 4px; margin-bottom: 16px;';
+
+        const passwordInput = document.createElement('input');
+        passwordInput.type = 'password';
+        passwordInput.required = true;
+        passwordInput.style.cssText = 'flex: 1; padding: 4px 8px;';
+
+        const eyeBtn = document.createElement('button');
+        eyeBtn.type = 'button';
+        eyeBtn.className = 'modal-button';
+        eyeBtn.textContent = '👁';
+        eyeBtn.title = 'Show/hide password';
+        eyeBtn.addEventListener('click', () => {
+            passwordInput.type = passwordInput.type === 'password' ? 'text' : 'password';
+        });
+
+        pwRow.appendChild(passwordInput);
+        pwRow.appendChild(eyeBtn);
+        newUserSection.appendChild(pwRow);
+
+        container.appendChild(newUserSection);
+
+        // -----------------------------------------------------------------------
+        // Action buttons
+        // -----------------------------------------------------------------------
+        const btnRow = document.createElement('div');
+        btnRow.style.cssText = 'display: flex; gap: 8px;';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'modal-button';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.addEventListener('click', () => void this.refresh());
+        btnRow.appendChild(cancelBtn);
+
+        const submitLabel = authEnabled ? 'Add user' : 'Secure & add user';
+        const submitBtn = document.createElement('button');
+        submitBtn.type = 'button';
+        submitBtn.className = 'modal-button modal-button-primary';
+        submitBtn.textContent = submitLabel;
+        submitBtn.addEventListener('click', () => {
+            void (async () => {
+                statusDiv.textContent = '';
+
+                const username = usernameInput.value.trim();
+                const role = roleSelect.value as Role;
+                const password = passwordInput.value;
+
+                if (!username || !password) {
+                    statusDiv.textContent = 'Username and password are required.';
+                    return;
+                }
+
+                if (!authEnabled) {
+                    // Lockdown flow
+                    const adminUsername = adminUsernameInput?.value.trim() ?? 'admin';
+                    const adminPassword = adminPasswordInput?.value ?? '';
+
+                    if (!adminUsername || !adminPassword) {
+                        statusDiv.textContent = 'Admin username and password are required to secure the account.';
+                        return;
+                    }
+
+                    const res = await authClient.lockdown({ adminUsername, adminPassword, username, role, password });
+                    if (!res.ok) {
+                        statusDiv.textContent = `Lockdown failed: HTTP ${res.status}`;
+                        return;
+                    }
+
+                    // App is now locked — show message and reload
+                    container.replaceChildren();
+                    const msg = document.createElement('p');
+                    msg.textContent = 'Login is now required. Reloading…';
+                    msg.style.cssText = 'text-align: center; padding: 24px;';
+                    container.appendChild(msg);
+                    window.location.reload();
+                } else {
+                    // Normal create-user flow
+                    const res = await authClient.createUser({ username, role, password });
+                    if (!res.ok) {
+                        statusDiv.textContent = `Failed to add user: HTTP ${res.status}`;
+                        return;
+                    }
+                    await this.refresh();
+                }
+            })();
+        });
+        btnRow.appendChild(submitBtn);
+
+        container.appendChild(btnRow);
+    }
+}

--- a/src/app/client/UsersModal.ts
+++ b/src/app/client/UsersModal.ts
@@ -94,6 +94,7 @@ export class UsersModal extends Modal {
                     const res = await authClient.patchUser(u.id, { role: roleSelect.value as Role });
                     if (!res.ok) {
                         this.showStatus(`Failed to change role (HTTP ${res.status})`);
+                        return;
                     }
                     await this.refresh();
                 })();
@@ -112,7 +113,9 @@ export class UsersModal extends Modal {
                 void (async () => {
                     const res = await authClient.patchUser(u.id, { disabled: disabledCb.checked });
                     if (!res.ok) {
+                        disabledCb.checked = u.disabled;
                         this.showStatus(`Failed to update disabled state (HTTP ${res.status})`);
+                        return;
                     }
                     await this.refresh();
                 })();
@@ -133,6 +136,7 @@ export class UsersModal extends Modal {
                         const res = await authClient.patchUser(u.id, { unlock: true });
                         if (!res.ok) {
                             this.showStatus(`Failed to unlock (HTTP ${res.status})`);
+                            return;
                         }
                         await this.refresh();
                     })();

--- a/src/app/client/__tests__/AuthClient.test.ts
+++ b/src/app/client/__tests__/AuthClient.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { authClient } from '../AuthClient';
+
+function stub(handler: (url: string, init?: RequestInit) => unknown): void {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn((url: string, init?: RequestInit) => Promise.resolve(handler(url, init))),
+    );
+}
+const fetchMock = () => fetch as unknown as ReturnType<typeof vi.fn>;
+function lastCall() {
+    return fetchMock().mock.calls.at(-1) as [string, RequestInit | undefined];
+}
+function bodyOf(init?: RequestInit) {
+    return init?.body ? JSON.parse(init.body as string) : undefined;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('AuthClient', () => {
+    it('me() GETs /api/auth/me and returns the parsed body', async () => {
+        stub(() => ({
+            ok: true,
+            json: () => Promise.resolve({ authEnabled: true, user: { username: 'bob', role: 'user' } }),
+        }));
+        const me = await authClient.me();
+        expect(lastCall()[0]).toBe('/api/auth/me');
+        expect(me).toEqual({ authEnabled: true, user: { username: 'bob', role: 'user' } });
+    });
+    it('login() POSTs credentials and returns res.ok', async () => {
+        stub(() => ({ ok: true }));
+        const ok = await authClient.login('admin', 'pw');
+        const [url, init] = lastCall();
+        expect(url).toBe('/api/auth/login');
+        expect(init?.method).toBe('POST');
+        expect(bodyOf(init)).toEqual({ username: 'admin', password: 'pw' });
+        expect(ok).toBe(true);
+    });
+    it('login() returns false on a 401', async () => {
+        stub(() => ({ ok: false, status: 401 }));
+        expect(await authClient.login('admin', 'bad')).toBe(false);
+    });
+    it('changePassword() POSTs current+new and returns res.ok', async () => {
+        stub(() => ({ ok: true }));
+        const ok = await authClient.changePassword('old', 'new');
+        const [url, init] = lastCall();
+        expect(url).toBe('/api/auth/change-password');
+        expect(bodyOf(init)).toEqual({ currentPassword: 'old', newPassword: 'new' });
+        expect(ok).toBe(true);
+    });
+    it('listUsers() GETs /api/users and unwraps .users', async () => {
+        stub(() => ({
+            ok: true,
+            json: () =>
+                Promise.resolve({
+                    users: [
+                        {
+                            id: 1,
+                            username: 'admin',
+                            role: 'admin',
+                            hasPassword: true,
+                            disabled: false,
+                            lockedUntil: null,
+                            lastLogin: null,
+                        },
+                    ],
+                }),
+        }));
+        const users = await authClient.listUsers();
+        expect(lastCall()[0]).toBe('/api/users');
+        expect(users).toHaveLength(1);
+        expect(users[0]!.username).toBe('admin');
+    });
+    it('createUser() POSTs to /api/users', async () => {
+        stub(() => ({ ok: true, status: 201 }));
+        await authClient.createUser({ username: 'carol', role: 'user', password: 'pw' });
+        const [url, init] = lastCall();
+        expect(url).toBe('/api/users');
+        expect(init?.method).toBe('POST');
+        expect(bodyOf(init)).toEqual({ username: 'carol', role: 'user', password: 'pw' });
+    });
+    it('lockdown() POSTs the admin creds + first user to /api/users', async () => {
+        stub(() => ({ ok: true, status: 201 }));
+        await authClient.lockdown({
+            adminUsername: 'owner',
+            adminPassword: 'ap',
+            username: 'bob',
+            role: 'user',
+            password: 'bp',
+        });
+        expect(bodyOf(lastCall()[1])).toEqual({
+            adminUsername: 'owner',
+            adminPassword: 'ap',
+            username: 'bob',
+            role: 'user',
+            password: 'bp',
+        });
+    });
+    it('patchUser() PATCHes /api/users/:id', async () => {
+        stub(() => ({ ok: true }));
+        await authClient.patchUser(3, { disabled: true });
+        const [url, init] = lastCall();
+        expect(url).toBe('/api/users/3');
+        expect(init?.method).toBe('PATCH');
+        expect(bodyOf(init)).toEqual({ disabled: true });
+    });
+    it('deleteUser() DELETEs /api/users/:id', async () => {
+        stub(() => ({ ok: true }));
+        await authClient.deleteUser(3);
+        const [url, init] = lastCall();
+        expect(url).toBe('/api/users/3');
+        expect(init?.method).toBe('DELETE');
+    });
+    it('enableAuth() POSTs /api/auth/enable (returns the Response so 409 is observable)', async () => {
+        stub(() => ({ ok: false, status: 409 }));
+        const res = await authClient.enableAuth();
+        expect(lastCall()[0]).toBe('/api/auth/enable');
+        expect(res.status).toBe(409);
+    });
+    it('disableAuth() POSTs /api/auth/disable', async () => {
+        stub(() => ({ ok: true }));
+        await authClient.disableAuth();
+        expect(lastCall()[0]).toBe('/api/auth/disable');
+    });
+    it('logout() POSTs /api/auth/logout', async () => {
+        stub(() => ({ ok: true }));
+        await authClient.logout();
+        expect(lastCall()[0]).toBe('/api/auth/logout');
+    });
+});

--- a/src/app/client/__tests__/SettingsModal.adminGate.test.ts
+++ b/src/app/client/__tests__/SettingsModal.adminGate.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authClient } from '../AuthClient';
+import { SettingsModal } from '../SettingsModal';
+
+/**
+ * Flush one macrotask tick — enough for the async queueMicrotask (which awaits
+ * me() then fills the body) to settle after me() resolves synchronously via
+ * mockResolvedValue. Call twice if fetch chains need extra settling.
+ */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+    // Stub fetch so refresh* calls don't throw — return a benign ok response.
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(
+            () =>
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({}),
+                }) as unknown as Promise<Response>,
+        ),
+    );
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+function bodyText(): string {
+    return (document.querySelector('.settings-modal .modal-body')?.textContent ?? '').toLowerCase();
+}
+
+describe('SettingsModal admin gating', () => {
+    describe('non-admin user (role=user)', () => {
+        it('does NOT show Updates or Service section headings', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'bob', role: 'user' },
+            });
+
+            new SettingsModal();
+            // First flush: resolves me() + fillBody runs.
+            await flush();
+            // Second flush: lets any refresh* calls (none for user) settle.
+            await flush();
+
+            const text = bodyText();
+            expect(text).not.toContain('updates');
+            expect(text).not.toContain('service');
+        });
+
+        it('does NOT show the web port row', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'bob', role: 'user' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).not.toContain('web port');
+        });
+
+        it('does NOT show stop-server or uninstall rows', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'bob', role: 'user' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).not.toContain('stop the server');
+            expect(text).not.toContain('uninstall ws-scrcpy-web');
+        });
+
+        it('DOES show the reset all my settings row', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'bob', role: 'user' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).toContain('reset all my settings');
+        });
+    });
+
+    describe('admin user (role=admin)', () => {
+        it('shows the Updates section heading', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: false,
+                user: { username: 'admin', role: 'admin' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).toContain('updates');
+        });
+
+        it('shows the Service section heading', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: false,
+                user: { username: 'admin', role: 'admin' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).toContain('service');
+        });
+
+        it('shows the web port row', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: false,
+                user: { username: 'admin', role: 'admin' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).toContain('web port');
+        });
+
+        it('shows the reset all my settings row', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: false,
+                user: { username: 'admin', role: 'admin' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            expect(text).toContain('reset all my settings');
+        });
+    });
+
+    describe('fail-open: me() throws', () => {
+        it('shows the full admin view when me() rejects', async () => {
+            vi.spyOn(authClient, 'me').mockRejectedValue(new Error('network error'));
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const text = bodyText();
+            // Fail-open = full admin view (server still enforces 403)
+            expect(text).toContain('updates');
+            expect(text).toContain('web port');
+            expect(text).toContain('reset all my settings');
+        });
+    });
+});

--- a/src/app/client/__tests__/SettingsModal.authControls.test.ts
+++ b/src/app/client/__tests__/SettingsModal.authControls.test.ts
@@ -210,6 +210,42 @@ describe('SettingsModal auth controls', () => {
         });
     });
 
+    describe('change-password blank guard (FIX 2)', () => {
+        beforeEach(() => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'alice', role: 'user' },
+            });
+        });
+
+        it('clicking save with blank fields shows validation message and does NOT call changePassword', async () => {
+            const changePwSpy = vi.spyOn(authClient, 'changePassword').mockResolvedValue(true);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            // Open the change-password form
+            const cpTrigger = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'change-password',
+            );
+            expect(cpTrigger).toBeDefined();
+            cpTrigger!.click();
+
+            // Leave inputs blank and click save
+            const saveBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.textContent === 'save' && b.closest('.settings-section'),
+            );
+            expect(saveBtn).toBeDefined();
+            saveBtn!.click();
+            await flush();
+            await flush();
+
+            expect(changePwSpy).not.toHaveBeenCalled();
+            expect(bodyText()).toContain('enter your current and new password');
+        });
+    });
+
     describe('change-password form interactions', () => {
         beforeEach(() => {
             vi.spyOn(authClient, 'me').mockResolvedValue({
@@ -277,6 +313,79 @@ describe('SettingsModal auth controls', () => {
             await flush();
 
             expect(bodyText()).toContain('current password incorrect');
+        });
+    });
+
+    describe('logout control (FIX 3)', () => {
+        it('log out button is present for admin when authEnabled=true', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'admin', role: 'admin' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const logoutBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'logout',
+            );
+            expect(logoutBtn).toBeDefined();
+        });
+
+        it('log out button is present for non-admin user when authEnabled=true', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'bob', role: 'user' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const logoutBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'logout',
+            );
+            expect(logoutBtn).toBeDefined();
+        });
+
+        it('log out button is ABSENT when authEnabled=false', async () => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: false,
+                user: { username: 'admin', role: 'admin' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const logoutBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'logout',
+            );
+            expect(logoutBtn).toBeUndefined();
+        });
+
+        it('clicking log out calls authClient.logout() then window.location.reload()', async () => {
+            const logoutSpy = vi.spyOn(authClient, 'logout').mockResolvedValue(undefined);
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'alice', role: 'user' },
+            });
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const logoutBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'logout',
+            ) as HTMLButtonElement | undefined;
+            expect(logoutBtn).toBeDefined();
+            logoutBtn!.click();
+            await flush();
+            await flush();
+
+            expect(logoutSpy).toHaveBeenCalledOnce();
+            expect(window.location.reload).toHaveBeenCalledOnce();
         });
     });
 });

--- a/src/app/client/__tests__/SettingsModal.authControls.test.ts
+++ b/src/app/client/__tests__/SettingsModal.authControls.test.ts
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authClient } from '../AuthClient';
+import { SettingsModal } from '../SettingsModal';
+
+/**
+ * Flush one macrotask tick — enough for the async queueMicrotask (which awaits
+ * me() then fills the body) to settle after me() resolves synchronously via
+ * mockResolvedValue. Call twice if fetch chains need extra settling.
+ */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+function bodyText(): string {
+    return (document.querySelector('.settings-modal .modal-body')?.textContent ?? '').toLowerCase();
+}
+
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+    // Stub fetch so refresh* calls don't throw — return a benign ok response.
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(
+            () =>
+                Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({}),
+                }) as unknown as Promise<Response>,
+        ),
+    );
+    // Stub window.location.reload so tests don't actually navigate.
+    const locationStub = { reload: vi.fn() };
+    Object.defineProperty(window, 'location', {
+        value: locationStub,
+        writable: true,
+        configurable: true,
+    });
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('SettingsModal auth controls', () => {
+    describe('admin + authEnabled=true', () => {
+        beforeEach(() => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'admin', role: 'admin' },
+            });
+        });
+
+        it('shows a "manage users" button', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).toContain('manage users');
+        });
+
+        it('clicking "manage users" opens a UsersModal (.users-modal appears in document)', async () => {
+            // Stub listUsers to avoid errors during UsersModal render
+            vi.spyOn(authClient, 'listUsers').mockResolvedValue([]);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const manageBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.textContent?.toLowerCase() === 'manage users',
+            );
+            expect(manageBtn).toBeDefined();
+            manageBtn!.click();
+            await flush();
+            await flush();
+
+            // UsersModal adds a .users-modal dialog to the document
+            expect(document.querySelector('.users-modal')).toBeTruthy();
+        });
+
+        it('shows a "disable login" button', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).toContain('disable login');
+        });
+
+        it('clicking "disable login" calls authClient.disableAuth and reloads', async () => {
+            const disableAuthSpy = vi.spyOn(authClient, 'disableAuth').mockResolvedValue(undefined);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const disableBtn = [...document.querySelectorAll('button')].find((b) =>
+                b.textContent?.toLowerCase().includes('disable login'),
+            );
+            expect(disableBtn).toBeDefined();
+            disableBtn!.click();
+            await flush();
+            await flush();
+
+            expect(disableAuthSpy).toHaveBeenCalledOnce();
+            expect(window.location.reload).toHaveBeenCalledOnce();
+        });
+
+        it('shows a change-password control', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).toContain('change password');
+        });
+    });
+
+    describe('non-admin (role=user) + authEnabled=true', () => {
+        beforeEach(() => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'bob', role: 'user' },
+            });
+        });
+
+        it('does NOT show "manage users"', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).not.toContain('manage users');
+        });
+
+        it('does NOT show "disable login"', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).not.toContain('disable login');
+        });
+
+        it('DOES show change-password (user-level when authEnabled)', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).toContain('change password');
+        });
+    });
+
+    describe('admin + authEnabled=false (open mode)', () => {
+        beforeEach(() => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: false,
+                user: { username: 'admin', role: 'admin' },
+            });
+        });
+
+        it('change-password is ABSENT in open mode', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).not.toContain('change password');
+        });
+
+        it('shows "enable login" button', async () => {
+            new SettingsModal();
+            await flush();
+            await flush();
+            expect(bodyText()).toContain('enable login');
+        });
+
+        it('clicking "enable login" when ok calls authClient.enableAuth and reloads', async () => {
+            const enableAuthSpy = vi
+                .spyOn(authClient, 'enableAuth')
+                .mockResolvedValue({ ok: true, status: 200 } as Response);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const enableBtn = [...document.querySelectorAll('button')].find((b) =>
+                b.textContent?.toLowerCase().includes('enable login'),
+            );
+            expect(enableBtn).toBeDefined();
+            enableBtn!.click();
+            await flush();
+            await flush();
+
+            expect(enableAuthSpy).toHaveBeenCalledOnce();
+            expect(window.location.reload).toHaveBeenCalledOnce();
+        });
+
+        it('clicking "enable login" when 409 shows inline hint', async () => {
+            vi.spyOn(authClient, 'enableAuth').mockResolvedValue({ ok: false, status: 409 } as Response);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const enableBtn = [...document.querySelectorAll('button')].find((b) =>
+                b.textContent?.toLowerCase().includes('enable login'),
+            );
+            enableBtn!.click();
+            await flush();
+            await flush();
+
+            expect(bodyText()).toContain('add a user with an admin password first');
+        });
+    });
+
+    describe('change-password form interactions', () => {
+        beforeEach(() => {
+            vi.spyOn(authClient, 'me').mockResolvedValue({
+                authEnabled: true,
+                user: { username: 'alice', role: 'user' },
+            });
+        });
+
+        it('on save → authClient.changePassword called with current and new password', async () => {
+            const changePwSpy = vi.spyOn(authClient, 'changePassword').mockResolvedValue(true);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            // Click the trigger button to open the form
+            const cpTrigger = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'change-password',
+            );
+            expect(cpTrigger).toBeDefined();
+            cpTrigger!.click();
+
+            // Fill in the inputs
+            const curInput = document.querySelector<HTMLInputElement>('[data-field="cp-current"]');
+            const newInput = document.querySelector<HTMLInputElement>('[data-field="cp-new"]');
+            expect(curInput).toBeDefined();
+            expect(newInput).toBeDefined();
+            curInput!.value = 'cur';
+            newInput!.value = 'new';
+
+            // Click save
+            const saveBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.textContent === 'save' && b.closest('.settings-section'),
+            );
+            expect(saveBtn).toBeDefined();
+            saveBtn!.click();
+            await flush();
+            await flush();
+
+            expect(changePwSpy).toHaveBeenCalledWith('cur', 'new');
+        });
+
+        it('on false return from changePassword, shows error status', async () => {
+            vi.spyOn(authClient, 'changePassword').mockResolvedValue(false);
+
+            new SettingsModal();
+            await flush();
+            await flush();
+
+            const cpTrigger = [...document.querySelectorAll('button')].find(
+                (b) => b.getAttribute('data-action') === 'change-password',
+            );
+            cpTrigger!.click();
+
+            const curInput = document.querySelector<HTMLInputElement>('[data-field="cp-current"]');
+            const newInput = document.querySelector<HTMLInputElement>('[data-field="cp-new"]');
+            curInput!.value = 'wrong';
+            newInput!.value = 'new';
+
+            const saveBtn = [...document.querySelectorAll('button')].find(
+                (b) => b.textContent === 'save' && b.closest('.settings-section'),
+            );
+            saveBtn!.click();
+            await flush();
+            await flush();
+
+            expect(bodyText()).toContain('current password incorrect');
+        });
+    });
+});

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as AdminConfirmModalModule from '../AdminConfirmModal';
+import { authClient } from '../AuthClient';
 import * as ResetConfirmModalModule from '../ResetConfirmModal';
 import {
     applySystemInstallGate,
@@ -12,8 +13,8 @@ import {
     buildUninstallControl,
     classifyInstallPoll,
     lockScopeRadioControl,
-    resetPromptsPayload,
     resetPromptSettingsPayload,
+    resetPromptsPayload,
     SettingsModal,
     scopeRadioState,
     stopServerButtonState,
@@ -22,6 +23,13 @@ import {
 } from '../SettingsModal';
 import * as SettingsServiceModule from '../SettingsService';
 import * as UninstallConfirmModalModule from '../UninstallConfirmModal';
+
+/** Stub authClient.me to return an admin view — used in tests that construct SettingsModal
+ *  to ensure the async me() resolves (rather than hanging on a never-resolving fetch mock)
+ *  so fillBody() runs and the DOM is populated. */
+function stubMeAsAdmin(): void {
+    vi.spyOn(authClient, 'me').mockResolvedValue({ authEnabled: false, user: { username: 'admin', role: 'admin' } });
+}
 
 /** Flush microtasks + a macrotask so the awaited fetch handlers settle. */
 const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -473,6 +481,8 @@ describe('Server section row order (folded App, beta.62)', () => {
     const flushMicrotasks = (): Promise<void> => new Promise((resolve) => queueMicrotask(resolve));
 
     it('Server-section rows appear in order: reset, install-for-all-users, stop-server, uninstall', async () => {
+        // Stub authClient.me so the async queueMicrotask resolves as admin (full view).
+        stubMeAsAdmin();
         // Stub fetch so the refresh* calls inside the constructor never settle
         // (we only need the base DOM structure, not service-status overlays).
         vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => undefined)));
@@ -513,6 +523,7 @@ describe('Settings section restructure (beta.62)', () => {
 
     it('renders sections in order Updates, Service, Server — no standalone App section', async () => {
         document.body.replaceChildren();
+        stubMeAsAdmin();
         vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => undefined)));
         HTMLDialogElement.prototype.showModal = vi.fn();
 
@@ -527,6 +538,7 @@ describe('Settings section restructure (beta.62)', () => {
 
     it('places the web-port save button inline with the input in the same control cell', async () => {
         document.body.replaceChildren();
+        stubMeAsAdmin();
         vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => undefined)));
         HTMLDialogElement.prototype.showModal = vi.fn();
 
@@ -611,6 +623,7 @@ describe('onInstallService takeover copy (§7 system-service hand-off)', () => {
     beforeEach(() => {
         document.body.replaceChildren();
         HTMLDialogElement.prototype.showModal = vi.fn();
+        stubMeAsAdmin();
         vi.useFakeTimers();
     });
 

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -521,7 +521,7 @@ describe('Server section row order (folded App, beta.62)', () => {
 describe('Settings section restructure (beta.62)', () => {
     const flushMicrotasks = (): Promise<void> => new Promise((resolve) => queueMicrotask(resolve));
 
-    it('renders sections in order Updates, Service, Server — no standalone App section', async () => {
+    it('renders sections in order Users, Updates, Service, Server — no standalone App section', async () => {
         document.body.replaceChildren();
         stubMeAsAdmin();
         vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => undefined)));
@@ -533,7 +533,9 @@ describe('Settings section restructure (beta.62)', () => {
         const headings = Array.from(document.body.querySelectorAll<HTMLElement>('.settings-section-heading')).map(
             (el) => el.textContent ?? '',
         );
-        expect(headings).toEqual(['Updates', 'Service', 'Server']);
+        // stubMeAsAdmin returns role=admin: admin sees Users, Updates, Service, Server.
+        // No standalone App section (folded into Server in beta.62).
+        expect(headings).toEqual(['Users', 'Updates', 'Service', 'Server']);
     });
 
     it('places the web-port save button inline with the input in the same control cell', async () => {

--- a/src/app/client/__tests__/UsersModal.test.ts
+++ b/src/app/client/__tests__/UsersModal.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse, UserRow } from '../AuthClient';
+import { authClient } from '../AuthClient';
+import { UsersModal } from '../UsersModal';
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+// ------------------------------------------------------------------
+// Test data
+// ------------------------------------------------------------------
+const adminUser: UserRow = {
+    id: 1,
+    username: 'admin',
+    role: 'admin',
+    hasPassword: true,
+    disabled: false,
+    lockedUntil: null,
+    lastLogin: null,
+};
+const bobUser: UserRow = {
+    id: 2,
+    username: 'bob',
+    role: 'user',
+    hasPassword: true,
+    disabled: false,
+    lockedUntil: null,
+    lastLogin: null,
+};
+const lockedUser: UserRow = {
+    id: 3,
+    username: 'carol',
+    role: 'user',
+    hasPassword: true,
+    disabled: false,
+    lockedUntil: Date.now() + 60_000, // locked for 1 minute
+    lastLogin: null,
+};
+const disabledUser: UserRow = {
+    id: 4,
+    username: 'dave',
+    role: 'user',
+    hasPassword: true,
+    disabled: true,
+    lockedUntil: null,
+    lastLogin: null,
+};
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+function modalBody(): string {
+    return document.querySelector('.users-modal .modal-body')?.textContent ?? '';
+}
+function buttons(): HTMLButtonElement[] {
+    return Array.from(document.querySelectorAll('.users-modal button')) as HTMLButtonElement[];
+}
+function findBtn(text: string): HTMLButtonElement | undefined {
+    return buttons().find((b) => b.textContent?.trim().toLowerCase() === text.toLowerCase());
+}
+function statusEl(): string {
+    return (document.querySelector('.users-modal-status') as HTMLElement | null)?.textContent ?? '';
+}
+
+// ------------------------------------------------------------------
+// Setup / teardown
+// ------------------------------------------------------------------
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+    });
+    // Provide a fetch stub so any un-spied authClient calls don't throw
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as unknown as Response)),
+    );
+});
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+// ------------------------------------------------------------------
+// Helper to mount the modal with mocked API
+// ------------------------------------------------------------------
+function mountModal(
+    meResult: MeResponse = { authEnabled: true, user: adminUser },
+    usersList: UserRow[] = [adminUser, bobUser],
+): UsersModal {
+    vi.spyOn(authClient, 'me').mockResolvedValue(meResult);
+    vi.spyOn(authClient, 'listUsers').mockResolvedValue(usersList);
+    return new UsersModal();
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+describe('UsersModal — list view', () => {
+    it('lists users: body contains usernames and roles', async () => {
+        mountModal();
+        await flush();
+        await flush(); // double flush for async refresh chain
+        const body = modalBody();
+        expect(body).toContain('admin');
+        expect(body).toContain('bob');
+        expect(body).toContain('user');
+    });
+
+    it('shows "disabled" status for a disabled user', async () => {
+        mountModal({ authEnabled: true, user: adminUser }, [adminUser, disabledUser]);
+        await flush();
+        await flush();
+        const body = modalBody();
+        expect(body).toContain('dave');
+        expect(body).toContain('disabled');
+    });
+
+    it('shows "locked" status for a locked user', async () => {
+        mountModal({ authEnabled: true, user: adminUser }, [adminUser, lockedUser]);
+        await flush();
+        await flush();
+        const body = modalBody();
+        expect(body).toContain('carol');
+        expect(body).toContain('locked');
+    });
+});
+
+describe('UsersModal — disable toggle', () => {
+    it('calls patchUser with { disabled: true } when checkbox is checked', async () => {
+        const patchSpy = vi.spyOn(authClient, 'patchUser').mockResolvedValue({ ok: true } as Response);
+        // Provide listUsers mock for the post-patch refresh too
+        vi.spyOn(authClient, 'listUsers').mockResolvedValue([adminUser, bobUser]);
+        vi.spyOn(authClient, 'me').mockResolvedValue({ authEnabled: true, user: adminUser });
+
+        new UsersModal();
+        await flush();
+        await flush();
+
+        // Find the disable checkbox for bob (id=2)
+        const checkboxes = Array.from(
+            document.querySelectorAll('input[type="checkbox"][data-user-id="2"]'),
+        ) as HTMLInputElement[];
+        expect(checkboxes.length).toBeGreaterThan(0);
+        const cb = checkboxes[0]!;
+        cb.checked = true;
+        cb.dispatchEvent(new Event('change'));
+
+        await flush();
+        await flush();
+
+        expect(patchSpy).toHaveBeenCalledWith(2, { disabled: true });
+    });
+});
+
+describe('UsersModal — unlock button', () => {
+    it('shows unlock button for a locked user and calls patchUser({ unlock: true })', async () => {
+        const patchSpy = vi.spyOn(authClient, 'patchUser').mockResolvedValue({ ok: true } as Response);
+        vi.spyOn(authClient, 'listUsers').mockResolvedValue([adminUser, lockedUser]);
+        vi.spyOn(authClient, 'me').mockResolvedValue({ authEnabled: true, user: adminUser });
+
+        new UsersModal();
+        await flush();
+        await flush();
+
+        const unlockBtn = buttons().find((b) => b.getAttribute('data-action') === 'unlock');
+        expect(unlockBtn).toBeTruthy();
+        unlockBtn!.click();
+
+        await flush();
+        await flush();
+
+        expect(patchSpy).toHaveBeenCalledWith(lockedUser.id, { unlock: true });
+    });
+});
+
+describe('UsersModal — delete with 409 error', () => {
+    it('shows inline error message on 409 and does not throw', async () => {
+        vi.spyOn(authClient, 'deleteUser').mockResolvedValue({ ok: false, status: 409 } as Response);
+        mountModal({ authEnabled: true, user: adminUser }, [adminUser]);
+        await flush();
+        await flush();
+
+        const deleteBtn = findBtn('delete');
+        expect(deleteBtn).toBeTruthy();
+        deleteBtn!.click();
+
+        await flush();
+        await flush();
+
+        const status = statusEl();
+        expect(status).toContain('409');
+        expect(status.length).toBeGreaterThan(0);
+    });
+});
+
+describe('UsersModal — add user (authEnabled = true)', () => {
+    it('shows "Add user" button; clicking it opens form WITHOUT lockdown section', async () => {
+        mountModal({ authEnabled: true, user: adminUser }, [adminUser]);
+        await flush();
+        await flush();
+
+        const addBtn = findBtn('add user');
+        expect(addBtn).toBeTruthy();
+        addBtn!.click();
+
+        await flush();
+
+        // lockdown section should NOT exist
+        const lockSection = document.querySelector('.lockdown-section');
+        expect(lockSection).toBeNull();
+
+        // New user section should exist
+        const newUserSection = document.querySelector('.new-user-section');
+        expect(newUserSection).toBeTruthy();
+    });
+
+    it('submit calls createUser with correct args', async () => {
+        const createSpy = vi.spyOn(authClient, 'createUser').mockResolvedValue({ ok: true } as Response);
+        // listUsers for the post-create refresh
+        vi.spyOn(authClient, 'listUsers').mockResolvedValue([adminUser]);
+        vi.spyOn(authClient, 'me').mockResolvedValue({ authEnabled: true, user: adminUser });
+
+        new UsersModal();
+        await flush();
+        await flush();
+
+        const addBtn = findBtn('add user');
+        expect(addBtn).toBeTruthy();
+        addBtn!.click();
+        await flush();
+
+        // Fill in the form
+        const inputs = Array.from(
+            document.querySelectorAll('.users-modal input[type="text"], .users-modal input[type="password"]'),
+        ) as HTMLInputElement[];
+        const usernameInput = inputs.find((i) => i.getAttribute('type') === 'text' || i.placeholder === '');
+        const passwordInput = inputs.find((i) => i.getAttribute('type') === 'password');
+
+        // More targeted: get the visible text inputs in the new-user section
+        const newSection = document.querySelector('.new-user-section');
+        expect(newSection).toBeTruthy();
+        const textInputs = Array.from(newSection!.querySelectorAll('input[type="text"]')) as HTMLInputElement[];
+        const pwInputs = Array.from(newSection!.querySelectorAll('input[type="password"]')) as HTMLInputElement[];
+
+        expect(textInputs.length).toBeGreaterThan(0);
+        expect(pwInputs.length).toBeGreaterThan(0);
+
+        textInputs[0]!.value = 'newuser';
+        pwInputs[0]!.value = 'secret123';
+
+        const submitBtn = findBtn('add user');
+        expect(submitBtn).toBeTruthy();
+        submitBtn!.click();
+
+        await flush();
+        await flush();
+
+        expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ username: 'newuser', password: 'secret123' }));
+
+        // Keep linter happy
+        void usernameInput;
+        void passwordInput;
+    });
+});
+
+describe('UsersModal — add user lockdown flow (authEnabled = false)', () => {
+    it('shows "Secure the admin account" section when authEnabled is false', async () => {
+        mountModal({ authEnabled: false, user: null }, []);
+        await flush();
+        await flush();
+
+        const addBtn = findBtn('add user');
+        expect(addBtn).toBeTruthy();
+        addBtn!.click();
+        await flush();
+
+        const lockSection = document.querySelector('.lockdown-section');
+        expect(lockSection).toBeTruthy();
+        // The admin-password field should be present
+        const adminPwInput = document.querySelector('[data-field="admin-password"]');
+        expect(adminPwInput).toBeTruthy();
+    });
+
+    it('submit calls authClient.lockdown with admin creds + new user, then reloads', async () => {
+        const lockdownSpy = vi.spyOn(authClient, 'lockdown').mockResolvedValue({ ok: true } as Response);
+        const reloadMock = vi.fn();
+        vi.stubGlobal('location', { reload: reloadMock });
+
+        mountModal({ authEnabled: false, user: null }, []);
+        await flush();
+        await flush();
+
+        // Click "Add user"
+        const addBtn = findBtn('add user');
+        expect(addBtn).toBeTruthy();
+        addBtn!.click();
+        await flush();
+
+        // Fill admin creds
+        const adminUserInput = document.querySelector('[data-field="admin-username"]') as HTMLInputElement;
+        const adminPwInput = document.querySelector('[data-field="admin-password"]') as HTMLInputElement;
+        expect(adminUserInput).toBeTruthy();
+        expect(adminPwInput).toBeTruthy();
+
+        adminUserInput.value = 'admin';
+        adminPwInput.value = 'strongpassword';
+
+        // Fill new user
+        const newSection = document.querySelector('.new-user-section');
+        expect(newSection).toBeTruthy();
+        const textInputs = Array.from(newSection!.querySelectorAll('input[type="text"]')) as HTMLInputElement[];
+        const pwInputs = Array.from(newSection!.querySelectorAll('input[type="password"]')) as HTMLInputElement[];
+
+        expect(textInputs.length).toBeGreaterThan(0);
+        textInputs[0]!.value = 'firstuser';
+        pwInputs[0]!.value = 'userpassword';
+
+        // Submit
+        const submitBtn = findBtn('secure & add user');
+        expect(submitBtn).toBeTruthy();
+        submitBtn!.click();
+
+        await flush();
+        await flush();
+
+        expect(lockdownSpy).toHaveBeenCalledWith({
+            adminUsername: 'admin',
+            adminPassword: 'strongpassword',
+            username: 'firstuser',
+            role: expect.any(String),
+            password: 'userpassword',
+        });
+
+        expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows error inline and does NOT reload when lockdown returns non-OK', async () => {
+        vi.spyOn(authClient, 'lockdown').mockResolvedValue({ ok: false, status: 400 } as Response);
+        const reloadMock = vi.fn();
+        vi.stubGlobal('location', { reload: reloadMock });
+
+        mountModal({ authEnabled: false, user: null }, []);
+        await flush();
+        await flush();
+
+        const addBtn = findBtn('add user');
+        addBtn!.click();
+        await flush();
+
+        const adminUserInput = document.querySelector('[data-field="admin-username"]') as HTMLInputElement;
+        const adminPwInput = document.querySelector('[data-field="admin-password"]') as HTMLInputElement;
+        adminUserInput.value = 'admin';
+        adminPwInput.value = 'pw';
+
+        const newSection = document.querySelector('.new-user-section');
+        const textInputs = Array.from(newSection!.querySelectorAll('input[type="text"]')) as HTMLInputElement[];
+        const pwInputs = Array.from(newSection!.querySelectorAll('input[type="password"]')) as HTMLInputElement[];
+        textInputs[0]!.value = 'user';
+        pwInputs[0]!.value = 'pass';
+
+        const submitBtn = findBtn('secure & add user');
+        submitBtn!.click();
+
+        await flush();
+        await flush();
+
+        expect(reloadMock).not.toHaveBeenCalled();
+        const status = statusEl();
+        expect(status).toContain('400');
+    });
+});

--- a/src/app/client/__tests__/UsersModal.test.ts
+++ b/src/app/client/__tests__/UsersModal.test.ts
@@ -158,6 +158,32 @@ describe('UsersModal — disable toggle', () => {
     });
 });
 
+describe('UsersModal — disable toggle failure keeps error visible', () => {
+    it('on failed patchUser (409) the error message stays visible and does not throw', async () => {
+        vi.spyOn(authClient, 'patchUser').mockResolvedValue({ ok: false, status: 409 } as Response);
+        vi.spyOn(authClient, 'listUsers').mockResolvedValue([adminUser, bobUser]);
+        vi.spyOn(authClient, 'me').mockResolvedValue({ authEnabled: true, user: adminUser });
+
+        new UsersModal();
+        await flush();
+        await flush();
+
+        // Find bob's disable checkbox (id=2)
+        const cb = document.querySelector('input[type="checkbox"][data-user-id="2"]') as HTMLInputElement | null;
+        expect(cb).toBeTruthy();
+        cb!.checked = true;
+        cb!.dispatchEvent(new Event('change'));
+
+        await flush();
+        await flush();
+
+        // Error must still be visible — refresh must NOT have been called (which would clear it)
+        const status = statusEl();
+        expect(status).toContain('Failed');
+        expect(status).toContain('409');
+    });
+});
+
 describe('UsersModal — unlock button', () => {
     it('shows unlock button for a locked user and calls patchUser({ unlock: true })', async () => {
         const patchSpy = vi.spyOn(authClient, 'patchUser').mockResolvedValue({ ok: true } as Response);

--- a/src/app/client/__tests__/adminGate.test.ts
+++ b/src/app/client/__tests__/adminGate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { ADMIN_ONLY_SECTIONS, canSeeSection } from '../adminGate';
+
+describe('canSeeSection', () => {
+    describe('admin role', () => {
+        it('can see every admin-only section', () => {
+            for (const section of ADMIN_ONLY_SECTIONS) {
+                expect(canSeeSection('admin', section), `admin should see '${section}'`).toBe(true);
+            }
+        });
+
+        it('can see user-level sections too', () => {
+            expect(canSeeSection('admin', 'theme')).toBe(true);
+        });
+    });
+
+    describe('user role', () => {
+        it('cannot see any admin-only section', () => {
+            for (const section of ADMIN_ONLY_SECTIONS) {
+                expect(canSeeSection('user', section), `user should NOT see '${section}'`).toBe(false);
+            }
+        });
+
+        it('can see user-level sections', () => {
+            expect(canSeeSection('user', 'theme')).toBe(true);
+        });
+    });
+
+    describe('null / undefined role', () => {
+        it('null cannot see an admin-only section', () => {
+            expect(canSeeSection(null, 'updates')).toBe(false);
+        });
+
+        it('null CAN see a user-level section', () => {
+            expect(canSeeSection(null, 'theme')).toBe(true);
+        });
+
+        it('undefined cannot see an admin-only section', () => {
+            expect(canSeeSection(undefined, 'updates')).toBe(false);
+        });
+
+        it('undefined CAN see a user-level section', () => {
+            expect(canSeeSection(undefined, 'theme')).toBe(true);
+        });
+    });
+
+    describe('specific admin-only section names (explicit smoke)', () => {
+        const adminSections = ['updates', 'service', 'users', 'webPort', 'serverControls'] as const;
+
+        for (const section of adminSections) {
+            it(`'${section}' requires admin`, () => {
+                expect(canSeeSection('admin', section)).toBe(true);
+                expect(canSeeSection('user', section)).toBe(false);
+                expect(canSeeSection(null, section)).toBe(false);
+            });
+        }
+    });
+});

--- a/src/app/client/adminGate.ts
+++ b/src/app/client/adminGate.ts
@@ -1,0 +1,12 @@
+import type { Role } from './AuthClient';
+
+// Settings areas that only an admin may see/use. Everything NOT listed here is
+// user-level and always visible. The SERVER enforces the same set via requireAdmin
+// (403) — this is the cosmetic UI half.
+export const ADMIN_ONLY_SECTIONS = new Set<string>(['updates', 'service', 'users', 'webPort', 'serverControls']);
+
+/** True if `role` may see `section`. User-level sections are always visible; admin-only ones require role==='admin'. */
+export function canSeeSection(role: Role | null | undefined, section: string): boolean {
+    if (!ADMIN_ONLY_SECTIONS.has(section)) return true;
+    return role === 'admin';
+}

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -2211,6 +2211,17 @@ describe('ServiceApi', () => {
     // ── reason discriminator + no-direct-uninstall guard (v0.1.25) ──────────
 
     it('service+LocalSystem uninstall writes marker and returns shutting-down (Phase 4 replaces handoff)', async () => {
+        // Use fake timers to prevent the hardcoded setTimeout(process.exit, 5000) in
+        // the LocalSystem uninstall path from leaking a real pending timer that fires
+        // during later tests (specifically the "schedules process.exit(0) after 5s"
+        // test that uses a global process.exit spy).
+        vi.useFakeTimers();
+        using _restoreTimers = {
+            [Symbol.dispose]() {
+                vi.useRealTimers();
+            },
+        };
+
         const uninstallSpy = vi.fn(async () => undefined);
         const client = fakeClient({
             uninstall: uninstallSpy,
@@ -2333,6 +2344,16 @@ describe('ServiceApi', () => {
 
     describe('handleUninstall — operation-server flow (Phase 4)', () => {
         it('writes uninstall-pending marker when service+LocalSystem on Windows', async () => {
+            // Use fake timers to prevent the hardcoded setTimeout(process.exit, 5000) in
+            // the LocalSystem uninstall path from leaking a real pending timer that fires
+            // during the "schedules process.exit(0) after 5s" test's global spy window.
+            vi.useFakeTimers();
+            using _restoreTimers = {
+                [Symbol.dispose]() {
+                    vi.useRealTimers();
+                },
+            };
+
             const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
             const factoryResult: ServiceClientFactoryResult = {
                 client,
@@ -2356,6 +2377,16 @@ describe('ServiceApi', () => {
         });
 
         it('returns 200 with status=shutting-down and no redirectTo', async () => {
+            // Use fake timers to prevent the hardcoded setTimeout(process.exit, 5000) in
+            // the LocalSystem uninstall path from leaking a real pending timer that fires
+            // during the "schedules process.exit(0) after 5s" test's global spy window.
+            vi.useFakeTimers();
+            using _restoreTimers = {
+                [Symbol.dispose]() {
+                    vi.useRealTimers();
+                },
+            };
+
             const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
             const factoryResult: ServiceClientFactoryResult = {
                 client,


### PR DESCRIPTION
## Optional user accounts + login — client UI (SQLite workstream, Phase 4 follow-up)

The browser-side of the opt-in auth feature, completing the server-side foundation in #436 (land them together). `release:none`. Pure client UI — the server already enforces all authorization (403) and serves the inline login page when locked; this adds the in-app management.

### What it adds
- **AuthClient** — a small `fetch` wrapper over `/api/auth/*` + `/api/users`.
- **Admin-only Settings** — the Settings modal resolves the current user's role (`GET /api/auth/me`) and hides the admin sections (Updates, Service, Users) and admin rows (web port, install-for-all, stop-server, uninstall) from a regular user. The server enforces the same set; this is the UI half. Fails open (full view) if `me()` errors.
- **Users modal** (admin) — list users with role + status; change role, reset password, disable/enable, unlock, delete (the last-enabled-admin guard's 409 is surfaced). "Add user" in open mode runs the airtight **"Secure the admin account"** flow: set the admin password + create the first user + lock the app, then reload to the login page.
- **Account controls** — change your own password (when logged in), a **log out** button, and an admin **enable/disable login** toggle (reversible open ↔ locked, with a hint when there's no admin password yet).

### Review + testing
Built subagent-driven: per-sub-task implement → independent review, then a whole-branch review on the most capable model that returned *READY TO MERGE* — its findings (keep action errors visible, guard blank change-password, wire the missing logout control) were folded in. `tsc` clean; **262 client tests** green (jsdom + fetch-spy). There is intentionally no client login page — the server serves a self-contained one inline. The pre-existing `ServiceApi.test` flake fix from #436 is cherry-picked here so CI is green regardless of merge order.

### Merge order
Land #436 (server) with or before this — the API these calls hit lives there. Both are `release:none`; a later beta exposes the feature (off by default, inert until the first real user is added).
