### PR TITLE
fix(auth): blind login timing oracle + fail-closed UsersModal me()

### DIFF
--- a/src/app/client/UsersModal.ts
+++ b/src/app/client/UsersModal.ts
@@ -31,7 +31,7 @@ export class UsersModal extends Modal {
             // enabled (that hides the lockdown affordance). Surface it instead.
             const err = document.createElement('div');
             err.className = 'users-modal-status';
-            err.style.cssText = 'color:#e05555;font-size:13px;margin-bottom:8px;';
+            err.style.cssText = 'color: #e05555; font-size: 13px; margin-bottom: 8px; min-height: 1.4em;';
             err.textContent = "Couldn't load auth state — reload the page.";
             this.bodyEl.replaceChildren(err);
             return;

--- a/src/app/client/UsersModal.ts
+++ b/src/app/client/UsersModal.ts
@@ -1,5 +1,5 @@
 import { Modal } from '../ui/Modal';
-import type { Role, UserRow } from './AuthClient';
+import type { MeResponse, Role, UserRow } from './AuthClient';
 import { authClient } from './AuthClient';
 
 export class UsersModal extends Modal {
@@ -23,7 +23,19 @@ export class UsersModal extends Modal {
     // -----------------------------------------------------------------------
 
     async refresh(): Promise<void> {
-        const me = await authClient.me().catch(() => ({ authEnabled: true, user: null }));
+        let me: MeResponse;
+        try {
+            me = await authClient.me();
+        } catch {
+            // Fail CLOSED on the UI: a transient me() error must not assume auth is
+            // enabled (that hides the lockdown affordance). Surface it instead.
+            const err = document.createElement('div');
+            err.className = 'users-modal-status';
+            err.style.cssText = 'color:#e05555;font-size:13px;margin-bottom:8px;';
+            err.textContent = "Couldn't load auth state — reload the page.";
+            this.bodyEl.replaceChildren(err);
+            return;
+        }
         const users = await authClient.listUsers().catch(() => [] as UserRow[]);
 
         const container = this.bodyEl;

--- a/src/app/client/__tests__/UsersModal.test.ts
+++ b/src/app/client/__tests__/UsersModal.test.ts
@@ -295,6 +295,28 @@ describe('UsersModal — add user (authEnabled = true)', () => {
     });
 });
 
+describe('UsersModal — me() failure is fail-closed (not fail-open)', () => {
+    it('when me() rejects, shows a reload-page error and does NOT render add-user button', async () => {
+        vi.spyOn(authClient, 'me').mockRejectedValue(new Error('network error'));
+        vi.spyOn(authClient, 'listUsers').mockResolvedValue([adminUser]);
+        new UsersModal();
+        await flush();
+        await flush();
+
+        // Must show the error message in the modal body
+        const body = modalBody();
+        expect(body).toContain("Couldn't load auth state");
+
+        // Must NOT render the Add user button (that would be fail-open)
+        const addBtn = findBtn('add user');
+        expect(addBtn).toBeUndefined();
+
+        // Must NOT render the lockdown section (authEnabled must not be assumed false)
+        const lockSection = document.querySelector('.lockdown-section');
+        expect(lockSection).toBeNull();
+    });
+});
+
 describe('UsersModal — add user lockdown flow (authEnabled = false)', () => {
     it('shows "Secure the admin account" section when authEnabled is false', async () => {
         mountModal({ authEnabled: false, user: null }, []);

--- a/src/app/client/__tests__/UsersModal.test.ts
+++ b/src/app/client/__tests__/UsersModal.test.ts
@@ -298,7 +298,6 @@ describe('UsersModal — add user (authEnabled = true)', () => {
 describe('UsersModal — me() failure is fail-closed (not fail-open)', () => {
     it('when me() rejects, shows a reload-page error and does NOT render add-user button', async () => {
         vi.spyOn(authClient, 'me').mockRejectedValue(new Error('network error'));
-        vi.spyOn(authClient, 'listUsers').mockResolvedValue([adminUser]);
         new UsersModal();
         await flush();
         await flush();

--- a/src/server/auth/__tests__/loginService.test.ts
+++ b/src/server/auth/__tests__/loginService.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Db } from '../../db/Db';
 import { LOCK_MS } from '../loginPolicy';
@@ -37,5 +37,36 @@ describe('login', () => {
         // auto-unlock after the window
         const r2 = login(db, 'admin', 'correct', 1000 + LOCK_MS + 1);
         expect(r2.ok).toBe(true);
+    });
+});
+
+describe('login timing-blind paths', () => {
+    it('calls blindVerify on unknown-username path and still returns invalid', async () => {
+        // Dynamic import so vi.spyOn can intercept the live module binding.
+        const passwordMod = await import('../password');
+        const spy = vi.spyOn(passwordMod, 'blindVerify');
+        const r = login(db, 'nobody', 'x', 1000);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(r).toEqual({ ok: false, reason: 'invalid' });
+        spy.mockRestore();
+    });
+
+    it('calls blindVerify on disabled-user path and still returns disabled', async () => {
+        const passwordMod = await import('../password');
+        const spy = vi.spyOn(passwordMod, 'blindVerify');
+        db.users.setDisabled(1, true);
+        const r = login(db, 'admin', 'correct', 1000);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(r).toEqual({ ok: false, reason: 'disabled' });
+        spy.mockRestore();
+    });
+
+    it('does NOT call blindVerify on the happy path (correct password)', async () => {
+        const passwordMod = await import('../password');
+        const spy = vi.spyOn(passwordMod, 'blindVerify');
+        const r = login(db, 'admin', 'correct', 1000);
+        expect(spy).not.toHaveBeenCalled();
+        expect(r.ok).toBe(true);
+        spy.mockRestore();
     });
 });

--- a/src/server/auth/loginService.ts
+++ b/src/server/auth/loginService.ts
@@ -1,6 +1,6 @@
 import type { Db } from '../db/Db';
 import { applyFailure, extendLock, isLocked } from './loginPolicy';
-import { verifyPassword } from './password';
+import { blindVerify, verifyPassword } from './password';
 import { SessionStore } from './session';
 
 export type LoginResult =
@@ -9,8 +9,14 @@ export type LoginResult =
 
 export function login(db: Db, username: string, password: string, now: number): LoginResult {
     const user = db.users.getByUsername(username);
-    if (!user) return { ok: false, reason: 'invalid' };
-    if (user.disabled) return { ok: false, reason: 'disabled' };
+    if (!user) {
+        blindVerify(password);
+        return { ok: false, reason: 'invalid' };
+    }
+    if (user.disabled) {
+        blindVerify(password);
+        return { ok: false, reason: 'disabled' };
+    }
 
     const state = {
         failedAttempts: user.failedAttempts,

--- a/src/server/auth/password.ts
+++ b/src/server/auth/password.ts
@@ -26,8 +26,16 @@ export function verifyPassword(plain: string, stored: string): boolean {
 }
 
 let dummyHash: string | undefined;
-/** Run a verification against a throwaway hash to blind login timing on the
- *  unknown-user / disabled-user paths (defeats username enumeration). */
+/**
+ * Run a verification against a throwaway hash to blind login timing on the
+ * unknown-user / disabled-user paths (defeats username enumeration).
+ *
+ * Cold-start note: the first call warms `dummyHash` via `??=`, which runs
+ * hashPassword() once (2 scrypts: one to generate the salt+hash, one inside
+ * verifyPassword). Every subsequent call is 1 scrypt — matching the real
+ * wrong-password path. This one-time asymmetry on process start is negligible
+ * and does NOT constitute a per-username timing oracle.
+ */
 export function blindVerify(plain: string): void {
     dummyHash ??= hashPassword('timing-blind-dummy-password');
     verifyPassword(plain, dummyHash);

--- a/src/server/auth/password.ts
+++ b/src/server/auth/password.ts
@@ -24,3 +24,11 @@ export function verifyPassword(plain: string, stored: string): boolean {
     const actual = scryptSync(plain, salt, expected.length, { N: n, r, p });
     return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
+
+let dummyHash: string | undefined;
+/** Run a verification against a throwaway hash to blind login timing on the
+ *  unknown-user / disabled-user paths (defeats username enumeration). */
+export function blindVerify(plain: string): void {
+    dummyHash ??= hashPassword('timing-blind-dummy-password');
+    verifyPassword(plain, dummyHash);
+}


### PR DESCRIPTION
Two small auth follow-ups from the #54 (auth) review — item 61 (a) + (c).

**Login timing-oracle (security).** `login()` returned on the unknown-username and disabled-user paths *before* any scrypt ran, so response timing distinguished "no such user" / "disabled" from "valid user, wrong password" — i.e. username enumeration. Added a memoized `blindVerify()` (reuses the real `verifyPassword` against a throwaway hash) and call it on both early-return paths, so they cost the same scrypt as a real wrong-password attempt. No DB side effects, lockout accounting untouched, `reason` codes unchanged.

**UsersModal `me()` fail-open (client).** `refresh()` did `me().catch(() => ({ authEnabled: true }))` — a transient error silently assumed auth was enabled, hiding the "Secure the admin account" lockdown affordance until reload. Now fails **closed**: on a `me()` error it surfaces "Couldn't load auth state — reload the page." and does not render the guessed add-user UI.

`node:crypto` only. tsc clean; server-auth + client UsersModal tests green.