### PR TITLE
chore(deps): bump @types/node to 26 + fix generic-Buffer socket handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
-        "@types/node": "^24.13.2",
+        "@types/node": "^26.0.0",
         "@types/ws": "^8",
         "@xterm/addon-attach": "^0.12.0",
         "@xterm/addon-fit": "^0.11.0",
@@ -952,13 +952,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/ws": {
@@ -3514,9 +3514,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.0.0",
     "@types/ws": "^8",
     "@xterm/addon-attach": "^0.12.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/src/server/ScrcpyConnection.ts
+++ b/src/server/ScrcpyConnection.ts
@@ -476,7 +476,7 @@ export class ScrcpyConnection extends Mw {
         });
 
         // Control socket: device messages → channel 3 → WS
-        this.controlSocket!.on('data', (data) => {
+        this.controlSocket!.on('data', (data: Buffer) => {
             this.sendChannel(ChannelId.DEVICE_MSG, data);
         });
     }

--- a/src/server/network/AdbHandshakeProbe.ts
+++ b/src/server/network/AdbHandshakeProbe.ts
@@ -188,7 +188,7 @@ export function probeAdb(
         socket.once('error', () => done({ isAdb: false }));
         socket.once('end', () => done(parseCnxnReply(Buffer.concat(chunks))));
         socket.once('close', () => done(parseCnxnReply(Buffer.concat(chunks))));
-        socket.on('data', (chunk) => {
+        socket.on('data', (chunk: Buffer) => {
             chunks.push(chunk);
             const all = Buffer.concat(chunks);
             if (all.length >= HEADER_SIZE) {


### PR DESCRIPTION
Migrates to `@types/node` 26 (the bump dependabot proposed in #435) and fixes the two type breaks it introduces.

Node 26's `@types/node` makes `Buffer` generic (`Buffer<ArrayBufferLike>`) and types `net.Socket` `'data'` payloads as `string | NonSharedBuffer`, which is no longer assignable where a plain `Buffer` is expected. Exactly two sites broke — both `socket.on('data', …)` handlers (`ScrcpyConnection.ts:480`, `AdbHandshakeProbe.ts:191`) — fixed by annotating the param `: Buffer`, the same pattern the sibling handler at `ScrcpyConnection.ts:273` already uses. Type-only; no runtime change.

Supersedes **#435** (red for exactly this reason). The lockfile change is only the `@types/node` version. tsc clean under @types/node 26; full suite green (1499 tests).