### PR TITLE
feat(scan): resolve device labels per-user instead of global admin

### DIFF
--- a/src/server/__tests__/networkScanner.test.ts
+++ b/src/server/__tests__/networkScanner.test.ts
@@ -44,7 +44,7 @@ describe('NetworkScanner — lifecycle', () => {
     it('emits scan.started then scan.complete on empty scan', async () => {
         const scanner = new NetworkScanner(baseDeps());
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet([])], ws);
+        await scanner.start([makeSubnet([])], ws, 0);
         expect(messages[0]!.type).toBe('scan.started');
         expect(messages.at(-1)?.type).toBe('scan.complete');
     });
@@ -53,7 +53,7 @@ describe('NetworkScanner — lifecycle', () => {
         const scanner = new NetworkScanner(baseDeps());
         expect(scanner.isScanning()).toBe(false);
         const { ws } = makeWs();
-        const p = scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws);
+        const p = scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws, 0);
         expect(scanner.isScanning()).toBe(true);
         await p;
         expect(scanner.isScanning()).toBe(false);
@@ -66,8 +66,8 @@ describe('NetworkScanner — lifecycle', () => {
             }),
         );
         const { ws } = makeWs();
-        const p1 = scanner.start([makeSubnet(['1.1.1.1'])], ws);
-        await expect(scanner.start([makeSubnet(['1.1.1.2'])], ws)).rejects.toThrow(/already scanning/);
+        const p1 = scanner.start([makeSubnet(['1.1.1.1'])], ws, 0);
+        await expect(scanner.start([makeSubnet(['1.1.1.2'])], ws, 0)).rejects.toThrow(/already scanning/);
         await p1;
     });
 });
@@ -85,7 +85,7 @@ describe('NetworkScanner — failure surfacing', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['10.0.0.1'])], ws);
+        await scanner.start([makeSubnet(['10.0.0.1'])], ws, 0);
         const errors = messages.filter((m) => m.type === 'scan.error');
         expect(errors).toHaveLength(1);
         expect((errors[0] as { reason: string }).reason).toMatch(/ENOENT/);
@@ -104,7 +104,7 @@ describe('NetworkScanner — failure surfacing', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([], ws, { mdnsOnly: true });
+        await scanner.start([], ws, 0, { mdnsOnly: true });
         const errors = messages.filter((m) => m.type === 'scan.error');
         expect(errors).toHaveLength(1);
         expect((errors[0] as { reason: string }).reason).toMatch(/timeout/);
@@ -120,7 +120,7 @@ describe('NetworkScanner — failure surfacing', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['10.0.0.1'])], ws);
+        await scanner.start([makeSubnet(['10.0.0.1'])], ws, 0);
         expect(messages[0]!.type).toBe('scan.started');
         expect(messages.at(-1)?.type).toBe('scan.error');
     });
@@ -143,7 +143,7 @@ describe('NetworkScanner — failure surfacing', () => {
             }),
         );
         const { ws } = makeWs();
-        await scanner.start([makeSubnet(['10.0.0.1'])], ws);
+        await scanner.start([makeSubnet(['10.0.0.1'])], ws, 0);
         // startServer must precede any adb-worker invocation.
         expect(callOrder[0]).toBe('startServer');
     });
@@ -161,7 +161,7 @@ describe('NetworkScanner — failure surfacing', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['10.0.0.1'])], ws);
+        await scanner.start([makeSubnet(['10.0.0.1'])], ws, 0);
         const errors = messages.filter((m) => m.type === 'scan.error');
         expect(errors).toHaveLength(1);
         expect((errors[0] as { reason: string }).reason).toMatch(/adb daemon not ready/);
@@ -191,7 +191,7 @@ describe('NetworkScanner — mdnsOnly mode', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['192.168.1.10', '192.168.1.11'])], ws, { mdnsOnly: true });
+        await scanner.start([makeSubnet(['192.168.1.10', '192.168.1.11'])], ws, 0, { mdnsOnly: true });
         expect(probeSpy).not.toHaveBeenCalled();
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits).toHaveLength(1);
@@ -206,7 +206,7 @@ describe('NetworkScanner — mdnsOnly mode', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws, { mdnsOnly: true });
+        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws, 0, { mdnsOnly: true });
         const started = messages.find((m) => m.type === 'scan.started') as any;
         expect(started.totalHosts).toBe(0);
         expect(started.totalSubnets).toBe(0);
@@ -226,7 +226,7 @@ describe('NetworkScanner — mdnsOnly mode', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([], ws, { mdnsOnly: true });
+        await scanner.start([], ws, 0, { mdnsOnly: true });
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits).toHaveLength(1);
     });
@@ -242,7 +242,7 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2', '1.1.1.3'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2', '1.1.1.3'])], ws, 0);
 
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits).toHaveLength(1);
@@ -263,7 +263,7 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.5'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.5'])], ws, 0);
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits[0]).toMatchObject({ name: '' });
     });
@@ -276,7 +276,7 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws, 0);
         expect(messages.filter((m) => m.type === 'scan.hit')).toHaveLength(0);
     });
 
@@ -294,21 +294,21 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.1'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.1'])], ws, 0);
         expect(calls[0]).toEqual({ connect: 250, reply: 4000 });
     });
 
-    it('resolves MAC and looks up label by MAC', async () => {
+    it('resolves MAC and looks up label by MAC for the requesting user', async () => {
         const scanner = new NetworkScanner(
             baseDeps({
                 adbHandshakeProbe: async () => ({ isAdb: true, model: 'Pixel 3' }),
                 resolveMac: async (ip: string) => (ip === '1.1.1.2' ? 'aa:bb:cc:dd:ee:ff' : null),
-                labelFor: (k: string) => (k === 'aa:bb:cc:dd:ee:ff' ? 'Jamies Pixel' : undefined),
+                labelFor: (_userId: number, k: string) => (k === 'aa:bb:cc:dd:ee:ff' ? 'Jamies Pixel' : undefined),
                 progressInterval: 1,
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.2'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.2'])], ws, 42);
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits[0]).toMatchObject({
             source: 'tcp',
@@ -317,17 +317,17 @@ describe('NetworkScanner — TCP track', () => {
         });
     });
 
-    it('falls back to labelFor(serial) when MAC lookup misses', async () => {
+    it('falls back to labelFor(userId, serial) when MAC lookup misses', async () => {
         const scanner = new NetworkScanner(
             baseDeps({
                 adbHandshakeProbe: async () => ({ isAdb: true }),
                 resolveMac: async () => 'aa:bb:cc:dd:ee:ff',
-                labelFor: (k: string) => (k === '1.1.1.2:5555' ? 'Serial Match' : undefined),
+                labelFor: (_userId: number, k: string) => (k === '1.1.1.2:5555' ? 'Serial Match' : undefined),
                 progressInterval: 1,
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.2'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.2'])], ws, 42);
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits[0]).toMatchObject({ label: 'Serial Match' });
     });
@@ -342,7 +342,7 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.2'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.2'])], ws, 42);
         expect(messages.filter((m) => m.type === 'scan.hit')[0]?.label).toBe('');
     });
 
@@ -354,7 +354,7 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2', '1.1.1.3', '1.1.1.4'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2', '1.1.1.3', '1.1.1.4'])], ws, 0);
         const progress = messages.filter((m) => m.type === 'scan.progress');
         expect(progress.length).toBeGreaterThanOrEqual(2);
         expect((progress.at(-1) as any)?.checked).toBe(4);
@@ -374,7 +374,7 @@ describe('NetworkScanner — TCP track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws, 0);
         // handshake should have been called for .2 but not .1
         expect(callHosts).toContain('1.1.1.2');
         expect(callHosts).not.toContain('1.1.1.1');
@@ -400,7 +400,7 @@ describe('NetworkScanner — TCP track', () => {
         );
         const { ws } = makeWs();
         const hosts = Array.from({ length: 20 }, (_, i) => `10.0.0.${i + 1}`);
-        await scanner.start([makeSubnet(hosts)], ws);
+        await scanner.start([makeSubnet(hosts)], ws, 0);
         expect(maxObserved).toBeLessThanOrEqual(3);
     });
 });
@@ -420,7 +420,7 @@ describe('NetworkScanner — mDNS track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet([])], ws);
+        await scanner.start([makeSubnet([])], ws, 0);
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits).toHaveLength(1);
         expect(hits[0]).toMatchObject({
@@ -431,17 +431,17 @@ describe('NetworkScanner — mDNS track', () => {
         });
     });
 
-    it('looks up mDNS label by serial', async () => {
+    it('looks up mDNS label by serial for the requesting user', async () => {
         const scanner = new NetworkScanner(
             baseDeps({
                 adbMdnsServices: async () => [
                     { name: 'adb-SERIAL1', service: '_adb._tcp.', address: '1.1.1.5', port: 5555 },
                 ],
-                labelFor: (k: string) => (k === 'SERIAL1' ? 'Living Room TV' : undefined),
+                labelFor: (_userId: number, k: string) => (k === 'SERIAL1' ? 'Living Room TV' : undefined),
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet([])], ws);
+        await scanner.start([makeSubnet([])], ws, 42);
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits[0]).toMatchObject({ label: 'Living Room TV' });
     });
@@ -459,7 +459,7 @@ describe('NetworkScanner — mDNS track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet(['1.1.1.5'])], ws);
+        await scanner.start([makeSubnet(['1.1.1.5'])], ws, 0);
         const hits = messages.filter((m) => m.type === 'scan.hit');
         expect(hits).toHaveLength(1);
         expect(hits[0]).toMatchObject({ source: 'mdns', serial: 'SERIAL1' });
@@ -477,7 +477,7 @@ describe('NetworkScanner — mDNS track', () => {
             }),
         );
         const { ws, messages } = makeWs();
-        await scanner.start([makeSubnet([])], ws);
+        await scanner.start([makeSubnet([])], ws, 0);
         expect(messages.filter((m) => m.type === 'scan.hit')).toHaveLength(0);
     });
 });
@@ -501,7 +501,7 @@ describe('NetworkScanner — cancel drain', () => {
         );
         const { ws, messages } = makeWs();
         const hosts = Array.from({ length: 100 }, (_, i) => `10.0.0.${i + 1}`);
-        const p = scanner.start([makeSubnet(hosts)], ws);
+        const p = scanner.start([makeSubnet(hosts)], ws, 0);
         setTimeout(() => scanner.cancel(), 5);
         await p;
 
@@ -528,13 +528,13 @@ describe('NetworkScanner — spectator snapshot', () => {
         );
         const { ws: ws1 } = makeWs();
         const hosts = Array.from({ length: 20 }, (_, i) => `10.0.0.${i + 1}`);
-        const scanPromise = scanner.start([makeSubnet(hosts)], ws1);
+        const scanPromise = scanner.start([makeSubnet(hosts)], ws1, 0);
 
         while (inFlight === 0) await new Promise((r) => setTimeout(r, 5));
         await new Promise((r) => setTimeout(r, 40));
 
         const { ws: ws2, messages: spectatorMessages } = makeWs();
-        scanner.attachSpectator(ws2);
+        scanner.attachSpectator(ws2, 0);
         await new Promise((r) => setTimeout(r, 5));
 
         expect(spectatorMessages.some((m) => m.type === 'scan.started')).toBe(true);
@@ -556,7 +556,7 @@ describe('NetworkScanner — getState', () => {
             }),
         );
         const { ws } = makeWs();
-        const p = scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws);
+        const p = scanner.start([makeSubnet(['1.1.1.1', '1.1.1.2'])], ws, 0);
         expect(scanner.getState()).toBe('scanning');
         await p;
         expect(scanner.getState()).toBe('idle');
@@ -582,11 +582,102 @@ describe('NetworkScanner — spectator cleanup', () => {
                 listeners.set(event, handler);
             },
         };
-        const p = scanner.start([makeSubnet(['1.1.1.1'])], ws);
+        const p = scanner.start([makeSubnet(['1.1.1.1'])], ws, 0);
         const closeHandler = listeners.get('close');
         expect(closeHandler).toBeDefined();
         closeHandler?.();
         await p;
-        // No assertion error means spectators set accepted the removal.
+        // No assertion error means spectators map accepted the removal.
+    });
+});
+
+describe('NetworkScanner — per-user label isolation', () => {
+    it('sends different labels to two spectators with different userIds for same device', async () => {
+        // User 1 labels the device "label-one"; user 2 labels it "label-two".
+        // Both watch the same scan. Each must receive only their own label.
+        const labelFor = (userId: number, _key: string): string | undefined => {
+            if (userId === 1) return 'label-one';
+            if (userId === 2) return 'label-two';
+            return undefined;
+        };
+
+        const scanner = new NetworkScanner(
+            baseDeps({
+                adbHandshakeProbe: async () => ({ isAdb: true, model: 'TestDevice' }),
+                resolveMac: async () => null,
+                labelFor,
+                progressInterval: 1,
+            }),
+        );
+
+        const { ws: ws1, messages: msgs1 } = makeWs();
+        const { ws: ws2, messages: msgs2 } = makeWs();
+
+        // ws1 starts the scan as user 1
+        const scanPromise = scanner.start([makeSubnet(['10.0.0.1'])], ws1, 1);
+        // ws2 joins as a spectator as user 2
+        scanner.attachSpectator(ws2, 2);
+        await scanPromise;
+
+        const hit1 = msgs1.find((m) => m.type === 'scan.hit') as any;
+        const hit2 = msgs2.find((m) => m.type === 'scan.hit') as any;
+
+        expect(hit1).toBeDefined();
+        expect(hit2).toBeDefined();
+        // No cross-contamination
+        expect(hit1.label).toBe('label-one');
+        expect(hit2.label).toBe('label-two');
+    });
+
+    it('sends scan.started identically to all spectators (non-hit messages are not per-user)', async () => {
+        const scanner = new NetworkScanner(
+            baseDeps({
+                adbHandshakeProbe: async () => ({ isAdb: false }),
+                progressInterval: 10,
+            }),
+        );
+
+        const { ws: ws1, messages: msgs1 } = makeWs();
+        const { ws: ws2, messages: msgs2 } = makeWs();
+
+        const scanPromise = scanner.start([makeSubnet(['10.0.0.1'])], ws1, 1);
+        scanner.attachSpectator(ws2, 2);
+        await scanPromise;
+
+        const started1 = msgs1.find((m) => m.type === 'scan.started') as any;
+        const started2 = msgs2.find((m) => m.type === 'scan.started') as any;
+
+        expect(started1).toBeDefined();
+        expect(started2).toBeDefined();
+        // Both should see identical scan.started content
+        expect(started1).toEqual(started2);
+    });
+
+    it('labelFor is called with the correct userId for each spectator', async () => {
+        const labelForCalls: Array<{ userId: number; key: string }> = [];
+        const labelFor = (userId: number, key: string): string | undefined => {
+            labelForCalls.push({ userId, key });
+            return undefined;
+        };
+
+        const scanner = new NetworkScanner(
+            baseDeps({
+                adbHandshakeProbe: async () => ({ isAdb: true }),
+                resolveMac: async () => null,
+                labelFor,
+                progressInterval: 1,
+            }),
+        );
+
+        const { ws: ws1 } = makeWs();
+        const { ws: ws2 } = makeWs();
+
+        const scanPromise = scanner.start([makeSubnet(['10.0.0.1'])], ws1, 7);
+        scanner.attachSpectator(ws2, 13);
+        await scanPromise;
+
+        const userIds = labelForCalls.map((c) => c.userId);
+        expect(userIds).toContain(7);
+        expect(userIds).toContain(13);
     });
 });

--- a/src/server/__tests__/scanMw.test.ts
+++ b/src/server/__tests__/scanMw.test.ts
@@ -20,6 +20,9 @@ async function collectMessages(ws: WebSocket, until: (msg: any) => boolean): Pro
     });
 }
 
+// Default userId for integration tests (open-mode admin equivalent)
+const TEST_USER_ID = 1;
+
 describe('ScanMw integration', () => {
     it('accepts scan.start and streams through to scan.complete', async () => {
         const scanner = new NetworkScanner({
@@ -34,7 +37,7 @@ describe('ScanMw integration', () => {
         const server = http.createServer();
         const wss = new WebSocketServer({ server });
         wss.on('connection', (ws, req) => {
-            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws);
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws, TEST_USER_ID);
         });
         await new Promise<void>((r) => server.listen(0, r));
         const port = (server.address() as any).port;
@@ -73,7 +76,7 @@ describe('ScanMw integration', () => {
         const server = http.createServer();
         const wss = new WebSocketServer({ server });
         wss.on('connection', (ws, req) => {
-            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws);
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws, TEST_USER_ID);
         });
         await new Promise<void>((r) => server.listen(0, r));
         const port = (server.address() as any).port;
@@ -107,7 +110,7 @@ describe('ScanMw integration', () => {
         const server = http.createServer();
         const wss = new WebSocketServer({ server });
         wss.on('connection', (ws, req) => {
-            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws);
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws, TEST_USER_ID);
         });
         await new Promise<void>((r) => server.listen(0, r));
         const port = (server.address() as any).port;
@@ -139,7 +142,7 @@ describe('ScanMw integration', () => {
         const server = http.createServer();
         const wss = new WebSocketServer({ server });
         wss.on('connection', (ws, req) => {
-            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws);
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws, TEST_USER_ID);
         });
         await new Promise<void>((r) => server.listen(0, r));
         const port = (server.address() as any).port;
@@ -171,7 +174,7 @@ describe('ScanMw integration', () => {
         const server = http.createServer();
         const wss = new WebSocketServer({ server });
         wss.on('connection', (ws, req) => {
-            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws);
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws, TEST_USER_ID);
         });
         await new Promise<void>((r) => server.listen(0, r));
         const port = (server.address() as any).port;
@@ -186,6 +189,54 @@ describe('ScanMw integration', () => {
         const messages = await collected;
 
         expect(messages[0].type).toBe('scan.error');
+
+        client.close();
+        await new Promise<void>((r) => wss.close(() => server.close(() => r())));
+    });
+
+    it('threads userId from attach() through to scanner.start and attachSpectator', async () => {
+        // Verify that the userId passed to ScanMw.attach() is passed into
+        // scanner.start()/scanner.attachSpectator() so labels resolve per-user.
+        const labelCalls: Array<{ userId: number; key: string }> = [];
+        const scanner = new NetworkScanner({
+            adbDevices: async () => [],
+            adbMdnsServices: async () => [
+                {
+                    name: 'adb-TESTDEV._adb._tcp.local.',
+                    service: '_adb._tcp.',
+                    address: '10.0.0.99',
+                    port: 5555,
+                },
+            ],
+            adbHandshakeProbe: async () => ({ isAdb: false }),
+            labelFor: (userId: number, key: string) => {
+                labelCalls.push({ userId, key });
+                return undefined;
+            },
+            concurrency: 4,
+            progressInterval: 10,
+        });
+        ScanMw.setScanner(scanner);
+
+        const server = http.createServer();
+        const wss = new WebSocketServer({ server });
+        const THE_USER_ID = 99;
+        wss.on('connection', (ws, req) => {
+            if (req.url === SCAN_WS_PATH) ScanMw.attach(ws, THE_USER_ID);
+        });
+        await new Promise<void>((r) => server.listen(0, r));
+        const port = (server.address() as any).port;
+
+        const client = new WebSocket(`ws://127.0.0.1:${port}${SCAN_WS_PATH}`);
+        await new Promise<void>((r) => client.once('open', r));
+
+        const collected = collectMessages(client, (m) => m.type === 'scan.complete');
+        client.send(JSON.stringify({ type: 'scan.start', subnets: [], mdnsOnly: true }));
+        await collected;
+
+        // Every labelFor call must have used THE_USER_ID
+        expect(labelCalls.length).toBeGreaterThan(0);
+        expect(labelCalls.every((c) => c.userId === THE_USER_ID)).toBe(true);
 
         client.close();
         await new Promise<void>((r) => wss.close(() => server.close(() => r())));

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,6 @@ import { SCAN_WS_PATH } from '../common/ScanMessage';
 import { AdbClient } from './AdbClient';
 import { AdbDaemonManager } from './AdbDaemonManager';
 import { AuthApi } from './api/AuthApi';
-import { UsersApi } from './api/UsersApi';
 import { CapabilitiesApi } from './api/CapabilitiesApi';
 import { ConfigApi } from './api/ConfigApi';
 import { DependencyApi } from './api/DependencyApi';
@@ -12,11 +11,12 @@ import { ServerShutdownApi } from './api/ServerShutdownApi';
 import { ServiceApi } from './api/ServiceApi';
 import { SettingsApi } from './api/SettingsApi';
 import { UpdatesApi } from './api/UpdatesApi';
+import { UsersApi } from './api/UsersApi';
 import { WhoamiApi } from './api/WhoamiApi';
+import { AuthGate } from './auth/AuthGate';
 import { Config } from './Config';
 import { DependencyManager } from './DependencyManager';
 import { DeviceProbe } from './DeviceProbe';
-import { IMPLICIT_ADMIN_ID } from './db/constants';
 import { Logger } from './Logger';
 import { HostTracker } from './mw/HostTracker';
 import type { MwFactory } from './mw/Mw';
@@ -29,7 +29,6 @@ import { NetworkScanner } from './network/NetworkScanner';
 import { consumeSuppressBrowserMarker, openBrowser, shouldAutoOpenBrowser } from './openBrowser';
 import { findAvailablePort, webPortOverride } from './PortPicker';
 import { ScrcpyConnection } from './ScrcpyConnection';
-import { AuthGate } from './auth/AuthGate';
 import { setAllowedHosts } from './security/originGuard';
 import { makeProductionCoreDeps, parseSystemServiceArgs, runSystemServiceCli } from './service/systemServiceCli';
 import { HttpServer } from './services/HttpServer';
@@ -194,7 +193,7 @@ if (__ssArgs) {
         // adb process is launched.
         adbStartServer: () => adbDaemon.ensureReady({ waitMs: 5_000 }),
         resolveMac,
-        labelFor: (key: string) => config.db.devices.getLabel(IMPLICIT_ADMIN_ID, key),
+        labelFor: (userId: number, key: string) => config.db.devices.getLabel(userId, key),
         concurrency: config.scanConcurrency,
         progressInterval: config.scanProgressInterval,
         tcpTimeoutMs: config.scanTcpTimeoutMs,
@@ -246,7 +245,7 @@ if (__ssArgs) {
                 WebsocketMultiplexer.registerMw(mwFactory);
             });
 
-            wsService.registerPathHandler(SCAN_WS_PATH, (ws) => ScanMw.attach(ws));
+            wsService.registerPathHandler(SCAN_WS_PATH, (ws, userId) => ScanMw.attach(ws, userId));
 
             // v0.1.9: auto-open browser on FIRST run, but only when this
             // is a normal user instance (not running as a service —

--- a/src/server/mw/ScanMw.ts
+++ b/src/server/mw/ScanMw.ts
@@ -29,7 +29,7 @@ export class ScanMw {
         ScanMw.scanner = scanner;
     }
 
-    public static attach(ws: WS): void {
+    public static attach(ws: WS, userId: number): void {
         const scanner = ScanMw.scanner;
         if (!scanner) {
             ScanMw.send(ws, { type: 'scan.error', reason: 'scanner not initialized' });
@@ -37,7 +37,7 @@ export class ScanMw {
         }
 
         if (scanner.isScanning()) {
-            scanner.attachSpectator(ws);
+            scanner.attachSpectator(ws, userId);
             // Subsequent messages from a spectator are ignored except cancel.
         }
 
@@ -89,7 +89,7 @@ export class ScanMw {
                     return;
                 }
                 // Fire and forget — scanner drives the WS directly.
-                scanner.start(parsed, ws, { mdnsOnly }).catch(() => {});
+                scanner.start(parsed, ws, userId, { mdnsOnly }).catch(() => {});
                 return;
             }
             if (msg.type === 'scan.cancel') {

--- a/src/server/network/NetworkScanner.ts
+++ b/src/server/network/NetworkScanner.ts
@@ -26,8 +26,9 @@ export interface NetworkScannerDeps {
     adbStartServer?: () => Promise<void>;
     /** Resolve an IPv4 to its MAC via ARP cache. Returns null when ARP has no entry. */
     resolveMac?: (ip: string) => Promise<string | null>;
-    /** Look up a saved label by device identifier (serial OR MAC). */
-    labelFor?: (key: string) => string | undefined;
+    /** Look up a saved label by userId and device identifier (serial OR MAC).
+     *  The userId ensures each user sees only their own labels. */
+    labelFor?: (userId: number, key: string) => string | undefined;
     concurrency: number;
     progressInterval: number;
     /** TCP connect timeout for the probe (fast-fail on closed port). Default 300ms. */
@@ -38,13 +39,31 @@ export interface NetworkScannerDeps {
 
 type State = 'idle' | 'scanning' | 'draining';
 
+/** Internal extension of ScanServerMessage that carries raw hit metadata for
+ *  per-spectator label resolution. The `_hitMeta` field is stripped before the
+ *  message is sent on the wire — it never reaches clients. */
+interface ScanHitInternal {
+    type: 'scan.hit';
+    source: 'mdns' | 'tcp';
+    address: string;
+    serial: string;
+    name: string;
+    /** Explicit label (from caller); takes precedence over DB lookup. */
+    label?: string;
+    /** Internal only — carries raw hit data so emit() can resolve labels per-spectator. */
+    _hitMeta: { mac: string | null; serial: string };
+}
+
+type InternalMessage = Exclude<ScanServerMessage, { type: 'scan.hit' }> | ScanHitInternal;
+
 export class NetworkScanner {
     private state: State = 'idle';
     private cancelFlag = false;
     // Resolves `cancelSignal` (created per scan in start()) the moment cancel()
     // fires, so the drain watcher reacts to an event instead of polling. (#77)
     private resolveCancel: (() => void) | null = null;
-    private spectators = new Set<WS | any>();
+    /** Map of ws → userId so each spectator gets labels resolved for their own user. */
+    private spectators = new Map<WS | any, number>();
     private emittedAddresses = new Set<string>();
     private foundSoFar = 0;
     private lastStartedMsg: ScanStartedMessage | null = null;
@@ -60,9 +79,9 @@ export class NetworkScanner {
         return this.state;
     }
 
-    attachSpectator(ws: WS | any): void {
+    attachSpectator(ws: WS | any, userId: number): void {
         if (this.state === 'idle') return;
-        this.spectators.add(ws);
+        this.spectators.set(ws, userId);
         // Send snapshot of current state so new spectators aren't stuck on empty chip
         if (this.lastStartedMsg && ws.readyState === ws.OPEN) {
             try {
@@ -91,7 +110,12 @@ export class NetworkScanner {
         this.resolveCancel?.();
     }
 
-    async start(subnets: ParsedSubnet[], ws: WS | any, options?: { mdnsOnly?: boolean }): Promise<void> {
+    async start(
+        subnets: ParsedSubnet[],
+        ws: WS | any,
+        userId: number,
+        options?: { mdnsOnly?: boolean },
+    ): Promise<void> {
         if (this.state !== 'idle') {
             throw new Error('scanner already scanning');
         }
@@ -108,7 +132,7 @@ export class NetworkScanner {
         this.lastStartedMsg = null;
         this.lastProgressMsg = null;
         this.spectators.clear();
-        this.spectators.add(ws);
+        this.spectators.set(ws, userId);
         if (typeof (ws as any).once === 'function') {
             (ws as any).once('close', () => this.spectators.delete(ws));
         }
@@ -296,36 +320,56 @@ export class NetworkScanner {
         if (this.emittedAddresses.has(partial.address)) return;
         this.emittedAddresses.add(partial.address);
         this.foundSoFar++;
-        // Label precedence: explicit > MAC lookup > serial lookup > ''.
-        // MAC-first helps TCP hits (where `serial` is address-as-placeholder);
-        // serial-fallback catches mDNS hits (where serial is authoritative).
-        let label = partial.label;
-        if (label === undefined && this.deps.labelFor) {
-            if (partial.mac) label = this.deps.labelFor(partial.mac);
-            if (label === undefined) label = this.deps.labelFor(partial.serial);
-        }
-        this.emit({
+        // Pass an internal hit message with raw metadata so emit() can resolve
+        // labels per-spectator. `_hitMeta` is stripped before sending on the wire.
+        const internalMsg: ScanHitInternal = {
             type: 'scan.hit',
             source: partial.source,
             address: partial.address,
             serial: partial.serial,
             name: partial.name,
-            label: label ?? '',
-        });
+            ...(partial.label !== undefined ? { label: partial.label } : {}),
+            _hitMeta: { mac: partial.mac ?? null, serial: partial.serial },
+        };
+        this.emit(internalMsg);
     }
 
-    protected emit(msg: ScanServerMessage): void {
+    protected emit(msg: InternalMessage): void {
         if (msg.type === 'scan.started') {
             this.lastStartedMsg = msg;
         } else if (msg.type === 'scan.progress') {
             this.lastProgressMsg = msg;
         }
-        for (const ws of this.spectators) {
-            if (ws.readyState !== ws.OPEN) continue;
-            try {
-                ws.send(JSON.stringify(msg));
-            } catch {
-                // Dropped spectator — silent
+
+        if (msg.type === 'scan.hit') {
+            // Per-spectator label resolution: each user sees their own saved labels.
+            const { _hitMeta, label: explicitLabel, ...hitBase } = msg;
+            for (const [ws, userId] of this.spectators) {
+                if (ws.readyState !== ws.OPEN) continue;
+                // Label precedence: explicit > MAC lookup > serial lookup > ''
+                let label = explicitLabel;
+                if (label === undefined && this.deps.labelFor) {
+                    if (_hitMeta.mac) label = this.deps.labelFor(userId, _hitMeta.mac);
+                    if (label === undefined) label = this.deps.labelFor(userId, _hitMeta.serial);
+                }
+                const wireMsg = { ...hitBase, label: label ?? '' };
+                try {
+                    ws.send(JSON.stringify(wireMsg));
+                } catch {
+                    // Dropped spectator — silent
+                }
+            }
+        } else {
+            // Non-hit messages (scan.started, scan.progress, scan.complete, etc.)
+            // are sent identically to all spectators — no per-user data.
+            const wireMsg = msg as ScanServerMessage;
+            for (const ws of this.spectators.keys()) {
+                if (ws.readyState !== ws.OPEN) continue;
+                try {
+                    ws.send(JSON.stringify(wireMsg));
+                } catch {
+                    // Dropped spectator — silent
+                }
             }
         }
     }

--- a/src/server/services/WebSocketServer.ts
+++ b/src/server/services/WebSocketServer.ts
@@ -1,10 +1,10 @@
 import type WS from 'ws';
 import { WebSocketServer as WSServer } from 'ws';
-import { Config } from '../Config';
 import { isAuthEnabled, parseCookie, SESSION_COOKIE } from '../auth/authState';
 import { SessionStore } from '../auth/session';
-import type { Db } from '../db/Db';
+import { Config } from '../Config';
 import { IMPLICIT_ADMIN_ID } from '../db/constants';
+import type { Db } from '../db/Db';
 import { Logger } from '../Logger';
 import type { MwFactory } from '../mw/Mw';
 import { evaluateWsConnection } from '../security/requestGate';
@@ -31,7 +31,7 @@ export class WebSocketServer implements Service {
     private static instance?: WebSocketServer;
     private servers: WSServer[] = [];
     private mwFactories: Set<MwFactory> = new Set();
-    private pathHandlers: Map<string, (ws: WS) => void> = new Map();
+    private pathHandlers: Map<string, (ws: WS, userId: number) => void> = new Map();
 
     protected constructor() {
         // nothing here
@@ -52,7 +52,7 @@ export class WebSocketServer implements Service {
         this.mwFactories.add(mwFactory);
     }
 
-    public registerPathHandler(path: string, handler: (ws: WS) => void): void {
+    public registerPathHandler(path: string, handler: (ws: WS, userId: number) => void): void {
         this.pathHandlers.set(path, handler);
     }
 
@@ -102,7 +102,7 @@ export class WebSocketServer implements Service {
             // Path-based handlers take priority over action-based MW dispatch.
             const pathHandler = this.pathHandlers.get(url.pathname);
             if (pathHandler) {
-                pathHandler(ws);
+                pathHandler(ws, userId);
                 return;
             }
 


### PR DESCRIPTION
Item 61 (b) — the deferred "Step 4" of the auth work. Device-scan labels were resolved with a hardcoded `IMPLICIT_ADMIN_ID`, so every logged-in user saw user 1's labels. Now each user sees their own.

The singleton scanner used to resolve one label and broadcast a single `scan.hit` to all spectators. This makes the broadcast **per-spectator**: `spectators` is now `Map<WS, number>` (ws → userId), the validated `userId` is threaded WebSocketServer → ScanMw → scanner, and labels resolve per-spectator at send time — `label = explicit ?? labelFor(userId, mac) ?? labelFor(userId, serial) ?? ''`, preserving the existing precedence. Non-hit messages (started/progress/complete) still broadcast identically; per-scan dedup and late-joiner caching are unchanged.

Reviewed independently: per-user isolation verified (no cross-contamination; the internal `_hitMeta` carrier is stripped from every wire path and the replay cache), and the tests prove two users get different labels for the same device. tsc clean; scan suite 39/39 green.