### PR TITLE
fix(auth): blind login timing on the locked-account path too

### DIFF
--- a/src/server/auth/__tests__/loginService.test.ts
+++ b/src/server/auth/__tests__/loginService.test.ts
@@ -61,6 +61,16 @@ describe('login timing-blind paths', () => {
         spy.mockRestore();
     });
 
+    it('calls blindVerify on the locked-account path and still returns locked', async () => {
+        const passwordMod = await import('../password');
+        for (let i = 0; i < 5; i++) login(db, 'admin', 'wrong', 1000); // lock the account
+        const spy = vi.spyOn(passwordMod, 'blindVerify');
+        const r = login(db, 'admin', 'correct', 1000); // correct pw, but locked
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(r).toEqual({ ok: false, reason: 'locked' });
+        spy.mockRestore();
+    });
+
     it('does NOT call blindVerify on the happy path (correct password)', async () => {
         const passwordMod = await import('../password');
         const spy = vi.spyOn(passwordMod, 'blindVerify');

--- a/src/server/auth/loginService.ts
+++ b/src/server/auth/loginService.ts
@@ -24,6 +24,7 @@ export function login(db: Db, username: string, password: string, now: number): 
         lockedUntil: user.lockedUntil,
     };
     if (isLocked(state, now)) {
+        blindVerify(password); // blind timing: a locked account must not answer faster than a wrong password
         db.users.setLockout(user.id, extendLock(now)); // inactivity timer resets on every attempt while locked
         return { ok: false, reason: 'locked' };
     }


### PR DESCRIPTION
Follow-up to #438. The lockout early-return path in `login()` returned **without** running scrypt, so a currently-locked account answered faster than a wrong-password attempt — a residual timing signal alongside the unknown/disabled paths #438 already blinded. (Weak in isolation: you can only lock an account you've already confirmed exists — flagged by the pre-beta review as a separate low-priority item.)

The locked path now also calls `blindVerify`, so every failed login — unknown user, disabled, locked, or wrong password — costs the same single scrypt.

tsc clean; loginService tests 8/8 (added a locked-path blind assertion). Lands on main for the next beta (beta.67 is already cut).