### PR TITLE
chore: resolve item-60 settings follow-ups (test flake + dead-code + doc)

### DIFF
--- a/src/app/client/AudioSettingsStore.ts
+++ b/src/app/client/AudioSettingsStore.ts
@@ -52,14 +52,4 @@ export const AudioSettingsStore = {
     save(udid: string, settings: StoredAudioSettings): void {
         settingsService.setDeviceAudio(udid, settings as unknown as Record<string, unknown>);
     },
-
-    /**
-     * Cache-only clear: drops the 'audio' scope from the singleton's device
-     * cache with NO network write. NON-DURABLE — a page reload re-hydrates
-     * from the server, restoring the old value. Test-only; no production caller.
-     * A durable clear needs a future server DELETE-scope endpoint.
-     */
-    clear(udid: string): void {
-        settingsService.clearDeviceAudio(udid);
-    },
 };

--- a/src/app/client/SettingsService.ts
+++ b/src/app/client/SettingsService.ts
@@ -143,19 +143,6 @@ export class SettingsService implements SettingsSink {
             console.error('[SettingsService] setDeviceAudio PATCH failed', e),
         );
     }
-
-    /**
-     * Cache-only: drop the 'audio' scope from the in-memory device cache.
-     * No network write — there is no server DELETE-scope endpoint this phase.
-     * NON-DURABLE: a page reload re-hydrates from the server, which still
-     * holds the old value. Intended for test teardown only; not called in
-     * production code. (A durable clear needs a future server DELETE-scope
-     * endpoint.)
-     */
-    clearDeviceAudio(udid: string): void {
-        const cur = this.deviceCache.get(udid);
-        if (cur && 'audio' in cur) delete cur['audio'];
-    }
 }
 
 // Singleton — the boot migration AND every call site import THIS so caches are

--- a/src/app/client/__tests__/audioSettingsStore.test.ts
+++ b/src/app/client/__tests__/audioSettingsStore.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Hoist the spy and the shared cache so they are available inside vi.mock()'s
 // factory (which is also hoisted). This is the standard vitest pattern for
 // accessing a vi.fn() from within a vi.mock() factory.
-const { _cache, mockClearDeviceAudio, mockSetDeviceAudio } = vi.hoisted(() => {
+const { _cache, mockSetDeviceAudio } = vi.hoisted(() => {
     const cache = new Map<string, Record<string, unknown>>();
     return {
         _cache: cache,
@@ -12,29 +12,22 @@ const { _cache, mockClearDeviceAudio, mockSetDeviceAudio } = vi.hoisted(() => {
             cur['audio'] = audio;
             cache.set(udid, cur);
         }),
-        mockClearDeviceAudio: vi.fn((udid: string) => {
-            const cur = cache.get(udid);
-            if (cur && 'audio' in cur) delete cur['audio'];
-        }),
     };
 });
 
 // Stub the SettingsService singleton so AudioSettingsStore reads/writes go
 // through an in-test Map instead of fetch(). The stub mirrors the subset of
 // SettingsService used by AudioSettingsStore: getDeviceAudio, setDeviceAudio,
-// clearDeviceAudio, and hydrateDevice.
+// and hydrateDevice.
 //
-// setDeviceAudio and clearDeviceAudio are vi.fn() spies (hoisted above) so
-// the clear() tests can assert clearDeviceAudio was called and setDeviceAudio
-// was NOT called — the assertion that catches a "clear fires a write-through
-// PATCH" regression.
+// setDeviceAudio is a vi.fn() spy (hoisted above) so the save() tests can
+// assert it routed through the write-through PATCH path.
 vi.mock('../SettingsService', () => ({
     settingsService: {
         getDeviceAudio(udid: string): Record<string, unknown> | undefined {
             return _cache.get(udid)?.['audio'] as Record<string, unknown> | undefined;
         },
         setDeviceAudio: mockSetDeviceAudio,
-        clearDeviceAudio: mockClearDeviceAudio,
         hydrateDevice(_udid: string): Promise<void> {
             // In tests that exercise read-after-hydrate: pre-seed _cache before
             // calling hydrateDevice; this is a no-op (the real service fetches
@@ -49,13 +42,11 @@ import { AudioSettingsStore, type StoredAudioSettings } from '../AudioSettingsSt
 beforeEach(() => {
     _cache.clear();
     mockSetDeviceAudio.mockClear();
-    mockClearDeviceAudio.mockClear();
 });
 
 afterEach(() => {
     _cache.clear();
     mockSetDeviceAudio.mockClear();
-    mockClearDeviceAudio.mockClear();
 });
 
 describe('AudioSettingsStore.load', () => {
@@ -104,26 +95,5 @@ describe('AudioSettingsStore.save', () => {
         AudioSettingsStore.save('dev1', { enabled: true, source: 'playback', codec: 'opus' });
         AudioSettingsStore.save('dev1', { enabled: false, source: 'output', codec: 'aac' });
         expect(AudioSettingsStore.load('dev1')).toEqual({ enabled: false, source: 'output', codec: 'aac' });
-    });
-});
-
-describe('AudioSettingsStore.clear', () => {
-    it('removes saved settings for a udid and does NOT trigger a network write', () => {
-        AudioSettingsStore.save('dev1', { enabled: true, source: 'playback', codec: 'opus' });
-        mockSetDeviceAudio.mockClear(); // reset after the save() above
-        AudioSettingsStore.clear('dev1');
-        // Post-clear load must return null (cache-only removal worked)
-        expect(AudioSettingsStore.load('dev1')).toBeNull();
-        // clear() must route through clearDeviceAudio (cache-only), NOT setDeviceAudio
-        // (which fires a write-through PATCH). This is the regression guard.
-        expect(mockClearDeviceAudio).toHaveBeenCalledOnce();
-        expect(mockClearDeviceAudio).toHaveBeenCalledWith('dev1');
-        expect(mockSetDeviceAudio).not.toHaveBeenCalled();
-    });
-
-    it('is a no-op when nothing was saved', () => {
-        expect(() => AudioSettingsStore.clear('dev1')).not.toThrow();
-        expect(mockClearDeviceAudio).toHaveBeenCalledOnce();
-        expect(mockSetDeviceAudio).not.toHaveBeenCalled();
     });
 });

--- a/src/app/googDevice/client/__tests__/FileListingClient.test.ts
+++ b/src/app/googDevice/client/__tests__/FileListingClient.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ACTION } from '../../../../common/Action';
 import type { ParamsFileListing } from '../../../../types/ParamsFileListing';
+import { FileListingClient } from '../FileListingClient';
 
 // Minimal WebSocket stub. jsdom does not implement WebSocket. Reporting
 // readyState=CONNECTING(0) makes Multiplexer buffer outgoing frames instead of
@@ -63,8 +64,7 @@ describe('FileListingClient hashchange listener lifecycle (#37)', () => {
         return call?.[1] as EventListener | undefined;
     }
 
-    it('removes the SAME hashchange handler reference on destroy()', async () => {
-        const { FileListingClient } = await import('../FileListingClient');
+    it('removes the SAME hashchange handler reference on destroy()', () => {
         const client = FileListingClient.start(params);
 
         const registered = getHashchangeHandler();
@@ -78,8 +78,7 @@ describe('FileListingClient hashchange listener lifecycle (#37)', () => {
         expect(removedCall?.[1]).toBe(registered);
     });
 
-    it('does not react to hashchange after destroy()', async () => {
-        const { FileListingClient } = await import('../FileListingClient');
+    it('does not react to hashchange after destroy()', () => {
         const client = FileListingClient.start(params);
         const loadSpy = vi.spyOn(client as any, 'loadContent');
 

--- a/src/app/player/__tests__/basePlayerStatsRaf.test.ts
+++ b/src/app/player/__tests__/basePlayerStatsRaf.test.ts
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import VideoSettings from '../../VideoSettings';
+import { BasePlayer } from '../BasePlayer';
 
 /**
  * Finding #44 at the BasePlayer level: stop() must cancelAnimationFrame the
  * stored stats-loop id, and the loop must not double-start (a second pushFrame
  * while a frame is pending creates no second loop). resetStats() must also cancel.
  *
- * We stub raf/caf globally BEFORE constructing so AnimationFrameGuard's default
- * params capture the stubs, then drive a minimal concrete BasePlayer subclass.
+ * We stub raf/caf globally in beforeEach (BEFORE each test constructs a player)
+ * so AnimationFrameGuard's constructor default params capture the stubs. That
+ * capture happens at CONSTRUCTION time, not module-eval, so BasePlayer is a
+ * plain static import — which also keeps its (heavy) transform at file-collection
+ * time, out of the per-test timeout, avoiding the full-suite parallel-load flake
+ * an in-test `await import()` exposed (item 60a).
  */
 
 let rafSpy: ReturnType<typeof vi.fn>;
@@ -36,9 +42,6 @@ describe('BasePlayer quality-stats rAF lifecycle (finding #44)', () => {
     });
 
     async function makePlayer() {
-        const { BasePlayer } = await import('../BasePlayer');
-        const VideoSettingsMod = await import('../../VideoSettings');
-        const VideoSettings = VideoSettingsMod.default;
         class TestPlayer extends BasePlayer {
             public getImageDataURL(): string {
                 return '';

--- a/src/server/api/SettingsApi.ts
+++ b/src/server/api/SettingsApi.ts
@@ -13,6 +13,22 @@ const log = Logger.for('SettingsApi');
  *   GET/PATCH  /api/settings              → global `user_settings`
  *   GET/PATCH  /api/settings/device?udid= → per-device `device_settings`
  *   POST       /api/settings/reset        → clear the caller's settings + labels
+ *
+ * Storage is intentionally schema-less: PATCH bodies are persisted as opaque
+ * per-user JSON keyed by setting name (global) or scope (device), so adding a
+ * new client setting — theme, iconSize, scanSubnets, dismissed-prompt flags,
+ * video/audio — needs no server change. We deliberately do NOT validate
+ * individual keys/values here:
+ *   - the body is already size-capped (1 MiB) and guaranteed a plain object by
+ *     `readJsonBody` (arrays/primitives/parse-failures collapse to `{}`), and
+ *     values are bound through prepared statements (no injection);
+ *   - every row is scoped to the calling user, who is also the sole consumer,
+ *     and the frontend coerces on read (e.g. a non-number iconSize → null);
+ *   - a per-key allowlist would break the schema-less contract above and add
+ *     ongoing fragility for nil security/correctness benefit (item 60c — judged
+ *     by-design on review).
+ * If a single setting ever needs a server-enforced invariant, validate that one
+ * key explicitly rather than reintroducing a global schema.
  */
 export class SettingsApi {
     async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {


### PR DESCRIPTION
## What
Resolves the remaining **item-60** follow-ups from the localStorage->SQLite migration (PR #429) - the (a)/(b)/(c) sub-items. Behaviour-preserving; `release:none` (rides the next beta).

## Changes
- **(a) Flaky parallel-load tests** - `FileListingClient` + `basePlayerStatsRaf` did an in-`it` `await import()` of a heavy module graph. Under full-suite parallel load (171 files; aggregate transform ~145-215s across workers) the one-time esbuild transform occasionally stalled past the per-test timeout. Hoisted both imports to top-level static imports so the transform lands at file collection, outside the per-test timeout; the `it()` bodies are now synchronous and can't hit that timeout. `AnimationFrameGuard` captures raf/caf at construction (not module-eval), so the static import is safe.
- **(b) Dead code** - removed `AudioSettingsStore.clear` + `SettingsService.clearDeviceAudio` (cache-only, non-durable, zero production callers) and their test. A durable per-scope delete stays deferred until a real "forget this device" feature needs it (no speculative endpoint).
- **(c) Settings validation** - documented the `SettingsApi` schema-less contract; per-field validation intentionally omitted (body already size-capped + object-guaranteed by `readJsonBody`, rows are per-user, values parameter-bound, frontend coerces on read). Judged by-design on review.

## Verification
- `tsc -p tsconfig.json --noEmit` - clean
- biome check - 0 errors
- full vitest suite green **3x** (1502 passed; was 1504, -2 removed dead tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)