### PR TITLE
style(auth): optional-chain the change-password guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Internal maintenance only — no user-facing changes. Stabilized two unit tests that could intermittently time out under full-suite parallel load (hoisted heavy in-test dynamic imports to the top level), removed an unused non-durable settings-clear code path, documented the per-user settings store's deliberately schema-less design, and a small lint cleanup (optional chaining) in the auth password-change handler.
+
 ## [0.1.30-beta.67] - 2026-06-23
 
 ### Added

--- a/src/server/api/AuthApi.ts
+++ b/src/server/api/AuthApi.ts
@@ -73,7 +73,7 @@ export class AuthApi {
                 return true;
             }
             const user = db.users.getById(resolveUserId(req));
-            if (!user || !user.passwordHash || !verifyPassword(current, user.passwordHash)) {
+            if (!user?.passwordHash || !verifyPassword(current, user.passwordHash)) {
                 sendJson(res, 400, { error: 'current password incorrect' });
                 return true;
             }


### PR DESCRIPTION
## What
Optional-chains the change-password guard in `AuthApi.ts` (`!user || !user.passwordHash` → `!user?.passwordHash`) — clears the last biome unsafe-fix warning. Behaviour-preserving (`db.users.getById` returns `object | undefined`).

## Why this is `release:beta`
This is the **beta.68** trigger. beta.68 carries the item-60 cleanup already merged to `main` (#445 — flaky-test stabilization, dead-code removal, schema-less SettingsApi doc) plus this lint fix. **Internal maintenance only — no user-facing changes.** CHANGELOG note is under `## [Unreleased]` (Mode 1's bump PR will promote it).

## Verification
- biome check — 0 warnings (the AuthApi unsafe-fix is gone)
- `tsc -p tsconfig.json --noEmit` — clean
- full vitest suite green (1502 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)