### PR TITLE
docs(smoke-tests): reframe Module 11 (PR #422) + beta.68 update-from

### DIFF
--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -7,7 +7,7 @@ Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups 
 stays the module-organized reference. Wherever a row shows a version, expect the **smoke-target version** (top of this doc),
 which carries the beta.48 port-discovery fix plus the Server-section UX (batch #15).
 
-**Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.40 artifact / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot) · 🌐 browser-only (no device or install state)
+**Legend:** ✅ passed · ☐ to run · 🧩 needs setup (fresh snapshot / 2nd user / 2nd admin / beta.68 from-build / no-libfuse2 host) · 📱 needs a real device · 🪟 Windows pass (separate snapshot) · 🌐 browser-only (no device or install state)
 
 ## Before each run — reset to a clean slate
 
@@ -104,20 +104,22 @@ Boxes start unticked — this is a fresh pass.
 | ☐ **5.2** `[L]` Different-admin uninstall | Uninstall via **pkexec as a different admin** (triggers `systemd-run --system` teardown) | PASS = teardown: service stopped + unit removed, `/opt/ws-scrcpy-web` and `/var/lib/ws-scrcpy-web` gone, fcontext clean, zero AVC. Tab: **relaunch the app manually** if it doesn't reconnect (auto-relaunch is a tracked follow-up) |
 | ☐ **5.3** `[L]` Headless uninstall | `sudo ./WsScrcpyWeb --uninstall-system-service` (no graphical session) | No relaunch; manual fallback; no orphan; no `data_root_for_linux` panic; full teardown verified |
 
-## #11 — Updates 🧩 *(needs the beta.40 "update-from" artifact)*
+## #11 — Updates 🧩 *(needs the beta.68 "update-from" release)*
 
-Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws-scrcpy-web --name linux-final`.
+Get the from-build first: `gh release download v0.1.30-beta.68 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-linux-beta.AppImage'`.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ **6.1** `[B]` Update check | Settings → Updates → Check | beta.40 **offers the latest**; the latest = up-to-date; no log spam |
-| ☐ **6.2** `[L]` Local update apply | beta.40 home (local mode) → Apply | Verifies + swaps + **auto-relaunches** to the latest; reconnects |
+| ☐ **6.1** `[B]` Update check | Settings → Updates → Check | beta.68 **offers the latest**; the latest = up-to-date; no log spam |
+| ☐ **6.2** `[L]` Local update apply | beta.68 home (local mode) → Apply | Verifies + swaps + **auto-relaunches** to the latest; reconnects |
 | ☐ **6.3** `[L]` No-service /opt update | Machine-wide `/opt`, no service → update | One pkexec; **rename**-swap; relabel bin_t; **no ETXTBSY**; FUSE intact |
-| ☐ **6.4** `[L]` Newer home over /opt | `/opt` beta.40 + newer home AppImage → launch | Offers system-wide update → swap → next launch runs updated `/opt` |
+| ☐ **6.4** `[L]` Newer home over /opt | `/opt` beta.68 + newer home AppImage → launch | Offers system-wide update → swap → next launch runs updated `/opt` |
 | ☐ **6.5** `[L]` User-service update | User-service → Apply | Unit stops, home swaps, restarts **same port**, **no prompt** |
 | ☐ **6.6** `[L]` System-service update | System-service → Apply | **No polkit**; `/opt` swaps; restorecon bin_t; **zero AVC**; helper survives `systemctl stop`; updated deps stay **bin_t** (`ls -Z /opt/ws-scrcpy-web/dependencies` — copied into the bin_t tree, no relabel) |
 
-## #12 — Velopack / no-libfuse2 🧩 *(needs a minimal Fedora host without libfuse2)*
+## #12 — Velopack / no-libfuse2 🧩 *(run the smoke on a no-libfuse2 Fedora host — folds in 11.1/11.2)*
+
+> Run the whole Linux smoke on a Fedora host with **no** `libfuse2` (`ldconfig -p | grep -i libfuse.so.2` → empty) and these ride the normal launch + Module 6 update. Regression check on the already-removed gate (PR #422) — **revert #422 if 11.2 fails.** Skippable if that host is friction (doesn't gate 0.1.30), but close it before wide publicity.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
@@ -155,7 +157,7 @@ Get the from-build first: `gh run download 26859605903 --repo bilbospocketses/ws
 | ☐ **5.6** `[W]` Handoff-failure guard | Kill all `tray.exe`, then uninstall | ~5s/~30s messages; button freed; **service still installed** |
 | ☐ **5.7** `[W]` Full uninstall | Add/Remove → Uninstall as Admin | Service unregistered; `HKLM…\Run\WsScrcpyWebTray` gone; Program Files cleared; **dataRoot preserved** |
 | ☐ **5.10** `[W]` UAC declined | Standard user → uninstall → **decline** UAC | 403 `reason=uac-declined`; retry message; button freed; service still installed |
-| ☐ **6.8** `[W]` Update + tray persists | beta.40 MSI → Updates → Apply | Applies; reachable; **one** tray after settling (persists across update) |
+| ☐ **6.8** `[W]` Update + tray persists | beta.68 MSI → Updates → Apply | Applies; reachable; **one** tray after settling (persists across update) |
 | ☐ **7.3** `[W]` USB device | Plug USB, authorize the RSA prompt | Appears; survives a reload |
 | ☐ **10.2** `[W]` Logs clean | Tail `ProgramData\WsScrcpyWeb\logs\{launcher,server}.log` | No `ERR`/`Error:` except known node-pty AttachConsole noise |
 | ☐ **11.4** `[W]` PerMachine intact | After the MSI install, check the location | `C:\Program Files\WsScrcpyWeb\` (PerMachine) |
@@ -232,4 +234,4 @@ New in beta.51, the wipe self-deletion fixed in beta.52. Run on the clean Win11 
 | **Auth opt-in** | Off by default; enabling via the first-user lockdown gates **both** HTTP and device/stream WebSockets; brute-force lockout + admin-unlock work; change-password / logout / disable-to-open-mode all work; the last admin can never be locked out. Open mode is unchanged |
 | **Per-user labels** | Each logged-in account sees only its own device labels in scan hits + the connected list; open mode (single implicit admin) is unchanged from prior betas |
 
-**Stop-and-report:** a `[Linux]` SELinux/lifecycle failure in Modules 2/4/5, the service-update rows 6.5/6.6 — run `capture-logs.sh <id>` (`.ps1` on Windows) for the evidence bundle, then fix before promoting 0.1.30 stable. Cosmetic/polish → note as beta-territory. **Module 11 (no-libfuse2)** gates closing item 31, not 0.1.30-stable on its own.
+**Stop-and-report:** a `[Linux]` SELinux/lifecycle failure in Modules 2/4/5, the service-update rows 6.5/6.6 — run `capture-logs.sh <id>` (`.ps1` on Windows) for the evidence bundle, then fix before promoting 0.1.30 stable. Cosmetic/polish → note as beta-territory. **Module 11 (no-libfuse2)** is the regression check on the already-removed libfuse2 gate (PR #422) — **revert #422 if 11.2 fails**; it doesn't gate 0.1.30-stable on its own.

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -12,18 +12,19 @@ All-encompassing manual smoke, grouped by function and tagged by platform (`[Win
 - **Windows:** Win11 VM, clean snapshot; three accounts `Admin` / `User1` / `User2`; `regedit` + Task Manager → Startup tab handy. Download `WsScrcpyWeb-beta.msi` from the **latest** release.
 - **Devices:** an Android device with **Wireless debugging** enabled (Android 11+) reachable from the VM, plus (Windows) one USB device if available.
 
-**Build-prep — the "update from" build (Module 6).** The releases page is curated to the latest only, so the update rows need an older build to update *from*. Don't rebuild — download the still-retained **beta.40** CI artifact (the exact published beta.40 AppImage: Velopack 1.1.1):
+**Build-prep — the "update from" build (Module 6).** The update rows need an older build to update *from*. The most recent **kept prior release** is **`v0.1.30-beta.68`** — deliberately retained as the update-from build (bump this when a newer prior release is kept and an older one is deleted). Download its AppImage (and the MSI, for the Windows pass) into a separate dir — the asset filename is identical across versions, so it'd otherwise collide with the latest:
 
 ```bash
 # Linux — the update "from" build
-gh run download 26859605903 --repo bilbospocketses/ws-scrcpy-web --name linux-final --dir ./beta40
-chmod +x ./beta40/WsScrcpyWeb-linux-beta.AppImage
-# Windows MSI (row 6.8 / the Windows pass): --name windows-final from the same run
+gh release download v0.1.30-beta.68 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-linux-beta.AppImage' --dir ./beta68
+chmod +x ./beta68/WsScrcpyWeb-linux-beta.AppImage
+# Windows MSI (row 6.8 / the Windows pass):
+gh release download v0.1.30-beta.68 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-beta.msi' --dir ./beta68
 ```
 
-Artifacts are retained ~90 days from 2026-06-03. **the latest release is feed-latest**, so any older install updates *to* it.
+It's a kept release (not an expiring CI artifact), so there's no retention window to beat. **The latest release is feed-latest**, so any older install updates *to* it.
 
-- **No-libfuse2 host (Module 11.1/11.2):** a minimal Fedora container/distro **without** `libfuse2`. This is the gate for closing item 31, not a 0.1.30-stable blocker on its own.
+- **No-libfuse2 host (Module 11.1/11.2) — fold it into this run.** Run the Linux smoke on a minimal Fedora host with **no** `libfuse2` (confirm: `ldconfig -p | grep -i libfuse.so.2` → empty and `rpm -q fuse-libs` → not installed; a base Fedora cloud/container image ships without it, else `sudo dnf remove fuse-libs` on a throwaway VM). Do the Module 6 update leg **on that host** and Module 11 rides along free — 11.1 = the AppImage launched there at all, 11.2 = that same in-app update. It's the regression check on the **already-removed** libfuse2 gate (PR #422); **revert #422 if 11.2 fails.** Not a 0.1.30-stable blocker on its own, so skip to a normal Fedora VM if the no-libfuse2 host is friction — but close Module 11 before any wide-publicity release.
 
 **Clean slate — `clear-install.sh` (recommended).** For a one-shot, verified teardown of the **entire** install footprint — user- *and* system-scope service, `/opt` + `/var/lib`, dataRoot, tray autostart, the system `.desktop`, **all** SELinux fcontext rules (incl. the legacy beta.40 `/opt/.../data`), the single-instance lock, and any stray processes — run `bash clear-install.sh` (sits beside this doc). It tears down, then prints a per-item PASS/FAIL ending in `CLEAN SLATE ✓` / `NOT CLEAN ✗` (exit 0/1); idempotent + safe on an already-clean VM.
 
@@ -105,17 +106,17 @@ sudo systemctl daemon-reload
 
 ## Module 6 — Updates
 
-Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact). The latest release is feed-latest, so every row updates *to* it.
+Get the "update from" build first (Pre-flight build-prep: the kept **beta.68** release). The latest release is feed-latest, so every row updates *to* it.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| **6.1** `[Both]` Update check | Settings → Updates → Check for updates. | A beta.40 install **offers the latest**; the latest reports **up-to-date**; no error spam in `server.log` / `launcher.log`. |
-| **6.2** `[Linux]` Local-mode (home) update apply + relaunch *(#27)* | beta.40 home AppImage in **local mode** (no service) → Settings → Updates → Apply. | Downloads + SHA-256 verifies; the "updating…" overlay shows **above** Settings; the AppImage **swaps and auto-relaunches** onto the latest unattended; browser reconnects; About = the new version. **Edge:** also confirm apply on an instance **relaunched right after a user-scope service uninstall** (the `systemd-run --collect` cgroup case) still swaps + relaunches. |
+| **6.1** `[Both]` Update check | Settings → Updates → Check for updates. | A beta.68 install **offers the latest**; the latest reports **up-to-date**; no error spam in `server.log` / `launcher.log`. |
+| **6.2** `[Linux]` Local-mode (home) update apply + relaunch *(#27)* | beta.68 home AppImage in **local mode** (no service) → Settings → Updates → Apply. | Downloads + SHA-256 verifies; the "updating…" overlay shows **above** Settings; the AppImage **swaps and auto-relaunches** onto the latest unattended; browser reconnects; About = the new version. **Edge:** also confirm apply on an instance **relaunched right after a user-scope service uninstall** (the `systemd-run --collect` cgroup case) still swaps + relaunches. |
 | **6.3** `[Linux]` No-service `/opt` update *(one pkexec)* | Machine-wide `/opt`, **no** service → trigger update. | One pkexec; `/opt` swapped by **rename**; relabel bin_t + restorecon; VERSION bumps; relaunches **as the user**; reconnects. No `ETXTBSY`; FUSE intact. |
-| **6.4** `[Linux]` Newer home over `/opt` | `/opt` at beta.40; place a newer home AppImage; launch. | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
+| **6.4** `[Linux]` Newer home over `/opt` | `/opt` at beta.68; place a newer home AppImage; launch. | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
 | **6.5** `[Linux]` User-scope service update apply *(item 39)* | User-scope service installed → Settings → Updates → Apply. | The `--user` unit stops, the home `$APPIMAGE` swaps, the unit restarts on the **same** web port, browser reconnects via the overlay. **No prompt.** |
 | **6.6** `[Linux]` System-scope headless service update apply *(item 39 — the SELinux risk)* | System-scope service installed → Apply. | **No polkit prompt** (root self-update); `/opt` copy swaps; `restorecon` re-applies `bin_t`; unit restarts; **zero AVC**. The `systemd-run` apply helper **survives `systemctl stop`** of the unit it's restarting (out-of-cgroup); the FUSE unmount settles within the helper's ~15s swap-retry window (widen if the VM is slow). If SELinux blocks the `init_t` `/opt` write or relabel → **narrow targeted policy only, never broad `audit2allow`**. Updated deps land **bin_t** with no relabel (the dep manager `copyFileSync`s them into the bin_t `/opt/.../dependencies` tree, so new files inherit the label) — confirm `ls -Z /opt/ws-scrcpy-web/dependencies`. |
-| **6.8** `[Win]` In-app update apply + tray persists *(SE-2)* | From a prior installed build (beta.40 MSI) → Settings → Updates → Apply. | Applies clean; app reachable post-update; **the tray persists across the update** (the `apply-update-pending` marker gates the reap off; the relaunched launcher keeps it) — **one** tray after settling, no duplicate/orphan. |
+| **6.8** `[Win]` In-app update apply + tray persists *(SE-2)* | From a prior installed build (beta.68 MSI) → Settings → Updates → Apply. | Applies clean; app reachable post-update; **the tray persists across the update** (the `apply-update-pending` marker gates the reap off; the relaunched launcher keeps it) — **one** tray after settling, no duplicate/orphan. |
 
 ## Module 7 — Devices: scan & connect
 
@@ -154,14 +155,14 @@ Get the "update from" build first (Pre-flight build-prep: the beta.40 artifact).
 | **10.4** `[Both]` Per-instance token / reload-on-restart *(beta.66 security)* | With the app open in a tab, **restart the server** (change the web port → save, or stop & relaunch the app). Then, separately, `curl http://localhost:<port>/api/service/status` with no cookie. | After a restart the **already-open tab must be reloaded** to reconnect — the server mints a **new per-instance token** on each boot and hands it to the page as a `SameSite=Strict; HttpOnly` cookie, so the stale tab's socket/API calls are rejected until it reloads (then it works normally). A non-browser `curl` that never loaded the page (no cookie) is **rejected** on the sensitive API surface. Normal browser use is unchanged. |
 | **10.5** `[Both]` 404 + security headers *(beta.66 security)* | `curl -I http://localhost:<port>/no-such-asset.js` ; `curl -I http://localhost:<port>/` ; then load a deep in-app route in the browser and refresh it. | A missing **asset / unknown API path → `404`** (no longer the HTML shell with `200`); an **in-app route navigation still falls back to the shell**. Every static response carries **`X-Content-Type-Options: nosniff`** and **`X-Frame-Options: SAMEORIGIN`** (the documented same-origin embed still works). |
 
-## Module 11 — Velopack 1.2.0 / item-31
+## Module 11 — Velopack 1.2.0 / no-libfuse2 (PR #422 regression check)
 
-Velopack is at 1.2.0 (bumped in beta.44). These rows close out item 31 (the libfuse2 first-run gate) and guard the 1.2.0 apply path.
+Velopack is at 1.2.0 (bumped in beta.44). The libfuse2 first-run gate is **already removed** (PR #422, beta.67) — these rows are the regression check that the bet behind that removal holds (the type-2 runtime launches **and** self-updates with no host `libfuse2`), plus a guard on the 1.2.0 apply path. **Fold them into the main run** by doing the Module 6 update leg on the no-libfuse2 Fedora host (see Pre-flight): 11.1 + 11.2 then come for free. **Revert #422 if 11.2 fails.** Module 11 does **not** gate 0.1.30-stable on its own, but close it before any wide-publicity release.
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
 | **11.1** `[Linux]` No-libfuse2 launch | On a minimal distro/container **without** `libfuse2` installed, run the smoke-target AppImage. | Launches (type-2 runtime has FUSE embedded); **no** `libfuse.so.2` / "dlopen libfuse" error. |
-| **11.2** `[Linux]` No-libfuse2 in-app update | From that no-libfuse2 host, run an in-app update (6.x flow). | Update succeeds. The libfuse2 gate code is already removed (`SystemdClient.ts`, `UpdatesApi.ts`, `UpdateEvents.ts`, `SettingsModal.ts`, README); this row is the regression check that the type-2 runtime self-updates with no host libfuse2. |
+| **11.2** `[Linux]` No-libfuse2 in-app update | From that no-libfuse2 host, run the **Module 6** in-app update (this row IS the 6.x flow, just done on the no-libfuse2 host). | Update succeeds. The libfuse2 gate code is already removed (`SystemdClient.ts`, `UpdatesApi.ts`, `UpdateEvents.ts`, `SettingsModal.ts`, README); this row is the regression check that the type-2 runtime self-updates with no host libfuse2 — **revert PR #422 if it fails.** |
 | **11.3** `[Linux]` Locator fix watch (velopack#921) | During **6.3 / 6.4 / 6.6** apply + relaunch on the machine-wide `/opt` install. | Apply + relaunch land correctly; no Velopack locator root-path regression (the 1.2.0 fix targets exactly this path). |
 | **11.4** `[Win]` PerMachine intact | After the 1.5 MSI install, check the install location. | Installed PerMachine to `C:\Program Files\WsScrcpyWeb\` (vpk 1.2.0 `--msi --instLocation PerMachine` unchanged). |
 
@@ -223,7 +224,7 @@ beta.66's security/quality pass restored the keyboard focus indicator, added a r
 | **16.1** `[Both]` Light/dark theme switch | Toggle the theme (the home-page theme control) light ↔ dark; open a couple of modals and the stream view in each. | The whole UI recolors live — backgrounds, text, borders, buttons — with no element stuck at the other theme's colors; the choice persists across a reload. |
 | **16.2** `[Both]` Keyboard focus ring *(WCAG 2.4.7)* | **Tab** through the home page and a modal's controls with the keyboard; then **click** controls with the mouse. | A clear **focus outline** (2px, accent color) appears on the **keyboard**-focused control (`:focus-visible`); it does **not** appear on a plain mouse click. Regression guard: the old global `:focus { outline: none }` that hid focus everywhere is gone. |
 | **16.3** `[Both]` Reduced motion *(WCAG 2.3.3)* | Turn on the OS "reduce motion" setting (GNOME: Settings → Accessibility; Windows: Settings → Accessibility → Visual effects → Animation effects **off**), reload the app, then trigger animated UI (open modals, spinners, transitions). | Animations and transitions collapse to **near-instant** — no meaningful slides / fades / spins (the global `prefers-reduced-motion: reduce` reset). Turn the setting back off → normal animation returns. |
-| **16.4** `[Both]` Light-mode status tints | In **light** theme: select a file row, hover the delete control, and (on a beta.40→latest update run) hover the apply-update control. | The selection / delete-hover / apply-update tints render as proper light-theme shades — they now resolve through the danger / success design tokens, **not** the slightly-off dark-theme channel values they were previously hardcoded to. |
+| **16.4** `[Both]` Light-mode status tints | In **light** theme: select a file row, hover the delete control, and (on a beta.68→latest update run) hover the apply-update control. | The selection / delete-hover / apply-update tints render as proper light-theme shades — they now resolve through the danger / success design tokens, **not** the slightly-off dark-theme channel values they were previously hardcoded to. |
 | **16.5** `[Both]` Embed page language | Open `embed.html` (the embeddable stream page); view source / inspect the `<html>` element. | `<html>` has a **`lang`** attribute set (assistive-tech hint), matching the main app shell. |
 
 ---
@@ -276,4 +277,4 @@ beta.66's security/quality pass restored the keyboard focus indicator, added a r
 | **Auth opt-in** | Off by default; enabling via the first-user lockdown gates **both** HTTP and the device/stream WebSockets; brute-force lockout + admin-unlock work; change-password / logout / disable-to-open-mode all work; the last admin can never be locked out. Open mode is unchanged. |
 | **Per-user labels** | Each logged-in account sees only its own device labels in scan hits + the connected list; open mode (single implicit admin) is unchanged from prior betas. |
 
-**If a `[Linux]` SELinux/lifecycle row (Modules 2, 4, 5, the service-mode update rows 6.5/6.6, or the Module 14 uninstall-cascade rows 14.4–14.7) or the core-flow criterion fails:** stop, run `capture-logs.sh <id>` (`.ps1` on Windows) for the evidence bundle, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker. **Module 11 (no-libfuse2)** is the gate for closing item 31, not a 0.1.30-stable blocker on its own — a failure there means keep the libfuse2 gate, don't remove it.
+**If a `[Linux]` SELinux/lifecycle row (Modules 2, 4, 5, the service-mode update rows 6.5/6.6, or the Module 14 uninstall-cascade rows 14.4–14.7) or the core-flow criterion fails:** stop, run `capture-logs.sh <id>` (`.ps1` on Windows) for the evidence bundle, report back — fix before promoting 0.1.30 stable. Cosmetic/polish failures: note and triage as beta-territory vs stable-blocker. **Module 11 (no-libfuse2)** is the regression check on the already-removed libfuse2 gate (PR #422), not a 0.1.30-stable blocker on its own — an 11.2 failure means **revert #422** (restore the gate).

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -83,12 +83,12 @@ This is **setup, not tests** — nothing here passes or fails the app; it just g
 5. Download `WsScrcpyWeb-linux-beta.AppImage` from the latest GitHub release. **Leave it non-executable** — double-clicking a NON-`chmod +x` AppImage straight from the file manager is the realistic path most users take, and it's exactly what surfaced the Linux service-mode bug. (Marking it runnable with `chmod +x WsScrcpyWeb-linux-beta.AppImage` is optional — only needed if you'd rather launch it from a terminal.)
 
 ### B. The older "update-from" build (only for the Module 6 update tests)
-The update tests need an **older** version installed first, then updated *to* the latest. The releases page now lists only the latest, so pull the older **beta.40** build from its saved CI artifact:
+The update tests need an **older** version installed first, then updated *to* the latest. The most recent **kept prior release** is **`v0.1.30-beta.68`** — download it into a separate dir (the AppImage filename is identical across versions, so it'd collide with the latest):
 ```bash
-gh run download 26859605903 --repo bilbospocketses/ws-scrcpy-web --name linux-final --dir ./beta40
-chmod +x ./beta40/WsScrcpyWeb-linux-beta.AppImage
+gh release download v0.1.30-beta.68 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-linux-beta.AppImage' --dir ./beta68
+chmod +x ./beta68/WsScrcpyWeb-linux-beta.AppImage
 ```
-(beta.40 = your "before", the smoke-target = your "after". The Windows MSI is in the same run under `--name windows-final`. Artifacts are kept ~90 days from 2026-06-03.)
+(beta.68 = your "before", the smoke-target = your "after". The Windows MSI is on the same release: add `--pattern 'WsScrcpyWeb-beta.msi'`. It's a kept release, so no artifact-expiry to track.)
 
 ### C. Android device
 An Android phone/tablet with **Wireless debugging** on (Settings → Developer options, Android 11+), reachable from the VM. Optionally one **USB**-connected device on Windows (for the single USB test, 7.3).
@@ -99,8 +99,8 @@ An Android phone/tablet with **Wireless debugging** on (Settings → Developer o
 3. Keep **Registry Editor** and **Task Manager → Startup** open (a few tests check those).
 4. Download `WsScrcpyWeb-beta.msi` from the same release.
 
-### E. No-libfuse2 host (optional — only for Module 11)
-A minimal Fedora container/VM **without** `libfuse2` installed. This only closes a cleanup item; it does **not** block 0.1.30 — safe to skip on a first pass.
+### E. No-libfuse2 host (recommended — folds Module 11 into the run)
+A minimal Fedora VM/container with **no** `libfuse2`. Confirm it's really absent: `ldconfig -p | grep -i libfuse.so.2` prints nothing and `rpm -q fuse-libs` says "not installed" (a base Fedora cloud/container image ships without it; otherwise `sudo dnf remove fuse-libs` on a throwaway VM). Run the **whole** Linux smoke on this host and Module 11 needs no extra steps — 11.1 is "the app launched here at all", 11.2 is the Module 6 update done here. It's the regression check on the already-removed libfuse2 gate — **revert PR #422 if 11.2 fails**. Not a 0.1.30 blocker on its own, so skip to a normal VM if this host is friction — but don't ship to a wide audience without it.
 
 ### F. Capture scripts — pull the logs at any checkpoint
 Beside this doc are two snapshot scripts. Run one **at every capture point, and the instant any test fails**, to collect a complete evidence bundle (a timestamped, labeled folder + an archive to attach):
@@ -320,17 +320,17 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 ```
 
 ### Module 6 — Updates
-*The smoke-target build is the newest, so every row updates **to** it. Get the beta.40 "from" build first (Pre-flight B).*
+*The smoke-target build is the newest, so every row updates **to** it. Get the beta.68 "from" build first (Pre-flight B).*
 
 ```text
 ┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
 │ Test                 │ OS   │ Do this                      │ Pass - what you should see                       │ Done │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 6.1 Update check     │ Both │ Settings > Updates > "Check  │ A beta.40 install offers the latest; the latest  │ [ ]  │
+│ 6.1 Update check     │ Both │ Settings > Updates > "Check  │ A beta.68 install offers the latest; the latest  │ [ ]  │
 │                      │      │ for updates".                │ install says "up to date". No error spam in the  │      │
 │                      │      │                              │ server/launcher logs.                            │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 6.2 Local (home)     │ Lin  │ Start from the beta.40       │ It downloads, verifies the checksum, shows an    │ [ ]  │
+│ 6.2 Local (home)     │ Lin  │ Start from the beta.68       │ It downloads, verifies the checksum, shows an    │ [ ]  │
 │ update +             │      │ AppImage in plain local mode │ "updating..." overlay, swaps to the latest and   │      │
 │ auto-relaunch        │      │ (no service). Settings >     │ relaunches on its own; the browser reconnects;   │      │
 │                      │      │ Updates > Apply.             │ About = the new version. Also confirm on a copy  │      │
@@ -342,7 +342,7 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │ password)            │      │ update.                      │ labels re-applied; the VERSION file bumps; it    │      │
 │                      │      │                              │ relaunches as you and reconnects.                │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 6.4 Newer home copy  │ Lin  │ With /opt at beta.40, drop a │ It runs the home copy, then offers "update the   │ [ ]  │
+│ 6.4 Newer home copy  │ Lin  │ With /opt at beta.68, drop a │ It runs the home copy, then offers "update the   │ [ ]  │
 │ over /opt            │      │ newer AppImage in            │ system-wide install to vX"; accept > it swaps    │      │
 │                      │      │ your home folder and launch  │ /opt; the next launch runs the updated /opt.     │      │
 │                      │      │ it.                          │                                                  │      │
@@ -358,7 +358,7 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │                              │ rule only - never a blanket audit2allow.         │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 6.8 Windows update   │ Win  │ From a prior installed build │ Updates cleanly; app reachable afterward; the    │ [ ]  │
-│ keeps the tray       │      │ (beta.40 MSI) > Settings >   │ tray icon SURVIVES the update - exactly one tray │      │
+│ keeps the tray       │      │ (beta.68 MSI) > Settings >   │ tray icon SURVIVES the update - exactly one tray │      │
 │                      │      │ Updates > Apply.             │ once it settles, no duplicate or orphan.         │      │
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
@@ -479,8 +479,8 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 └──────────────────────┴──────┴──────────────────────────────┴──────────────────────────────────────────────────┴──────┘
 ```
 
-### Module 11 — Velopack 1.2.0 / libfuse2 (optional)
-*Confirms the new packaging runs without the old libfuse2 dependency. Closes a cleanup item; does NOT block 0.1.30.*
+### Module 11 — Velopack 1.2.0 / no-libfuse2 (fold into the run)
+*The libfuse2 special-case code is already gone (PR #422); this confirms the packaging still launches and self-updates without it. Run the smoke on a no-libfuse2 host (Pre-flight E) and 11.1/11.2 ride along free. **Revert PR #422 if 11.2 fails.** Doesn't block 0.1.30 on its own — but close it before any wide release.*
 
 ```text
 ┌──────────────────────┬──────┬──────────────────────────────┬──────────────────────────────────────────────────┬──────┐
@@ -491,8 +491,8 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 │                      │      │ libfuse2, run the            │                                                  │      │
 │                      │      │ smoke-target AppImage.       │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
-│ 11.2 Updates without │ Lin  │ From that same no-libfuse2   │ The update succeeds. (Passing this lets the old  │ [ ]  │
-│ libfuse2             │      │ machine, run an in-app       │ libfuse2 special-case code be deleted.)          │      │
+│ 11.2 Updates without │ Lin  │ From that same no-libfuse2   │ Update succeeds; gate code already gone (#422).  │ [ ]  │
+│ libfuse2             │      │ machine, run an in-app       │ Revert PR #422 if this row fails.                │      │
 │                      │      │ update.                      │                                                  │      │
 ├──────────────────────┼──────┼──────────────────────────────┼──────────────────────────────────────────────────┼──────┤
 │ 11.3 Update path     │ Lin  │ During the /opt update tests │ Apply and relaunch land correctly - no           │ [ ]  │
@@ -833,6 +833,6 @@ Mark the **Done** column as you go: `x` pass · `F` fail · `-` skip.
 └──────────────────────┴────────────────────────────────────────────────────────────────┴──────┘
 ```
 
-**If any Linux SELinux/lifecycle test (Modules 2, 4, 5, the service-update rows 6.5/6.6) — or the core-flow criterion — fails:** stop, **run `capture-logs.sh <id>` (Pre-flight F; `.ps1` on Windows)** for the evidence bundle, and report it before promoting 0.1.30 to stable. Cosmetic/polish failures: note and triage later. **Module 11 (no-libfuse2)** is optional — a failure there just means keep the libfuse2 code; it doesn't block 0.1.30.
+**If any Linux SELinux/lifecycle test (Modules 2, 4, 5, the service-update rows 6.5/6.6) — or the core-flow criterion — fails:** stop, **run `capture-logs.sh <id>` (Pre-flight F; `.ps1` on Windows)** for the evidence bundle, and report it before promoting 0.1.30 to stable. Cosmetic/polish failures: note and triage later. **Module 11 (no-libfuse2)** is the regression check on the already-removed libfuse2 gate — an 11.2 failure means **revert PR #422** (restore the gate); it doesn't block 0.1.30 on its own.
 
 *Plain-English companion to [`smoke-full.md`](./smoke-full.md), the canonical machine-precise checklist. The same tests as the repo doc, with the jargon spelled out; if the two ever diverge, the full doc wins.*


### PR DESCRIPTION
Two doc-drift fixes in the Linux smoke docs (`docs/smoke-tests/`) — docs only, no code or release impact.

**1. Module 11 (no-libfuse2) reframed around PR #422.** The docs still called this "closing item 31" and said a failure means "keep the libfuse2 gate, don't remove it" — but #422 already removed that gate in beta.67. So Module 11 isn't a pending cleanup; it's the regression check that the removal holds. All three docs now frame it that way: **revert #422 if 11.2 fails**, and fold it into the normal run by doing the Module 6 update leg on a no-libfuse2 Fedora host (11.1 = launched there, 11.2 = that same update). Added the host-confirm commands (`ldconfig -p | grep -i libfuse.so.2`, `rpm -q fuse-libs`). Still doesn't gate 0.1.30-stable on its own.

**2. Module 6 "update-from" build: beta.40 -> beta.68.** Build-prep pinned beta.40 via a CI artifact (`gh run download`, 90-day retention). beta.68 is the deliberately-kept prior release now, so build-prep / Pre-flight B / the 6.x row refs use `gh release download v0.1.30-beta.68` — no expiry to track. Historical beta.40 mentions (the bookmark-reset fix, the legacy SELinux fcontext path clear-install strips) left intact.

Verified with `gh release view` that beta.68 + beta.69 both carry the AppImage + MSI assets, so the new download command resolves. Grep-swept for `item 31`, stale "removal pending" wording, and old artifact mechanics — all clean; the runbook ASCII boxes still align (same-length swaps).