### PR TITLE
chore(docs): remove old-embed-mode migration note + stale migration comments

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -576,16 +576,7 @@ Calling `startStream()` a second time on the same container without first callin
 
 `embed.html` sets `body { background: transparent }` so iframe consumers can place any background they like behind the video. A small status overlay in the top-left shows `connecting...`, then `connected <codec> <resolution>` (auto-hides after 2 s), or an error / disconnect message.
 
-### 6.7 Migration from the Old Embed Mode
-
-This section replaces the previous CSS-hack embed mode. Breaking changes:
-
-- **`#!action=stream&udid=...` hash routing is REMOVED.** Direct-link stream access now uses `/embed.html?device=<udid>` (or call `startStream()` directly from your own page).
-- **`?embed=true` URL param is REMOVED** along with the `body.embed` CSS class. `embed.html` always runs with a transparent background — there is no flag to toggle.
-- **The `more-box` overflow UI is REMOVED** (YAGNI — all its functions were already duplicated in the toolbar). Clipboard sync is now first-class: the toolbar has separate GET and SET clipboard buttons.
-- **TypeScript types are shipped** as `dist/public/ws-scrcpy.d.ts`, bundled so no `src/**` imports leak.
-
-### 6.8 Internal Architecture
+### 6.7 Internal Architecture
 
 `StreamClientScrcpy` (in `src/app/googDevice/client/`) is the rendering engine. It handles the WebSocket connection, video demuxer, WebCodecs decoder, audio worklet, touch / keyboard / UHID input, and toolbar wiring.
 

--- a/src/app/client/SettingsService.ts
+++ b/src/app/client/SettingsService.ts
@@ -3,7 +3,7 @@ async function ok(res: Response): Promise<Response> {
     return res;
 }
 
-// Shape stored under device scope 'video' (mirrors what the migration writes).
+// Shape stored under device scope 'video'.
 export interface StoredVideo {
     settings?: Record<string, unknown> | undefined; // raw VideoSettings JSON
     fit?: boolean | undefined;
@@ -143,7 +143,7 @@ export class SettingsService {
     }
 }
 
-// Singleton — the boot migration AND every call site import THIS so caches are
+// Singleton — every call site imports THIS so caches are
 // shared. A module singleton (rather than DI) is required because BasePlayer's
 // static methods have no `this`-instance to thread a service reference through.
 export const settingsService = new SettingsService();

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -181,7 +181,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
     // removed — video settings now route through the SettingsService singleton
     // (Task 4c). The legacy localStorage key scheme (viewport-keyed per udid) is
     // no longer used; all video prefs are stored as one collapsed 'video' scope per
-    // udid by the migration and the new accessors below.
+    // udid via the new accessors below.
 
     /**
      * Returns whether fit-to-screen is enabled for the given udid.
@@ -208,7 +208,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
      * The coercion block is preserved verbatim from the pre-Task-4c implementation;
      * only the source of `parsed` changes: was JSON.parse(localStorage), now the
      * plain parsed object from the SettingsService sync cache (which holds the same
-     * shape written by the migration and by putVideoSettingsToStorage).
+     * shape written by putVideoSettingsToStorage).
      *
      * `storageKeyPrefix` and `displayInfo` are kept for call-site compatibility but
      * are no longer used for storage lookups (viewport-key collapse — see Task 3).


### PR DESCRIPTION
Follow-up to #452 - removes the two borderline items I held back from that PR.

- `TECHNICAL_GUIDE.md` 6.7 "Migration from the Old Embed Mode" - a 4-bullet old->new embed-API note. Removed; 6.8 Internal Architecture renumbered to 6.7 (no TOC / cross-refs pointed at it).
- Two comments referencing the now-deleted settings migration (`SettingsService.ts`, `BasePlayer.ts`) rewritten present-tense.

Comment/doc only; `tsc --noEmit` clean.