### PR TITLE
fix(release): pin the AppImage type2-runtime to an immutable tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Pinned the AppImage's embedded `type2-runtime` to an immutable release tag.** Packaging pinned the rolling `continuous` runtime channel, whose `runtime-x86_64` hash drifts as upstream rebuilds it — that drift broke a release build. It now pins a dated, immutable release (`20251108`), so the build is reproducible and won't break when upstream rebuilds. It is the same kind of static-FUSE type-2 runtime, so the AppImage still launches and self-updates without a host `libfuse2`.
+
 ## [0.1.30-beta.70] - 2026-06-24
 
 ### Changed

--- a/scripts/swap-appimage-runtime.mjs
+++ b/scripts/swap-appimage-runtime.mjs
@@ -42,19 +42,22 @@ import { basename, join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { pathToFileURL } from 'node:url';
 
-// Pin to a known-good URL. The continuous channel is built from main and
-// updates frequently. If reproducibility ever matters, swap to a tagged
-// release URL.
+// Pin to a STABLE, immutable type2-runtime release (a dated tag), NOT the
+// rolling `continuous` channel. `continuous` is rebuilt from main frequently,
+// so its `runtime-x86_64` hash drifts out from under this pin and breaks the
+// release build (2026-06-24: continuous moved a2419dce... -> 1cc49bcf...). A
+// dated tag never changes. Latest immutable stable as of 2026-06-24 is
+// 20251108; bump the tag here AND the SHA below together to adopt a newer one.
 const RUNTIME_URL =
-    'https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64';
+    'https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-x86_64';
 
-// SHA-256 of the known-good runtime, verified before it is embedded into the
-// shipped .AppImage — this binary is the first code that runs on launch. The
-// continuous channel is rebuilt from main; when intentionally adopting a newer
-// runtime, download it from a trusted source, verify it, and update this
-// digest. The build refuses any runtime whose hash does not match.
+// SHA-256 of the pinned runtime, verified before it is embedded into the
+// shipped .AppImage — this binary is the first code that runs on launch. When
+// intentionally adopting a newer stable tag, download it from a trusted source,
+// verify it, and update BOTH the tag in RUNTIME_URL and this digest together.
+// The build refuses any runtime whose hash does not match.
 const RUNTIME_SHA256 =
-    'a2419dce47568395ae79c01ffa9a5a341dd339581352ff104d073527543177e5';
+    '2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d';
 
 /**
  * Verify downloaded runtime bytes against an expected SHA-256, throwing on


### PR DESCRIPTION
The beta.70 Release build failed because we pinned the upstream `type2-runtime` **`continuous`** channel — a rolling tag. Upstream rebuilt it, so the `runtime-x86_64` hash drifted out from under our pin and `swap-appimage-runtime.mjs` correctly refused to embed the unverified binary. The version bump itself landed (`package.json` is at beta.70), but no release published — so **beta.70 is a tombstone tag**, and merging this cuts **beta.71**.

## Fix
Pin a dated, **immutable** type2-runtime release instead of the rolling channel:
- `RUNTIME_URL` → `.../releases/download/20251108/runtime-x86_64` (the latest immutable stable; the next-oldest is the 2022 `old` tag).
- `RUNTIME_SHA256` → `2fca8b44…` — downloaded, ELF-verified, and hashed locally.
- Documented the rolling-tag fragility in the comments so it isn't reintroduced.

It's the same kind of static-FUSE type-2 runtime as before, so the AppImage still launches and self-updates without a host `libfuse2`. The runtime swap is exercised by the smoke's launch (2b.1 / 11.1) and in-app-update (6.x / 11.2) rows, so the binary change is regression-checked there.

`swap-appimage-runtime` unit test green; no other reference to the old pin remains in the tree.
