### PR TITLE
docs(smoke): bump smoke target to v0.1.30-beta.71

### DIFF
--- a/docs/smoke-tests/smoke-checklist.md
+++ b/docs/smoke-tests/smoke-checklist.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Smoke Run-Sheet
 
-> **Smoke target: `v0.1.30-beta.69`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.71`** — bump this one line each release; everything below is version-agnostic.
 
 Execution-ordered, tickable checklist for the 0.1.30 Linux smoke gate. Regroups the canonical rows from
 [`smoke-full.md`](./smoke-full.md) by **app state** — the order you actually run them; that doc

--- a/docs/smoke-tests/smoke-full.md
+++ b/docs/smoke-tests/smoke-full.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Full Smoke Test
 
-> **Smoke target: `v0.1.30-beta.69`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.71`** — bump this one line each release; everything below is version-agnostic.
 
 All-encompassing manual smoke, grouped by function and tagged by platform. Each row is a single test: **what to verify**, **how to perform it**, and the **expected result + how to verify**. Walk top to bottom; some rows depend on state from earlier rows in the same module.
 

--- a/docs/smoke-tests/smoke-runbook.md
+++ b/docs/smoke-tests/smoke-runbook.md
@@ -1,6 +1,6 @@
 # ws-scrcpy-web — Smoke Test Runbook (plain-English)
 
-> **Smoke target: `v0.1.30-beta.69`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.71`** — bump this one line each release; everything below is version-agnostic.
 
 **What this is.** A step-by-step manual test pass for the **ws-scrcpy-web** app. Completing it is the agreed gate before cutting the **0.1.30 final** release — the "prove it really installs, updates, and streams on Windows + Linux" check. You run it by hand on your test VMs plus a real Android device; it can't be automated from a chat.
 


### PR DESCRIPTION
Bump the three smoke docs' target line from beta.69 to **beta.71** (the published Latest; beta.70 was a tombstone after the rolling-runtime-pin build failure fixed in #458). Docs-only, `release:none`.
