### PR TITLE
docs(readme): note the userns restriction also applies to Ubuntu 26.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The bundled `node-pty` native binary is built against glibc. Musl-based distros 
 
 The AppImage needs no host `libfuse2`. Packaging swaps in the static [type-2 AppImage runtime](https://github.com/AppImage/type2-runtime) (libfuse is statically linked), and the in-app updater uses Velopack's bundled type-2 runtime for the update mount — so on any glibc-based distro the app **self-updates** without a host `libfuse2`, and on Fedora 40+, Arch, and most distros it **launches** straight from a `chmod +x` (no libfuse2 install needed).
 
-> **Ubuntu 23.10+ / 24.04 note.** These releases ship an AppArmor profile that **restricts unprivileged user namespaces** (`kernel.apparmor_restrict_unprivileged_userns=1`) — the mechanism an AppImage uses to mount itself — which can block launch **independently of libfuse**. If the AppImage won't start on stock Ubuntu 24.04, run it extracted with `APPIMAGE_EXTRACT_AND_RUN=1 ./WsScrcpyWeb-linux-*.AppImage`, or (as admin) relax the restriction: `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. A built-in extract-and-run fallback is planned (see the smoke-test Module 2b).
+> **Ubuntu 23.10+ note (24.04 / 26.04).** These releases ship an AppArmor profile that **restricts unprivileged user namespaces** (`kernel.apparmor_restrict_unprivileged_userns=1`) — the mechanism an AppImage uses to mount itself — which can block launch **independently of libfuse**. If the AppImage won't start on stock Ubuntu 24.04 or 26.04, run it extracted with `APPIMAGE_EXTRACT_AND_RUN=1 ./WsScrcpyWeb-linux-*.AppImage`, or (as admin) relax the restriction: `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. A built-in extract-and-run fallback is planned (see the smoke-test Module 2b).
 
 #### Tray icon
 


### PR DESCRIPTION
The README's libfuse2/userns note named only "Ubuntu 23.10+ / 24.04," but the unprivileged-userns restriction (which can block an AppImage from launching) is default on **26.04** too. Updates the note's header and the "stock Ubuntu 24.04" workaround line to cover **24.04 or 26.04**, aligning the README with this session''s smoke-doc retarget (#461).

Docs only — no behaviour change.