### PR TITLE
ci(dependabot): auto-merge the grouped github-actions PR

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,8 @@
 # Auto-merge Dependabot PRs.
 #
-# Patch/minor version bumps AND security updates (any size) auto-merge once required
-# status checks pass (--auto waits for green). Non-security MAJOR bumps are held with a
-# needs-manual-review label (framework upgrades / breaking changes).
+# Patch/minor version bumps, security updates (any size), AND the grouped github-actions
+# bump auto-merge once required status checks pass (--auto waits for green). Non-security
+# MAJOR bumps are held with a needs-manual-review label (framework upgrades / breaking changes).
 
 name: Dependabot auto-merge
 on: pull_request
@@ -25,11 +25,12 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Auto-merge patch/minor, or any security update
+      - name: Auto-merge patch/minor, any security update, or the grouped actions bump
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.ghsa-id != ''
+          steps.metadata.outputs.ghsa-id != '' ||
+          steps.metadata.outputs.dependency-group == 'actions'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Extend the Dependabot auto-merge workflow to also auto-merge the grouped github-actions PR (`dependency-group == 'actions'`), gated on green CI like everything else.

**Why:** grouping action bumps into one PR (added this session) fixed the codeql-action split, but a grouped PR reports an empty `update-type` from fetch-metadata — so it matched neither the patch/minor auto-merge condition nor the major-hold condition and just sat CLEAN-but-unmerged. This closes that gap: grouped action PRs now self-clear on green CI. A breaking action major still fails CI and won't merge.

Config-only, single-file change to `.github/workflows/dependabot-auto-merge.yml`.