### PR TITLE
chore(dependabot): group npm minor+patch, guard auto-merge against closed PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,17 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    # Batch all minor + patch bumps into ONE weekly PR. Interlocking families
+    # (@xterm/* addons must match the xterm core; webpack + its loaders; the
+    # typescript / ts-loader / ts-node toolchain) break when bumped singly.
+    # Grouping keeps them in lockstep; majors still open individually for review.
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # github-actions: tracks SHA-pinned action references in .github/workflows/.
   # Dependabot keys on the `# vX.Y.Z` comment after each SHA to detect

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -31,7 +31,17 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
           steps.metadata.outputs.ghsa-id != '' ||
           steps.metadata.outputs.dependency-group == 'actions'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          # Live-state guard: the pull_request event payload is a snapshot from when
+          # the event fired, so it can report "open" for a PR that was closed or
+          # superseded before this job ran -- and `gh pr merge --auto` then fails with
+          # "Pull request is closed". Re-check the CURRENT state right before enabling.
+          state=$(gh pr view "$PR_URL" --json state --jq .state)
+          if [ "$state" != "OPEN" ]; then
+            echo "PR is $state (not OPEN) -- skipping auto-merge enable."
+            exit 0
+          fi
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## What
1. **npm minor/patch grouping** — batch all non-major npm bumps into one weekly PR.
2. **Auto-merge live-state guard** — re-check PR state before enabling auto-merge.

## Why
Several dependency families here break when Dependabot bumps them singly:
`@xterm/*` addons must match the xterm core, the webpack loaders peer-depend on
webpack, and `ts-loader`/`ts-node` track the `typescript` version. Grouping all
minor+patch bumps into one PR keeps each family in lockstep. Majors still open
individually so a breaking upgrade gets a human.

The auto-merge workflow also occasionally ran `gh pr merge --auto` on an already-closed
PR (stale event payload) and errored with "Pull request is closed"; it now checks live
state first.

## Risk
Config only — no source or lockfile changes.