### PR TITLE
build: swap ts-loader/ts-node for swc (TS 7 migration, phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-ws-scrcpy-web-ts7-phase1.md
+++ b/docs/superpowers/plans/2026-07-18-ws-scrcpy-web-ts7-phase1.md
@@ -1,0 +1,232 @@
+# ws-scrcpy-web TS 7 — Phase 1 (swc-loader swap) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ts-loader and ts-node with swc so the webpack build no longer imports the TypeScript compiler API, while staying on TypeScript 6 with no change to shipped behavior.
+
+**Architecture:** ts-loader (already `transpileOnly`) → `swc-loader`; the `webpack/*.ts` configs load via `@swc-node/register` instead of `ts-node`. Type-safety stays with the separate `tsc --noEmit` CI step. Every task ends green (`tsc --noEmit` + `npm test`) and the final task proves output equivalence vs `main` plus a runtime smoke.
+
+**Tech Stack:** webpack 5, `@swc/core` + `swc-loader`, `@swc-node/register`, TypeScript 6.0.x, vitest, Node 24.
+
+## Global Constraints
+
+- **Stay on TypeScript 6.x** — no `typescript` version bump in Phase 1 (that is Phase 2). Verbatim: `typescript@^6.0.2`.
+- **No runtime behavior change** — the merge gate is: `dist/` functionally equivalent to `main`, `tsc --noEmit` green, `npm test` green, and a smoke-run of the built server.
+- **Local-dependencies rule:** the swap is build-time devDependencies only (resolved from `node_modules`, exactly like `ts-loader` was). The vendored runtime binaries under `dependencies/` (node, scrcpy-server, node-pty) are NOT touched.
+- **Branch:** `feat/ts7-phase1-swc-loader` (already created off `origin/main`).
+- **Commits:** SSH-signed, no AI attribution.
+
+---
+
+### Task 1: isolatedModules safety net
+
+**Files:**
+- Modify: `tsconfig.json` (compilerOptions)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a tsconfig that forbids constructs swc can't transpile per-file; later tasks rely on `tsc --noEmit` being green with this flag on.
+
+- [ ] **Step 1: Add `isolatedModules` to tsconfig**
+
+In `tsconfig.json`, inside `compilerOptions`, add:
+
+```json
+    "isolatedModules": true,
+```
+
+(place it near the other module options, e.g. after `"resolveJsonModule": true,`)
+
+- [ ] **Step 2: Run the type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS with no errors. If it reports `TS1205` (re-exported type) or `TS2748` (const enum), fix each by using `export type { X }` / replacing the `const enum` with a regular `enum` or a `const` object, then re-run until clean. (Expected to already be clean: ts-loader `transpileOnly` already transpiles per-file.)
+
+- [ ] **Step 3: Confirm nothing else regressed**
+
+Run: `npm test`
+Expected: PASS (unchanged — this is a compiler-flag-only change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web add tsconfig.json
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web commit -m "build: enable isolatedModules (prep for swc per-file transpile)"
+```
+
+---
+
+### Task 2: Replace ts-loader with swc-loader
+
+**Files:**
+- Modify: `package.json` (devDependencies)
+- Modify: `webpack/ws-scrcpy-web.common.ts:73-77` (the `/\.tsx?$/` rule)
+
+**Interfaces:**
+- Consumes: `isolatedModules` from Task 1.
+- Produces: a webpack build that transpiles TS via swc. Later tasks rely on `npm run build` succeeding without ts-loader present.
+
+- [ ] **Step 1: Install swc, remove ts-loader**
+
+Run:
+```
+npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web install --save-dev @swc/core@^1 swc-loader@^0.2
+npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web uninstall ts-loader
+```
+Expected: `@swc/core` + `swc-loader` in devDependencies; `ts-loader` gone.
+
+- [ ] **Step 2: Swap the loader rule**
+
+In `webpack/ws-scrcpy-web.common.ts`, replace:
+
+```ts
+                {
+                    test: /\.tsx?$/,
+                    use: [{ loader: 'ts-loader', options: { transpileOnly: true } }],
+                    exclude: /node_modules/,
+                },
+```
+
+with:
+
+```ts
+                {
+                    test: /\.tsx?$/,
+                    exclude: /node_modules/,
+                    use: {
+                        loader: 'swc-loader',
+                        options: {
+                            // Transpile-only (type-safety stays with `tsc --noEmit`),
+                            // matching the tsconfig emit: ES2022, esModuleInterop-style
+                            // default imports, define-semantics class fields.
+                            jsc: {
+                                parser: { syntax: 'typescript', tsx: true },
+                                target: 'es2022',
+                                transform: { useDefineForClassFields: true },
+                            },
+                            // Leave module form to webpack (swc emits ESM; webpack bundles).
+                        },
+                    },
+                },
+```
+
+- [ ] **Step 3: Build (dev, readable output) and type-check**
+
+Run: `npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web run build:dev`
+Expected: build SUCCEEDS, emits `dist/public/bundle.js`, `dist/index.js`, etc.
+
+Run: `npx tsc --noEmit` (cwd = repo)
+Expected: PASS.
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web test`
+Expected: PASS (vitest transpiles via esbuild independently, so this is a regression check on the app, not on swc).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web add package.json package-lock.json webpack/ws-scrcpy-web.common.ts
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web commit -m "build: transpile with swc-loader instead of ts-loader"
+```
+
+---
+
+### Task 3: Remove ts-node (config runtime → @swc-node/register)
+
+**Files:**
+- Modify: `package.json` (devDependencies)
+
+**Interfaces:**
+- Consumes: `@swc/core` from Task 2.
+- Produces: a build whose `webpack/*.ts` config loads without ts-node. Later tasks rely on `npm run build` working with ts-node absent.
+
+- [ ] **Step 1: Install @swc-node/register, remove ts-node**
+
+Run:
+```
+npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web install --save-dev @swc-node/register@^1
+npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web uninstall ts-node
+```
+
+- [ ] **Step 2: Verify webpack loads the .ts config via swc (the risky bit)**
+
+Run: `npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web run build`
+Expected: build SUCCEEDS (webpack resolves the `.ts` config through `@swc-node/register`; `interpret` lists it for `.ts`). The step exercises loading `webpack/ws-scrcpy-web.prod.ts` → `.common.ts`.
+
+**If it FAILS to load the config** (e.g. "Unable to use specified module loader"): apply the fallback — convert the three `webpack/ws-scrcpy-web.{common,prod,dev}.ts` files to `.cjs`:
+- rename to `.cjs`, change `import X from 'y'` → `const X = require('y')` and `import { a } from './z'` → `const { a } = require('./z.cjs')`, keep `module.exports = [...]`,
+- update the `build`/`build:dev` scripts in `package.json` to point at the `.cjs` config paths,
+- add `/** @type {import('webpack').Configuration} */` above the config objects for authoring hints,
+- then re-run `npm run build` and confirm success.
+
+- [ ] **Step 3: Type-check + tests still green**
+
+Run: `npx tsc --noEmit`  → PASS
+Run: `npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web test` → PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web add -A
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web commit -m "build: load webpack config via @swc-node/register, drop ts-node"
+```
+
+---
+
+### Task 4: Prove equivalence + smoke, open PR
+
+**Files:** none (verification + release).
+
+**Interfaces:**
+- Consumes: the swc build from Tasks 2–3.
+- Produces: a merged, verified Phase 1.
+
+- [ ] **Step 1: Build a reference `dist/` from `main` (ts-loader)**
+
+```bash
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web worktree add ../wssw-main origin/main
+npm --prefix C:/Users/jscha/source/repos/wssw-main ci
+npm --prefix C:/Users/jscha/source/repos/wssw-main run build:dev
+```
+
+- [ ] **Step 2: Build the branch `dist/` and compare**
+
+Run: `npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web run build:dev`
+Compare the two `dist/` trees:
+```
+# same set of emitted files + comparable sizes; content diffs are expected (swc vs tsc)
+Compare-Object (Get-ChildItem -Recurse ../wssw-main/dist | Select Name,Length) (Get-ChildItem -Recurse ./dist | Select Name,Length)
+```
+Expected: same file set; no missing/extra bundles; sizes within a small delta. Content byte-diffs are acceptable (cosmetic transpile differences); a missing module/entry is NOT.
+
+- [ ] **Step 3: Smoke-run the built server**
+
+Run: `npm --prefix C:/Users/jscha/source/repos/ws-scrcpy-web run build && node C:/Users/jscha/source/repos/ws-scrcpy-web/dist/index.js` (background; stop after check)
+Verify: server boots without error and serves the client — `curl -sf http://localhost:8000/ | Select-String '<script'` returns the index referencing `bundle.js`, and `curl -sf http://localhost:8000/bundle.js -o $null` succeeds (valid JS served). Stop the server.
+Expected: boots, serves index + bundle, no unhandled exception in the log. (Full device streaming needs a real Android target and is out of scope for CI smoke.)
+
+- [ ] **Step 4: Clean up the worktree**
+
+```bash
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web worktree remove ../wssw-main
+```
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git -C C:/Users/jscha/source/repos/ws-scrcpy-web push -u origin feat/ts7-phase1-swc-loader
+```
+Open the PR (base `main`) titled `build: swap ts-loader/ts-node for swc (TS 7 migration, phase 1)`, body summarizing: removes the compiler-API-bound loader/config-runtime, stays on TS 6, verified by output diff + `tsc --noEmit` + tests + smoke. Enable squash auto-merge; CI (`tsc --noEmit`, tests, `npm run build`) is the final gate.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Phase 1 items all mapped — isolatedModules (Task 1), swc-loader (Task 2), ts-node removal + fallback (Task 3), verification: output diff / tsc / tests / smoke (Task 4). Phase 2 (TS 7 bump, dts-bundle-generator, #487) is explicitly out of scope for this plan. ✓
+
+**Placeholder scan:** No TBD/TODO; the `.cjs` fallback in Task 3 is fully specified (rename, require-conversion, script path update). ✓
+
+**Type consistency:** No new code types introduced (build-config only); swc options block is self-consistent across tasks. ✓
+
+**Note on TDD:** this is a build-system refactor, so the verification cycle is the existing test suite + `tsc --noEmit` + build-output equivalence + smoke, run at each task — not new unit tests (there is no new runtime code to unit-test).

--- a/docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md
+++ b/docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md
@@ -1,0 +1,92 @@
+# ws-scrcpy-web → TypeScript 7 migration (design)
+
+**Date:** 2026-07-18
+**Status:** Approved — Phase 1 ready to implement; Phase 2 outlined.
+**Scope:** The build-system changes needed for ws-scrcpy-web to run on the TypeScript 7 native compiler.
+
+## Problem
+
+TypeScript 7.0 (the native / Go compiler) ships no stable *programmatic* API — that lands in 7.1. ws-scrcpy-web's build depends on three tools that import the compiler as a library, so none of them can run on TS 7:
+
+- **ts-loader** — the webpack loader that transpiles the app's TS. It already runs `transpileOnly: true`, i.e. it only transpiles and does not type-check.
+- **ts-node** — loads the TypeScript webpack configs (`webpack/ws-scrcpy-web.{common,prod,dev}.ts`).
+- **dts-bundle-generator** — emits the bundled public `dist/public/ws-scrcpy.d.ts` consumed by the UMD/ESM/embed library builds.
+
+**Key evidence — the code is already TS-7-clean.** In CI (`.github/workflows/ci.yml`), `npx tsc --noEmit` runs at step 2, *before* `npm run build` at step 6. Dependabot PR #487 (`typescript 6.0.3 → 7.0.2`) failed at `npm run build`; because steps are sequential, `tsc --noEmit` therefore **passed on TS 7**. So the type-check is happy on the native compiler — the only blockers are the three build tools above.
+
+## Goal
+
+Run ws-scrcpy-web on the TS 7 native compiler by replacing the compiler-API-bound build tools with API-free equivalents, with **no change to the shipped runtime behavior**.
+
+## Non-goals
+
+- No source/type changes to satisfy TS 7 — there are none (`tsc --noEmit` passes).
+- No change to what the app does or how it is packaged/released (Velopack).
+- Bundler stays webpack (no migration to vite/rspack).
+
+## Approach: decoupled, two phases
+
+Phase 1 removes the two fragile blockers (ts-loader, ts-node) **while staying on TypeScript 6**, so any behavior delta is provably the loader swap alone and not the compiler change. Phase 2 is a separate PR that bumps to TS 7 and resolves dts-bundle-generator.
+
+---
+
+## Phase 1 — swc-based build, still on TypeScript 6
+
+### 1. `isolatedModules` safety net (lands first)
+
+Enable `isolatedModules: true` in `tsconfig.json` and run `tsc --noEmit`. swc transpiles each file independently, so it cannot do the cross-file type erasure `tsc` performs; `isolatedModules` makes `tsc` flag anything that would break under per-file transpile (type re-exports without `export type`, `const enum`, etc.). The code already survives per-file transpile today — ts-loader `transpileOnly` uses `transpileModule`, which is per-file — so this is expected to pass clean. It lands first as cheap insurance, so any latent violation surfaces as a type error rather than a silent runtime break after the loader swap.
+
+### 2. Loader: ts-loader → swc-loader
+
+- Add `@swc/core` + `swc-loader` (devDependencies); remove `ts-loader`.
+- Replace the webpack rule `{ test: /\.tsx?$/, use: [{ loader: 'ts-loader', options: { transpileOnly: true } }] }` (in `webpack/ws-scrcpy-web.common.ts`) with `swc-loader`.
+- Configure swc to match the current tsconfig emit: TypeScript parser (tsx on), `jsc.target: es2022` (matches tsconfig `target: ES2022`), interop equivalent to `esModuleInterop`, and leave module form to webpack. The repo uses no decorators and no `const enum` (the usual swc/tsc divergence points).
+- Remains transpile-only, exactly as today. Type safety stays with the separate `tsc --noEmit`.
+
+### 3. Config runtime: remove ts-node
+
+The `webpack/*.ts` configs are loaded by ts-node today (webpack auto-detects the `.ts` extension via `interpret`/`rechoir`). These files are outside `tsconfig`'s `include` (`src/**/*`), so they are not type-checked in CI regardless.
+
+- **Primary:** keep the configs as `.ts` and let webpack's config resolver load them via `@swc-node/register` (swc-based, no compiler API; listed in `interpret` for `.ts`). Add it, remove `ts-node`.
+- **Fallback (if the resolver does not pick it up cleanly):** convert the three `webpack/*.ts` files to plain `.cjs` (they already use `module.exports = [...]`), with JSDoc `@type {import('webpack').Configuration}` for authoring hints.
+
+Either fully removes `ts-node`; the choice is settled during Phase 1 verification and has no runtime impact.
+
+### 4. Verification (the gate — this is a shipping app)
+
+- **Output equivalence:** build `dist/` on `main` (ts-loader) and on the branch (swc), then diff the emitted JS. Cosmetic transpile differences (helper naming, whitespace) are acceptable; functional differences are not.
+- `npx tsc --noEmit` passes with `isolatedModules` on.
+- `npm test` (vitest) passes; the Rust `cargo test` / `cargo clippy` steps are unaffected.
+- **Smoke:** start the built app and confirm it actually runs (serves, a device session connects). A green build is necessary but not sufficient.
+
+**Phase 1 done** = `ts-loader` and `ts-node` removed, build output equivalent, all checks green, app smoke-verified — still on TypeScript 6.
+
+---
+
+## Phase 2 — TypeScript 7 (separate PR, outlined)
+
+1. Bump `typescript` → `7.0.2`. `tsc --noEmit` already passes on TS 7 (per #487).
+2. Resolve **dts-bundle-generator** (the last TS-6-API tool). Decision taken at Phase 2 start:
+   - **(a)** keep the single bundled `ws-scrcpy.d.ts` by vendoring TypeScript 6 (an npm alias in devDependencies) for *only* the `build:types` step — respects the local-dependencies rule (no network fetch at build time); or
+   - **(b)** replace it with `tsc --emitDeclarationOnly` (TS 7 native) — no TS 6 anywhere, but emits per-file `.d.ts` instead of one bundle (a small change to the shipped types layout), pending confirmation of whether/how the `.d.ts` is consumed.
+3. Close Dependabot #487 — its naive whole-repo TS 7 bump is superseded by this staged migration; add a `typescript` major-bump `ignore` so the un-buildable jump stops being re-proposed until we do it deliberately.
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| swc emit differs subtly from tsc emit | `isolatedModules` on + build-output diff + smoke run; repo uses no decorators / `const enum` (the usual divergence points). |
+| Webpack config loses authoring type-safety when de-TS'd | Prefer keeping `.ts` behind `@swc-node/register`; if converting to `.cjs`, add JSDoc `@type`. Configs are not CI-type-checked today, so no CI coverage is lost. |
+| Regression on a shipping app | Phase 1 is TypeScript-version-neutral; gated on output diff + smoke before merge; Velopack release flow untouched. |
+| dts-bundle-generator has no TS 7 path | Isolated to Phase 2; two concrete, local-deps-compliant options. |
+
+## Rollback
+
+Phase 1 is a self-contained PR; reverting it restores ts-loader/ts-node. No data, release-format, or public-API changes.
+
+## Success criteria
+
+- **Phase 1:** ts-loader + ts-node gone; `dist/` output functionally identical to `main`; `tsc --noEmit` (isolatedModules) + `npm test` green; app smoke-verified; on TS 6.
+- **Phase 2:** `typescript@7.0.2`; full build + type-check + tests green on the native compiler; `build:types` produces a working public type surface; #487 closed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.4",
+        "@swc/core": "^1.15.43",
         "@types/node": "^26.1.1",
         "@types/ws": "^8",
         "@xterm/addon-attach": "^0.12.0",
@@ -24,7 +25,7 @@
         "jsdom": "^29.1.1",
         "mini-css-extract-plugin": "^2.6.1",
         "style-loader": "^4.0.0",
-        "ts-loader": "^9.6.2",
+        "swc-loader": "^0.2.7",
         "ts-node": "^10.9.1",
         "typescript": "^6.0.2",
         "vitest": "^4.1.10",
@@ -888,6 +889,286 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -1514,23 +1795,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -3196,16 +3460,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3296,19 +3550,6 @@
         "webpack": "^5.27.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -3320,6 +3561,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swc-loader": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.7.tgz",
+      "integrity": "sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1.2.147",
+        "webpack": ">=2"
       }
     },
     "node_modules/symbol-tree": {
@@ -3450,31 +3705,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/ts-loader": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.6.2.tgz",
-      "integrity": "sha512-R4iuczmtgxvtuI556s+hTZ6/7Ee03VCAk/l/M8LY1OAsUgB7YydsCxkgq9D9pKRaD7GJqUi2u8fp9zZP/ufjKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "picomatch": "^4.0.0",
-        "source-map": "^0.7.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "loader-utils": "*",
-        "typescript": "*",
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "loader-utils": {
-          "optional": true
-        }
       }
     },
     "node_modules/ts-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "mini-css-extract-plugin": "^2.6.1",
         "style-loader": "^4.0.0",
         "swc-loader": "^0.2.7",
-        "ts-node": "^10.9.1",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.2",
         "vitest": "^4.1.10",
         "webpack": "^5.108.4",
@@ -278,19 +278,6 @@
         "specificity": "bin/cli.js"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -475,6 +462,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -553,17 +982,6 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1169,34 +1587,6 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1598,19 +1988,6 @@
         "acorn": "^8.14.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -1684,13 +2061,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1871,13 +2241,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1987,16 +2350,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dts-bundle-generator": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-9.5.1.tgz",
@@ -2084,6 +2437,48 @@
       "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2830,13 +3225,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
@@ -3707,50 +4095,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3758,6 +4102,25 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -3825,13 +4188,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4342,16 +4698,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "mini-css-extract-plugin": "^2.6.1",
     "style-loader": "^4.0.0",
     "swc-loader": "^0.2.7",
-    "ts-node": "^10.9.1",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.10",
     "webpack": "^5.108.4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",
+    "@swc/core": "^1.15.43",
     "@types/node": "^26.1.1",
     "@types/ws": "^8",
     "@xterm/addon-attach": "^0.12.0",
@@ -65,7 +66,7 @@
     "jsdom": "^29.1.1",
     "mini-css-extract-plugin": "^2.6.1",
     "style-loader": "^4.0.0",
-    "ts-loader": "^9.6.2",
+    "swc-loader": "^0.2.7",
     "ts-node": "^10.9.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.10",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,12 +27,5 @@
         "importHelpers": false
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "dist", "build"],
-    "ts-node": {
-        "compilerOptions": {
-            "module": "CommonJS",
-            "moduleResolution": "node",
-            "types": ["node"]
-        }
-    }
+    "exclude": ["node_modules", "dist", "build"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "resolveJsonModule": true,
+        "isolatedModules": true,
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,

--- a/webpack/ws-scrcpy-web.common.ts
+++ b/webpack/ws-scrcpy-web.common.ts
@@ -72,8 +72,22 @@ export const common = () => {
                 },
                 {
                     test: /\.tsx?$/,
-                    use: [{ loader: 'ts-loader', options: { transpileOnly: true } }],
                     exclude: /node_modules/,
+                    use: {
+                        loader: 'swc-loader',
+                        options: {
+                            // Transpile-only (type-safety stays with the separate
+                            // `tsc --noEmit` CI step), matching the tsconfig emit:
+                            // ES2022, esModuleInterop-style default imports,
+                            // define-semantics class fields. Module form is left to
+                            // webpack (swc emits ESM; webpack bundles).
+                            jsc: {
+                                parser: { syntax: 'typescript', tsx: true },
+                                target: 'es2022',
+                                transform: { useDefineForClassFields: true },
+                            },
+                        },
+                    },
                 },
                 {
                     test: /\.svg$/,


### PR DESCRIPTION
## What
Phase 1 of the TypeScript 7 migration (design: `docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md`): remove the two build tools that import the TypeScript compiler API, **staying on TypeScript 6** so any behavior delta is provably the loader swap alone.

- **`ts-loader` → `swc-loader`** — the app transpiles via swc (it was already `transpileOnly`; type-safety stays with the separate `tsc --noEmit` CI step).
- **`ts-node` → `tsx`** — the `webpack/*.ts` configs load via `tsx` (webpack-cli's config resolver recognizes `tsx/cjs`; `@swc-node/register` isn't in its list). Removed the now-dead `ts-node` tsconfig block.
- **`isolatedModules: true`** — enforces the per-file transpile constraints swc relies on (the code was already clean).

## Why
TS 7.0's native compiler ships no programmatic API until 7.1, so `ts-loader`/`ts-node` cannot run on it. `tsc --noEmit` already passes on TS 7 (proven by #487, which failed only at `npm run build`), so the code is TS-7-ready — only the build plumbing blocked. Phase 2 (a later PR) bumps `typescript` to 7.0.2 and resolves `dts-bundle-generator`.

## Verification (local)
- `tsc --noEmit` (isolatedModules) clean; **1478/1478 vitest pass**.
- Full `npm run build` succeeds (webpack ×5 + `build:types`).
- **Output equivalence:** built `dist/` on this branch (swc) vs a `main` worktree (ts-loader) — **identical 41-file set** (nothing only in either), total size **−2.5%** (swc is slightly more compact).
- **Boot control:** `node dist/index.js` behaves identically on both builds (standalone serving needs the dev-supervisor's seeded assets on both — not an swc difference).

## Risk
Build-time devDependencies only; the vendored runtime binaries under `dependencies/` are untouched. No TypeScript version change, no runtime behavior change. Reverting restores ts-loader/ts-node.