### PR TITLE
docs+deps: record TS 7 phase 1 + stage the TypeScript major bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,17 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    # TypeScript 7 is the native compiler with no programmatic API until 7.1, so the
+    # webpack build (dts-bundle-generator; historically ts-loader/ts-node) can't build
+    # against it yet. The 6->7 migration is staged deliberately -- see
+    # docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md. Block the
+    # major so Dependabot stops re-proposing the un-buildable jump.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     # Batch all minor + patch bumps into ONE weekly PR. Interlocking families
     # (@xterm/* addons must match the xterm core; webpack + its loaders; the
-    # typescript / ts-loader / ts-node toolchain) break when bumped singly.
+    # typescript / swc-loader / tsx toolchain) break when bumped singly.
     # Grouping keeps them in lockstep; majors still open individually for review.
     groups:
       npm-minor-patch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Swapped the webpack build's TypeScript tooling from `ts-loader`/`ts-node` to `swc-loader`/`tsx`.** These are transpile-only replacements (type-checking is unchanged — it stays with the separate `tsc --noEmit`), and the emitted `dist/` output was verified equivalent to the previous build. This is phase 1 of moving onto the TypeScript 7 native compiler: it removes the build tools that import the old compiler's programmatic API, which TypeScript 7.0 does not ship. `isolatedModules` was enabled to enforce the per-file transpile constraints swc relies on.
+
 ## [0.1.30-beta.72] - 2026-07-08
 
 ### Fixed

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -884,8 +884,8 @@ Run `npm outdated` to check all at once. Update one at a time, build + test afte
 | 3 | `webpack-cli` | 7.0.3 | Command-line interface for webpack | Major versions usually just drop old Node support |
 | 4 | `css-loader` | 7.1.4 | Processes CSS imports for webpack bundling | Major versions may need webpack config changes |
 | 5 | `mini-css-extract-plugin` | 2.10.2 | Extracts CSS into separate .css files | Tied to webpack version |
-| 6 | `ts-loader` | 9.6.0 | Lets webpack process TypeScript files | Must be compatible with TypeScript version |
-| 7 | `ts-node` | 10.9.2 | Runs webpack config files written in TypeScript | Must be compatible with TypeScript version |
+| 6 | `swc-loader` (+ `@swc/core`) | 0.2.7 | Transpiles TypeScript for webpack | Transpile-only; type-safety is the separate `tsc --noEmit` |
+| 7 | `tsx` | 4.x | Runs the TypeScript webpack config files | esbuild-based; webpack-cli loads the `.ts` config via `tsx/cjs` |
 | 8 | `@biomejs/biome` | 2.4.16 | Linter and code formatter (replaces ESLint + Prettier) | Major versions need config migration (`npx @biomejs/biome migrate`) |
 | 9 | `@types/node` | 24.12.2 | TypeScript type definitions for Node.js APIs | Must match target Node.js LTS major version (even numbers only, never odd) |
 | 10 | `@types/ws` | 8.18.1 | TypeScript type definitions for ws library | Must match `ws` major version |


### PR DESCRIPTION
Wrap-up follow-up to the TS 7 phase 1 swc-loader swap (#493):
- CHANGELOG `[Unreleased]` entry for the ts-loader/ts-node -> swc-loader/tsx swap.
- `docs/TECHNICAL_GUIDE.md` build-dependency table updated (removed ts-loader/ts-node rows).
- **Dependabot now ignores `typescript` major bumps** — TS 7.0 has no programmatic API until 7.1, so ts-loader/dts-bundle-generator can't build on it; the 6->7 move is staged (spec in `docs/superpowers/specs/`). This stops the un-buildable bump (#487) from being re-proposed until we do phase 2 deliberately.

Config/docs only.