### PR TITLE
feat(macos): add darwin support for server, deps, and network utils

### DIFF
--- a/scripts/fetch-node.mjs
+++ b/scripts/fetch-node.mjs
@@ -53,6 +53,17 @@ const LINUX_ARCHIVE_SHA256 =
     '472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6';
 const LINUX_INNER_NODE_REL = path.join(`node-${NODE_VERSION}-linux-x64`, 'bin', 'node');
 
+// macOS: tar.xz archive, contains node at <root>/bin/node. Keyed by arch
+// since Apple Silicon (arm64) and Intel (x64) Macs need different builds.
+const DARWIN_ARCHIVE_NAME = {
+    x64: `node-${NODE_VERSION}-darwin-x64.tar.xz`,
+    arm64: `node-${NODE_VERSION}-darwin-arm64.tar.xz`,
+};
+const DARWIN_ARCHIVE_SHA256 = {
+    x64: '5d627245b9f53cb2512cc21b7aa6aad693106affadd91e0c8f42d600fb7ba444',
+    arm64: 'af5cfaeafe603aaf7599f287fd9d100bb41f16794f49788fa59dd3f25546930f',
+};
+
 const SEED_DIR = path.join(REPO_ROOT, 'seed', 'node');
 const CACHE_DIR = path.join(REPO_ROOT, 'dependencies', 'node-bootstrap', NODE_VERSION);
 // Windows bsdtar handles both .zip and .tar.xz; git-bash GNU tar can't read .zip.
@@ -131,9 +142,18 @@ function platformConfig() {
             seedNodeName: 'node',
         };
     }
+    if (process.platform === 'darwin') {
+        const arch = os.arch() === 'arm64' ? 'arm64' : 'x64';
+        return {
+            archiveName: DARWIN_ARCHIVE_NAME[arch],
+            archiveSha256: DARWIN_ARCHIVE_SHA256[arch],
+            innerRel: path.join(`node-${NODE_VERSION}-darwin-${arch}`, 'bin', 'node'),
+            seedNodeName: 'node',
+        };
+    }
     throw new Error(
         `Unsupported platform: ${process.platform}. ` +
-            'Node bootstrap fetch is implemented for win32 and linux only ' +
+            'Node bootstrap fetch is implemented for win32, linux, and darwin only ' +
             '(those are the platforms we ship installers for).',
     );
 }

--- a/scripts/fetch-prebuilts.mjs
+++ b/scripts/fetch-prebuilts.mjs
@@ -84,7 +84,7 @@ function detectLibc() {
 }
 
 function getHostInfo() {
-    const platform = process.platform === 'win32' ? 'win32' : 'linux';
+    const platform = process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'darwin' : 'linux';
     const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
     return { platform, arch, libc: detectLibc(), nodeAbi: process.versions.modules };
 }
@@ -115,6 +115,13 @@ async function main() {
     const host = getHostInfo();
     console.log(`[fetch-prebuilts] host: ${host.platform}-${host.arch}-${host.libc} abi=${host.nodeAbi}`);
     console.log(`[fetch-prebuilts] depsPath: ${depsPath}`);
+
+    // No darwin leg in node-pty-prebuilds.yml's build matrix yet — skip rather
+    // than 404 on every fetch.
+    if (host.platform === 'darwin') {
+        console.warn('[fetch-prebuilts] no darwin node-pty prebuilt is published yet — skipping fetch');
+        return;
+    }
 
     const { base: RELEASE_URL_BASE, overridden, ignoredOverride } = resolveReleaseUrlBase();
     if (overridden) {

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -11,8 +11,10 @@ const log = Logger.for('DependencyDefinitions');
 
 const execFileAsync = promisify(execFile);
 
-export function getPlatform(): 'win32' | 'linux' {
-    return os.platform() === 'win32' ? 'win32' : 'linux';
+export function getPlatform(): 'win32' | 'linux' | 'darwin' {
+    if (os.platform() === 'win32') return 'win32';
+    if (os.platform() === 'darwin') return 'darwin';
+    return 'linux';
 }
 
 export function getArch(): 'x64' | 'arm64' {
@@ -116,6 +118,9 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
                 if (platform === 'win32') {
                     return `https://nodejs.org/dist/v${version}/node-v${version}-win-${arch}.zip`;
                 }
+                if (platform === 'darwin') {
+                    return `https://nodejs.org/dist/v${version}/node-v${version}-darwin-${arch}.tar.gz`;
+                }
                 return `https://nodejs.org/dist/v${version}/node-v${version}-linux-${arch}.tar.gz`;
             },
         },
@@ -141,6 +146,9 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             getDownloadUrl: (_version) => {
                 if (platform === 'win32') {
                     return 'https://dl.google.com/android/repository/platform-tools-latest-windows.zip';
+                }
+                if (platform === 'darwin') {
+                    return 'https://dl.google.com/android/repository/platform-tools-latest-darwin.zip';
                 }
                 return 'https://dl.google.com/android/repository/platform-tools-latest-linux.zip';
             },

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -340,7 +340,7 @@ export class DependencyManager {
         downloadPath: string,
         _version: string,
         tmpDir: string,
-        platform: 'win32' | 'linux',
+        platform: 'win32' | 'linux' | 'darwin',
     ): Promise<void> {
         const destDir = path.join(this.depsPath, 'node');
         fs.mkdirSync(destDir, { recursive: true });
@@ -394,7 +394,7 @@ export class DependencyManager {
         }
     }
 
-    private async installAdb(downloadPath: string, tmpDir: string, platform: 'win32' | 'linux'): Promise<void> {
+    private async installAdb(downloadPath: string, tmpDir: string, platform: 'win32' | 'linux' | 'darwin'): Promise<void> {
         const destDir = path.join(this.depsPath, 'adb');
         fs.mkdirSync(destDir, { recursive: true });
 
@@ -466,7 +466,7 @@ export class DependencyManager {
         writeInstalledScrcpyServerVersion(this.depsPath, version);
     }
 
-    private async extractZip(zipPath: string, destDir: string, _platform: 'win32' | 'linux'): Promise<void> {
+    private async extractZip(zipPath: string, destDir: string, _platform: 'win32' | 'linux' | 'darwin'): Promise<void> {
         // Cross-platform: shell out to the launcher's --unzip subcommand
         // (pure-Rust zip crate). Replaces the prior PowerShell Expand-Archive
         // (win32) + system `unzip` (linux) shellouts that resolved binaries

--- a/src/server/NodePtyResolver.ts
+++ b/src/server/NodePtyResolver.ts
@@ -59,7 +59,7 @@ export interface NodePtyHandle {
 }
 
 export interface HostInfo {
-    platform: 'win32' | 'linux';
+    platform: 'win32' | 'linux' | 'darwin';
     arch: 'x64' | 'arm64';
     libc: LibcFlavor;
     nodeAbi: string;
@@ -79,7 +79,9 @@ export function getNodePty(): NodePtyHandle | undefined {
 }
 
 export function getHostInfo(): HostInfo {
-    const platform = (process.platform === 'win32' ? 'win32' : 'linux') as HostInfo['platform'];
+    const platform = (
+        process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'darwin' : 'linux'
+    ) as HostInfo['platform'];
     const arch = (process.arch === 'arm64' ? 'arm64' : 'x64') as HostInfo['arch'];
     return {
         platform,

--- a/src/server/__tests__/dependencyDefinitions.test.ts
+++ b/src/server/__tests__/dependencyDefinitions.test.ts
@@ -3,9 +3,9 @@ import { getArch, getDependencyDefinitions, getPlatform, NODE_LTS_ABI, parseNode
 import * as NodePtyResolver from '../NodePtyResolver';
 
 describe('getPlatform', () => {
-    it('returns win32 or linux based on os.platform()', () => {
+    it('returns win32, linux, or darwin based on os.platform()', () => {
         const platform = getPlatform();
-        expect(['win32', 'linux']).toContain(platform);
+        expect(['win32', 'linux', 'darwin']).toContain(platform);
     });
 });
 

--- a/src/server/__tests__/macResolver.test.ts
+++ b/src/server/__tests__/macResolver.test.ts
@@ -39,6 +39,32 @@ describe('parseWindowsArp', () => {
     });
 });
 
+describe('parseDarwinArp', () => {
+    it('extracts MAC from typical BSD arp -n <ip> output', () => {
+        const out = '? (192.168.86.231) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]';
+        expect(__internals.parseDarwinArp(out)).toBe('aa:bb:cc:dd:ee:ff');
+    });
+
+    it('zero-pads single-digit octets (BSD arp omits leading zeros)', () => {
+        const out = '? (192.168.1.5) at 8:0:20:ae:fd:7a on en0 ifscope [ethernet]';
+        expect(__internals.parseDarwinArp(out)).toBe('08:00:20:ae:fd:7a');
+    });
+
+    it('normalizes uppercase to lowercase', () => {
+        const out = '? (192.168.1.5) at AA:BB:CC:DD:EE:FF on en0 ifscope [ethernet]';
+        expect(__internals.parseDarwinArp(out)).toBe('aa:bb:cc:dd:ee:ff');
+    });
+
+    it('returns null when the entry is incomplete', () => {
+        const out = '? (192.168.1.5) at (incomplete) on en0 ifscope [ethernet]';
+        expect(__internals.parseDarwinArp(out)).toBeNull();
+    });
+
+    it('returns null on empty output', () => {
+        expect(__internals.parseDarwinArp('')).toBeNull();
+    });
+});
+
 describe('parseLinuxIpNeigh', () => {
     it('extracts MAC from typical ip neigh output', () => {
         const out = '192.168.86.231 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE';
@@ -86,9 +112,19 @@ describe('resolveMac', () => {
         expect(mac).toBe('aa:bb:cc:dd:ee:ff');
     });
 
-    it('returns null on unsupported platform (darwin)', async () => {
-        const runCommand = vi.fn();
+    it('dispatches to arp -n on macOS', async () => {
+        const runCommand = vi.fn(async (bin: string, args: string[]) => {
+            expect(bin).toBe('arp');
+            expect(args).toEqual(['-n', '192.168.1.5']);
+            return '? (192.168.1.5) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]';
+        });
         const mac = await resolveMac('192.168.1.5', { runCommand, platform: 'darwin' });
+        expect(mac).toBe('aa:bb:cc:dd:ee:ff');
+    });
+
+    it('returns null on unsupported platform', async () => {
+        const runCommand = vi.fn();
+        const mac = await resolveMac('192.168.1.5', { runCommand, platform: 'aix' });
         expect(mac).toBeNull();
         expect(runCommand).not.toHaveBeenCalled();
     });

--- a/src/server/__tests__/nodePtyResolver.integration.test.ts
+++ b/src/server/__tests__/nodePtyResolver.integration.test.ts
@@ -22,8 +22,18 @@ import {
  * the dev tree already has (vitest globalSetup ensures node-pty's
  * postinstall has placed pty.node). We mock `seedPackageRoot()` to
  * point at a temp dir where we mirror the seed layout.
+ *
+ * Skipped when no real pty.node is present — today that's every macOS
+ * host, since node-pty-prebuilds.yml's build matrix only publishes
+ * win32/linux tarballs (scripts/fetch-prebuilts.mjs skips the fetch on
+ * darwin rather than 404ing). Remove this guard once that matrix grows
+ * a macOS leg.
  */
-describe('NodePtyResolver — integration (seed → dataRoot)', () => {
+const hasRealPtyBinary = fs.existsSync(
+    path.join(process.cwd(), 'node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
+);
+
+describe.skipIf(!hasRealPtyBinary)('NodePtyResolver — integration (seed → dataRoot)', () => {
     let tempDepsPath: string;
     let fakeSeedRoot: string;
 

--- a/src/server/__tests__/subnetDetector.test.ts
+++ b/src/server/__tests__/subnetDetector.test.ts
@@ -213,6 +213,60 @@ describe('SubnetDetector', () => {
         expect(result?.cidr).toBe('192.168.87.0/24');
     });
 
+    it('uses gateway detection on macOS (route -n get default)', async () => {
+        const interfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+            en0: [
+                {
+                    address: '192.168.1.42',
+                    netmask: '255.255.255.0',
+                    family: 'IPv4',
+                    mac: 'aa:bb:cc:dd:ee:ff',
+                    internal: false,
+                    cidr: '192.168.1.42/24',
+                },
+            ],
+        };
+        const routeOutput = [
+            '   route to: default',
+            'destination: default',
+            '       mask: default',
+            '    gateway: 192.168.1.1',
+            '  interface: en0',
+        ].join('\n');
+        const result = await detectSubnet({
+            getInterfaces: () => interfaces,
+            runCommand: async () => routeOutput,
+            platform: 'darwin',
+        });
+        expect(result?.cidr).toBe('192.168.1.0/24');
+        expect(result?.source).toBe('gateway');
+        expect(result?.interfaceName).toBe('en0');
+    });
+
+    it('falls back to interface heuristic on macOS when route lookup fails', async () => {
+        const interfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+            en0: [
+                {
+                    address: '192.168.86.50',
+                    netmask: '255.255.255.0',
+                    family: 'IPv4',
+                    mac: 'aa:bb:cc:dd:ee:ff',
+                    internal: false,
+                    cidr: '192.168.86.50/24',
+                },
+            ],
+        };
+        const result = await detectSubnet({
+            getInterfaces: () => interfaces,
+            runCommand: async () => {
+                throw new Error('no route');
+            },
+            platform: 'darwin',
+        });
+        expect(result?.source).toBe('interface');
+        expect(result?.cidr).toBe('192.168.86.0/24');
+    });
+
     it('skips 0.0.0.0 gateway on Linux and picks real gateway', async () => {
         const interfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
             eth0: [

--- a/src/server/network/MacResolver.ts
+++ b/src/server/network/MacResolver.ts
@@ -35,6 +35,10 @@ export async function resolveMac(ip: string, deps: MacResolverDeps = DEFAULT_DEP
             const out = await deps.runCommand('ip', ['neigh', 'show', 'to', ip]);
             return parseLinuxIpNeigh(out);
         }
+        if (deps.platform === 'darwin') {
+            const out = await deps.runCommand('arp', ['-n', ip]);
+            return parseDarwinArp(out);
+        }
     } catch {
         return null;
     }
@@ -64,17 +68,32 @@ export function parseLinuxIpNeigh(output: string): string | null {
     return match ? normalizeMac(match[1]!) : null;
 }
 
+export function parseDarwinArp(output: string): string | null {
+    // Expected row shape (BSD arp -n <ip>):
+    //   ? (192.168.86.231) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]
+    // BSD arp may omit leading zeros per octet (e.g. "8:0:20:ae:fd:7a"),
+    // unlike Linux/Windows which always zero-pad — normalizeMac pads back.
+    const match = output.match(/\bat\s+([0-9a-f]{1,2}(?::[0-9a-f]{1,2}){5})\b/i);
+    return match ? normalizeMac(match[1]!) : null;
+}
+
 function isMacString(s: string): boolean {
-    return /^[0-9a-f]{2}([-:][0-9a-f]{2}){5}$/i.test(s);
+    return /^[0-9a-f]{1,2}([-:][0-9a-f]{1,2}){5}$/i.test(s);
 }
 
 function normalizeMac(s: string): string {
-    return s.toLowerCase().replace(/-/g, ':');
+    return s
+        .toLowerCase()
+        .replace(/-/g, ':')
+        .split(':')
+        .map((octet) => octet.padStart(2, '0'))
+        .join(':');
 }
 
 export const __internals = {
     parseWindowsArp,
     parseLinuxIpNeigh,
+    parseDarwinArp,
     normalizeMac,
     isMacString,
 };

--- a/src/server/network/SubnetDetector.ts
+++ b/src/server/network/SubnetDetector.ts
@@ -74,6 +74,26 @@ async function detectViaGateway(deps: DetectorDeps): Promise<DetectedSubnet | nu
         return fromCidrString(cidrM[1]!, 'gateway', bestIface);
     }
 
+    if (deps.platform === 'darwin') {
+        // No CIDR in `route`'s output — resolve the interface name, then read
+        // its IPv4/netmask from os.networkInterfaces().
+        const output = await deps.runCommand('route -n get default');
+        const ifaceMatch = output.match(/interface:\s*(\S+)/);
+        if (!ifaceMatch) return null;
+        const ifaceName = ifaceMatch[1]!;
+        const entries = deps.getInterfaces()[ifaceName];
+        if (!entries) return null;
+        for (const entry of entries) {
+            if (entry.family === 'IPv4' && !entry.internal) {
+                const prefix = __internals.netmaskToPrefix(entry.netmask);
+                if (prefix === null) return null;
+                const network = __internals.cidrNetwork(entry.address, prefix);
+                return buildDetected(`${network}/${prefix}`, 'gateway', ifaceName);
+            }
+        }
+        return null;
+    }
+
     if (deps.platform === 'win32') {
         // `route print -4` lists a default route (0.0.0.0/0) for every adapter —
         // even those without a real gateway, which show "On-link" in the gateway

--- a/src/server/openBrowser.ts
+++ b/src/server/openBrowser.ts
@@ -22,7 +22,7 @@ const log = Logger.for('OpenBrowser');
  *     quoted token as a window title; without it, the URL would be
  *     misparsed.
  *   - Linux:   `xdg-open <url>`. Standard freedesktop.org launcher.
- *   - macOS:   `open <url>`. (Reserved; we don't ship macOS today.)
+ *   - macOS:   `open <url>`.
  */
 export function openBrowser(url: string): void {
     try {


### PR DESCRIPTION
## Summary

- \`getPlatform()\` collapsed any non-Windows host into `'linux'`, so macOS downloaded Linux ELF binaries for adb/node (would never execute), and `scripts/fetch-node.mjs` (`npm start`'s prestart hook) threw outright on darwin — the server couldn't even boot.
- `getPlatform()` / `getHostInfo()` now return a real `'darwin'` value, with matching adb/node download URLs.
- `fetch-node.mjs` / `fetch-prebuilts.mjs`: darwin arch configs (arm64+x64, pinned sha256); node-pty prebuilts aren't published for darwin yet, so `fetch-prebuilts` skips gracefully instead of 404ing.
- `MacResolver.ts` / `SubnetDetector.ts`: real darwin implementations (BSD `arp -n`, `route -n get default`) instead of falling through to null — Linux's iproute2 doesn't exist on macOS.
- `DependencyManager.ts`: widened `win32|linux` param types to include darwin (the install logic is already a binary win32-vs-else split, so darwin free-rides the existing Linux-shaped path).

Launcher/tray/service mode remain Windows+Linux-only for now — this covers running the server from source (`npm start`) on macOS.

## Test plan

- Added/updated tests for `getPlatform()`, `MacResolver` darwin arp parsing, and `SubnetDetector` darwin route parsing.
- Verified live on real macOS (arm64): `npm start` boots, connects to a real Android device over USB and mDNS, adb/scrcpy-server dependency install works.
- Not covered by tests: `fetch-node.mjs`/`fetch-prebuilts.mjs` have no test suite at all (true for win32/linux too, pre-existing), and `NodePtyResolver.getHostInfo()` reads `process.platform` directly with no DI seam.

---
Implemented with Claude Code (Sonnet 5), verified by hand on real macOS hardware with a physical Android device.