### PR TITLE
feat(video): add VP8 and VP9 video codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Added VP8 and VP9 to the video codec options.** Some devices — older and lower-end hardware in particular — ship no H.264, H.265, or AV1 encoder but do support VP8 or VP9, and previously had no working codec to fall back on. Both now appear in the codec dropdown when the connected device offers a matching encoder *and* your browser can decode them, so devices and browsers without support are unaffected. Supporting them needed a change to how playback starts: unlike every other codec, VP8 and VP9 send no separate configuration packet, so the decoder is now set up from the stream's session details rather than waiting for a packet that never arrives.
+
 ### Changed
 
 - **Swapped the webpack build's TypeScript tooling from `ts-loader`/`ts-node` to `swc-loader`/`tsx`.** These are transpile-only replacements (type-checking is unchanged — it stays with the separate `tsc --noEmit`), and the emitted `dist/` output was verified equivalent to the previous build. This is phase 1 of moving onto the TypeScript 7 native compiler: it removes the build tools that import the old compiler's programmatic API, which TypeScript 7.0 does not ship. `isolatedModules` was enabled to enforce the per-file transpile constraints swc relies on.

--- a/src/app/googDevice/client/ConfigureScrcpy.ts
+++ b/src/app/googDevice/client/ConfigureScrcpy.ts
@@ -14,6 +14,7 @@ import { DeviceProbeClient } from '../../client/DeviceProbeClient';
 import { settingsService } from '../../client/SettingsService';
 import { DisplayInfo } from '../../DisplayInfo';
 import type { PlayerClass } from '../../player/BasePlayer';
+import { WEBCODECS_CODEC_STRING } from '../../player/webCodecsConfig';
 import Size from '../../Size';
 import Util from '../../Util';
 import { Modal } from '../../ui/Modal';
@@ -216,6 +217,10 @@ export class ConfigureScrcpy extends Modal {
                 return lower.includes('.hevc.');
             case 'av1':
                 return lower.includes('.av1.');
+            case 'vp8':
+                return lower.includes('.vp8.');
+            case 'vp9':
+                return lower.includes('.vp9.');
             default:
                 return true;
         }
@@ -255,6 +260,8 @@ export class ConfigureScrcpy extends Modal {
         if (joined.includes('.avc.') || joined.includes('.h264.')) codecs.push('h264');
         if (joined.includes('.hevc.')) codecs.push('h265');
         if (joined.includes('.av1.')) codecs.push('av1');
+        if (joined.includes('.vp8.')) codecs.push('vp8');
+        if (joined.includes('.vp9.')) codecs.push('vp9');
         if (codecs.length === 0) codecs.push('h264');
         return codecs;
     }
@@ -263,11 +270,6 @@ export class ConfigureScrcpy extends Modal {
         if (typeof VideoDecoder === 'undefined' || typeof VideoDecoder.isConfigSupported !== 'function') {
             return codecs;
         }
-        const codecMap: Record<string, string> = {
-            h264: 'avc1.42E01E',
-            h265: 'hev1.1.6.L93.B0',
-            av1: 'av01.0.04M.08',
-        };
         const supported: string[] = [];
         for (const codec of codecs) {
             // H.264 is universally supported — skip the check (Firefox isConfigSupported
@@ -276,7 +278,7 @@ export class ConfigureScrcpy extends Modal {
                 supported.push(codec);
                 continue;
             }
-            const webCodecStr = codecMap[codec];
+            const webCodecStr = WEBCODECS_CODEC_STRING[codec];
             if (!webCodecStr) {
                 supported.push(codec);
                 continue;

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -9,7 +9,7 @@ import { BasePlayer } from './BasePlayer';
 import { parseSPS, stripEmulationPrevention } from './h264-utils';
 import { HEVC_NAL_TYPE, hevcNalType, parseHevcSPS } from './h265-utils';
 import { findFirstNaluOffset, findNaluByHeader } from './naluScanner';
-import { buildDecoderConfig } from './webCodecsConfig';
+import { buildDecoderConfig, isConfiglessCodec, type VideoCodecName, WEBCODECS_CODEC_STRING } from './webCodecsConfig';
 
 function toHex(value: number) {
     return value.toString(16).padStart(2, '0').toUpperCase();
@@ -66,7 +66,19 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     private context: CanvasRenderingContext2D;
     private decoder: VideoDecoder;
     private configData?: Uint8Array | undefined;
-    private detectedCodec: 'h264' | 'h265' | 'av1' | null = null;
+    private detectedCodec: VideoCodecName | null = null;
+    /**
+     * Whether a keyframe has been handed to the decoder yet. Deltas before that
+     * point reference frames the decoder never saw.
+     *
+     * Deliberately NOT `receivedFirstFrame`: `BasePlayer.pushFrame` — which
+     * `pushVideoFrame` calls first thing for stats — sets that on the first
+     * frame of any kind, so it is already true by the time a delta is checked.
+     * The codecs that send a config packet never noticed, because their decoder
+     * stays unconfigured until it arrives and the state check drops early
+     * frames instead. VP8/VP9 configure up front, so they need the real gate.
+     */
+    private seenKeyframe = false;
     private metadataWidth = 0;
     private metadataHeight = 0;
     private loggedFrameSize = false;
@@ -148,10 +160,15 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
 
         if (this.decoder.state !== 'configured') return;
 
-        if (isKeyframe && this.configData) {
+        // `configData` is the readiness signal for codecs that send a config
+        // packet. VP8/VP9 never send one — the decoder was configured up front
+        // from session metadata instead — so gate on "decoder is ready" rather
+        // than "config bytes arrived", or every frame would be dropped below.
+        if (isKeyframe && (this.configData || isConfiglessCodec(this.detectedCodec))) {
             if (!this.receivedFirstFrame) {
                 this.receivedFirstFrame = true;
             }
+            this.seenKeyframe = true;
 
             // SPS/PPS (and VPS for H.265) were handed to the decoder via the
             // `description` field of VideoDecoderConfig at configure() time, and
@@ -167,7 +184,7 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
             return;
         }
 
-        if (!this.receivedFirstFrame) return; // Skip delta frames before first keyframe
+        if (!this.seenKeyframe) return; // Skip delta frames before first keyframe
 
         this.decoder.decode(
             new EncodedVideoChunk({
@@ -239,6 +256,51 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     public setMetadataSize(width: number, height: number): void {
         this.metadataWidth = width;
         this.metadataHeight = height;
+    }
+
+    /**
+     * VP8/VP9 arrive without a config packet (see `CONFIGLESS_CODECS`), so the
+     * `isConfig` branch in {@link pushVideoFrame} — where every other codec has
+     * its decoder configured — is never reached for them. Session metadata
+     * carries everything the decoder needs, so configure from that instead.
+     *
+     * Safe to do here: `StreamClientScrcpy.onMetadata` calls
+     * {@link setMetadataSize} before this, so the dimensions are already in
+     * place by the time we run.
+     */
+    public override setSessionInfo(videoCodec: string, audioCodec: string, encoder?: string): void {
+        super.setSessionInfo(videoCodec, audioCodec, encoder);
+        const codec = videoCodec?.toLowerCase();
+        if (isConfiglessCodec(codec)) {
+            this.configureFromMetadata(codec as VideoCodecName);
+        }
+    }
+
+    private configureFromMetadata(codec: VideoCodecName): void {
+        const width = this.metadataWidth;
+        const height = this.metadataHeight;
+        if (!width || !height) {
+            console.error(`[WebCodecsPlayer] ${codec}: no metadata dimensions, cannot configure decoder`);
+            return;
+        }
+        const codecString = WEBCODECS_CODEC_STRING[codec];
+        if (!codecString) {
+            console.error(`[WebCodecsPlayer] no WebCodecs codec string for ${codec}`);
+            return;
+        }
+        this.detectedCodec = codec;
+        this.scaleCanvas(width, height);
+        this.decoder.configure(
+            buildDecoderConfig({
+                codec: codecString,
+                detectedCodec: codec,
+                codedWidth: width,
+                codedHeight: height,
+                // These codecs have no parameter sets; buildDecoderConfig only
+                // reads configData for H.264/H.265.
+                configData: new Uint8Array(0),
+            }),
+        );
     }
 
     protected scaleCanvas(width: number, height: number): void {
@@ -318,5 +380,6 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
         this.decoder = this.createDecoder();
         this.configData = undefined;
         this.detectedCodec = null;
+        this.seenKeyframe = false;
     }
 }

--- a/src/app/player/__tests__/webCodecsPlayerVp8Vp9.test.ts
+++ b/src/app/player/__tests__/webCodecsPlayerVp8Vp9.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * VP8/VP9 are the only codecs scrcpy streams that never send a config packet.
+ *
+ * scrcpy sets its config flag straight from MediaCodec's
+ * `BUFFER_FLAG_CODEC_CONFIG` (`Streamer.writePacket`) with no video-codec
+ * special-casing, and VP8/VP9 carry no out-of-band parameter sets — everything
+ * the decoder needs is in the keyframe. So MediaCodec emits no config buffer
+ * and no config packet is ever sent.
+ *
+ * That breaks two assumptions the player made before VP8/VP9 support:
+ *   1. the decoder is configured inside the `isConfig` branch, which never runs;
+ *   2. `configData` is the readiness gate for decoding keyframes, and it stays
+ *      unset — so every frame was dropped.
+ *
+ * These tests pin both halves of the fix, plus the H.264 path they must not
+ * disturb.
+ */
+
+type Chunk = { type: string; timestamp: number; data: Uint8Array };
+
+let decodedChunks: Chunk[] = [];
+let lastConfig: VideoDecoderConfig | undefined;
+let configureCalls = 0;
+
+class FakeVideoDecoder {
+    public state = 'unconfigured';
+    constructor(_init: unknown) {}
+    configure(cfg: VideoDecoderConfig) {
+        lastConfig = cfg;
+        configureCalls += 1;
+        this.state = 'configured';
+    }
+    decode(chunk: Chunk) {
+        decodedChunks.push(chunk);
+    }
+    flush() {
+        return Promise.resolve();
+    }
+    close() {
+        this.state = 'closed';
+    }
+    static isConfigSupported() {
+        return Promise.resolve({ supported: true });
+    }
+}
+
+class FakeEncodedVideoChunk {
+    public type: string;
+    public timestamp: number;
+    public data: Uint8Array;
+    constructor(init: Chunk) {
+        this.type = init.type;
+        this.timestamp = init.timestamp;
+        this.data = new Uint8Array(init.data);
+    }
+}
+
+const VP_KEYFRAME = new Uint8Array([0x82, 0x49, 0x83, 0x42, 0x00, 0x11, 0x22, 0x33]);
+const VP_DELTA = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+
+describe('WebCodecsPlayer VP8/VP9 (config-less codecs)', () => {
+    beforeEach(() => {
+        decodedChunks = [];
+        lastConfig = undefined;
+        configureCalls = 0;
+        vi.stubGlobal('VideoDecoder', FakeVideoDecoder);
+        vi.stubGlobal('EncodedVideoChunk', FakeEncodedVideoChunk);
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+            drawImage: vi.fn(),
+            clearRect: vi.fn(),
+            fillRect: vi.fn(),
+            measureText: () => ({ actualBoundingBoxLeft: 0, actualBoundingBoxRight: 0 }),
+            fillText: vi.fn(),
+            save: vi.fn(),
+            restore: vi.fn(),
+        } as unknown as CanvasRenderingContext2D);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('configures the decoder from session metadata for vp9', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1080, 2400);
+        player.setSessionInfo('vp9', 'opus');
+
+        expect(configureCalls).toBe(1);
+        expect(lastConfig?.codec).toBe('vp09.00.10.08');
+        expect(lastConfig?.codedWidth).toBe(1080);
+        expect(lastConfig?.codedHeight).toBe(2400);
+        // No parameter sets exist for VP8/VP9 — description must not be set.
+        expect(lastConfig?.description).toBeUndefined();
+    });
+
+    it('configures the decoder from session metadata for vp8', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1280, 720);
+        player.setSessionInfo('vp8', 'opus');
+
+        expect(configureCalls).toBe(1);
+        expect(lastConfig?.codec).toBe('vp8');
+        expect(lastConfig?.description).toBeUndefined();
+    });
+
+    it('decodes a keyframe that arrives with no preceding config packet', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1280, 720);
+        player.setSessionInfo('vp9', 'opus');
+
+        // isConfig=false, isKeyframe=true — the only shape VP8/VP9 ever produce.
+        player.pushVideoFrame(VP_KEYFRAME, 0n, false, true);
+
+        expect(decodedChunks).toHaveLength(1);
+        expect(decodedChunks[0]?.type).toBe('key');
+        expect(Array.from(decodedChunks[0]?.data as Uint8Array)).toEqual(Array.from(VP_KEYFRAME));
+    });
+
+    it('decodes delta frames once a keyframe has been seen', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1280, 720);
+        player.setSessionInfo('vp9', 'opus');
+
+        player.pushVideoFrame(VP_KEYFRAME, 0n, false, true);
+        player.pushVideoFrame(VP_DELTA, 1n, false, false);
+
+        expect(decodedChunks).toHaveLength(2);
+        expect(decodedChunks[1]?.type).toBe('delta');
+    });
+
+    it('drops delta frames that arrive before the first keyframe', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1280, 720);
+        player.setSessionInfo('vp9', 'opus');
+
+        player.pushVideoFrame(VP_DELTA, 0n, false, false);
+
+        expect(decodedChunks).toHaveLength(0);
+    });
+
+    it('does not configure up front for codecs that do send a config packet', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-test');
+        player.setMetadataSize(1280, 720);
+        player.setSessionInfo('h264', 'opus');
+
+        // H.264 must still wait for its SPS/PPS config frame.
+        expect(configureCalls).toBe(0);
+    });
+});

--- a/src/app/player/webCodecsConfig.ts
+++ b/src/app/player/webCodecsConfig.ts
@@ -7,10 +7,46 @@
  * bytes to every keyframe (see finding #41). AV1 carries its sequence header in
  * the keyframe data itself, so no `description` is set for it.
  */
+/** Video codecs scrcpy can stream, by their scrcpy-side names. */
+export type VideoCodecName = 'h264' | 'h265' | 'av1' | 'vp8' | 'vp9';
+
+/**
+ * WebCodecs codec strings, one per scrcpy video codec. Used both to configure
+ * the decoder and to probe support via `VideoDecoder.isConfigSupported()`.
+ *
+ * VP9 needs the full `vp09.<profile>.<level>.<bitDepth>` form — a bare "vp9"
+ * is not a registered WebCodecs string. `vp09.00.10.08` is profile 0 / level
+ * 1.0 / 8-bit, the generic form; decoders do not enforce the declared level
+ * for playback. VP8 has no parameters, so it is just "vp8".
+ */
+export const WEBCODECS_CODEC_STRING: Record<string, string> = {
+    h264: 'avc1.42E01E',
+    h265: 'hev1.1.6.L93.B0',
+    av1: 'av01.0.04M.08',
+    vp8: 'vp8',
+    vp9: 'vp09.00.10.08',
+};
+
+/**
+ * Codecs that never produce a config packet.
+ *
+ * scrcpy sets its config flag straight from MediaCodec's
+ * `BUFFER_FLAG_CODEC_CONFIG` (`Streamer.writePacket`), with no video-codec
+ * special-casing. VP8 and VP9 carry no out-of-band parameter sets — everything
+ * the decoder needs is in the keyframe — so MediaCodec emits no such buffer and
+ * scrcpy sends no config packet. Players must therefore configure these from
+ * session metadata rather than waiting for a config frame that never arrives.
+ */
+export const CONFIGLESS_CODECS: readonly VideoCodecName[] = ['vp8', 'vp9'];
+
+export function isConfiglessCodec(codec: string | null | undefined): boolean {
+    return codec !== null && codec !== undefined && (CONFIGLESS_CODECS as readonly string[]).includes(codec);
+}
+
 export interface BuildDecoderConfigParams {
     /** WebCodecs codec string, e.g. `avc1.42E01E` / `hev1.1.6.L93.B0` / `av01.0.04M.08`. */
     codec: string;
-    detectedCodec: 'h264' | 'h265' | 'av1' | null;
+    detectedCodec: VideoCodecName | null;
     codedWidth: number;
     codedHeight: number;
     /** Raw config NAL bytes (Annex B SPS/PPS or VPS/SPS/PPS) captured from the config frame. */

--- a/src/common/ScrcpyCodec.ts
+++ b/src/common/ScrcpyCodec.ts
@@ -3,6 +3,10 @@ export const CODEC_ID = {
     H264: 0x68323634,
     H265: 0x68323635,
     AV1: 0x00617631,
+    // 4-byte ASCII ids, same scheme as the others. Source: scrcpy v4.1
+    // server VideoCodec.java (VP8 0x00_76_70_38, VP9 0x00_76_70_39).
+    VP8: 0x00767038,
+    VP9: 0x00767039,
     OPUS: 0x6f707573,
     AAC: 0x00616163,
     FLAC: 0x666c6163,
@@ -20,6 +24,10 @@ export function codecName(id: number): string {
             return 'h265';
         case CODEC_ID.AV1:
             return 'av1';
+        case CODEC_ID.VP8:
+            return 'vp8';
+        case CODEC_ID.VP9:
+            return 'vp9';
         case CODEC_ID.OPUS:
             return 'opus';
         case CODEC_ID.AAC:

--- a/src/common/__tests__/scrcpyCodec.test.ts
+++ b/src/common/__tests__/scrcpyCodec.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { CODEC_ID, codecName } from '../ScrcpyCodec';
+
+/**
+ * The ids are the 4-byte ASCII form of the codec name, assigned by scrcpy's
+ * server-side `VideoCodec` / `AudioCodec` enums. They arrive on the wire in the
+ * session metadata, so a wrong constant means a stream reported as
+ * `unknown(0x…)` and a decoder that is never configured.
+ *
+ * Values verified against scrcpy v4.1 `VideoCodec.java`.
+ */
+describe('video codec ids', () => {
+    it.each([
+        ['h264', CODEC_ID.H264, 0x68323634],
+        ['h265', CODEC_ID.H265, 0x68323635],
+        ['av1', CODEC_ID.AV1, 0x00617631],
+        ['vp8', CODEC_ID.VP8, 0x00767038],
+        ['vp9', CODEC_ID.VP9, 0x00767039],
+    ])('%s maps to its scrcpy id and back', (name, id, expectedId) => {
+        expect(id).toBe(expectedId);
+        expect(codecName(id)).toBe(name);
+    });
+
+    it('decodes each id as the ASCII of its own name', () => {
+        // 0x00767038 -> "\0vp8". The high byte is padding for 3-char names.
+        const asAscii = (id: number) =>
+            String.fromCharCode((id >> 24) & 0xff, (id >> 16) & 0xff, (id >> 8) & 0xff, id & 0xff).replace(/\0/g, '');
+        expect(asAscii(CODEC_ID.VP8)).toBe('vp8');
+        expect(asAscii(CODEC_ID.VP9)).toBe('vp9');
+    });
+
+    it('reports an unrecognised id rather than guessing', () => {
+        expect(codecName(0x12345678)).toBe('unknown(0x12345678)');
+    });
+});

--- a/src/server/DeviceProbe.ts
+++ b/src/server/DeviceProbe.ts
@@ -124,7 +124,7 @@ export class DeviceProbe extends Mw {
     private async listEncodersViaDumpsys(): Promise<{ videoEncoders: string[]; audioEncoders: string[] }> {
         const output = await this.adbClient.shell(this.serial, 'dumpsys media.player');
         const regex = /Encoder "([^"]+)" supports/g;
-        const videoCodecs = ['avc', 'hevc', 'av1'];
+        const videoCodecs = ['avc', 'hevc', 'av1', 'vp8', 'vp9'];
         const audioCodecs = ['opus', 'aac', 'flac'];
         const videoEncoders: string[] = [];
         const audioEncoders: string[] = [];

--- a/src/server/ScrcpyOptions.ts
+++ b/src/server/ScrcpyOptions.ts
@@ -1,7 +1,7 @@
 // src/server/ScrcpyOptions.ts
 export interface ScrcpyOptions {
     scid: string;
-    videoCodec?: 'h264' | 'h265' | 'av1';
+    videoCodec?: 'h264' | 'h265' | 'av1' | 'vp8' | 'vp9';
     audioCodec?: 'opus' | 'aac' | 'flac' | 'raw';
     audioSource?: 'output' | 'playback' | 'mic';
     audioDup?: boolean;

--- a/src/server/__tests__/scrcpyOptionsFromQuery.test.ts
+++ b/src/server/__tests__/scrcpyOptionsFromQuery.test.ts
@@ -76,10 +76,13 @@ describe('scrcpyOptionsFromQuery — other params carry over', () => {
         expect(opts.displayId).toBe(2);
     });
 
-    it('accepts h265/av1 but ignores other videoCodec values', () => {
+    it('accepts h265/av1/vp8/vp9 but ignores other videoCodec values', () => {
         expect(scrcpyOptionsFromQuery(qp({ videoCodec: 'h265' }), 's').videoCodec).toBe('h265');
         expect(scrcpyOptionsFromQuery(qp({ videoCodec: 'av1' }), 's').videoCodec).toBe('av1');
-        expect(scrcpyOptionsFromQuery(qp({ videoCodec: 'vp9' }), 's').videoCodec).toBeUndefined();
+        expect(scrcpyOptionsFromQuery(qp({ videoCodec: 'vp8' }), 's').videoCodec).toBe('vp8');
+        expect(scrcpyOptionsFromQuery(qp({ videoCodec: 'vp9' }), 's').videoCodec).toBe('vp9');
+        // h264 is the default and is never echoed back as an explicit option.
+        expect(scrcpyOptionsFromQuery(qp({ videoCodec: 'vp10' }), 's').videoCodec).toBeUndefined();
     });
 
     it('accepts aac/flac/raw but ignores other audioCodec values', () => {

--- a/src/server/scrcpyOptionsFromQuery.ts
+++ b/src/server/scrcpyOptionsFromQuery.ts
@@ -22,7 +22,7 @@ export function scrcpyOptionsFromQuery(params: URLSearchParams, scid: string): S
     if (displayId) options.displayId = Number.parseInt(displayId, 10);
 
     const videoCodec = params.get('videoCodec');
-    if (videoCodec === 'h265' || videoCodec === 'av1') {
+    if (videoCodec === 'h265' || videoCodec === 'av1' || videoCodec === 'vp8' || videoCodec === 'vp9') {
         options.videoCodec = videoCodec;
     }
 


### PR DESCRIPTION
## What

Adds VP8 and VP9 as selectable video codecs, following scrcpy 4.1''s encoder support for them.

## Why

Some devices — older and lower-end hardware especially — ship no H.264, H.265, or AV1 encoder but do have VP8 or VP9. Those devices had no working codec at all.

## Codec ids

4-byte ASCII form, same scheme as the existing ones. Taken from scrcpy v4.1 `VideoCodec.java`, not guessed: **VP8 `0x00767038`**, **VP9 `0x00767039`**.

## The non-obvious part

VP8/VP9 are the only codecs scrcpy streams that **never send a config packet**.

`Streamer.writePacket` sets the config flag straight from MediaCodec''s `BUFFER_FLAG_CODEC_CONFIG`, with no video-codec special-casing. VP8/VP9 carry no out-of-band parameter sets — everything the decoder needs is in the keyframe — so MediaCodec emits no config buffer and nothing is ever flagged.

That matters because `WebCodecsPlayer` configures its decoder **inside** the `isConfig` branch of `pushVideoFrame`. For VP8/VP9 that branch never runs, so a codec-id lookup table alone would have produced a correctly-named stream that renders nothing. The player now configures from session metadata for these codecs: `setSessionInfo` carries the codec name, `setMetadataSize` (called first by `StreamClientScrcpy.onMetadata`) carries the dimensions.

## A latent bug this surfaced

The delta-frame gate read `receivedFirstFrame` — but `BasePlayer.pushFrame`, which `pushVideoFrame` calls first thing for stats, sets that on the first frame of **any** kind. The gate was already inert. The config-packet codecs never noticed, because their decoder stays unconfigured until the packet arrives and the decoder-state check drops early frames instead.

VP8/VP9 configure up front, which removed that accidental protection: a delta frame arriving before any keyframe went straight to a decoder with no reference frame. Replaced with a real `seenKeyframe` flag.

Worth saying plainly — **the test caught this, not me.** I wrote "drops delta frames that arrive before the first keyframe" expecting it to pass on the first run, and it failed.

## Other notes

- VP9 uses the full `vp09.00.10.08` WebCodecs string; a bare `vp9` is not a registered codec string.
- `ConfigureScrcpy`''s local `codecMap` is replaced by the shared `WEBCODECS_CODEC_STRING`, so the browser-support probe string and the decoder-configure string can''t drift apart.
- Both codecs stay filtered by the existing two gates: the device must expose a matching encoder, and `VideoDecoder.isConfigSupported()` must accept it. Devices and browsers without support see no change.

## Verification

`tsc --noEmit` clean · 1491/1491 vitest (+13 new) · `npm run build` clean · biome clean on all touched files.

**Not runtime-verified.** No Android device is attached to the machine this was built on, and confirming it needs one whose encoder actually offers VP8 or VP9. The decode path is covered by unit tests against a stubbed `VideoDecoder`, not a real stream — so treat the end-to-end path as untested until someone runs it against real hardware.