### PR TITLE
fix(deps): raise the fast-uri override to ^3.1.5 (3 high Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2496,9 +2496,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     "webpack-cli": "^7.2.2"
   },
   "overrides": {
-    "fast-uri": "3.1.2"
+    "fast-uri": "^3.1.5"
   }
 }


### PR DESCRIPTION
## What

Raises the `fast-uri` override from an exact `3.1.2` to `^3.1.5`. Resolves to **3.1.6**.

## Why Dependabot couldn''t do this itself

All three open high-severity alerts are the same package, and all three are closed by 3.1.5:

| Vulnerable range | Issue |
|---|---|
| `>=3.0.0 <3.1.3` | host confusion via failed IDN canonicalization |
| `>=3.0.0 <=3.1.3` | host confusion via literal backslash authority delimiter |
| `>=3.0.0 <3.1.5` | host confusion via backslash authority introducer |

**We were pinning the vulnerable version.** `5ae93da` added `overrides: { "fast-uri": "3.1.2" }` to close two *earlier* advisories on this same package. An exact pin on a transitive dep closes today''s advisory and blocks tomorrow''s fix — and that is precisely what happened here: three new advisories landed against a version we were holding in place, and no automated bump could move it.

So the caret matters more than the number. `^3.1.5` lets patch-level security fixes flow through on their own instead of waiting for someone to notice a third round of alerts. `ajv`''s own constraint is `^3.0.0`, so the wider range is compatible.

## Scope

`fast-uri` is a dev-only transitive — `mini-css-extract-plugin` → `schema-utils` → `ajv` → `fast-uri` — and never reaches the shipped bundle. No runtime impact, so no CHANGELOG entry.

The lockfile diff is **three lines**, `fast-uri` only.

## Verification

- `npm ls fast-uri --all` → `fast-uri@3.1.6`
- `npm audit` → **0 vulnerabilities**
- `tsc --noEmit` clean · 1478/1478 vitest · `npm run build` clean