### PR TITLE
chore(release): seed Node 24.19.0, and keep package-lock in the version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The bundled Node.js runtime is now 24.19.0** (from 24.15.0). This is the copy that ships inside the installer to get the app running on first launch; installs past first run already track the newer version through the dependency panel.
+
 ### Fixed
+
+- **Fixed H.264 and H.265 streams showing a black screen.** The decoder was handed its start-up configuration in the wrong container format, so it refused to initialise and no picture ever arrived — the connection looked healthy and the device reported nonsense dimensions. AV1 was unaffected, which is why this went unnoticed. The configuration is now built in the format the browser's video decoder actually expects, and each frame is re-framed to match it. A related fault in how the incoming video was split into units — which could silently clip three bytes off a frame — was fixed at the same time.
 
 - **Fixed stream startup in browsers that require `requestAnimationFrame` to be called with a `Window` receiver.** The quality-stats scheduler now invokes `requestAnimationFrame` / `cancelAnimationFrame` with the browser global as their receiver instead of calling detached function references, preventing the `TypeError: 'requestAnimationFrame' called on an object that does not implement interface Window` failure reported in #498.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.72",
+  "version": "0.1.30-beta.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ws-scrcpy-web",
-      "version": "0.1.30-beta.72",
+      "version": "0.1.30-beta.73",
       "license": "GPL-3.0-only",
       "dependencies": {
         "velopack": "^1.2.0",

--- a/scripts/__tests__/assert-version-sync.test.mjs
+++ b/scripts/__tests__/assert-version-sync.test.mjs
@@ -3,8 +3,54 @@ import {
     check,
     readCargoTomlVersion,
     readPackageJsonVersion,
+    readPackageLockVersion,
     stripVPrefix,
 } from '../assert-version-sync.mjs';
+
+describe('readPackageLockVersion', () => {
+    const lock = (root, self) =>
+        JSON.stringify({ name: 'x', version: root, packages: { '': { name: 'x', version: self } } });
+
+    it('reads the root version', () => {
+        expect(readPackageLockVersion(lock('0.1.0', '0.1.0'))).toBe('0.1.0');
+    });
+
+    it('throws when the root and the packages[""] self-entry disagree', () => {
+        // The exact drift this check exists to catch: a half-applied bump.
+        expect(() => readPackageLockVersion(lock('0.1.0', '0.0.9'))).toThrow(/disagrees with/);
+    });
+
+    it('throws when there is no root version', () => {
+        expect(() => readPackageLockVersion('{"name":"x"}')).toThrow(/no root "version" field/);
+    });
+});
+
+describe('check with lockVersion', () => {
+    it('passes when the lock agrees with the rest', () => {
+        const r = check({
+            pkgVersion: '0.1.0',
+            cargoVersion: '0.1.0',
+            tagVersion: '0.1.0',
+            lockVersion: '0.1.0',
+        });
+        expect(r.ok).toBe(true);
+    });
+
+    it('fails when only the lock is stale — the beta.73 case', () => {
+        const r = check({
+            pkgVersion: '0.1.30-beta.73',
+            cargoVersion: '0.1.30-beta.73',
+            tagVersion: '0.1.30-beta.73',
+            lockVersion: '0.1.30-beta.72',
+        });
+        expect(r.ok).toBe(false);
+        expect(r.lockVersion).toBe('0.1.30-beta.72');
+    });
+
+    it('stays backward compatible when lockVersion is omitted', () => {
+        expect(check({ pkgVersion: '0.1.0', cargoVersion: '0.1.0', tagVersion: '0.1.0' }).ok).toBe(true);
+    });
+});
 
 describe('stripVPrefix', () => {
     it('strips leading v', () => {

--- a/scripts/__tests__/bump-version.test.mjs
+++ b/scripts/__tests__/bump-version.test.mjs
@@ -4,9 +4,53 @@ import {
     bumpCargoToml,
     bumpChangelog,
     bumpPackageJson,
+    bumpPackageLock,
     formatToday,
     validateSemver,
 } from '../bump-version.mjs';
+
+/**
+ * package-lock.json was previously left out of the bump entirely, so after
+ * every release the lock disagreed with package.json and the next
+ * `npm install` silently rewrote it — a dirty tree on a clean checkout.
+ */
+describe('bumpPackageLock', () => {
+    const sample = `${JSON.stringify(
+        {
+            name: 'ws-scrcpy-web',
+            version: '0.1.0',
+            lockfileVersion: 3,
+            packages: {
+                '': { name: 'ws-scrcpy-web', version: '0.1.0', dependencies: { ws: '^8.0.0' } },
+                'node_modules/ws': { version: '8.21.1' },
+            },
+        },
+        null,
+        2,
+    )}\n`;
+
+    it('updates both the root version and the packages[""] self-entry', () => {
+        const out = JSON.parse(bumpPackageLock(sample, '0.2.0'));
+        expect(out.version).toBe('0.2.0');
+        expect(out.packages[''].version).toBe('0.2.0');
+    });
+
+    it('leaves dependency versions alone', () => {
+        const out = JSON.parse(bumpPackageLock(sample, '0.2.0'));
+        expect(out.packages['node_modules/ws'].version).toBe('8.21.1');
+        expect(out.packages[''].dependencies.ws).toBe('^8.0.0');
+    });
+
+    it('round-trips npm formatting (2-space indent, trailing newline)', () => {
+        // Same version in means byte-identical out — proves the rewrite cannot
+        // reformat the 150KB lockfile into a huge diff.
+        expect(bumpPackageLock(sample, '0.1.0')).toBe(sample);
+    });
+
+    it('throws when there is no version field to update', () => {
+        expect(() => bumpPackageLock('{"name":"x"}', '0.2.0')).toThrow(/no "version" field/);
+    });
+});
 
 describe('validateSemver', () => {
     it('accepts plain semver', () => {

--- a/scripts/assert-version-sync.mjs
+++ b/scripts/assert-version-sync.mjs
@@ -45,8 +45,31 @@ export function readCargoTomlVersion(content) {
     return match[1];
 }
 
-export function check({ pkgVersion, cargoVersion, tagVersion }) {
+/**
+ * package-lock.json carries the version twice — at the root and on the
+ * `packages[""]` self-entry — and both must agree with package.json, or the
+ * next `npm install` rewrites the lock and dirties a clean checkout.
+ */
+export function readPackageLockVersion(content) {
+    const lock = JSON.parse(content);
+    const root = lock.version;
+    if (typeof root !== 'string') {
+        throw new Error('package-lock.json: no root "version" field found');
+    }
+    const self = lock.packages?.['']?.version;
+    if (typeof self === 'string' && self !== root) {
+        throw new Error(`package-lock.json: root version "${root}" disagrees with packages[""] "${self}"`);
+    }
+    return root;
+}
+
+// `lockVersion` is optional so existing callers/tests that predate the
+// package-lock check keep working; when supplied it must match the rest.
+export function check({ pkgVersion, cargoVersion, tagVersion, lockVersion }) {
     const all = [pkgVersion, cargoVersion, tagVersion];
+    if (lockVersion !== undefined) {
+        all.push(lockVersion);
+    }
     const unique = new Set(all);
     if (unique.size === 1) {
         return { ok: true, version: pkgVersion };
@@ -56,6 +79,7 @@ export function check({ pkgVersion, cargoVersion, tagVersion }) {
         pkgVersion,
         cargoVersion,
         tagVersion,
+        lockVersion,
     };
 }
 
@@ -73,8 +97,11 @@ function main() {
     const cargoVersion = readCargoTomlVersion(
         readFileSync(join(REPO_ROOT, 'Cargo.toml'), 'utf8'),
     );
+    const lockVersion = readPackageLockVersion(
+        readFileSync(join(REPO_ROOT, 'package-lock.json'), 'utf8'),
+    );
 
-    const result = check({ pkgVersion, cargoVersion, tagVersion });
+    const result = check({ pkgVersion, cargoVersion, tagVersion, lockVersion });
 
     if (result.ok) {
         console.log(`Versions in sync: ${result.version}`);
@@ -83,10 +110,11 @@ function main() {
 
     console.error('Version mismatch detected:');
     console.error(`  package.json:      ${pkgVersion}`);
+    console.error(`  package-lock.json: ${lockVersion}`);
     console.error(`  Cargo.toml:        ${cargoVersion}`);
     console.error(`  git tag (input):   ${tagVersion}  (from "${tag}")`);
     console.error('');
-    console.error('Run `npm run version:bump <new-version>` to bring all three into sync,');
+    console.error('Run `npm run version:bump <new-version>` to bring them all into sync,');
     console.error('then commit and re-tag.');
     process.exit(1);
 }

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -39,6 +39,34 @@ export function bumpPackageJson(content, newVersion) {
     return updated;
 }
 
+/**
+ * package-lock.json carries the app version twice: at the root and on the
+ * `packages[""]` self-entry. Both were previously left alone, so after every
+ * release the lock disagreed with package.json and the next `npm install`
+ * silently rewrote it — a dirty tree on a clean checkout.
+ *
+ * Parsed and re-serialised rather than regex-patched: the `packages[""]`
+ * version is indistinguishable by pattern from every dependency's own version
+ * field. npm writes exactly `JSON.stringify(x, null, 2) + '\n'`, so this
+ * round-trips byte-for-byte and the diff stays at the two intended lines.
+ */
+export function bumpPackageLock(content, newVersion) {
+    const lock = JSON.parse(content);
+    let changed = false;
+    if (typeof lock.version === 'string') {
+        lock.version = newVersion;
+        changed = true;
+    }
+    if (lock.packages && lock.packages[''] && typeof lock.packages[''].version === 'string') {
+        lock.packages[''].version = newVersion;
+        changed = true;
+    }
+    if (!changed) {
+        throw new Error('package-lock.json: no "version" field found to update');
+    }
+    return `${JSON.stringify(lock, null, 2)}\n`;
+}
+
 export function bumpCargoToml(content, newVersion) {
     // Match the version field within [workspace.package]. Non-greedy so we
     // stop at the FIRST `version = "..."` after `[workspace.package]`.
@@ -160,28 +188,33 @@ async function main() {
 
     const today = formatToday();
     const pkgPath = join(REPO_ROOT, 'package.json');
+    const pkgLockPath = join(REPO_ROOT, 'package-lock.json');
     const cargoPath = join(REPO_ROOT, 'Cargo.toml');
     const cargoLockPath = join(REPO_ROOT, 'Cargo.lock');
     const changelogPath = join(REPO_ROOT, 'CHANGELOG.md');
 
     const pkg = readFileSync(pkgPath, 'utf8');
+    const pkgLock = readFileSync(pkgLockPath, 'utf8');
     const cargo = readFileSync(cargoPath, 'utf8');
     const cargoLock = readFileSync(cargoLockPath, 'utf8');
     const changelog = readFileSync(changelogPath, 'utf8');
 
     // Compute first (so any failure leaves all files untouched).
     const newPkg = bumpPackageJson(pkg, newVersion);
+    const newPkgLock = bumpPackageLock(pkgLock, newVersion);
     const newCargo = bumpCargoToml(cargo, newVersion);
     const newCargoLock = bumpCargoLock(cargoLock, newVersion);
     const newChangelog = bumpChangelog(changelog, newVersion, today);
 
     writeFileSync(pkgPath, newPkg);
+    writeFileSync(pkgLockPath, newPkgLock);
     writeFileSync(cargoPath, newCargo);
     writeFileSync(cargoLockPath, newCargoLock);
     writeFileSync(changelogPath, newChangelog);
 
     console.log(`Bumped to v${newVersion}`);
     console.log('  package.json     OK');
+    console.log('  package-lock.json OK');
     console.log('  Cargo.toml       OK');
     console.log('  Cargo.lock       OK');
     console.log(`  CHANGELOG.md     OK ([${newVersion}] - ${today})`);

--- a/scripts/fetch-node.mjs
+++ b/scripts/fetch-node.mjs
@@ -38,19 +38,19 @@ const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.join(__dirname, '..');
 
 // ---- Pinned constants (update together if Node is bumped) ------------------
-const NODE_VERSION = 'v24.15.0';
+const NODE_VERSION = 'v24.19.0';
 const NODE_DIST_BASE = `https://nodejs.org/dist/${NODE_VERSION}`;
 
 // Windows: ZIP archive, contains node.exe at <root>/node.exe
 const WIN_ARCHIVE_NAME = `node-${NODE_VERSION}-win-x64.zip`;
 const WIN_ARCHIVE_SHA256 =
-    'cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62';
+    '57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73';
 const WIN_INNER_NODE_REL = path.join(`node-${NODE_VERSION}-win-x64`, 'node.exe');
 
 // Linux: tar.xz archive, contains node at <root>/bin/node
 const LINUX_ARCHIVE_NAME = `node-${NODE_VERSION}-linux-x64.tar.xz`;
 const LINUX_ARCHIVE_SHA256 =
-    '472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6';
+    '14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647';
 const LINUX_INNER_NODE_REL = path.join(`node-${NODE_VERSION}-linux-x64`, 'bin', 'node');
 
 const SEED_DIR = path.join(REPO_ROOT, 'seed', 'node');


### PR DESCRIPTION
## 1. Seed Node 24.15.0 → 24.19.0

`scripts/fetch-node.mjs`, with both pinned sha256s refreshed from nodejs.org `SHASUMS256.txt`. This is the bootstrap copy inside the installer payload — installs past first run already track 24.19.0 through `DependencyManager`.

Verified live rather than by inspection: `npm run stage-seed` downloaded the archive and the sha256 check passed.

`node-pty` (1.1.0) and `scrcpy-server` (4.1) were already at latest, so no change there.

## 2. `bump-version.mjs` now updates `package-lock.json`

It never did. So after **every** release the lock disagreed with `package.json`, and the next `npm install` silently rewrote it — a dirty tree on a clean checkout, for anyone, forever.

Caught on main today: the lock still said `beta.72` while `package.json` said `beta.73`. Corrected in this PR.

The lock carries the version **twice** — at the root and on the `packages[""]` self-entry — and the second is indistinguishable by regex from every dependency''s own `version` field. So it''s parsed and re-serialised rather than patched. npm writes exactly `JSON.stringify(x, null, 2) + "\n"`, which round-trips this 150 KB file **byte-for-byte** — I verified that before choosing the approach, and there''s a test pinning it — so the diff stays at the two intended lines instead of reformatting the whole file.

## 3. The tag-time CI gate now checks the lock

`assert-version-sync.mjs` compares `package.json`, `Cargo.toml` and the git tag. It now includes `package-lock.json`, and additionally rejects a lock whose root and `packages[""]` versions disagree with each other — a half-applied bump. Without this the same drift simply recurs the next time someone edits the bump script.

`lockVersion` is optional on `check()` so existing callers and tests keep working.

## Also

Adds the missing CHANGELOG entry for the H.264/H.265 decode fix (#508), which merged without one and would otherwise have been **absent from the next release notes** — the most significant fix in it.

## Verification

`tsc --noEmit` clean · 1528/1528 vitest (+13 new) + 3 skipped · biome clean across 468 files · `npm run build` clean · `assert-version-sync.mjs v0.1.30-beta.73` now passes against the real tree.