### PR TITLE
fix(ci): include package-lock.json in the auto-release bump commit

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -135,17 +135,25 @@ jobs:
               | gh api "repos/$GITHUB_REPOSITORY/git/blobs" --input - --jq '.sha'
           }
           PKG_BLOB=$(create_blob package.json)
+          PKGLOCK_BLOB=$(create_blob package-lock.json)
           CARGO_BLOB=$(create_blob Cargo.toml)
           LOCK_BLOB=$(create_blob Cargo.lock)
           CL_BLOB=$(create_blob CHANGELOG.md)
 
-          # Create a new tree with the four updated files
+          # Create a new tree with the five updated files.
+          # This list must stay in step with what bump-version.mjs writes --
+          # the script edits the working tree on the runner, but only the paths
+          # named here become blobs and reach the commit. package-lock.json was
+          # missing, so the bump for v0.1.30-beta.74 shipped a lock still
+          # pinned at beta.73 and the tag-time version-sync gate failed the
+          # release.
           NEW_TREE=$(gh api "repos/$GITHUB_REPOSITORY/git/trees" \
             --input - --jq '.sha' <<TREEOF
           {
             "base_tree": "$TREE_SHA",
             "tree": [
               {"path": "package.json", "mode": "100644", "type": "blob", "sha": "$PKG_BLOB"},
+              {"path": "package-lock.json", "mode": "100644", "type": "blob", "sha": "$PKGLOCK_BLOB"},
               {"path": "Cargo.toml", "mode": "100644", "type": "blob", "sha": "$CARGO_BLOB"},
               {"path": "Cargo.lock", "mode": "100644", "type": "blob", "sha": "$LOCK_BLOB"},
               {"path": "CHANGELOG.md", "mode": "100644", "type": "blob", "sha": "$CL_BLOB"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.73",
+  "version": "0.1.30-beta.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ws-scrcpy-web",
-      "version": "0.1.30-beta.73",
+      "version": "0.1.30-beta.74",
       "license": "GPL-3.0-only",
       "dependencies": {
         "velopack": "^1.2.0",


### PR DESCRIPTION
## What broke

The **v0.1.30-beta.74** release build failed at the tag-time version-sync gate:

```
Version mismatch detected:
  package.json:      0.1.30-beta.74
  package-lock.json: 0.1.30-beta.73
  Cargo.toml:        0.1.30-beta.74
  git tag (input):   0.1.30-beta.74
```

## Why

`auto-release.yml` builds the bump commit through the GitHub API rather than `git commit` — deliberately, so the commit is signed with the web-flow key and satisfies the `required_signatures` rule. That means it assembles a tree from an **explicit list of file blobs**:

```bash
PKG_BLOB=$(create_blob package.json)
CARGO_BLOB=$(create_blob Cargo.toml)
LOCK_BLOB=$(create_blob Cargo.lock)
CL_BLOB=$(create_blob CHANGELOG.md)
```

`package-lock.json` was not on it. So `bump-version.mjs` rewrote the lock correctly on the runner, and the change was then silently dropped on the floor — it never became a blob, never reached the commit, never landed in the bump PR.

This is fallout from #519, which taught `assert-version-sync.mjs` to check the lock without also teaching the automated bump path to *commit* it. The gate was right; the automation had to catch up. Worth noting it failed loudly at exactly the right moment rather than shipping a mismatched release.

## Fix

Adds the fifth blob and tree entry, with a comment tying the list to what `bump-version.mjs` writes — the two have to move together and nothing else couples them, which is precisely how this slipped.

Also syncs the lock on `main` to beta.74, which unblocks the existing tag so it can be re-cut without a version bump.

**Deliberately unlabeled** — this must not trigger another release.

## Verification

`assert-version-sync.mjs v0.1.30-beta.74` now passes against the real tree · 1528/1528 vitest + 3 skipped.

No CHANGELOG entry: release plumbing, nothing user-facing.