### PR TITLE
docs(smoke): retarget to beta.75, update-from beta.73, note the beta.74 tombstone

### DIFF
--- a/docs/smoke-tests/smoke-test.md
+++ b/docs/smoke-tests/smoke-test.md
@@ -1,6 +1,8 @@
 # ws-scrcpy-web — Smoke Test
 
-> **Smoke target: `v0.1.30-beta.72`** — bump this one line each release; everything below is version-agnostic.
+> **Smoke target: `v0.1.30-beta.75`** — bump this one line each release; everything below is version-agnostic.
+>
+> **`v0.1.30-beta.74` is a tombstone** — the tag exists but no release was ever published. Its bump commit shipped a `package-lock.json` still pinned at beta.73, so the tag-time version-sync gate failed the build before publish (fixed in #521). Release tags are protected against deletion and non-fast-forward, so the number was retired rather than reused. Don't go looking for its assets.
 
 The single manual smoke for the **0.1.30 final** gate (the first true Windows + Linux release). It is **execution-ordered** — work top to bottom; within a phase, some rows depend on state left by earlier rows. This doc is the sole source of truth: it consolidates the former module-reference, plain-English, and run-sheet smoke docs into one. For a by-feature view use [§ Index by module](#index-by-module); for terminology use the [§ Glossary](#glossary).
 
@@ -28,14 +30,14 @@ The single manual smoke for the **0.1.30 final** gate (the first true Windows + 
 
 **Devices:** an Android device with **Wireless debugging** enabled (Android 11+) reachable from the VM, plus (Windows) one USB device if available.
 
-**Build-prep — the "update from" build (Module 6).** The update rows need an older build to update *from*. The most recent **kept prior release** is **`v0.1.30-beta.71`** (bump when a newer prior is kept). Download its AppImage (and MSI, for Windows) into a separate dir — the asset filename is identical across versions:
+**Build-prep — the "update from" build (Module 6).** The update rows need an older build to update *from*. The most recent **kept prior release** is **`v0.1.30-beta.73`** (bump when a newer prior is kept). Download its AppImage (and MSI, for Windows) into a separate dir — the asset filename is identical across versions:
 
 ```bash
 # Linux — the update "from" build
-gh release download v0.1.30-beta.71 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-linux-beta.AppImage' --dir ./beta71
-chmod +x ./beta71/WsScrcpyWeb-linux-beta.AppImage
+gh release download v0.1.30-beta.73 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-linux-beta.AppImage' --dir ./beta73
+chmod +x ./beta73/WsScrcpyWeb-linux-beta.AppImage
 # Windows MSI (row 6.8 / the Windows pass):
-gh release download v0.1.30-beta.71 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-beta.msi' --dir ./beta71
+gh release download v0.1.30-beta.73 --repo bilbospocketses/ws-scrcpy-web --pattern 'WsScrcpyWeb-beta.msi' --dir ./beta73
 ```
 
 It's a kept release (not an expiring CI artifact), so no retention window to beat. **The latest release is feed-latest**, so any older install updates *to* it.
@@ -213,14 +215,14 @@ Mark each `☐`: `x` pass · `F` fail · `-` skip. Boxes start empty — this is
 | ☐ <a id="t-5-2"></a> **5.2** `[Linux]` Different-admin uninstall | Uninstall via **pkexec as a different admin** (triggers `systemd-run --system` teardown same as 5.1) | PASS = teardown verified: service stopped + unit removed; `/opt` + `/var/lib` gone; fcontext clean; zero AVC. Tab: **relaunch manually** if it doesn't reconnect — auto-relaunch is a tracked follow-up. |
 | ☐ <a id="t-5-3"></a> **5.3** `[Linux]` Headless uninstall | `sudo ./WsScrcpyWeb --uninstall-system-service` (no active graphical session) | No relaunch; manual fallback; **no orphan**; no `data_root_for_linux` panic; full teardown: unit removed, `/opt` + `/var/lib` gone. |
 
-### #11 — Updates 🧩 *(needs the beta.71 "update-from" release — see Pre-flight)*
+### #11 — Updates 🧩 *(needs the beta.73 "update-from" release — see Pre-flight)*
 
 | Test | How to perform | Expected + verify |
 |---|---|---|
-| ☐ <a id="t-6-1"></a> **6.1** `[Both]` Update check | Settings → Updates → Check | A beta.71 install **offers the latest**; the latest reports **up-to-date**; no error spam in `server.log`/`launcher.log`. |
-| ☐ <a id="t-6-2"></a> **6.2** `[Linux]` Local-mode (home) update apply + relaunch *(#27)* | beta.71 home AppImage in **local mode** (no service) → Settings → Updates → Apply | Downloads + SHA-256 verifies; the "updating…" overlay above Settings; the AppImage **swaps and auto-relaunches** onto the latest unattended; browser reconnects; About = the new version. **Edge:** also confirm apply on an instance relaunched right after a user-scope service uninstall (the `systemd-run --collect` cgroup case). |
+| ☐ <a id="t-6-1"></a> **6.1** `[Both]` Update check | Settings → Updates → Check | A beta.73 install **offers the latest**; the latest reports **up-to-date**; no error spam in `server.log`/`launcher.log`. |
+| ☐ <a id="t-6-2"></a> **6.2** `[Linux]` Local-mode (home) update apply + relaunch *(#27)* | beta.73 home AppImage in **local mode** (no service) → Settings → Updates → Apply | Downloads + SHA-256 verifies; the "updating…" overlay above Settings; the AppImage **swaps and auto-relaunches** onto the latest unattended; browser reconnects; About = the new version. **Edge:** also confirm apply on an instance relaunched right after a user-scope service uninstall (the `systemd-run --collect` cgroup case). |
 | ☐ <a id="t-6-3"></a> **6.3** `[Linux]` No-service `/opt` update *(one pkexec)* | Machine-wide `/opt`, **no** service → trigger update | One pkexec; `/opt` swapped by **rename**; relabel bin_t + [restorecon](#g-restorecon); VERSION bumps; relaunches as the user; reconnects. No [ETXTBSY](#g-etxtbsy); FUSE intact. |
-| ☐ <a id="t-6-4"></a> **6.4** `[Linux]` Newer home over `/opt` | `/opt` at beta.71; place a newer home AppImage; launch | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
+| ☐ <a id="t-6-4"></a> **6.4** `[Linux]` Newer home over `/opt` | `/opt` at beta.73; place a newer home AppImage; launch | Bootstrapper runs home in place → offers "update the system-wide install to vX" → accept → swap → next launch runs updated `/opt`. |
 | ☐ <a id="t-6-5"></a> **6.5** `[Linux]` User-scope service update apply *(item 39)* | User-scope service installed → Settings → Updates → Apply | The `--user` unit stops, the home `$APPIMAGE` swaps, the unit restarts on the **same** web port, browser reconnects via the overlay. **No prompt.** |
 | ☐ <a id="t-6-6"></a> **6.6** `[Linux]` System-scope headless service update apply *(item 39 — the SELinux risk)* | System-scope service installed → Apply | **No** polkit prompt (root self-update); `/opt` copy swaps; restorecon re-applies bin_t; unit restarts; **zero AVC**. The `systemd-run` apply helper **survives `systemctl stop`** of the unit it's restarting (out-of-cgroup); the FUSE unmount settles within the helper's ~15s swap-retry window. If SELinux blocks the `init_t` `/opt` write or relabel → **narrow targeted policy only, never broad [audit2allow](#g-audit2allow)**. Updated deps land **bin_t** with no relabel — confirm `ls -Z /opt/ws-scrcpy-web/dependencies`. |
 
@@ -271,7 +273,7 @@ Mark each `☐`: `x` pass · `F` fail · `-` skip. Boxes start empty — this is
 | ☐ <a id="t-5-6"></a> **5.6** `[Win]` Uninstall handoff-failure guard | Service mode; kill all `ws-scrcpy-web-tray.exe`; then uninstall | ~5s → "still waiting…"; ~30s → "couldn't reach the user session…"; button freed; **service STILL installed** (no silent direct uninstall). |
 | ☐ <a id="t-5-7"></a> **5.7** `[Win]` Full uninstall | Add/Remove Programs → ws-scrcpy-web → Uninstall as `Admin` | Service stops/unregisters; `Program Files\WsScrcpyWeb` cleared; **user data under dataRoot preserved**; admin tray disappears. (Legacy `HKLM…\Run\WsScrcpyWebTray` removed **if present** — but fresh installs **no longer create any Run key**, so this passes vacuously; the live invariant is **3.8**.) |
 | ☐ <a id="t-5-10"></a> **5.10** `[Win]` Non-admin uninstall, UAC declined *(D.6)* | Service mode, as a **standard user** → uninstall service → continue → **decline/cancel** the UAC | Backend returns **403 `reason='uac-declined'`**; frontend "administrative privileges were declined. try again and approve the prompt."; button freed; **service still installed**. (UAC accepted → uninstalls cleanly, back to local mode.) |
-| ☐ <a id="t-6-8"></a> **6.8** `[Win]` In-app update apply + tray persists *(SE-2)* | From a prior installed build (beta.71 MSI) → Settings → Updates → Apply | Applies clean; app reachable post-update; the tray **persists across the update** (the `apply-update-pending` marker gates the reap off) — **one** tray after settling, no duplicate/orphan. |
+| ☐ <a id="t-6-8"></a> **6.8** `[Win]` In-app update apply + tray persists *(SE-2)* | From a prior installed build (beta.73 MSI) → Settings → Updates → Apply | Applies clean; app reachable post-update; the tray **persists across the update** (the `apply-update-pending` marker gates the reap off) — **one** tray after settling, no duplicate/orphan. |
 | ☐ <a id="t-7-3"></a> **7.3** `[Win]` USB device | Plug a USB device (authorize the RSA prompt on device) | Appears in connected devices; survives a home-page reload. |
 | ☐ <a id="t-10-2"></a> **10.2** `[Win]` Logs clean | Tail `C:\ProgramData\WsScrcpyWeb\logs\{launcher,ws-scrcpy-web}.log` during normal use (canonical logs). `server.log`/`service.log` are thin crash-catchers; a `.1` backup may appear | No `ERR` / `Error:` except known cosmetic node-pty AttachConsole noise. |
 | ☐ <a id="t-11-4"></a> **11.4** `[Win]` PerMachine intact | After the 1.5 MSI install, check the install location | Installed PerMachine to `C:\Program Files\WsScrcpyWeb\` (vpk 1.2.0 `--msi --instLocation PerMachine` unchanged). |


### PR DESCRIPTION
## What

- **Smoke target** `beta.72` → **`beta.75`** — the release this PR cuts.
- **"Update from" build** `beta.71` → **`beta.73`**, the most recent *kept published* release. That covers the `gh release download` commands, the `./beta71` → `./beta73` directories, and every row that named it (6.1, 6.2, 6.4, 6.8).
- Records **beta.74 as a tombstone**.

## On beta.74

Its tag exists but **no release was ever published**. The bump commit shipped a `package-lock.json` still pinned at beta.73, so the tag-time version-sync gate failed the build before the publish step (root cause and fix in #521).

Release tags are protected against both deletion and non-fast-forward, so the tag could not be moved onto the corrected commit — the number was retired rather than reused. That is worth writing down: anyone reading the tag list would otherwise go hunting for assets that do not exist.

## Note

Labeled `release:beta`, so merging this cuts **beta.75** — which is exactly the build the retargeted doc names. The two have to land together or the doc is wrong the moment it merges.

The carried smoke campaign still hasn''t been run against any of today''s changes; this only retargets the document.