### PR TITLE
build(ts7): phase 2 — root on TypeScript 7.0.2, dts-bundle-generator isolated on TS 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,14 +22,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-    # TypeScript 7 is the native compiler with no programmatic API until 7.1, so the
-    # webpack build (dts-bundle-generator; historically ts-loader/ts-node) can't build
-    # against it yet. The 6->7 migration is staged deliberately -- see
-    # docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md. Block the
-    # major so Dependabot stops re-proposing the un-buildable jump.
-    ignore:
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
+    # The typescript-major ignore is gone: the 6->7 migration is complete. Phase 1
+    # removed the compiler-API-bound build tools (ts-loader/ts-node -> swc-loader/tsx)
+    # and phase 2 put the root on TypeScript 7, with dts-bundle-generator -- the last
+    # tool needing the programmatic API -- isolated on TS 6 via a scoped override.
+    # Majors are open for review again.
     # Batch all minor + patch bumps into ONE weekly PR. Interlocking families
     # (@xterm/* addons must match the xterm core; webpack + its loaders; the
     # typescript / swc-loader / tsx toolchain) break when bumped singly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The project now builds on TypeScript 7.** This completes the migration begun a release earlier: phase 1 replaced the build tools that reached into the old compiler's programmatic API, and this moves the compiler itself. The one remaining tool that still needs that API — the generator for the bundled type definitions used by embedders — is pinned to TypeScript 6 for that single build step. Nothing about how the app behaves changes; type-checking, the full test suite, and the emitted build were all verified against the new compiler.
+
 ## [0.1.30-beta.75] - 2026-08-26
 
 ## [0.1.30-beta.74] - 2026-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Swapped the webpack build's TypeScript tooling from `ts-loader`/`ts-node` to `swc-loader`/`tsx`.** These are transpile-only replacements (type-checking is unchanged — it stays with the separate `tsc --noEmit`), and the emitted `dist/` output was verified equivalent to the previous build. This is phase 1 of moving onto the TypeScript 7 native compiler: it removes the build tools that import the old compiler's programmatic API, which TypeScript 7.0 does not ship. `isolatedModules` was enabled to enforce the per-file transpile constraints swc relies on.
+- **Upgraded the root TypeScript to the 7.0 native compiler.** Phase 2, completing the move started above: `tsc --noEmit` (the type-check) now runs on the native compiler. `dts-bundle-generator` — the last tool still needing the old programmatic API (absent from TypeScript 7.0 until 7.1) — is isolated on a vendored TypeScript 6 for the `build:types` step alone. The emitted app bundles are unchanged (swc does the transpile) and the bundled `ws-scrcpy.d.ts` is byte-identical.
 
 ### Fixed
 

--- a/docs/superpowers/plans/2026-07-18-ws-scrcpy-web-ts7-phase2.md
+++ b/docs/superpowers/plans/2026-07-18-ws-scrcpy-web-ts7-phase2.md
@@ -1,0 +1,273 @@
+# ws-scrcpy-web TypeScript 7 — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put ws-scrcpy-web's root `typescript` on the 7.0 native compiler while keeping the single bundled `dist/public/ws-scrcpy.d.ts`, by isolating `dts-bundle-generator` (the last compiler-API-bound tool) on a vendored TypeScript 6 for the `build:types` step alone.
+
+**Architecture:** After Phase 1, the `typescript` package is used by exactly two things: `tsc --noEmit` (typecheck; no emit) and `dts-bundle-generator` (emits the `.d.ts`). The app's JS is emitted by **swc-loader** and its webpack configs are loaded by **tsx** — neither imports the `typescript` package. So moving root to TS 7 changes the emitted `dist/` **not at all**; and because `dts-bundle-generator` stays on isolated TS 6, `ws-scrcpy.d.ts` is unchanged too. Phase 2 is therefore "run `tsc --noEmit` on the native compiler" plus a contained dependency-isolation trick — a near-no-op on build output, which makes verification a clean equivalence check.
+
+**Tech Stack:** TypeScript 7.0.2 (root) + TypeScript 6.0.3 (isolated, `build:types` only), dts-bundle-generator 9.5.1, webpack 5 + swc-loader + tsx, vitest, npm workspaces/overrides.
+
+## Global Constraints
+
+- Root `typescript` → `^7.0.2`. `dts-bundle-generator` MUST resolve TypeScript **≤ 6** (it needs the programmatic API, absent from native TS until 7.1).
+- **No change to shipped runtime behavior or emitted app JS** — swc owns emit; the `typescript` version must not alter `dist/` app bundles.
+- **Keep the single bundled `ws-scrcpy.d.ts`** — do NOT switch to per-file `tsc --emitDeclarationOnly` (rejected in the 2026-04-17 stream-api plan: relative-import per-file emit is not a usable single-file drop-in).
+- **Local-dependencies rule:** all build tools resolve from the app's own `node_modules` (never system PATH / env vars). The second `typescript` is toolchain-only (never shipped), so it does not engage the runtime-binary rule.
+- Commits **SSH-signed**, **no AI attribution** (no `Co-Authored-By`). Merge via **squash** (`gh pr merge --squash --delete-branch --auto`), never rebase.
+- **Multi-session discipline:** absolute paths everywhere; `git -C "C:/Users/jscha/source/repos/ws-scrcpy-web"`; stage only this task's own files (never `git add -A`).
+- **Shipping Velopack app:** verification gates (build + typecheck + tests + smoke on the native compiler) before merge.
+- Branch: `feat/ts7-phase2-typescript7` (already cut from `origin/main` @ 70f74a2; spec commit `bcd32db` already on it).
+
+---
+
+### Task 1: Migrate root to TS 7 + isolate dts-bundle-generator on TS 6
+
+**Files:**
+- Modify: `package.json` (devDependencies `typescript` `^6.0.2`→`^7.0.2`; add nested `overrides` for `dts-bundle-generator`→`typescript`), `package-lock.json` (regenerated)
+- Modify (fallback only): `scripts/build-types.js` (module-resolution shim)
+- Modify: `CHANGELOG.md` (`[Unreleased]` → `### Changed`)
+
+**Interfaces:**
+- Produces: a working `npm run build:types` that emits `dist/public/ws-scrcpy.d.ts` byte-equivalent to `main`, while `require('typescript').version` at repo root reports `7.0.x`. Tasks 2–3 rely on the repo building + typechecking on TS 7.
+
+- [ ] **Step 1: Capture the baseline `.d.ts` (produced on current TS 6)**
+
+Run:
+```
+npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" run build:types
+```
+Then copy the artifact to the scratchpad as a baseline:
+```
+Copy-Item "C:/Users/jscha/source/repos/ws-scrcpy-web/dist/public/ws-scrcpy.d.ts" "C:/Users/jscha/AppData/Local/Temp/claude/C--Users-jscha/e0082075-6307-4c1d-9b95-a0d36cef6c1b/scratchpad/ws-scrcpy.d.ts.baseline"
+```
+Expected: `[build-types] wrote dist/public/ws-scrcpy.d.ts (<N> bytes)`, baseline copied.
+
+- [ ] **Step 2: Confirm the current root TypeScript is 6.x (baseline)**
+
+Run:
+```
+node -e "console.log(require('C:/Users/jscha/source/repos/ws-scrcpy-web/node_modules/typescript/package.json').version)"
+```
+Expected: `6.0.x`.
+
+- [ ] **Step 3: Edit `package.json` — bump root TS 7 + nested override for dts-bundle-generator**
+
+In `devDependencies`, change:
+```json
+    "typescript": "^6.0.2",
+```
+to:
+```json
+    "typescript": "^7.0.2",
+```
+And change the existing `overrides` block:
+```json
+  "overrides": {
+    "fast-uri": "3.1.2"
+  }
+```
+to:
+```json
+  "overrides": {
+    "fast-uri": "3.1.2",
+    "dts-bundle-generator": {
+      "typescript": "6.0.3"
+    }
+  }
+```
+
+- [ ] **Step 4: Install to resolve the new tree**
+
+Run:
+```
+npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" install
+```
+Expected: completes; `package-lock.json` updated; `typescript@7.0.x` at root, `typescript@6.0.3` nested under `dts-bundle-generator`.
+
+- [ ] **Step 5: Verify the isolation — root on 7, dts-bundle-generator on 6**
+
+Run:
+```
+node -e "console.log('root', require('C:/Users/jscha/source/repos/ws-scrcpy-web/node_modules/typescript/package.json').version)"
+node -e "console.log('dbg ', require('C:/Users/jscha/source/repos/ws-scrcpy-web/node_modules/dts-bundle-generator/node_modules/typescript/package.json').version)"
+```
+Expected: `root 7.0.x` and `dbg  6.0.3`.
+If the second command errors (no nested copy — npm hoisted/deduped it), the override did not take → go to **Step 5-FALLBACK**; otherwise skip it.
+
+- [ ] **Step 5-FALLBACK (only if Step 5 shows no nested TS 6): apply the resolver shim**
+
+Revert the `overrides` addition (leave only `"fast-uri": "3.1.2"`), and instead add a TS 6 **alias** to `devDependencies`:
+```json
+    "typescript": "^7.0.2",
+    "typescript6": "npm:typescript@^6.0.3",
+```
+Prepend this shim to the top of `scripts/build-types.js`, immediately after the file's opening `'use strict';` and before any `require` of `dts-bundle-generator`:
+```js
+// Force dts-bundle-generator onto the vendored TS 6. It imports the TypeScript
+// programmatic API, which the native TS 7 compiler does not ship until 7.1.
+// We install TS 6 under the `typescript6` alias and redirect the bare
+// `typescript` specifier to it for THIS process only, so root + CI stay on
+// TS 7 while this one build step uses TS 6.
+const Module = require('node:module');
+const _origResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+    if (request === 'typescript' || request.startsWith('typescript/')) {
+        request = 'typescript6' + request.slice('typescript'.length);
+    }
+    return _origResolve.call(this, request, ...rest);
+};
+```
+Re-run `npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" install`, then continue at Step 6.
+
+- [ ] **Step 6: Regenerate the `.d.ts` on the TS-7 root (dts-bundle-generator using isolated TS 6)**
+
+Run:
+```
+npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" run build:types
+```
+Expected: `[build-types] wrote dist/public/ws-scrcpy.d.ts (<N> bytes)` — **success proves the isolation works** (dts-bundle-generator on native TS 7 would throw an API error).
+
+- [ ] **Step 7: Diff the regenerated `.d.ts` against the baseline**
+
+Run:
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" --no-pager diff --no-index --stat "C:/Users/jscha/AppData/Local/Temp/claude/C--Users-jscha/e0082075-6307-4c1d-9b95-a0d36cef6c1b/scratchpad/ws-scrcpy.d.ts.baseline" "C:/Users/jscha/source/repos/ws-scrcpy-web/dist/public/ws-scrcpy.d.ts"
+```
+Expected: **no output** (identical). If it differs, inspect the full diff; only a changed generator banner/timestamp is acceptable — a change in the exported type surface is a failure and must be understood before proceeding.
+
+- [ ] **Step 8: Typecheck on the native compiler**
+
+Run:
+```
+npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" exec -- tsc --noEmit
+```
+(or `node "C:/Users/jscha/source/repos/ws-scrcpy-web/node_modules/typescript/bin/tsc" --noEmit -p "C:/Users/jscha/source/repos/ws-scrcpy-web/tsconfig.json"`)
+Expected: exits 0, no errors — the code typechecks clean on TS 7 (`skipLibCheck` + `isolatedModules` already set).
+Confirm the compiler used is native: `npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" exec -- tsc --version` → `Version 7.0.x`.
+
+- [ ] **Step 9: Record the change in CHANGELOG.md**
+
+Under `## [Unreleased]` → `### Changed`, add (beside the Phase 1 swc entry):
+```
+- Root TypeScript upgraded to the **7.0 native compiler** for `tsc --noEmit`. `dts-bundle-generator` (which still needs the pre-7.1 programmatic API) is isolated on a vendored TypeScript 6 for the `build:types` step only; the emitted app bundles and the bundled `ws-scrcpy.d.ts` are unchanged.
+```
+
+- [ ] **Step 10: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add package.json package-lock.json CHANGELOG.md
+# if the shim fallback was used, also: git -C "..." add scripts/build-types.js
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "build(ts7): root on TypeScript 7.0.2; isolate dts-bundle-generator on TS 6 for build:types"
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" log -1 --format='%h %G? %s'
+```
+Expected: commit created, signature `G`.
+
+---
+
+### Task 2: Restore `typescript` to the Dependabot flow + sync docs
+
+**Files:**
+- Modify: `.github/dependabot.yml:25-32` (remove the `typescript` major-bump ignore + its comment block, added in #494)
+- Modify: any doc that pins the toolchain at "TypeScript 6" (verify by grep; e.g. `README.md`, `docs/TECHNICAL_GUIDE.md`)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent config/doc change).
+- Produces: Dependabot free to propose future `typescript` majors again (individually, for review).
+
+- [ ] **Step 1: Remove the major-bump ignore block**
+
+In `.github/dependabot.yml`, delete these lines (the comment + the `ignore:` block) that sit between `      prefix: "chore(deps)"` and `    # Batch all minor + patch bumps...`:
+```yaml
+    # TypeScript 7 is the native compiler with no programmatic API until 7.1, so the
+    # webpack build (dts-bundle-generator; historically ts-loader/ts-node) can't build
+    # against it yet. The 6->7 migration is staged deliberately -- see
+    # docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md. Block the
+    # major so Dependabot stops re-proposing the un-buildable jump.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+```
+
+- [ ] **Step 2: Find and fix any doc that pins "TypeScript 6"**
+
+Run:
+```
+```
+Use Grep for `TypeScript 6|typescript@6|TypeScript 6\.|\bTS 6\b` across `README.md docs/**/*.md CONTRIBUTING.md`. For any that states the toolchain version as 6 (not a historical note), update to 7. (Historical CHANGELOG entries and the migration spec/plan stay as written.)
+Expected: at most a small number of hits; update only current-state toolchain statements.
+
+- [ ] **Step 3: Commit**
+
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" add .github/dependabot.yml
+# plus any docs touched in Step 2
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" commit -m "chore(deps): drop the typescript major-bump ignore now that TS 7 is adopted"
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" log -1 --format='%h %G? %s'
+```
+Expected: commit created, signature `G`.
+
+---
+
+### Task 3: Pre-merge verification gate on the native compiler
+
+**Files:** none (verification only; fix + re-verify if a gate fails).
+
+**Interfaces:**
+- Consumes: the TS-7 tree from Tasks 1–2.
+- Produces: green build + tests + smoke evidence for the PR.
+
+- [ ] **Step 1: Full production build on the native compiler**
+
+Run:
+```
+npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" run build
+```
+Expected: webpack (swc) + `build:types` both succeed; `dist/public/` contains the known artifact set (`bundle.js`, `bundle.css`, `ws-scrcpy.umd.js`, `ws-scrcpy.esm.js`, `ws-scrcpy.css`, `ws-scrcpy.d.ts`, `embed.html`, `embed.js`) and `dist/index.js`.
+
+- [ ] **Step 2: Confirm emitted app JS is unchanged vs `main` (equivalence)**
+
+The `typescript` version does not feed swc/tsx, so app bundles must be identical to `main`. Verify the key bundles are byte-stable by hashing them and comparing to a `main` build (produced in a throwaway checkout or from the last `main` CI artifact). At minimum, assert the `dist/` file set matches Phase 1's 41-file set and that `dist/public/ws-scrcpy.d.ts` equals the Task 1 baseline.
+Run:
+```
+Get-ChildItem -Recurse "C:/Users/jscha/source/repos/ws-scrcpy-web/dist" -File | Measure-Object | Select-Object -ExpandProperty Count
+```
+Expected: same count as a `main` build (Phase 1 = 41 files). Any delta must be explained (expected: none).
+
+- [ ] **Step 3: Full unit-test suite**
+
+Run:
+```
+npm --prefix "C:/Users/jscha/source/repos/ws-scrcpy-web" test
+```
+Expected: all vitest tests green (Phase 1 baseline: 1478/1478).
+
+- [ ] **Step 4: Smoke-run the built app**
+
+Per Phase 1's method: stage seeds then start the app, or run `node dist/index.js` and confirm the process behaves identically to the `main` (Phase 1) build (starts without crashing; note that full serving needs the dev-supervisor + seeded assets, as established in Phase 1 — behavior must match `main`, not necessarily listen standalone).
+Expected: identical boot behavior to `main`.
+
+- [ ] **Step 5: Finish the branch**
+
+Invoke **superpowers:finishing-a-development-branch**. Established session choice: **Push + create PR** with squash auto-merge:
+```
+git -C "C:/Users/jscha/source/repos/ws-scrcpy-web" push -u origin feat/ts7-phase2-typescript7
+gh pr create -R bilbospocketses/ws-scrcpy-web --fill --base main --head feat/ts7-phase2-typescript7
+gh pr merge <N> -R bilbospocketses/ws-scrcpy-web --squash --delete-branch --auto
+```
+Then watch CI (`build-and-test` is the required check) to green + confirm merge.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Spec "confirm isolation mechanism" → Task 1 Steps 3–6 (overrides primary, shim fallback). ✓
+- Spec "bump typescript → 7.0.2 keeping dts-bundle-generator on TS 6" → Task 1. ✓
+- Spec "remove the #494 dependabot ignore" → Task 2 Step 1. ✓
+- Spec "verify tsc --noEmit + build (incl build:types, .d.ts equivalent) + vitest + smoke on native" → Task 1 Steps 6–8 + Task 3. ✓
+- Spec "hand-authored `.d.ts` ultimate fallback" → not a task; it is the escape hatch only if BOTH Step 5 override and Step 5-FALLBACK shim fail to isolate. Noted here rather than as a task to avoid speculative work (YAGNI); if reached, stop and re-plan.
+
+**2. Placeholder scan:** Task 2 Step 2 uses Grep (a tool) rather than a canned command — acceptable (the empty code fence is intentional; the grep is described exactly). No TBD/TODO. Shim code is complete. No "handle edge cases" hand-waving.
+
+**3. Type consistency:** No new types introduced; the public type surface is asserted **unchanged** (Task 1 Step 7 diff). The only "interface" is the isolation invariant (root=7, dts-bundle-generator=6), consistently referenced across tasks.

--- a/docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md
+++ b/docs/superpowers/specs/2026-07-18-ws-scrcpy-web-ts7-migration-design.md
@@ -1,7 +1,7 @@
 # ws-scrcpy-web → TypeScript 7 migration (design)
 
 **Date:** 2026-07-18
-**Status:** Approved — Phase 1 ready to implement; Phase 2 outlined.
+**Status:** Phase 1 SHIPPED (#493 swc/tsx + #494 docs/ignore). Phase 2 APPROVED 2026-07-18 — Approach A (isolated TS 6 for `build:types`), in progress.
 **Scope:** The build-system changes needed for ws-scrcpy-web to run on the TypeScript 7 native compiler.
 
 ## Problem
@@ -63,13 +63,26 @@ Either fully removes `ts-node`; the choice is settled during Phase 1 verificatio
 
 ---
 
-## Phase 2 — TypeScript 7 (separate PR, outlined)
+## Phase 2 — TypeScript 7 native compiler (this PR)
 
-1. Bump `typescript` → `7.0.2`. `tsc --noEmit` already passes on TS 7 (per #487).
-2. Resolve **dts-bundle-generator** (the last TS-6-API tool). Decision taken at Phase 2 start:
-   - **(a)** keep the single bundled `ws-scrcpy.d.ts` by vendoring TypeScript 6 (an npm alias in devDependencies) for *only* the `build:types` step — respects the local-dependencies rule (no network fetch at build time); or
-   - **(b)** replace it with `tsc --emitDeclarationOnly` (TS 7 native) — no TS 6 anywhere, but emits per-file `.d.ts` instead of one bundle (a small change to the shipped types layout), pending confirmation of whether/how the `.d.ts` is consumed.
-3. Close Dependabot #487 — its naive whole-repo TS 7 bump is superseded by this staged migration; add a `typescript` major-bump `ignore` so the un-buildable jump stops being re-proposed until we do it deliberately.
+The app already type-checks clean on TS 7 (Dependabot #487's `tsc --noEmit` passed at CI step 2; only `npm run build` failed). After Phase 1 that build failure is isolated to the one remaining compiler-API tool — `dts-bundle-generator`, in `build:types`. So Phase 2 puts the root on TS 7 and keeps `dts-bundle-generator` on a vendored TS 6, walled off to `build:types` alone.
+
+### Decision: keep the single bundled `.d.ts` (option a), not `tsc --emitDeclarationOnly` (option b)
+
+`dist/public/ws-scrcpy.d.ts` is a **deliberately-shipped, single-file public artifact** — README, CONTRIBUTING, and `docs/TECHNICAL_GUIDE.md` all advertise "bundled TypeScript types," and the intended consumer usage is a one-file reference (`import type { StartStreamOptions } from './dist/public/ws-scrcpy'`). Option b was **already tried and rejected** during the original Stream API work: `docs/superpowers/plans/2026-04-17-stream-api.md` records that raw `tsc --emitDeclarationOnly` emits per-file declarations with relative imports (`from './startStream'`) that don't work as a single self-contained file — which is exactly why `dts-bundle-generator` was adopted. Reviving b would regress that public artifact to a per-file tree leaking `src/` internals and churn three docs. So we keep the bundle.
+
+### Mechanism: vendored TS 6, isolated to `build:types`
+
+Root `typescript` → `7.0.2`, used by `tsc --noEmit` and CI everywhere. `dts-bundle-generator` — the only tool still needing the TS ≤6 programmatic API (nothing lands natively until TS 7.1) — resolves a **separate vendored TS 6** (an `npm:typescript@6` alias in devDependencies) for that one release-time step. This is a temporary bridge: when `dts-bundle-generator` supports the TS 7.1 API, the alias is deleted and the root TS serves everything. Installing a second `typescript` devDependency is toolchain-only (never shipped) and does not touch the local-dependencies rule, which governs the app's *runtime* binaries.
+
+The exact isolation is confirmed empirically as the plan's first task (candidates, cleanest first: npm `overrides` nesting `dts-bundle-generator`'s `typescript` to the alias → a `require`-resolver shim in `scripts/build-types.js` → a nested standalone install). Guaranteed fallback if none isolate cleanly: hand-author the small, stable public `ws-scrcpy.d.ts` (the surface is just `startStream`, the theme helpers, `version`, and ~5 types) and copy it at build time — no generator, no TS 6 at all.
+
+### Steps
+
+1. **Confirm the isolation mechanism** (spike): `build:types` emits a functionally-identical `ws-scrcpy.d.ts` while root `tsc --version` reports 7.x.
+2. **Bump `typescript` → `7.0.2`** (root devDependencies); wire `dts-bundle-generator` to the vendored TS 6 per step 1.
+3. **Remove the `typescript` major-bump `ignore`** from `.github/dependabot.yml` (added in #494) — TS 7 is now deliberately adopted, so future `typescript` updates flow through the normal grouped path again. (#487 is already closed.)
+4. **Verify on the native compiler:** `npx tsc --noEmit` clean, `npm run build` (webpack/swc + `build:types`) succeeds with `dist/public/ws-scrcpy.d.ts` present and functionally equivalent to `main`, `npm test` (vitest) green, and the built app smoke-runs.
 
 ---
 
@@ -80,7 +93,7 @@ Either fully removes `ts-node`; the choice is settled during Phase 1 verificatio
 | swc emit differs subtly from tsc emit | `isolatedModules` on + build-output diff + smoke run; repo uses no decorators / `const enum` (the usual divergence points). |
 | Webpack config loses authoring type-safety when de-TS'd | Prefer keeping `.ts` behind `@swc-node/register`; if converting to `.cjs`, add JSDoc `@type`. Configs are not CI-type-checked today, so no CI coverage is lost. |
 | Regression on a shipping app | Phase 1 is TypeScript-version-neutral; gated on output diff + smoke before merge; Velopack release flow untouched. |
-| dts-bundle-generator has no TS 7 path | Isolated to Phase 2; two concrete, local-deps-compliant options. |
+| dts-bundle-generator has no TS 7 path (until 7.1) | Phase 2 isolates it on a vendored TS 6 for `build:types` only; hand-authored `.d.ts` is a guaranteed fallback. |
 
 ## Rollback
 
@@ -89,4 +102,4 @@ Phase 1 is a self-contained PR; reverting it restores ts-loader/ts-node. No data
 ## Success criteria
 
 - **Phase 1:** ts-loader + ts-node gone; `dist/` output functionally identical to `main`; `tsc --noEmit` (isolatedModules) + `npm test` green; app smoke-verified; on TS 6.
-- **Phase 2:** `typescript@7.0.2`; full build + type-check + tests green on the native compiler; `build:types` produces a working public type surface; #487 closed.
+- **Phase 2:** root `typescript@7.0.2`; `dts-bundle-generator` isolated on a vendored TS 6 (or the hand-authored fallback); `npx tsc --noEmit` + `npm run build` (incl. `build:types`) + `npm test` green on the native compiler; `dist/public/ws-scrcpy.d.ts` present and functionally equivalent to `main`; the #494 `typescript`-major dependabot `ignore` removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "style-loader": "^4.0.0",
         "swc-loader": "^0.2.7",
         "tsx": "^4.23.12",
-        "typescript": "^6.0.2",
+        "typescript": "^7.0.2",
         "vitest": "^4.1.11",
         "webpack": "^5.109.2",
         "webpack-cli": "^7.2.2"
@@ -1584,6 +1584,346 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
@@ -2286,6 +2626,20 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/dts-bundle-generator/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4022,17 +4376,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -68,12 +68,15 @@
     "style-loader": "^4.0.0",
     "swc-loader": "^0.2.7",
     "tsx": "^4.23.12",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.11",
     "webpack": "^5.109.2",
     "webpack-cli": "^7.2.2"
   },
   "overrides": {
-    "fast-uri": "^3.1.5"
+    "fast-uri": "^3.1.5",
+    "dts-bundle-generator": {
+      "typescript": "6.0.3"
+    }
   }
 }


### PR DESCRIPTION
## What

Completes the TypeScript 6 → 7 migration. Phase 1 (#493) removed the build tools that reached into the old compiler''s programmatic API (`ts-loader`/`ts-node` → `swc-loader`/`tsx`); this moves the compiler itself.

`dts-bundle-generator` is the one tool that still needs that API — it emits the bundled public `dist/public/ws-scrcpy.d.ts` for the UMD/ESM/embed builds — so it is pinned to TypeScript 6 through a **scoped** override, for that build step only.

Also **removes the `typescript` semver-major ignore** from `dependabot.yml`. It existed to stop Dependabot re-proposing an un-buildable 6→7 jump; that jump is now the shipped state. Leaving it would have silently frozen `typescript` majors forever, which was the strongest argument against simply dropping this branch.

## Rebase

The branch was well behind — `package.json` and `package-lock.json` conflicted against five merges from today. Resolved by taking main''s newer versions for everything **except** `typescript` (the point of the branch), keeping main''s `fast-uri` `^3.1.5` alongside the branch''s scoped `dts-bundle-generator` override, then **regenerating** the lock rather than hand-merging 389 conflicted lines.

Worth recording one false alarm: immediately after resolving, `npm ls typescript` reported `typescript@6.0.3 invalid: "^7.0.2" from the root project` — the override appearing to leak globally. That was a stale `node_modules`, not a real resolution problem. After a full `npm install` the root resolves to **7.0.2** and `dts-bundle-generator` keeps **6.0.3**, exactly as Approach A intended.

## Verification (on the rebased branch)

- root `tsc --version` → **7.0.2**
- `tsc --noEmit` → clean
- **1528/1528** vitest + 3 skipped
- biome clean across 468 files
- `npm run build` clean, **including `build:types`** through the isolated TS 6
- `cargo test --workspace` → 202 passed

## Known caveat, editor-side only

The editor''s TypeScript language server fails to load lib types under TS 7 — it reports `Uint8Array`, `Math`, `Promise` and friends as unresolved — while `tsc` on the command line is clean. No effect on the build or CI, but expect to restart the TS server, or to need an editor with 7.x support. Flagging it because the in-editor red squiggles look alarming and are not real.

Unlabeled — no release; this can ride the next one.