### PR TITLE
docs: correct the beta.74/75 changelog split and refresh stale version pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.30-beta.75] - 2026-08-26
 
-## [0.1.30-beta.74] - 2026-08-26
-
 ### Changed
 
 - **The bundled Node.js runtime is now 24.19.0** (from 24.15.0). This is the copy that ships inside the installer to get the app running on first launch; installs past first run already track the newer version through the dependency panel.
@@ -35,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed stream startup in browsers that require `requestAnimationFrame` to be called with a `Window` receiver.** The quality-stats scheduler now invokes `requestAnimationFrame` / `cancelAnimationFrame` with the browser global as their receiver instead of calling detached function references, preventing the `TypeError: 'requestAnimationFrame' called on an object that does not implement interface Window` failure reported in #498.
 
+## [0.1.30-beta.74] - 2026-08-26
+
+Never published — the tag exists but the build failed before the publish step, so there are no assets under this version. Its bump commit shipped a `package-lock.json` still pinned at beta.73, which the tag-time version-sync check correctly rejected. Everything intended for it shipped in beta.75 instead.
+
 ## [0.1.30-beta.73] - 2026-08-26
 
 ### Added
@@ -44,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Swapped the webpack build's TypeScript tooling from `ts-loader`/`ts-node` to `swc-loader`/`tsx`.** These are transpile-only replacements (type-checking is unchanged — it stays with the separate `tsc --noEmit`), and the emitted `dist/` output was verified equivalent to the previous build. This is phase 1 of moving onto the TypeScript 7 native compiler: it removes the build tools that import the old compiler's programmatic API, which TypeScript 7.0 does not ship. `isolatedModules` was enabled to enforce the per-file transpile constraints swc relies on.
-- **Upgraded the root TypeScript to the 7.0 native compiler.** Phase 2, completing the move started above: `tsc --noEmit` (the type-check) now runs on the native compiler. `dts-bundle-generator` — the last tool still needing the old programmatic API (absent from TypeScript 7.0 until 7.1) — is isolated on a vendored TypeScript 6 for the `build:types` step alone. The emitted app bundles are unchanged (swc does the transpile) and the bundled `ws-scrcpy.d.ts` is byte-identical.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ dist/public/embed.js          embed page entry script
 ## Code Style
 
 - **Biome** is the single source of truth for linting and formatting. Run `npm run format` before committing.
-- **TypeScript 6** with `strict` enabled. No implicit `any`.
+- **TypeScript 7** with `strict` enabled. No implicit `any`.
 - **No Node.js Buffer polyfill in the browser** — use `Uint8Array` + the project's `BinaryReader` / `BinaryWriter`.
 - **Dynamic HTML via DOM manipulation**, not string interpolation — the `html\`\`` tagged template in `HtmlTag.ts` XSS-escapes interpolated values. Build complex DOM with `document.createElement`.
 - **Native `<dialog>` for modals** via the `Modal` base class in `src/app/ui/Modal.ts`. See existing subclasses for patterns.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
 ## scrcpy
 
-This project bundles the [scrcpy](https://github.com/Genymobile/scrcpy) server component (v3.3.4) by Genymobile, licensed under the Apache License 2.0. The vanilla, unmodified scrcpy-server binary is included in `assets/scrcpy-server`.
+This project bundles the [scrcpy](https://github.com/Genymobile/scrcpy) server component (v4.1) by Genymobile, licensed under the Apache License 2.0. The vanilla, unmodified scrcpy-server binary is included in `assets/scrcpy-server`.
 
 ```
 Copyright (c) 2018 Genymobile

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -764,7 +764,7 @@ Browser WS connect (action=stream, udid=xxx, videoCodec=h265, ...)
 ### 10.2 Stack
 
 - **Runtime:** Node.js 24 LTS
-- **Language:** TypeScript 6.x
+- **Language:** TypeScript 7.x (native compiler; `dts-bundle-generator` is isolated on TS 6 for `build:types` only)
 - **Bundler:** Webpack 5 (separate configs for dev/prod in `webpack/`)
 - **Linter/Formatter:** Biome 2.x (replaces ESLint + Prettier)
 - **Tests:** Vitest 4.x
@@ -879,7 +879,7 @@ Run `npm outdated` to check all at once. Update one at a time, build + test afte
 
 | # | Package | Current | Purpose | Update notes |
 |---|---------|---------|---------|--------------|
-| 1 | `typescript` | 6.0.2 | Compiles TypeScript source to JavaScript | Major versions may need `tsconfig.json` changes |
+| 1 | `typescript` | 7.0.2 | Type-checks the source (`tsc --noEmit`); swc does the transpile | `dts-bundle-generator` still needs the TS 6 programmatic API, so it is pinned to 6.0.3 via a scoped override |
 | 2 | `webpack` | 5.106.2 | Bundles source into server and browser output | Patch updates are safe |
 | 3 | `webpack-cli` | 7.0.3 | Command-line interface for webpack | Major versions usually just drop old Node support |
 | 4 | `css-loader` | 7.1.4 | Processes CSS imports for webpack bundling | Major versions may need webpack config changes |


### PR DESCRIPTION
Wrap-up doc sweep for today''s session. Four fixes, all surfaced by grepping the session''s changed identifiers rather than by review.

## CHANGELOG restructure

The failed beta.74 bump had **already promoted `[Unreleased]` into a dated `beta.74` section** before its build died. So the three things that actually shipped in **beta.75** — bundled Node 24.19.0, the H.264/H.265 black-screen fix, and the `requestAnimationFrame` receiver fix — were filed under a version that was never published, and the **beta.75 section was empty**.

That is not cosmetic: `extract-changelog.mjs` pulls the release body from the matching section, so **the published beta.75 release notes contained nothing but the unsigned-build warning** — for the release two issue reporters were just told to install. Release body corrected alongside this.

Moved the entries to beta.75 and left beta.74 as an explicit tombstone note. The tag exists, so someone reading the tag list needs to know why it has no assets.

Also removed a **duplicate TypeScript 7 phase-2 entry** that had landed in the beta.73 section — rebasing the TS7 branch re-anchored its `[Unreleased]` hunk next to the phase-1 entry it reads as a sibling of. The published beta.73 notes do not contain it, so this was changelog-only drift.

## Stale version pins

None of these were touched by the PR that invalidated them, which is exactly why a session-scoped sweep catches them and per-PR review cannot:

- **`THIRD-PARTY-NOTICES.md`** still attributed scrcpy-server **v3.3.4**; we now bundle **v4.1**. This is an attribution/licensing statement, so accuracy matters beyond tidiness.
- **`CONTRIBUTING.md`** said TypeScript 6.
- **`docs/TECHNICAL_GUIDE.md`** said TypeScript 6.x, and its dependency table listed `typescript 6.0.2`.

## Sweep result

Grepped **18 identifiers** across README, CONTRIBUTING, SECURITY, PRIVACY, THIRD-PARTY-NOTICES, RELEASE_NOTES and `docs/` → **4 updates**. README carries no version pins at all (stripped 2026-05-19) and held up. `docs/plans/` and `docs/specs/` are point-in-time snapshots and were deliberately left alone.

One thing left alone but worth noting: the same `TECHNICAL_GUIDE` dependency table lists `webpack 5.106.2` / `webpack-cli 7.0.3` while `package.json` is on `^5.109.2` / `^7.2.2`. Unrelated to this session, so out of scope here.