### PR TITLE
fix(deps): unpack archives in-process so a source run installs ADB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed ADB and Node.js never being downloaded when the app is run from source.** Unpacking a downloaded dependency was done by handing the archive to the launcher program that ships inside an installed copy — which does not exist in a source checkout, so on first run the app quietly declined to fetch either one and said so only in a log line. On Windows this was almost invisible, because a source run and an installed copy share the same dependency folder and ADB was usually already sitting there; on Linux and macOS, where a source run starts with an empty folder, it meant no ADB at all and nothing on screen to explain why. Archives are now unpacked by the app itself, so a source run sets itself up exactly like an installed one. The dependency panel's per-dependency update buttons, which were disabled for the same reason, now work there too.
+
 ### Changed
 
 - **The project now builds on TypeScript 7.** This completes the migration begun a release earlier: phase 1 replaced the build tools that reached into the old compiler's programmatic API, and this moves the compiler itself. The one remaining tool that still needs that API — the generator for the bundled type definitions used by embedders — is pinned to TypeScript 6 for that single build step. Nothing about how the app behaves changes; type-checking, the full test suite, and the emitted build were all verified against the new compiler.

--- a/src/common/DependencyTypes.ts
+++ b/src/common/DependencyTypes.ts
@@ -25,7 +25,6 @@ export interface UpdateResult {
     newVersion?: string | undefined;
     errorMessage?: string | undefined;
     requiresRestart: boolean;
-    reason?: 'launcher-required' | undefined;
 }
 
 interface ParsedVersion {

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -46,7 +46,6 @@ export interface DependencyDefinition {
     description: string;
     requiresRestart: boolean;
     pairedWith?: string;
-    requiresLauncher: boolean;
     checkInstalled: (depsPath: string) => Promise<string | null>;
     checkLatest: () => Promise<string | null>;
     getDownloadUrl: (version: string) => string;
@@ -73,7 +72,6 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             description: 'JavaScript runtime that runs the ws-scrcpy-web server',
             requiresRestart: true,
             pairedWith: 'node-pty',
-            requiresLauncher: true,
             checkInstalled: async (depsPath) => {
                 const ext = platform === 'win32' ? '.exe' : '';
                 // Linux tarball extracts with bin/ subdirectory; Windows zip is flat.
@@ -124,7 +122,6 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             displayName: 'ADB (Android Debug Bridge)',
             description: 'Communicates with Android devices (push, shell, tunnel)',
             requiresRestart: false,
-            requiresLauncher: true,
             checkInstalled: async (depsPath) => {
                 const ext = platform === 'win32' ? '.exe' : '';
                 const exe = path.join(depsPath, 'adb', `adb${ext}`);
@@ -150,7 +147,6 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             displayName: 'scrcpy-server',
             description: 'Runs on Android device to capture screen, audio, and accept input',
             requiresRestart: false,
-            requiresLauncher: false,
             checkInstalled: async (depsPath) => {
                 // The JAR file presence gates "installed at all"; the actual version
                 // comes from the .version marker (or SERVER_VERSION as fallback for

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -11,8 +11,9 @@ import type { DependencyDefinition } from './DependencyDefinitions';
 import { getDependencyDefinitions, getPlatform } from './DependencyDefinitions';
 import { Logger } from './Logger';
 import { writeInstalledScrcpyServerVersion } from './scrcpyServerVersion';
-import { launcherIsAvailable, resolveLauncherPath } from './service/elevatedRunner';
+import { resolveSystemTool } from './service/systemTools';
 import { copyFileAtomicSync, writeFileAtomicSync } from './util/atomicFile';
+import { extractZipTo } from './zipExtract';
 
 const log = Logger.for('DependencyManager');
 const execFileAsync = promisify(execFile);
@@ -50,12 +51,15 @@ export class DependencyManager {
     }
 
     public async getAll(): Promise<DependencyInfo[]> {
-        const launcherAvail = await launcherIsAvailable();
         // In-place mutation: callers (incl. getByName) hold references to state
         // entries and mutate them; spread copies would orphan those mutations.
         for (const info of this.state.values()) {
-            const def = this.definitions.find((d) => d.name === info.name);
-            info.canUpdate = !def?.requiresLauncher || launcherAvail;
+            // Every dependency is updatable everywhere the server runs. This was
+            // gated on the packaged launcher being present, because extraction
+            // shelled out to it; extraction is in-process now, so the gate is
+            // gone. The field stays on the wire — the panel reads it, and a future
+            // dependency may genuinely need gating (a Docker-mode pin, say).
+            info.canUpdate = true;
         }
         return Array.from(this.state.values());
     }
@@ -127,17 +131,6 @@ export class DependencyManager {
         if (!def || !info) {
             return { success: false, errorMessage: `Unknown dependency: ${name}`, requiresRestart: false };
         }
-        if (def.requiresLauncher && !(await launcherIsAvailable())) {
-            return {
-                success: false,
-                reason: 'launcher-required',
-                errorMessage:
-                    `${def.displayName} updates require an installed build. ` +
-                    'In dev mode, populate dependencies/ via scripts/fetch-node.mjs.',
-                requiresRestart: false,
-            };
-        }
-
         info.status = DependencyStatus.Updating;
         const fromVersion = info.installedVersion ?? 'not installed';
         const tmpDir = path.join(os.tmpdir(), 'ws-scrcpy-web', `update-${name}-${Date.now()}`);
@@ -218,14 +211,15 @@ export class DependencyManager {
             log.warn(`seed-promote scrcpy-server failed: ${(err as Error).message}`);
         }
 
-        const launcherAvail = await launcherIsAvailable();
         for (const info of this.state.values()) {
             if (info.installedVersion === null && info.latestVersion !== null) {
-                const def = this.definitions.find((d) => d.name === info.name);
-                if (def?.requiresLauncher && !launcherAvail) {
-                    log.info(`Skipping auto-install of ${info.name} in dev mode (no launcher)`);
-                    continue;
-                }
+                // Nothing is skipped here any more. Node and adb used to be, on
+                // every platform, whenever the packaged launcher was absent —
+                // which is every source checkout. On Windows that was invisible
+                // (dev and MSI share %PROGRAMDATA%\WsScrcpyWeb\dependencies\, so
+                // adb was usually already there); on Linux and macOS, where the
+                // dev deps folder starts empty, it meant a from-source run had no
+                // adb and one info-level log line to say so.
                 log.info(`First-run: auto-installing ${info.name}`);
                 await this.update(info.name);
             }
@@ -348,9 +342,11 @@ export class DependencyManager {
 
         // 1. Non-destructive: extract to tmpDir (both platforms).
         if (platform === 'win32') {
-            await this.extractZip(downloadPath, tmpDir, platform);
+            await this.extractZip(downloadPath, tmpDir);
         } else {
-            await execFileAsync('tar', ['xzf', downloadPath, '-C', tmpDir]);
+            // Absolute path via resolveSystemTool -- never the bare name, which would
+            // resolve through $PATH (Local-Dependencies-Only).
+            await execFileAsync(resolveSystemTool('tar'), ['xzf', downloadPath, '-C', tmpDir]);
         }
         const archiveDir = fs.readdirSync(tmpDir).find((d) => d.startsWith('node-v'));
         if (!archiveDir) {
@@ -411,7 +407,7 @@ export class DependencyManager {
         }
 
         // 1. Non-destructive: extract to tmpDir.
-        await this.extractZip(downloadPath, tmpDir, platform);
+        await this.extractZip(downloadPath, tmpDir);
 
         const platformToolsDir = path.join(tmpDir, 'platform-tools');
         if (!fs.existsSync(platformToolsDir)) {
@@ -467,27 +463,20 @@ export class DependencyManager {
         writeInstalledScrcpyServerVersion(this.depsPath, version);
     }
 
-    private async extractZip(zipPath: string, destDir: string, _platform: 'win32' | 'linux'): Promise<void> {
-        // Cross-platform: shell out to the launcher's --unzip subcommand
-        // (pure-Rust zip crate). Replaces the prior PowerShell Expand-Archive
-        // (win32) + system `unzip` (linux) shellouts that resolved binaries
-        // via system PATH — local-dependencies-only violations
-        // that §30 missed because §30's scope was the elevation path only.
-        // The launcher binary is SHA-pinned-to-release and ships in
-        // `current/` alongside this Node process, so no external binary
-        // discovery is needed.
-        if (!(await launcherIsAvailable())) {
-            throw new Error(
-                `extractZip requires the packaged launcher binary at ${resolveLauncherPath()}. ` +
-                    'Dev mode should populate dependencies/ via scripts/fetch-node.mjs (Node) or ' +
-                    `by pre-seeding from a prior install; the dependency-manager's autoInstall ` +
-                    'extractZip path is intended for Velopack-installed deployments only.',
-            );
-        }
-        await execFileAsync(resolveLauncherPath(), ['--unzip', zipPath, destDir], {
-            windowsHide: true,
-            maxBuffer: 1024 * 1024,
-        });
+    private async extractZip(zipPath: string, destDir: string): Promise<void> {
+        // In-process, pure JS (src/server/zipExtract.ts). No PATH lookup and no
+        // external binary, so this satisfies Local-Dependencies-Only the same way
+        // `ws` does — compiled into the app's own artifact.
+        //
+        // History worth not repeating: this was PowerShell `Expand-Archive` /
+        // system `unzip` (PATH-resolved — the violation), then the Rust
+        // launcher's `--unzip` subcommand (no PATH, but the launcher only exists
+        // in a packaged install, so `autoInstallMissing` silently skipped adb and
+        // Node in every source checkout). Extracting in-process is the first
+        // version that is both PATH-free and available everywhere the server runs
+        // — including a Docker image, which would otherwise have needed a Rust
+        // build stage purely to unzip.
+        await extractZipTo(zipPath, destDir);
     }
 
     private copyDirContents(src: string, dest: string): void {

--- a/src/server/NodePtyResolver.ts
+++ b/src/server/NodePtyResolver.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from './Logger';
 import { detectLibc, type LibcFlavor } from './libcDetect';
+import { resolveSystemTool } from './service/systemTools';
 import { writeFileAtomicSync } from './util/atomicFile';
 
 /*
@@ -284,7 +285,11 @@ export async function downloadAndOverlayPtyNode(version: string, host: HostInfo,
         const { execFileSync } = await import('child_process');
         // GNU tar on Windows (Git Bash) interprets 'C:\\...' as 'host:path'.
         // Pass only the filename and cwd into staging so tar uses relative paths.
-        execFileSync('tar', ['-xzf', path.basename(tarPath), '--strip-components=1'], {
+        // resolveSystemTool gives an absolute path rather than the bare name, which
+        // would resolve through $PATH (Local-Dependencies-Only) -- and on Windows it
+        // pins System32's bsdtar instead of whichever GNU tar a Git Bash install
+        // happens to put ahead of it, which is what the note above is about.
+        execFileSync(resolveSystemTool('tar'), ['-xzf', path.basename(tarPath), '--strip-components=1'], {
             stdio: 'inherit',
             cwd: stagingDir,
         });

--- a/src/server/__tests__/dependencyApi.update.test.ts
+++ b/src/server/__tests__/dependencyApi.update.test.ts
@@ -59,12 +59,15 @@ describe('DependencyApi.update endpoint', () => {
         while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
     });
 
-    it('returns 503 when update result has reason=launcher-required', async () => {
-        const mgr = new DependencyManager('/tmp/test-api-503');
+    it('returns 500 for any failed update — there is no special-cased status', async () => {
+        // This used to be a 503 branch for reason='launcher-required', emitted when
+        // a dependency could not be extracted without the packaged launcher.
+        // Extraction is in-process now, that reason no longer exists, and a failed
+        // update is just a failed update.
+        const mgr = new DependencyManager('/tmp/test-api-500');
         vi.spyOn(mgr, 'update').mockResolvedValue({
             success: false,
-            reason: 'launcher-required',
-            errorMessage: 'Node.js updates require an installed build.',
+            errorMessage: 'download failed',
             requiresRestart: false,
         });
         const api = new DependencyApi(mgr);
@@ -74,10 +77,10 @@ describe('DependencyApi.update endpoint', () => {
         const handled = await api.handle(req, res);
 
         expect(handled).toBe(true);
-        expect(res.statusCode).toBe(503);
+        expect(res.statusCode).toBe(500);
         const body = JSON.parse(res.body!);
         expect(body.success).toBe(false);
-        expect(body.reason).toBe('launcher-required');
+        expect(body.reason).toBeUndefined();
     });
 
     it('returns 200 when update succeeds (no launcher gate)', async () => {

--- a/src/server/__tests__/dependencyDefinitions.test.ts
+++ b/src/server/__tests__/dependencyDefinitions.test.ts
@@ -49,14 +49,16 @@ describe('getDependencyDefinitions', () => {
         expect(scrcpy?.requiresRestart).toBe(false);
     });
 
-    it('nodejs and adb require the launcher (extractZip path); scrcpy-server does not', () => {
+    it('carries no launcher requirement — extraction is in-process', () => {
+        // `requiresLauncher` is gone. It marked the dependencies whose install
+        // shelled out to the packaged launcher's --unzip, which meant they were
+        // skipped in every source checkout. Extraction moved in-process
+        // (src/server/zipExtract.ts), so nothing is gated on a packaged binary.
         const defs = getDependencyDefinitions('/tmp/test-deps');
-        const node = defs.find((d) => d.name === 'nodejs');
-        const adb = defs.find((d) => d.name === 'adb');
-        const scrcpy = defs.find((d) => d.name === 'scrcpy-server');
-        expect(node?.requiresLauncher).toBe(true);
-        expect(adb?.requiresLauncher).toBe(true);
-        expect(scrcpy?.requiresLauncher).toBe(false);
+        expect(defs.length).toBeGreaterThan(0);
+        for (const def of defs) {
+            expect(def).not.toHaveProperty('requiresLauncher');
+        }
     });
 });
 

--- a/src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
+++ b/src/server/__tests__/dependencyManager.autoInstallMissing.test.ts
@@ -85,12 +85,24 @@ describe('DependencyManager.autoInstallMissing', () => {
         expect(updateSpy).toHaveBeenCalledWith('scrcpy-server');
     });
 
-    it('skips launcher-required deps in dev mode (no launcher available)', async () => {
+    it('installs every missing dep with no launcher present (dev / source checkout)', async () => {
+        // Regression guard for the gap this replaced. nodejs and adb used to be
+        // skipped whenever the packaged launcher was absent — true of every source
+        // checkout — because their install shelled out to its --unzip subcommand.
+        // The only trace was an info-level log line, which is why it went unnoticed
+        // on Windows (dev and MSI share %PROGRAMDATA%\WsScrcpyWeb\dependencies\, so
+        // adb was usually already present) and bit hard on Linux and macOS, where
+        // the dev deps folder starts empty. Extraction is in-process now, so a
+        // missing launcher must change nothing.
         vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockResolvedValue(false);
 
         const nodejs = mgr.getByName('nodejs')!;
         nodejs.installedVersion = null;
-        nodejs.latestVersion = '24.15.0';
+        nodejs.latestVersion = '24.19.0';
+
+        const adb = mgr.getByName('adb')!;
+        adb.installedVersion = null;
+        adb.latestVersion = 'latest';
 
         const scrcpy = mgr.getByName('scrcpy-server')!;
         scrcpy.installedVersion = null;
@@ -98,9 +110,8 @@ describe('DependencyManager.autoInstallMissing', () => {
 
         await mgr.autoInstallMissing();
 
-        // nodejs is skipped (requiresLauncher && !launcherIsAvailable)
-        expect(updateSpy).not.toHaveBeenCalledWith('nodejs');
-        // scrcpy-server still gets installed (no launcher needed)
+        expect(updateSpy).toHaveBeenCalledWith('nodejs');
+        expect(updateSpy).toHaveBeenCalledWith('adb');
         expect(updateSpy).toHaveBeenCalledWith('scrcpy-server');
 
         vi.mocked(elevatedRunnerModule.launcherIsAvailable).mockResolvedValue(true);

--- a/src/server/__tests__/dependencyManager.test.ts
+++ b/src/server/__tests__/dependencyManager.test.ts
@@ -55,7 +55,11 @@ describe('DependencyManager.getAll() canUpdate', () => {
         vi.resetModules();
     });
 
-    it('reports canUpdate=false for launcher-required deps when launcher is unavailable', async () => {
+    it('reports canUpdate=true with no launcher present — extraction is in-process', async () => {
+        // Previously nodejs and adb reported canUpdate=false whenever the packaged
+        // launcher was missing, which is every source checkout: the dependency
+        // panel's update buttons were dead in dev on all three platforms. Nothing
+        // consults the launcher any more, so the absence of one changes nothing.
         vi.resetModules();
         vi.doMock('../service/elevatedRunner', () => ({
             launcherIsAvailable: async () => false,
@@ -64,8 +68,8 @@ describe('DependencyManager.getAll() canUpdate', () => {
         const { DependencyManager: Mgr } = await import('../DependencyManager');
         const mgr = new Mgr('/tmp/test-deps-canupdate-no');
         const byName = Object.fromEntries((await mgr.getAll()).map((d) => [d.name, d]));
-        expect(byName['nodejs']?.canUpdate).toBe(false);
-        expect(byName['adb']?.canUpdate).toBe(false);
+        expect(byName['nodejs']?.canUpdate).toBe(true);
+        expect(byName['adb']?.canUpdate).toBe(true);
         expect(byName['scrcpy-server']?.canUpdate).toBe(true);
         vi.resetModules();
     });

--- a/src/server/__tests__/dependencyManager.update.test.ts
+++ b/src/server/__tests__/dependencyManager.update.test.ts
@@ -71,12 +71,18 @@ describe('DependencyManager.update("scrcpy-server") — loop fix', () => {
     });
 });
 
-describe('DependencyManager.update() launcher-required gate', () => {
+describe('DependencyManager.update() has no launcher gate', () => {
     afterEach(() => {
         vi.doUnmock('../service/elevatedRunner');
     });
 
-    it('returns reason=launcher-required for nodejs when launcher is unavailable', async () => {
+    it('does not refuse nodejs when the launcher is unavailable', async () => {
+        // The inverse of the gate this replaced: nodejs and adb used to short-
+        // circuit with reason='launcher-required' before doing any work, because
+        // extraction shelled out to the packaged launcher. Extraction is in-process
+        // now, so update() must proceed and fail (or succeed) on its own merits.
+        // We assert on the *absence of the gate*, not on the outcome — the download
+        // is unmocked here and expected to fail.
         vi.doMock('../service/elevatedRunner', () => ({
             launcherIsAvailable: async () => false,
             resolveLauncherPath: () => '/fake/launcher.exe',
@@ -88,15 +94,20 @@ describe('DependencyManager.update() launcher-required gate', () => {
                 fs.rmSync(tmp, { recursive: true, force: true });
             },
         };
+        const fetchSpy = vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network disabled in test'));
+        using _restoreFetch = {
+            [Symbol.dispose]() {
+                fetchSpy.mockRestore();
+            },
+        };
         const mgr = new Mgr(tmp);
         const result = await mgr.update('nodejs');
-        expect(result.success).toBe(false);
-        expect(result.reason).toBe('launcher-required');
-        expect(result.errorMessage).toMatch(/installed build/);
-        expect(result.requiresRestart).toBe(false);
-        const info = mgr.getByName('nodejs')!;
-        expect(info.status).not.toBe(DependencyStatus.Updating);
-        expect(info.status).not.toBe(DependencyStatus.Error);
+        // No `reason` field to assert on: it only ever carried 'launcher-required',
+        // and removing it from UpdateResult makes the old gate unrepresentable.
+        expect(result.errorMessage).not.toMatch(/installed build/);
+        // It got past the gate and into the real work, so the failure is a
+        // download failure and the entry is marked Error rather than left pristine.
+        expect(mgr.getByName('nodejs')!.status).toBe(DependencyStatus.Error);
     });
 
     it('does not gate scrcpy-server (no launcher needed)', async () => {
@@ -132,7 +143,6 @@ describe('DependencyManager.update() launcher-required gate', () => {
         info.latestVersion = '4.0';
         const result = await mgr.update('scrcpy-server');
         expect(result.success).toBe(true);
-        expect(result.reason).toBeUndefined();
     });
 });
 

--- a/src/server/__tests__/zipExtract.test.ts
+++ b/src/server/__tests__/zipExtract.test.ts
@@ -1,0 +1,240 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as zlib from 'node:zlib';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { extractZipTo, readCentralDirectory, resolveEntryPath } from '../zipExtract';
+
+/**
+ * These tests build ZIPs byte by byte rather than leaning on a library, because
+ * the point is to pin the exact on-disk layout our extractor claims to read —
+ * a library fixture would only prove we agree with that library.
+ */
+
+const MADE_BY_UNIX = 3;
+const MADE_BY_DOS = 0;
+
+interface FixtureEntry {
+    name: string;
+    content?: Buffer;
+    /** 0 = store, 8 = deflate. */
+    method?: number;
+    /** POSIX mode; omit for a DOS-made entry with no mode bits. */
+    unixMode?: number;
+    madeBy?: number;
+    /** Corrupt the recorded CRC on purpose. */
+    breakCrc?: boolean;
+}
+
+function buildZip(entries: FixtureEntry[]): Buffer {
+    const locals: Buffer[] = [];
+    const centrals: Buffer[] = [];
+    let offset = 0;
+
+    for (const e of entries) {
+        const isDir = e.name.endsWith('/');
+        const content = isDir ? Buffer.alloc(0) : (e.content ?? Buffer.alloc(0));
+        const method = isDir ? 0 : (e.method ?? 0);
+        const data = method === 8 ? zlib.deflateRawSync(content) : content;
+        const crc = e.breakCrc ? 0xdeadbeef : zlib.crc32(content) >>> 0;
+        const nameBuf = Buffer.from(e.name, 'utf8');
+        const madeBy = e.madeBy ?? (e.unixMode !== undefined ? MADE_BY_UNIX : MADE_BY_DOS);
+
+        const local = Buffer.alloc(30 + nameBuf.length);
+        local.writeUInt32LE(0x04034b50, 0);
+        local.writeUInt16LE(20, 4);
+        local.writeUInt16LE(0, 6);
+        local.writeUInt16LE(method, 8);
+        local.writeUInt16LE(0, 10);
+        local.writeUInt16LE(0, 12);
+        local.writeUInt32LE(crc, 14);
+        local.writeUInt32LE(data.length, 18);
+        local.writeUInt32LE(content.length, 22);
+        local.writeUInt16LE(nameBuf.length, 26);
+        local.writeUInt16LE(0, 28);
+        nameBuf.copy(local, 30);
+
+        const central = Buffer.alloc(46 + nameBuf.length);
+        central.writeUInt32LE(0x02014b50, 0);
+        central.writeUInt16LE((madeBy << 8) | 20, 4);
+        central.writeUInt16LE(20, 6);
+        central.writeUInt16LE(0, 8);
+        central.writeUInt16LE(method, 10);
+        central.writeUInt16LE(0, 12);
+        central.writeUInt16LE(0, 14);
+        central.writeUInt32LE(crc, 16);
+        central.writeUInt32LE(data.length, 20);
+        central.writeUInt32LE(content.length, 24);
+        central.writeUInt16LE(nameBuf.length, 28);
+        central.writeUInt16LE(0, 30);
+        central.writeUInt16LE(0, 32);
+        central.writeUInt16LE(0, 34);
+        central.writeUInt16LE(0, 36);
+        // `<< 16` on a mode like 0o100755 overflows into the sign bit, so the
+        // unsigned coercion has to come after the shift, not before.
+        central.writeUInt32LE(e.unixMode !== undefined ? (e.unixMode << 16) >>> 0 : 0, 38);
+        central.writeUInt32LE(offset, 42);
+        nameBuf.copy(central, 46);
+
+        locals.push(local, data);
+        centrals.push(central);
+        offset += local.length + data.length;
+    }
+
+    const centralBuf = Buffer.concat(centrals);
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(0, 4);
+    eocd.writeUInt16LE(0, 6);
+    eocd.writeUInt16LE(entries.length, 8);
+    eocd.writeUInt16LE(entries.length, 10);
+    eocd.writeUInt32LE(centralBuf.length, 12);
+    eocd.writeUInt32LE(offset, 16);
+    eocd.writeUInt16LE(0, 20);
+
+    return Buffer.concat([...locals, centralBuf, eocd]);
+}
+
+let tmp: string;
+let zipPath: string;
+let destDir: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'zipextract-'));
+    zipPath = path.join(tmp, 'fixture.zip');
+    destDir = path.join(tmp, 'out');
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeZip(entries: FixtureEntry[]): void {
+    fs.writeFileSync(zipPath, buildZip(entries));
+}
+
+describe('extractZipTo', () => {
+    it('round-trips stored and deflated entries', async () => {
+        const small = Buffer.from('hello');
+        // Repetitive so deflate actually compresses and we exercise inflateRawSync.
+        const big = Buffer.from('abcdefgh'.repeat(500));
+        writeZip([
+            { name: 'plain.txt', content: small, method: 0 },
+            { name: 'nested/deflated.txt', content: big, method: 8 },
+        ]);
+
+        await extractZipTo(zipPath, destDir);
+
+        expect(fs.readFileSync(path.join(destDir, 'plain.txt'))).toEqual(small);
+        expect(fs.readFileSync(path.join(destDir, 'nested', 'deflated.txt'))).toEqual(big);
+    });
+
+    it('creates explicit directory entries', async () => {
+        writeZip([{ name: 'platform-tools/' }, { name: 'platform-tools/adb', content: Buffer.from('bin') }]);
+
+        await extractZipTo(zipPath, destDir);
+
+        expect(fs.statSync(path.join(destDir, 'platform-tools')).isDirectory()).toBe(true);
+    });
+
+    it.skipIf(process.platform === 'win32')('preserves the executable bit', async () => {
+        // The whole reason mode handling exists: adb ships 0755 in Google's
+        // platform-tools zip and is useless without it.
+        writeZip([
+            { name: 'adb', content: Buffer.from('#!/bin/sh\n'), unixMode: 0o100755 },
+            { name: 'NOTICE.txt', content: Buffer.from('legal'), unixMode: 0o100644 },
+        ]);
+
+        await extractZipTo(zipPath, destDir);
+
+        expect(fs.statSync(path.join(destDir, 'adb')).mode & 0o777).toBe(0o755);
+        expect(fs.statSync(path.join(destDir, 'NOTICE.txt')).mode & 0o777).toBe(0o644);
+    });
+
+    it.skipIf(process.platform === 'win32')('falls back to 0644 for DOS-made archives with no mode bits', async () => {
+        writeZip([{ name: 'readme.txt', content: Buffer.from('x'), madeBy: MADE_BY_DOS }]);
+
+        await extractZipTo(zipPath, destDir);
+
+        expect(fs.statSync(path.join(destDir, 'readme.txt')).mode & 0o777).toBe(0o644);
+    });
+
+    it('refuses an entry that escapes the destination (zip slip)', async () => {
+        writeZip([{ name: '../escaped.txt', content: Buffer.from('nope') }]);
+
+        await expect(extractZipTo(zipPath, destDir)).rejects.toThrow(/escapes the destination/i);
+        expect(fs.existsSync(path.join(tmp, 'escaped.txt'))).toBe(false);
+    });
+
+    it('rejects a CRC mismatch rather than writing corrupt bytes', async () => {
+        writeZip([{ name: 'adb', content: Buffer.from('truncated'), breakCrc: true }]);
+
+        await expect(extractZipTo(zipPath, destDir)).rejects.toThrow(/CRC32 mismatch/i);
+    });
+
+    it('rejects an unsupported compression method', async () => {
+        writeZip([{ name: 'weird.bin', content: Buffer.from('x'), method: 0 }]);
+        // Rewrite the central-directory method field to bzip2 (12).
+        const buf = fs.readFileSync(zipPath);
+        const entries = readCentralDirectory(buf);
+        expect(entries).toHaveLength(1);
+        const centralStart = buf.length - 22 - (46 + 'weird.bin'.length);
+        buf.writeUInt16LE(12, centralStart + 10);
+        fs.writeFileSync(zipPath, buf);
+
+        await expect(extractZipTo(zipPath, destDir)).rejects.toThrow(/unsupported ZIP compression method 12/i);
+    });
+
+    it('rejects symlink entries instead of silently dropping them', async () => {
+        writeZip([{ name: 'link', content: Buffer.from('target'), unixMode: 0o120777 }]);
+
+        await expect(extractZipTo(zipPath, destDir)).rejects.toThrow(/symlink entries are not supported/i);
+    });
+
+    it('rejects an encrypted entry', async () => {
+        writeZip([{ name: 'secret.txt', content: Buffer.from('x') }]);
+        const buf = fs.readFileSync(zipPath);
+        const centralStart = buf.length - 22 - (46 + 'secret.txt'.length);
+        buf.writeUInt16LE(0x0001, centralStart + 8);
+        fs.writeFileSync(zipPath, buf);
+
+        await expect(extractZipTo(zipPath, destDir)).rejects.toThrow(/encrypted/i);
+    });
+});
+
+describe('readCentralDirectory', () => {
+    it('throws a named error when the EOCD is missing', () => {
+        expect(() => readCentralDirectory(Buffer.from('not a zip at all'))).toThrow(
+            /end-of-central-directory record not found/i,
+        );
+    });
+
+    it('detects a ZIP64 locator rather than misreading the sentinels', () => {
+        const base = buildZip([{ name: 'a.txt', content: Buffer.from('a') }]);
+        // Splice a ZIP64 EOCD locator immediately before the EOCD.
+        const locator = Buffer.alloc(20);
+        locator.writeUInt32LE(0x07064b50, 0);
+        const eocd = base.subarray(base.length - 22);
+        const withLocator = Buffer.concat([base.subarray(0, base.length - 22), locator, eocd]);
+
+        expect(() => readCentralDirectory(withLocator)).toThrow(/ZIP64/i);
+    });
+
+    it('reports the unix mode only for UNIX-made archives', () => {
+        const unix = readCentralDirectory(buildZip([{ name: 'a', content: Buffer.from('a'), unixMode: 0o100755 }]));
+        expect(unix[0]!.unixMode).toBe(0o100755);
+
+        const dos = readCentralDirectory(buildZip([{ name: 'a', content: Buffer.from('a'), madeBy: MADE_BY_DOS }]));
+        expect(dos[0]!.unixMode).toBeNull();
+    });
+});
+
+describe('resolveEntryPath', () => {
+    it('allows ordinary nested paths', () => {
+        const dest = path.resolve('/tmp/dest');
+        expect(resolveEntryPath(dest, 'platform-tools/adb')).toBe(path.join(dest, 'platform-tools', 'adb'));
+    });
+
+    it.each(['../escape.txt', 'a/../../escape.txt', '/etc/passwd'])('rejects %s', (name) => {
+        expect(() => resolveEntryPath(path.resolve('/tmp/dest'), name)).toThrow(/escapes the destination/i);
+    });
+});

--- a/src/server/api/DependencyApi.ts
+++ b/src/server/api/DependencyApi.ts
@@ -38,11 +38,10 @@ export class DependencyApi {
             if (req.method === 'POST' && updateMatch) {
                 const name = updateMatch[1]!;
                 const result = await this.manager.update(name);
-                if (result.reason === 'launcher-required') {
-                    res.writeHead(503);
-                } else {
-                    res.writeHead(result.success ? 200 : 500);
-                }
+                // The 503 "launcher-required" branch is gone: extraction is
+                // in-process now, so no dependency is unupdatable for want of a
+                // packaged binary.
+                res.writeHead(result.success ? 200 : 500);
                 res.end(JSON.stringify(result));
                 return true;
             }

--- a/src/server/zipExtract.ts
+++ b/src/server/zipExtract.ts
@@ -1,0 +1,232 @@
+/**
+ * Minimal ZIP extractor — pure JS, no dependencies, bundled into the server
+ * bundle by webpack.
+ *
+ * Why this exists: the dependency manager has to unpack two ZIPs (Google's
+ * `platform-tools-latest-<os>.zip` and, on Windows, the Node.js distribution).
+ * It used to shell out to PowerShell `Expand-Archive` / system `unzip`, which
+ * resolved binaries via `PATH` — a Local-Dependencies-Only violation. That was
+ * replaced by shelling out to the Rust launcher's `--unzip` subcommand, which
+ * fixed the PATH problem but made extraction depend on a binary that only
+ * exists in a packaged install: `resolveLauncherPath()` is
+ * `cwd/ws-scrcpy-web-launcher`, absent from every source checkout. The result
+ * was that `autoInstallMissing` silently skipped adb (and Node) in dev on all
+ * three platforms — invisible on Windows, where the dev tree and an MSI install
+ * share `%PROGRAMDATA%\WsScrcpyWeb\dependencies\`, and fatal on Linux/macOS,
+ * where the dev deps folder starts empty.
+ *
+ * Doing it in-process solves both: no PATH lookup and no external binary, which
+ * is Local-Dependencies-Only compliant in the same way `ws` is — compiled into
+ * the app's own artifact rather than resolved from the host.
+ *
+ * Scope is deliberately narrow. We read the **central directory** rather than
+ * streaming local headers, which means data descriptors (the streaming-writer
+ * case where sizes trail the data) are simply never consulted. Store and
+ * deflate are supported because that is what our two inputs use. Anything else
+ * — ZIP64, encryption, symlinks, an unknown compression method — throws with a
+ * named reason instead of producing a subtly wrong tree.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as zlib from 'node:zlib';
+
+const EOCD_SIG = 0x06054b50;
+const EOCD64_LOCATOR_SIG = 0x07064b50;
+const CENTRAL_SIG = 0x02014b50;
+const LOCAL_SIG = 0x04034b50;
+
+const EOCD_MIN_SIZE = 22;
+/** ZIP comment length is a uint16, so the EOCD starts at most this far from EOF. */
+const MAX_COMMENT = 0xffff;
+
+const METHOD_STORE = 0;
+const METHOD_DEFLATE = 8;
+
+/** `versionMadeBy >> 8` for archives written on a UNIX host (mode bits are meaningful). */
+const MADE_BY_UNIX = 3;
+
+const S_IFMT = 0o170000;
+const S_IFLNK = 0o120000;
+
+const DEFAULT_FILE_MODE = 0o644;
+const DEFAULT_DIR_MODE = 0o755;
+
+export interface ZipEntry {
+    /** Entry path as recorded, always forward-slashed. */
+    name: string;
+    method: number;
+    compressedSize: number;
+    uncompressedSize: number;
+    crc32: number;
+    localHeaderOffset: number;
+    /** POSIX mode from the external attributes, or null when the archive carries none. */
+    unixMode: number | null;
+    isDirectory: boolean;
+}
+
+function findEocdOffset(buf: Buffer): number {
+    const start = Math.max(0, buf.length - (EOCD_MIN_SIZE + MAX_COMMENT));
+    for (let i = buf.length - EOCD_MIN_SIZE; i >= start; i--) {
+        if (buf.readUInt32LE(i) === EOCD_SIG) return i;
+    }
+    throw new Error('not a ZIP archive: end-of-central-directory record not found');
+}
+
+/**
+ * Parse the central directory. Exported for tests — extraction goes through
+ * {@link extractZipTo}.
+ */
+export function readCentralDirectory(buf: Buffer): ZipEntry[] {
+    const eocd = findEocdOffset(buf);
+
+    // ZIP64 archives put the real counts/offsets in a separate record and leave
+    // 0xffff/0xffffffff sentinels here. Neither of our inputs is anywhere near
+    // the 4 GiB / 65535-entry thresholds, so rather than implement it, detect it.
+    if (eocd >= 20 && buf.readUInt32LE(eocd - 20) === EOCD64_LOCATOR_SIG) {
+        throw new Error('ZIP64 archives are not supported by this extractor');
+    }
+
+    const entryCount = buf.readUInt16LE(eocd + 10);
+    const centralSize = buf.readUInt32LE(eocd + 12);
+    const centralOffset = buf.readUInt32LE(eocd + 16);
+    if (entryCount === 0xffff || centralSize === 0xffffffff || centralOffset === 0xffffffff) {
+        throw new Error('ZIP64 archives are not supported by this extractor');
+    }
+
+    const entries: ZipEntry[] = [];
+    let p = centralOffset;
+    for (let i = 0; i < entryCount; i++) {
+        if (buf.readUInt32LE(p) !== CENTRAL_SIG) {
+            throw new Error(`corrupt ZIP: bad central-directory signature at entry ${i}`);
+        }
+        const versionMadeBy = buf.readUInt16LE(p + 4);
+        const flags = buf.readUInt16LE(p + 8);
+        const method = buf.readUInt16LE(p + 10);
+        const crc32 = buf.readUInt32LE(p + 16);
+        const compressedSize = buf.readUInt32LE(p + 20);
+        const uncompressedSize = buf.readUInt32LE(p + 24);
+        const nameLen = buf.readUInt16LE(p + 28);
+        const extraLen = buf.readUInt16LE(p + 30);
+        const commentLen = buf.readUInt16LE(p + 32);
+        const externalAttrs = buf.readUInt32LE(p + 38);
+        const localHeaderOffset = buf.readUInt32LE(p + 42);
+        const name = buf.toString('utf8', p + 46, p + 46 + nameLen).replace(/\\/g, '/');
+
+        // Bit 0 = encrypted. We have no business decrypting anything.
+        if (flags & 0x0001) {
+            throw new Error(`encrypted ZIP entry is not supported: ${name}`);
+        }
+
+        const unixMode = versionMadeBy >> 8 === MADE_BY_UNIX ? (externalAttrs >>> 16) & 0xffff : null;
+        if (unixMode !== null && (unixMode & S_IFMT) === S_IFLNK) {
+            // Symlinks in an archive are an extraction-escape vector and neither
+            // of our inputs has any. Fail loudly rather than silently drop a file
+            // something later depends on.
+            throw new Error(`symlink entries are not supported: ${name}`);
+        }
+
+        entries.push({
+            name,
+            method,
+            compressedSize,
+            uncompressedSize,
+            crc32,
+            localHeaderOffset,
+            unixMode,
+            isDirectory: name.endsWith('/'),
+        });
+
+        p += 46 + nameLen + extraLen + commentLen;
+    }
+    return entries;
+}
+
+/**
+ * Resolve an entry name under `destDir`, refusing anything that escapes it
+ * (`../`, an absolute path, a drive-relative Windows path). Zip-slip guard.
+ */
+export function resolveEntryPath(destDir: string, entryName: string): string {
+    const resolvedDest = path.resolve(destDir);
+    const target = path.resolve(resolvedDest, entryName);
+    const withSep = resolvedDest.endsWith(path.sep) ? resolvedDest : resolvedDest + path.sep;
+    if (target !== resolvedDest && !target.startsWith(withSep)) {
+        throw new Error(`ZIP entry escapes the destination directory: ${entryName}`);
+    }
+    return target;
+}
+
+function readEntryData(buf: Buffer, entry: ZipEntry): Buffer {
+    if (buf.readUInt32LE(entry.localHeaderOffset) !== LOCAL_SIG) {
+        throw new Error(`corrupt ZIP: bad local header for ${entry.name}`);
+    }
+    // The local header's name/extra lengths can differ from the central
+    // directory's, so the data offset must come from the local header itself.
+    const nameLen = buf.readUInt16LE(entry.localHeaderOffset + 26);
+    const extraLen = buf.readUInt16LE(entry.localHeaderOffset + 28);
+    const dataStart = entry.localHeaderOffset + 30 + nameLen + extraLen;
+    const raw = buf.subarray(dataStart, dataStart + entry.compressedSize);
+
+    let data: Buffer;
+    if (entry.method === METHOD_STORE) {
+        data = Buffer.from(raw);
+    } else if (entry.method === METHOD_DEFLATE) {
+        data = zlib.inflateRawSync(raw);
+    } else {
+        throw new Error(`unsupported ZIP compression method ${entry.method} for ${entry.name}`);
+    }
+
+    if (data.length !== entry.uncompressedSize) {
+        throw new Error(`ZIP entry ${entry.name}: expected ${entry.uncompressedSize} bytes, got ${data.length}`);
+    }
+    // zlib.crc32 landed in Node 20.15; we ship 24. Catching a bad byte here beats
+    // discovering it when adb refuses to run.
+    const actual = zlib.crc32(data) >>> 0;
+    if (actual !== entry.crc32 >>> 0) {
+        throw new Error(`ZIP entry ${entry.name}: CRC32 mismatch`);
+    }
+    return data;
+}
+
+/**
+ * Extract `zipPath` into `destDir`, creating it if needed.
+ *
+ * POSIX modes recorded by the archive are applied, so an `adb` marked
+ * executable by Google's build stays executable. Archives written on Windows
+ * carry no mode bits; those entries get 0644 / 0755.
+ */
+export async function extractZipTo(zipPath: string, destDir: string): Promise<void> {
+    const buf = await fs.promises.readFile(zipPath);
+    const entries = readCentralDirectory(buf);
+
+    await fs.promises.mkdir(destDir, { recursive: true });
+
+    // Directories first, so a file can never be written before its parent and
+    // an explicit directory entry's mode is not clobbered by mkdir recursion.
+    for (const entry of entries) {
+        if (!entry.isDirectory) continue;
+        const target = resolveEntryPath(destDir, entry.name);
+        await fs.promises.mkdir(target, { recursive: true });
+    }
+
+    for (const entry of entries) {
+        if (entry.isDirectory) continue;
+        const target = resolveEntryPath(destDir, entry.name);
+        await fs.promises.mkdir(path.dirname(target), { recursive: true });
+        const data = readEntryData(buf, entry);
+        await fs.promises.writeFile(target, data);
+        if (process.platform !== 'win32') {
+            const mode = entry.unixMode !== null ? entry.unixMode & 0o7777 : DEFAULT_FILE_MODE;
+            await fs.promises.chmod(target, mode || DEFAULT_FILE_MODE);
+        }
+    }
+
+    if (process.platform !== 'win32') {
+        for (const entry of entries) {
+            if (!entry.isDirectory) continue;
+            const target = resolveEntryPath(destDir, entry.name);
+            const mode = entry.unixMode !== null ? entry.unixMode & 0o7777 : DEFAULT_DIR_MODE;
+            await fs.promises.chmod(target, mode || DEFAULT_DIR_MODE);
+        }
+    }
+}


### PR DESCRIPTION
`autoInstallMissing` has been silently skipping **nodejs and adb in every source checkout, on all three platforms**, since extraction moved to the Rust launcher. `resolveLauncherPath()` is `cwd/ws-scrcpy-web-launcher`, which exists only in a Velopack install, so `requiresLauncher` short-circuited both dependencies — with one info-level log line and nothing in the UI.

It hid because of where the deps folder lives. On Windows a dev tree and an MSI install share `%PROGRAMDATA%\WsScrcpyWeb\dependencies\`, so adb was usually already there from a prior install and nothing looked wrong. On Linux and macOS the dev deps folder is `<repo>/dependencies` and starts empty — so a from-source run had no adb, no device scanning, and no explanation.

## Why in-process rather than a fourth shellout

The history is the argument:

1. PowerShell `Expand-Archive` / system `unzip` — PATH-resolved, a Local-Dependencies-Only violation.
2. The launcher's `--unzip` subcommand — fixed PATH, but made extraction depend on a binary that only exists in a package.
3. `src/server/zipExtract.ts` — no PATH lookup **and** no external binary, compiled into our own bundle exactly the way `ws` is.

Only the third is both. It's also why this needed no new runtime dependency: `zlib.inflateRawSync` and `zlib.crc32` are built into Node.

## The extractor

Reads the **central directory** rather than streaming local headers, so data descriptors never come up. Store and deflate are supported because that's what our two inputs use (Google's `platform-tools-latest-<os>.zip`, and the Node.js distribution on Windows). ZIP64, encryption, symlinks, and unknown compression methods each throw a **named** error rather than producing a subtly wrong tree.

Two details that matter in practice:

- **POSIX modes** are read from the external file attributes and applied, which is what keeps `adb` executable. Archives written on Windows carry no mode bits; those fall back to 0644/0755.
- **Zip slip** — every entry path is resolved against the destination and refused if it escapes.

## Also: the last two bare-`tar` calls

`DependencyManager` (Node tarballs on POSIX) and `NodePtyResolver` (prebuilt overlay) both invoked bare `tar`, resolved through `$PATH`. Both now use `resolveSystemTool('tar')` for an absolute path out of the canonical system directories. On Windows that additionally pins System32's bsdtar instead of whichever GNU tar a Git Bash install puts ahead of it — which is exactly what the pre-existing comment in `NodePtyResolver` was warning about.

`src/` now has no bare-name binary invocations outside test fixtures.

## Removals

With both extractors PATH-free and launcher-free, `requiresLauncher` has no purpose: it's gone, along with the `launcher-required` `UpdateResult` reason and the 503 branch in `DependencyApi` that rendered it. `canUpdate` stays on the wire — the panel reads it, and a future dependency may genuinely need gating — but nothing sets it false today.

## Tests

16 new cases, all against ZIPs built **byte by byte in the test** rather than by a library (a library fixture would only prove we agree with that library): store/deflate round trip, the executable bit, DOS-made archives with no mode bits, zip slip, CRC mismatch, unsupported method, symlink and encrypted entries, missing EOCD, ZIP64 detection.

The four tests that asserted the old gate now assert its absence — including a regression guard in `autoInstallMissing` that installs *every* missing dep with no launcher present.

## Risk

This replaces a path that **works today in packaged installs**. The launcher's Rust unzip isn't broken; it was just unavailable in dev. Swapping production onto a hand-rolled extractor is the real risk here, not the dev fix — the mitigations are the fixture tests above plus smoke row 9.4, which exercises the dependency panel on a real install. The two POSIX-mode tests are skipped on Windows, so the Linux CI leg is what actually proves the executable bit.

## Side effect worth noting for SP4

A Docker image no longer needs a Rust build stage — or a shipped launcher binary — purely to unzip a dependency. The locked SP4 design has the dep manager auto-updating inside the container; that no longer implies carrying a native tool along for extraction.

## Verification

`tsc --noEmit` clean · 173 test files, 1542 passed / 5 skipped · `biome check` clean.

`release:none` — no user-visible behavior change on an installed build.
