### PR TITLE
ci(node-pty): publish darwin arm64 prebuilts

### DIFF
--- a/.github/workflows/node-pty-prebuilds.yml
+++ b/.github/workflows/node-pty-prebuilds.yml
@@ -76,6 +76,15 @@ jobs:
           - { os: ubuntu-24.04-arm,  arch: arm64, libc: glibc, abi_label: prior,   container: '' }
           - { os: ubuntu-latest,     arch: x64,   libc: musl,  abi_label: current, container: 'alpine' }
           - { os: ubuntu-latest,     arch: x64,   libc: musl,  abi_label: prior,   container: 'alpine' }
+          # macOS: Apple silicon only. GitHub's macOS runners are arm64, and
+          # node-pty builds natively there with the Xcode command line tools the
+          # image already carries -- no conpty equivalent, no extra toolchain.
+          # Intel Macs are NOT covered: producing an x64 tarball would mean
+          # cross-compiling with npm_config_arch=x64 and publishing a binary no
+          # runner can load, let alone test. Tracked as a follow-up rather than
+          # shipped untested.
+          - { os: macos-latest,      arch: arm64, libc: '',    abi_label: current, container: '' }
+          - { os: macos-latest,      arch: arm64, libc: '',    abi_label: prior,   container: '' }
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container == 'alpine' && format('node:{0}-alpine', matrix.abi_label == 'current' && needs.precheck.outputs.current_node_version_bare || needs.precheck.outputs.prior_node_version_bare) || null }}
     steps:
@@ -132,7 +141,11 @@ jobs:
 
           UPSTREAM_VER="${{ needs.precheck.outputs.node_pty_version }}"
           ABI="${{ matrix.abi_label == 'current' && needs.precheck.outputs.current_node_abi || needs.precheck.outputs.prior_node_abi }}"
-          PLATFORM="${{ startsWith(matrix.os, 'windows') && 'win32' || 'linux' }}"
+          # Must match composePrebuiltKey() in src/server/NodePtyResolver.ts.
+          # This used to be a two-way windows/else split, which would have keyed a
+          # macOS build as linux -- and appended a libc suffix it has no business
+          # carrying -- so it is spelled out per-OS.
+          PLATFORM="${{ startsWith(matrix.os, 'windows') && 'win32' || startsWith(matrix.os, 'macos') && 'darwin' || 'linux' }}"
           ARCH="${{ matrix.arch }}"
           LIBC_SUFFIX=""
           if [ "$PLATFORM" = "linux" ]; then LIBC_SUFFIX="-${{ matrix.libc }}"; fi

--- a/.github/workflows/node-pty-prebuilds.yml
+++ b/.github/workflows/node-pty-prebuilds.yml
@@ -249,8 +249,13 @@ jobs:
 
             Upstream: microsoft/node-pty v${{ needs.precheck.outputs.node_pty_version }}
             Covered ABIs: current ${{ needs.precheck.outputs.current_node_abi }} (Node ${{ needs.precheck.outputs.current_node_version }}), prior ${{ needs.precheck.outputs.prior_node_abi }} (Node ${{ needs.precheck.outputs.prior_node_version }})
-            Platforms: win32-x64, win32-arm64, linux-x64-glibc, linux-arm64-glibc, linux-x64-musl
-            (linux-arm64-musl excluded — GH Actions JS-action runtime doesn't run in Alpine+arm64 containers; those users fall back to compile-at-install.)
+            Platforms: win32-x64, win32-arm64, linux-x64-glibc, linux-arm64-glibc, linux-x64-musl, darwin-arm64
+
+            Not published, deliberately:
+            - linux-arm64-musl — the GH Actions JS-action runtime doesn't run in Alpine+arm64 containers.
+            - darwin-x64 (Intel Macs) — GH's macOS runners are Apple silicon; an x64 build would have to be cross-compiled and published untested.
+
+            Hosts on either fall back to compile-at-install, or run with the shell modal disabled.
 
       - name: Update "latest" alias
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1488,19 +1488,31 @@ A GitHub Actions workflow at `.github/workflows/node-pty-prebuilds.yml`
 runs weekly (Mondays 09:00 UTC) and on manual dispatch. A pre-check
 compares tracked state in `.github/state/node-pty-prebuilds-state.json`
 against the latest Node LTS list from `nodejs.org/dist/index.json` and
-the latest `microsoft/node-pty` upstream release. On any change, a 10-row
+the latest `microsoft/node-pty` upstream release. On any change, a 12-row
 matrix builds prebuilts for:
 
 ```
-{win32 x64, win32 arm64, linux x64 glibc, linux arm64 glibc, linux x64 musl}
+{win32 x64, win32 arm64, linux x64 glibc, linux arm64 glibc, linux x64 musl, darwin arm64}
 × {current LTS, prior LTS}
 ```
 
-`linux arm64 musl` is intentionally excluded: GitHub Actions' JS-action
-runtime (checkout, setup-node, upload-artifact) cannot execute inside an
-Alpine container on an ARM64 runner. Hosts on arm64+musl land in the
-`{ available: false, reason: 'no-prebuilt-for-abi-...' }` path and use the
-shell-disabled UI. See `actions/runner#801`.
+Two gaps, both deliberate. Hosts in either land in the
+`{ available: false, reason: 'no-prebuilt-for-abi-...' }` path and get the
+shell-disabled UI; everything else keeps working.
+
+- **`linux arm64 musl`** — GitHub Actions' JS-action runtime (checkout,
+  setup-node, upload-artifact) cannot execute inside an Alpine container on
+  an ARM64 runner. See `actions/runner#801`.
+- **`darwin x64` (Intel Macs)** — GitHub's macOS runners are Apple silicon.
+  Producing an Intel tarball would mean cross-compiling with
+  `npm_config_arch=x64` and publishing a binary no runner can load, let
+  alone test, which is a worse trade than the shell-disabled UI.
+
+Note that the darwin rows publish artifacts the resolver cannot yet find:
+`getHostInfo()` still collapses `darwin` to `linux`, so it looks for a
+`-linux-arm64-glibc` key. Widening that is the macOS-support work tracked
+separately — publishing the tarballs is the half that has to come first,
+because there is nothing to find otherwise.
 
 The workflow attaches the tarballs + `SHA256SUMS` + `manifest.json` to a
 versioned GitHub Release and updates a `node-pty-prebuilds-latest`
@@ -1537,7 +1549,7 @@ card as disabled-via-CSS + `aria-disabled` + tooltip when
 | `src/app/googDevice/client/DeviceTracker.ts` | Fetch capabilities on mount, gate shell anchor client-side |
 | `scripts/fetch-prebuilts.mjs` | Pure-JS CLI for pre-fetching prebuilts (air-gapped setups, CI pre-test) |
 | `vitest.globalSetup.ts` | Runs fetch-prebuilts before any test to ensure node-pty binary is present |
-| `.github/workflows/node-pty-prebuilds.yml` | Weekly/manual dispatch CI; 10-row matrix, SHA256 verification, release publish |
+| `.github/workflows/node-pty-prebuilds.yml` | Weekly/manual dispatch CI; 12-row matrix, SHA256 verification, release publish |
 | `.github/state/node-pty-prebuilds-state.json` | Tracked build state (Node LTS versions, upstream release) |
 | `scripts/compute-matrix-versions.mjs` | Pre-check script for workflow matrix computation |
 | `.npmrc` | `ignore-scripts=true` — prevents node-pty's install script from firing node-gyp rebuild |


### PR DESCRIPTION
The prebuilt matrix covers the platforms we ship installers for, so it has never built a macOS tarball. Combined with the resolver having **no `node_modules` fallback** — it goes seed → dataRoot → download-prebuilt, and never `require('node-pty')` out of `node_modules` — that means macOS has no shell modal *even in a dev checkout where `npm ci` compiled a perfectly good `pty.node`*. The fix is in the matrix, not the resolver.

Adds `macos-latest` arm64 for both the current and prior LTS ABIs. node-pty builds natively there against the Xcode command line tools already in the image — no conpty equivalent, no extra toolchain step.

## The matrix row alone wasn't enough

The key-composition step read:

```bash
PLATFORM="${{ startsWith(matrix.os, 'windows') && 'win32' || 'linux' }}"
```

A macOS row would have been labelled `linux` **and** had a libc suffix appended that it has no business carrying — publishing `node-pty-...-linux-arm64-glibc` from a Mac and silently shadowing the real Linux artifact of the same name. It's now spelled out per-OS to match `composePrebuiltKey()` in `NodePtyResolver`.

Everything downstream was already portable: `cp -r`, `tar -czf`, and the existing `sha256sum` → `shasum -a 256` fallback all work as-is on macOS, and the artifact name already tolerates an empty `libc` from the Windows rows.

## Intel Macs are deliberately not covered

GitHub's macOS runners are Apple silicon. An x64 tarball would have to be cross-compiled with `npm_config_arch=x64` and published without any runner able to load it, let alone test it. Shipping an untested native binary is a worse trade than the shell-disabled UI, so it's left out and **written down** — in the workflow comment and in `TECHNICAL_GUIDE` §18.2 alongside the existing `linux arm64 musl` exclusion — rather than quietly half-done. Worth a decision later if Intel Mac users turn up.

## Sequencing

These tarballs **are not yet reachable**. `getHostInfo()` still collapses `darwin` to `linux`, so the resolver looks for a `-linux-arm64-glibc` key. That widening is the macOS-support work in flight separately (#507); publishing has to land first, because otherwise there's nothing for it to find. Neither half is useful alone.

## Verification

Workflow YAML parses; matrix is 12 rows with the two darwin entries present. `TECHNICAL_GUIDE` §18.2 updated to match (10-row → 12-row, and the exclusions section now covers both gaps).

Note this workflow can't be exercised by opening a PR — it runs weekly and on manual dispatch, so the first real proof is a `workflow_dispatch` run after merge.

`release:none` — CI-only, no runtime change.
