### PR TITLE
ci(node-pty): pull the Alpine image by major tag, not exact patch

### DIFF
--- a/.github/state/node-pty-prebuilds-state.json
+++ b/.github/state/node-pty-prebuilds-state.json
@@ -1,12 +1,12 @@
 {
   "nodePtyVersion": "1.1.0",
   "nodeCurrentLts": {
-    "version": "v24.15.0",
+    "version": "v24.20.0",
     "abi": "137"
   },
   "nodePriorLts": {
-    "version": "v22.22.2",
+    "version": "v22.23.2",
     "abi": "127"
   },
-  "lastBuiltAt": "2026-04-21T12:57:41Z"
+  "lastBuiltAt": "2026-08-26T18:34:32.598Z"
 }

--- a/.github/workflows/node-pty-prebuilds.yml
+++ b/.github/workflows/node-pty-prebuilds.yml
@@ -25,10 +25,10 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
       node_pty_version: ${{ steps.check.outputs.node_pty_version }}
       current_node_version: ${{ steps.check.outputs.current_node_version }}
-      current_node_version_bare: ${{ steps.check.outputs.current_node_version_bare }}
+      current_node_major: ${{ steps.check.outputs.current_node_major }}
       current_node_abi: ${{ steps.check.outputs.current_node_abi }}
       prior_node_version: ${{ steps.check.outputs.prior_node_version }}
-      prior_node_version_bare: ${{ steps.check.outputs.prior_node_version_bare }}
+      prior_node_major: ${{ steps.check.outputs.prior_node_major }}
       prior_node_abi: ${{ steps.check.outputs.prior_node_abi }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,9 +50,34 @@ jobs:
           jq -r '.fresh | "node_pty_version=\(.nodePtyVersion)"' /tmp/check.json >> "$GITHUB_OUTPUT"
           jq -r '.fresh.nodeCurrentLts | "current_node_version=\(.version)\ncurrent_node_abi=\(.abi)"' /tmp/check.json >> "$GITHUB_OUTPUT"
           jq -r '.fresh.nodePriorLts | "prior_node_version=\(.version)\nprior_node_abi=\(.abi)"' /tmp/check.json >> "$GITHUB_OUTPUT"
-          # v-stripped forms for Docker Hub tags (node:24.15.0-alpine etc.)
-          jq -r '.fresh.nodeCurrentLts.version | sub("^v"; "") | "current_node_version_bare=\(.)"' /tmp/check.json >> "$GITHUB_OUTPUT"
-          jq -r '.fresh.nodePriorLts.version | sub("^v"; "") | "prior_node_version_bare=\(.)"' /tmp/check.json >> "$GITHUB_OUTPUT"
+          # MAJOR only, for the Alpine legs' Docker Hub tag (node:24-alpine).
+          # Deliberately not the exact patch: nodejs.org publishes a release the
+          # moment it is cut, but the official Docker images are built afterwards,
+          # so `node:<exact-patch>-alpine` 404s during that window. On 2026-08-26
+          # precheck resolved 24.20.0, Docker Hub had no 24.20.0 tag at all, the
+          # musl-current leg died on `docker pull`, and because publish requires
+          # every build leg to succeed it took the whole release with it --
+          # blocking all six platforms over one upstream lag.
+          #
+          # The major tag is the honest key anyway: the artifact name encodes the
+          # Node ABI (node-abi137), not the patch, and every 24.x is ABI 137. It
+          # also self-follows -- when the LTS pair moves to 26, precheck emits 26
+          # and `node:26-alpine` is what gets pulled, with nothing here to edit.
+          CUR_MAJOR=$(jq -r '.fresh.nodeCurrentLts.version | sub("^v"; "") | split(".")[0]' /tmp/check.json)
+          PRI_MAJOR=$(jq -r '.fresh.nodePriorLts.version | sub("^v"; "") | split(".")[0]' /tmp/check.json)
+          # Fail here, with the offending value, rather than three retries into a
+          # `docker pull` 404 twenty lines deep in a container-init log.
+          for pair in "current:$CUR_MAJOR" "prior:$PRI_MAJOR"; do
+            case "${pair#*:}" in
+              ''|*[!0-9]*)
+                echo "::error::could not derive the ${pair%%:*} Node major (got '${pair#*:}') — check compute-matrix-versions.mjs output"
+                exit 1
+                ;;
+            esac
+          done
+          echo "Alpine container tags: node:${CUR_MAJOR}-alpine (current), node:${PRI_MAJOR}-alpine (prior)"
+          echo "current_node_major=$CUR_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "prior_node_major=$PRI_MAJOR" >> "$GITHUB_OUTPUT"
 
   build:
     needs: precheck
@@ -86,7 +111,7 @@ jobs:
           - { os: macos-latest,      arch: arm64, libc: '',    abi_label: current, container: '' }
           - { os: macos-latest,      arch: arm64, libc: '',    abi_label: prior,   container: '' }
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container == 'alpine' && format('node:{0}-alpine', matrix.abi_label == 'current' && needs.precheck.outputs.current_node_version_bare || needs.precheck.outputs.prior_node_version_bare) || null }}
+    container: ${{ matrix.container == 'alpine' && format('node:{0}-alpine', matrix.abi_label == 'current' && needs.precheck.outputs.current_node_major || needs.precheck.outputs.prior_node_major) || null }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1543,6 +1543,17 @@ shell-disabled UI; everything else keeps working.
   `npm_config_arch=x64` and publishing a binary no runner can load, let
   alone test, which is a worse trade than the shell-disabled UI.
 
+**The Alpine legs pull a MAJOR Docker tag (`node:24-alpine`), never an exact
+patch.** nodejs.org publishes a release the moment it is cut; the official
+Docker images are built afterwards, so `node:<exact-patch>-alpine` 404s during
+that window. On 2026-08-26 the pre-check resolved 24.20.0, Docker Hub had no
+24.20.0 tag at all, the musl-current leg died on `docker pull` — and because
+`publish` is gated on *every* build leg succeeding, one upstream image lag
+blocked the release for all six platforms. The major tag is the honest key
+regardless: artifact names encode the ABI (`node-abi137`), not the patch, and
+every 24.x is ABI 137. It also self-follows when the LTS pair moves on, so the
+next major needs no edit here.
+
 Note that the darwin rows publish artifacts the resolver cannot yet find:
 `getHostInfo()` still collapses `darwin` to `linux`, so it looks for a
 `-linux-arm64-glibc` key. Widening that is the macOS-support work tracked


### PR DESCRIPTION
Fixes the failure that blocked today's forced prebuilds run (#530) and stops it recurring until we deliberately move to the next LTS.

## What happened

The musl legs run in `node:${exact-patch}-alpine`. nodejs.org publishes a release the moment it's cut; the official Docker images are built afterwards — so that tag 404s during the gap.

```
docker pull node:24.20.0-alpine
Error response from daemon: manifest for node:24.20.0-alpine not found
```

The pre-check resolved current LTS **24.20.0**; Docker Hub had no 24.20.0 tag at all. `musl-prior` passed on 22.23.2 because that image had long existed, which is exactly what made it look platform-specific rather than timing-specific.

The real damage is the blast radius: **`publish` is gated on every build leg succeeding**, so one missing upstream image blocked the release for all six platforms — including the darwin tarballs the run existed to produce. Both macOS legs built fine and shipped nothing.

## The fix

Pull the **major** tag: `node:24-alpine`, `node:22-alpine`.

That's the honest key regardless of the outage. Artifact names encode the Node **ABI** (`node-abi137`), not the patch, and every 24.x is ABI 137 — pinning the patch bought reproducibility we never claimed, at the cost of coupling our build to someone else's publish schedule.

It also **self-follows**. When the LTS pair moves to 26, the pre-check emits `26` and `node:26-alpine` is what gets pulled, with nothing in this file to edit.

## Also

`*_version_bare` existed solely to feed this tag, so it's renamed to `*_major` rather than adding a parallel pair. Deriving it moved from a one-line jq into an explicit block that:

- validates the result is numeric and **fails at the pre-check with the offending string**, rather than as a `docker pull` 404 twenty lines into a container-init log
- logs the tags it resolved (`Alpine container tags: node:24-alpine (current), node:22-alpine (prior)`)

`TECHNICAL_GUIDE` §18.2 documents the policy and why, next to the two existing platform-gap notes.

## Verification

`jq` isn't available locally, so rather than assume: workflow YAML parses, the precheck outputs and container expression resolve as intended, and the numeric guard was exercised both ways (accepts `24`/`22`, rejects empty and `v24`). Against today's real pre-check output — current `v24.20.0`, prior `v22.23.2` — it yields `node:24-alpine` and `node:22-alpine`, both of which exist on Docker Hub.

The workflow itself can't be exercised by a PR; the proof is a `workflow_dispatch -f force=true` after merge, which should also publish the darwin tarballs and auto-close #530.

`release:none` — CI-only.
