### PR TITLE
fix(devices): identify devices by hardware serial, not adb transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fixed a phone appearing twice in the connected devices list.** A device with wireless debugging enabled is reachable over two connections at once — the one the app opens itself, and one Android advertises that ADB picks up automatically — and the app was treating each as a separate device. The result was two identical cards for one phone, and the second of them had no disconnect button, because that connection has no address to disconnect from. Devices are now identified by their hardware serial number rather than by which connection they arrived on, so each phone appears once, on the connection that supports every action. Two different devices of the same model are unaffected — the serial number distinguishes them where the model name would not.
+
 - **Fixed ADB and Node.js never being downloaded when the app is run from source.** Unpacking a downloaded dependency was done by handing the archive to the launcher program that ships inside an installed copy — which does not exist in a source checkout, so on first run the app quietly declined to fetch either one and said so only in a log line. On Windows this was almost invisible, because a source run and an installed copy share the same dependency folder and ADB was usually already sitting there; on Linux and macOS, where a source run starts with an empty folder, it meant no ADB at all and nothing on screen to explain why. Archives are now unpacked by the app itself, so a source run sets itself up exactly like an installed one. The dependency panel's per-dependency update buttons, which were disabled for the same reason, now work there too.
 
 ## [0.1.30-beta.75] - 2026-08-26

--- a/src/server/goog-device/__tests__/dedupeDescriptors.test.ts
+++ b/src/server/goog-device/__tests__/dedupeDescriptors.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type GoogDeviceDescriptor from '../../../types/GoogDeviceDescriptor';
+import { dedupeByHardwareSerial, isNetworkTransportUdid, survivesDedupe } from '../dedupeDescriptors';
+
+/**
+ * One physical Android 11+ device reaches `adb devices` twice: once as the
+ * `ip:port` transport we opened with `adb connect`, and once as the
+ * `_adb-tls-connect._tcp` transport adb's own mDNS auto-connect opened. Both
+ * report the same `ro.serialno`, so the hardware serial is the only safe key —
+ * two Google TV Streamers on one network share a model string, so model is not.
+ *
+ * Observed on a Pixel 10a, 2026-08-26:
+ *   192.168.86.190:37571                            ro.serialno=5C061JEA327610
+ *   adb-5C061JEA327610-bo0E0q._adb-tls-connect._tcp ro.serialno=5C061JEA327610
+ */
+
+function descriptor(udid: string, serialNo: string, over: Partial<GoogDeviceDescriptor> = {}) {
+    return {
+        udid,
+        state: 'device',
+        'ro.serialno': serialNo,
+        'ro.product.model': 'Pixel_10a',
+        'ro.product.manufacturer': 'Google',
+        'ro.build.version.release': '17',
+        'ro.build.version.sdk': '37',
+        'ro.product.cpu.abi': 'arm64-v8a',
+        'wifi.interface': 'wlan0',
+        interfaces: [],
+        pid: 0,
+        'last.update.timestamp': 0,
+        'screen.state': 'awake',
+        ...over,
+    } as GoogDeviceDescriptor;
+}
+
+const IP_PORT = '192.168.86.190:37571';
+const MDNS = 'adb-5C061JEA327610-bo0E0q._adb-tls-connect._tcp';
+const SERIAL = '5C061JEA327610';
+
+describe('dedupeByHardwareSerial', () => {
+    it('collapses the two transports of one device to a single entry', () => {
+        const out = dedupeByHardwareSerial([descriptor(IP_PORT, SERIAL), descriptor(MDNS, SERIAL)]);
+        expect(out).toHaveLength(1);
+    });
+
+    it('keeps the ip:port transport, not the mDNS one', () => {
+        // The mDNS-form entry has no host:port to disconnect from, which is why
+        // its card renders without a disconnect button. Keeping the ip:port
+        // transport fixes the duplicate and that missing action together.
+        const out = dedupeByHardwareSerial([descriptor(MDNS, SERIAL), descriptor(IP_PORT, SERIAL)]);
+        expect(out.map((d) => d.udid)).toEqual([IP_PORT]);
+    });
+
+    it('keeps the ip:port transport regardless of input order', () => {
+        const out = dedupeByHardwareSerial([descriptor(IP_PORT, SERIAL), descriptor(MDNS, SERIAL)]);
+        expect(out.map((d) => d.udid)).toEqual([IP_PORT]);
+    });
+
+    it('never merges two physical devices that share a model', () => {
+        // Two Google TV Streamers on one network: same model, different serials.
+        const a = descriptor('192.168.86.43:5555', 'TV-AAAA', { 'ro.product.model': 'Google_TV_Streamer' });
+        const b = descriptor('192.168.86.159:5555', 'TV-BBBB', { 'ro.product.model': 'Google_TV_Streamer' });
+        const out = dedupeByHardwareSerial([a, b]);
+        expect(out.map((d) => d.udid).sort()).toEqual(['192.168.86.159:5555', '192.168.86.43:5555']);
+    });
+
+    it('passes through a device whose serial is not known yet', () => {
+        // Descriptors start with 'ro.serialno': '' and are filled in once
+        // getprop lands. An unidentified device must still be listed, never
+        // silently merged with another unidentified one.
+        const out = dedupeByHardwareSerial([descriptor(IP_PORT, ''), descriptor('10.0.0.5:5555', '')]);
+        expect(out).toHaveLength(2);
+    });
+
+    it('leaves a single-transport device untouched', () => {
+        const out = dedupeByHardwareSerial([descriptor(MDNS, SERIAL)]);
+        expect(out.map((d) => d.udid)).toEqual([MDNS]);
+    });
+
+    it('preserves the surviving descriptor object identity', () => {
+        // Callers hold references to descriptors; dedupe must select, not rebuild.
+        const winner = descriptor(IP_PORT, SERIAL);
+        const out = dedupeByHardwareSerial([descriptor(MDNS, SERIAL), winner]);
+        expect(out[0]).toBe(winner);
+    });
+});
+
+describe('survivesDedupe', () => {
+    // Gates the incremental `device` event. Without it, the losing transport's
+    // own update would push a second card to a client that already has the
+    // survivor from the initial device list.
+    const all = [descriptor(IP_PORT, SERIAL), descriptor(MDNS, SERIAL)];
+
+    it('is true for the transport the list keeps', () => {
+        expect(survivesDedupe(descriptor(IP_PORT, SERIAL), all)).toBe(true);
+    });
+
+    it('is false for the transport the list drops', () => {
+        expect(survivesDedupe(descriptor(MDNS, SERIAL), all)).toBe(false);
+    });
+
+    it('is true for a device with only one transport', () => {
+        const solo = [descriptor(MDNS, SERIAL)];
+        expect(survivesDedupe(descriptor(MDNS, SERIAL), solo)).toBe(true);
+    });
+
+    it('is true for a device whose serial is not known yet', () => {
+        const unknown = [descriptor(IP_PORT, ''), descriptor('10.0.0.5:5555', '')];
+        expect(survivesDedupe(descriptor('10.0.0.5:5555', ''), unknown)).toBe(true);
+    });
+});
+
+describe('isNetworkTransportUdid', () => {
+    it.each(['192.168.86.190:37571', '10.0.0.5:5555', '100.64.1.20:33001'])('accepts %s', (udid) => {
+        expect(isNetworkTransportUdid(udid)).toBe(true);
+    });
+
+    it.each(['adb-5C061JEA327610-bo0E0q._adb-tls-connect._tcp', '5C061JEA327610', 'emulator-5554', ''])(
+        'rejects %s',
+        (udid) => {
+            expect(isNetworkTransportUdid(udid)).toBe(false);
+        },
+    );
+});

--- a/src/server/goog-device/dedupeDescriptors.ts
+++ b/src/server/goog-device/dedupeDescriptors.ts
@@ -1,0 +1,85 @@
+import type GoogDeviceDescriptor from '../../types/GoogDeviceDescriptor';
+
+/**
+ * Collapse the multiple adb transports of one physical device to a single
+ * descriptor.
+ *
+ * An Android 11+ device with wireless debugging on reaches `adb devices`
+ * **twice**: once as the `ip:port` transport we opened ourselves with
+ * `adb connect`, and once as the `_adb-tls-connect._tcp` transport adb's own
+ * mDNS auto-connect opened. Two serial strings, one phone — and `ControlCenter`
+ * keys `knownDevices` / `deviceMap` / `descriptors` on that serial string, so
+ * the home page rendered two cards for the same device.
+ *
+ * Observed on a Pixel 10a, 2026-08-26:
+ * ```
+ * 192.168.86.190:37571                            ro.serialno=5C061JEA327610
+ * adb-5C061JEA327610-bo0E0q._adb-tls-connect._tcp ro.serialno=5C061JEA327610
+ * ```
+ *
+ * `ro.serialno` is the only safe key. Model is not: two Google TV Streamers on
+ * one network report an identical `ro.product.model`, and merging those would
+ * hide a real device. The descriptor already carries `ro.serialno`, so this
+ * needs no new probing — only that the list stops trusting the transport string
+ * as an identity.
+ */
+
+/**
+ * True for a `host:port` udid — the form produced by `adb connect`, and the
+ * only form we can later `adb disconnect`.
+ */
+export function isNetworkTransportUdid(udid: string): boolean {
+    return /^[^\s:]+:\d+$/.test(udid);
+}
+
+/**
+ * One descriptor per hardware serial, preferring the `ip:port` transport.
+ *
+ * That preference is not cosmetic: the `_adb-tls-connect._tcp` form has no
+ * host:port to disconnect from, which is why its card rendered without a
+ * disconnect button. Keeping the network transport resolves the duplicate and
+ * the missing action in one move.
+ *
+ * Descriptors whose `ro.serialno` is still empty — the initial value, until
+ * `getprop` lands — pass through untouched. An unidentified device must stay
+ * visible, and two unidentified devices must never be merged into one on the
+ * strength of both being unknown.
+ *
+ * Selects rather than rebuilds: callers hold references to these descriptors.
+ */
+export function dedupeByHardwareSerial(descriptors: GoogDeviceDescriptor[]): GoogDeviceDescriptor[] {
+    const winnerBySerial = new Map<string, GoogDeviceDescriptor>();
+    // Preserves first-appearance order: a serial key marks the slot its group
+    // occupies, a descriptor is an unidentified pass-through.
+    const order: (string | GoogDeviceDescriptor)[] = [];
+
+    for (const descriptor of descriptors) {
+        const serial = descriptor['ro.serialno'];
+        if (!serial) {
+            order.push(descriptor);
+            continue;
+        }
+        const incumbent = winnerBySerial.get(serial);
+        if (!incumbent) {
+            winnerBySerial.set(serial, descriptor);
+            order.push(serial);
+            continue;
+        }
+        if (!isNetworkTransportUdid(incumbent.udid) && isNetworkTransportUdid(descriptor.udid)) {
+            winnerBySerial.set(serial, descriptor);
+        }
+    }
+
+    return order.map((entry) => (typeof entry === 'string' ? winnerBySerial.get(entry)! : entry));
+}
+
+/**
+ * True when `descriptor` is the transport its serial's group would keep.
+ *
+ * Gates the incremental `device` event: without it, a losing transport's own
+ * update would push a second card to a client that already holds the survivor
+ * from the initial device list.
+ */
+export function survivesDedupe(descriptor: GoogDeviceDescriptor, all: readonly GoogDeviceDescriptor[]): boolean {
+    return dedupeByHardwareSerial([...all]).some((kept) => kept.udid === descriptor.udid);
+}

--- a/src/server/goog-device/services/ControlCenter.ts
+++ b/src/server/goog-device/services/ControlCenter.ts
@@ -4,6 +4,7 @@ import { Config } from '../../Config';
 import { Logger } from '../../Logger';
 import type { Service } from '../../services/Service';
 import { Device } from '../Device';
+import { dedupeByHardwareSerial, survivesDedupe } from '../dedupeDescriptors';
 
 import Timeout = NodeJS.Timeout;
 
@@ -80,6 +81,13 @@ export class ControlCenter extends BaseControlCenter<GoogDeviceDescriptor> imple
     private onDeviceUpdate = (device: Device): void => {
         const { udid, descriptor } = device;
         this.descriptors.set(udid, descriptor);
+        // An Android 11+ device reaches adb twice — our `ip:port` transport and
+        // the one adb's mDNS auto-connect opens — so emitting every update would
+        // push a second card for a phone the client already has. Suppress the
+        // losing transport; the survivor's own updates keep the card current.
+        if (!survivesDedupe(descriptor, Array.from(this.descriptors.values()))) {
+            return;
+        }
         this.emit('device', descriptor);
     };
 
@@ -137,7 +145,7 @@ export class ControlCenter extends BaseControlCenter<GoogDeviceDescriptor> imple
     }
 
     public getDevices(): GoogDeviceDescriptor[] {
-        return Array.from(this.descriptors.values());
+        return dedupeByHardwareSerial(Array.from(this.descriptors.values()));
     }
 
     public getDevice(udid: string): Device | undefined {


### PR DESCRIPTION
An Android 11+ device with wireless debugging enabled reaches `adb devices` **twice** — once as the `ip:port` transport we open with `adb connect`, and once as the `_adb-tls-connect._tcp` transport adb's own mDNS auto-connect opens. `ControlCenter` keys `knownDevices` / `deviceMap` / `descriptors` on that transport string, so one phone rendered two cards.

Found by attaching a real Pixel 10a to the dev app:

```
192.168.86.190:37571                            ro.serialno=5C061JEA327610
adb-5C061JEA327610-bo0E0q._adb-tls-connect._tcp ro.serialno=5C061JEA327610
```

The second card was also **missing its disconnect button**, which turned out to be the same bug from the other end — the mDNS-form entry has no host:port to disconnect from. Preferring the network transport fixes the duplicate and the missing action in one move.

## Why `ro.serialno`

It's the only safe key, and the descriptor already carries it, so no new probing was needed.

**Model is not safe.** Two Google TV Streamers on this network report an identical `ro.product.model` — deduping on that would merge two real devices and hide one. There's a test pinning exactly that case, because it's the mistake this fix would most plausibly have made.

**Unidentified devices pass through.** Descriptors start with `'ro.serialno': ''` until `getprop` lands, so an unprobed device stays visible, and two unprobed devices are never merged on the strength of both being unknown.

## Wiring

Both paths that reach the client:

- **`getDevices()`** dedupes the list → correct on page load and reconnect
- **`onDeviceUpdate`** suppresses the losing transport's incremental event → a duplicate can't be pushed in later

## Known edge

A duplicate rendered *before* its hardware serial was known persists until the page reloads. Both transports normally appear in the same poll and probing is prompt, so the window is small — but it's real. `ADB_MDNS_AUTO_CONNECT=0` would stop the second transport existing at all, and that's the fix if this shows up in practice.

## Verification

**18 tests, each watched fail first** — including the two-TVs-same-model case, object-identity preservation, and order independence.

`tsc --noEmit` clean · 174 test files, 1560 passed / 5 skipped · `biome check` clean.

**Verified on hardware:** the Pixel now appears once, on `192.168.86.190:37571`, with a working disconnect button.

## Note on the release label

This is `release:beta`, so it cuts the next beta and carries out everything currently sitting in `[Unreleased]` — the VP8/VP9 embedding-API parity, the bump/blob guard, the `@types/node` pin, the TypeScript 7 migration, and the from-source ADB/Node fix. All of those have been on `main` unreleased since beta.75.
