### PR TITLE
fix(player): honour a browser that cannot decode H.264, and report a mute decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed a black screen on machines whose browser cannot actually decode H.264.** The app treated H.264 as supported everywhere and never asked the browser about it — a deliberate workaround, because Firefox sometimes reports that it cannot play a specific H.264 variant that it in fact plays fine. On a machine with no H.264 decoder at all, though, that workaround overrode an accurate refusal: H.264 was selected automatically, handed to a decoder that produced nothing, and the stream appeared as a black rectangle with no error anywhere to explain it. The app now asks about several H.264 variants and only accepts the answer when every one of them is refused, so a machine that genuinely cannot decode H.264 falls through to a codec it can play instead. Firefox on Windows is where this shows up, because it asks the operating system to decode H.264 while carrying its own AV1 decoder — which is why AV1 kept working when nothing else would.
+
+- **A stream that never produces a picture now says so.** A video decoder that starts up cleanly, accepts every frame sent to it and then emits nothing used to leave a black screen and a silent console, indistinguishable from a slow connection. The app now reports the stall, names the codec involved, and points at the things worth trying — a different codec, or a Chromium-based browser.
+
 ## [0.1.30-beta.76] - 2026-08-26
 
 ### Added

--- a/src/app/googDevice/client/ConfigureScrcpy.ts
+++ b/src/app/googDevice/client/ConfigureScrcpy.ts
@@ -14,7 +14,7 @@ import { DeviceProbeClient } from '../../client/DeviceProbeClient';
 import { settingsService } from '../../client/SettingsService';
 import { DisplayInfo } from '../../DisplayInfo';
 import type { PlayerClass } from '../../player/BasePlayer';
-import { WEBCODECS_CODEC_STRING } from '../../player/webCodecsConfig';
+import { CODEC_PROBE_STRINGS, probeDecodeSupport } from '../../player/webCodecsConfig';
 import Size from '../../Size';
 import Util from '../../Util';
 import { Modal } from '../../ui/Modal';
@@ -267,32 +267,18 @@ export class ConfigureScrcpy extends Modal {
     }
 
     private async filterSupportedCodecs(codecs: string[]): Promise<string[]> {
-        if (typeof VideoDecoder === 'undefined' || typeof VideoDecoder.isConfigSupported !== 'function') {
-            return codecs;
-        }
         const supported: string[] = [];
         for (const codec of codecs) {
-            // H.264 is universally supported — skip the check (Firefox isConfigSupported
-            // returns false for some H.264 profile strings despite decoding fine)
-            if (codec === 'h264') {
-                supported.push(codec);
+            // Only a definite `false` drops a codec from the list. An
+            // unanswerable probe leaves it on offer rather than hiding
+            // something that might work — but a real "no" is now honoured for
+            // H.264 too, which it previously was not. See issue #498.
+            if ((await probeDecodeSupport(codec)) === false) {
+                const tried = CODEC_PROBE_STRINGS[codec]?.join(', ') ?? codec;
+                console.log(this.TAG, `Browser does not support decoding ${codec} (tried ${tried})`);
                 continue;
             }
-            const webCodecStr = WEBCODECS_CODEC_STRING[codec];
-            if (!webCodecStr) {
-                supported.push(codec);
-                continue;
-            }
-            try {
-                const result = await VideoDecoder.isConfigSupported({ codec: webCodecStr });
-                if (result.supported) {
-                    supported.push(codec);
-                } else {
-                    console.log(this.TAG, `Browser does not support decoding ${codec} (${webCodecStr})`);
-                }
-            } catch {
-                console.log(this.TAG, `Browser does not support decoding ${codec} (${webCodecStr})`);
-            }
+            supported.push(codec);
         }
         return supported.length > 0 ? supported : codecs;
     }

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -18,6 +18,7 @@ import {
 } from '../../interactionHandler/FeaturedInteractionHandler';
 import { BasePlayer, type PlayerClass } from '../../player/BasePlayer';
 import type { WebCodecsPlayer } from '../../player/WebCodecsPlayer';
+import { probeDecodeSupport } from '../../player/webCodecsConfig';
 import { ScrcpyDemuxer, type SessionMetadata } from '../../ScrcpyDemuxer';
 import Size from '../../Size';
 import Util from '../../Util';
@@ -44,12 +45,6 @@ type StartParams = {
 
 const TAG = '[StreamClientScrcpy]';
 
-const CODEC_WEBCODEC_MAP: Record<string, string> = {
-    h264: 'avc1.42E01E',
-    h265: 'hev1.1.6.L93.B0',
-    av1: 'av01.0.04M.08',
-};
-
 // Maps codec names to patterns that identify them in encoder names
 const CODEC_ENCODER_PATTERN: Record<string, string> = {
     h264: '.avc.',
@@ -61,20 +56,12 @@ const CODEC_ENCODER_PATTERN: Record<string, string> = {
 const HW_ENCODER_RE = /\.mtk\.|\.qcom\.|\.exynos\.|\.intel\.|\.nvidia\./i;
 
 async function browserSupportsCodec(codec: string): Promise<boolean> {
-    // H.264 is universally supported — skip the check (Firefox isConfigSupported
-    // returns false for some H.264 profile strings despite decoding fine)
-    if (codec === 'h264') return true;
-    if (typeof VideoDecoder === 'undefined' || typeof VideoDecoder.isConfigSupported !== 'function') {
-        return false;
-    }
-    const webCodecStr = CODEC_WEBCODEC_MAP[codec];
-    if (!webCodecStr) return false;
-    try {
-        const result = await VideoDecoder.isConfigSupported({ codec: webCodecStr });
-        return !!result.supported;
-    } catch {
-        return false;
-    }
+    // An unanswerable probe (no WebCodecs API) resolves to false so the caller
+    // exhausts its preference loop and falls through to its plain h264 default,
+    // rather than committing to a codec we have even less reason to believe in.
+    // A definite `false` is honoured for every codec, H.264 included — see
+    // probeDecodeSupport and issue #498.
+    return (await probeDecodeSupport(codec)) ?? false;
 }
 
 async function detectBestCodecAndEncoder(

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -82,6 +82,13 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     private metadataWidth = 0;
     private metadataHeight = 0;
     private loggedFrameSize = false;
+    /**
+     * Grace period between configuring the decoder and the first frame landing.
+     * Generous on purpose: this only has to beat "the user gives up", and a
+     * cold hardware decoder plus a wait for the first keyframe can take a while.
+     */
+    private static readonly DECODE_WATCHDOG_MS = 5000;
+    private decodeWatchdog: ReturnType<typeof setTimeout> | undefined;
 
     constructor(udid: string, displayInfo?: DisplayInfo, name = WebCodecsPlayer.playerFullName) {
         super(udid, displayInfo, name, WebCodecsPlayer.storageKeyPrefix);
@@ -96,6 +103,8 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     private createDecoder(): VideoDecoder {
         return new VideoDecoder({
             output: (frame) => {
+                // Frames are flowing; whatever the watchdog was waiting for happened.
+                this.clearDecodeWatchdog();
                 if (!this.loggedFrameSize) {
                     console.log(
                         `[WebCodecsPlayer] First decoded frame: display=${frame.displayWidth}x${frame.displayHeight} coded=${frame.codedWidth}x${frame.codedHeight} canvas=${this.tag.width}x${this.tag.height}`,
@@ -109,6 +118,37 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
                 this.stop();
             },
         });
+    }
+
+    /**
+     * Watch for a decoder that configures cleanly, accepts every chunk, and
+     * then never emits a frame.
+     *
+     * The `error` callback covers decoders that fault. This covers the silent
+     * shape: on a browser that reports support it does not actually have — or
+     * delegates to an OS decoder that isn't installed — `configure()` and
+     * `decode()` both succeed and nothing ever comes out, leaving a black
+     * canvas and an empty console. That cost issue #498 three round trips to
+     * identify, so it now says so out loud.
+     */
+    private armDecodeWatchdog(codec: string): void {
+        this.clearDecodeWatchdog();
+        this.decodeWatchdog = setTimeout(() => {
+            this.decodeWatchdog = undefined;
+            console.error(
+                `[WebCodecsPlayer] ${codec}: decoder configured but produced no frames after ` +
+                    `${WebCodecsPlayer.DECODE_WATCHDOG_MS}ms. Video is arriving but this browser is not ` +
+                    'decoding it — try a different video codec, or a Chromium-based browser. Firefox on ' +
+                    'Windows relies on the operating system to decode H.264 and cannot decode H.265 at all.',
+            );
+        }, WebCodecsPlayer.DECODE_WATCHDOG_MS);
+    }
+
+    private clearDecodeWatchdog(): void {
+        if (this.decodeWatchdog !== undefined) {
+            clearTimeout(this.decodeWatchdog);
+            this.decodeWatchdog = undefined;
+        }
     }
 
     /**
@@ -153,6 +193,7 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
                         configData: data,
                     }),
                 );
+                this.armDecodeWatchdog(this.detectedCodec ?? result.codec);
             }
             this.configData = new Uint8Array(data);
             return;
@@ -304,6 +345,7 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
                 configData: new Uint8Array(0),
             }),
         );
+        this.armDecodeWatchdog(codec);
     }
 
     protected scaleCanvas(width: number, height: number): void {
@@ -377,6 +419,7 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
 
     public override stop(): void {
         super.stop();
+        this.clearDecodeWatchdog();
         if (this.decoder.state === 'configured') {
             this.decoder.close();
         }

--- a/src/app/player/__tests__/decodeSupportProbe.test.ts
+++ b/src/app/player/__tests__/decodeSupportProbe.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CODEC_PROBE_STRINGS, probeDecodeSupport } from '../webCodecsConfig';
+
+/**
+ * Guard for issue #498: the app used to hardcode H.264 as supported and never
+ * ask the browser at all —
+ *
+ *     if (codec === 'h264') return true;
+ *
+ * That was written to dodge Firefox answering a definite `false` for individual
+ * H.264 profile strings it can in fact decode. But it also overrode the honest
+ * `false` from a machine with no H.264 decoder at all (Windows N without the
+ * Media Feature Pack, for one), so the app auto-selected h264, handed it to a
+ * decoder that produced nothing, and rendered a black screen with no error.
+ *
+ * The rule these tests pin down: a definite `false` is authoritative, a throw
+ * is not an answer, and probing several profile strings absorbs the Firefox
+ * pessimism the original workaround was reaching for.
+ */
+
+type ProbeResult = { supported: boolean };
+
+function stubVideoDecoder(impl: (codec: string) => Promise<ProbeResult>): void {
+    vi.stubGlobal('VideoDecoder', {
+        isConfigSupported: (config: { codec: string }) => impl(config.codec),
+    });
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('probeDecodeSupport', () => {
+    it('reports supported when the only candidate says yes', async () => {
+        stubVideoDecoder(async () => ({ supported: true }));
+        await expect(probeDecodeSupport('av1')).resolves.toBe(true);
+    });
+
+    it('reports UNSUPPORTED when every H.264 candidate gives a definite no', async () => {
+        // A box with no H.264 decoder. The old code returned true here and
+        // produced the black screen in issue #498.
+        stubVideoDecoder(async () => ({ supported: false }));
+        await expect(probeDecodeSupport('h264')).resolves.toBe(false);
+    });
+
+    it('reports supported when only a later H.264 candidate says yes', async () => {
+        // The Firefox case the original workaround existed for: pessimistic
+        // about baseline, fine with high. One yes is enough.
+        stubVideoDecoder(async (codec) => ({ supported: codec === 'avc1.640028' }));
+        await expect(probeDecodeSupport('h264')).resolves.toBe(true);
+    });
+
+    it('tries every H.264 candidate before concluding no', async () => {
+        const seen: string[] = [];
+        stubVideoDecoder(async (codec) => {
+            seen.push(codec);
+            return { supported: false };
+        });
+        await probeDecodeSupport('h264');
+        expect(seen).toEqual([...CODEC_PROBE_STRINGS['h264']!]);
+        expect(seen.length).toBeGreaterThan(1);
+    });
+
+    it('returns undefined — not false — when every candidate throws', async () => {
+        // A refusal to answer is not a "no". Callers decide what to assume.
+        stubVideoDecoder(async () => {
+            throw new TypeError('Unsupported configuration');
+        });
+        await expect(probeDecodeSupport('h264')).resolves.toBeUndefined();
+    });
+
+    it('still reports supported when one candidate throws and another says yes', async () => {
+        stubVideoDecoder(async (codec) => {
+            if (codec === 'avc1.42E01E') throw new TypeError('malformed');
+            return { supported: true };
+        });
+        await expect(probeDecodeSupport('h264')).resolves.toBe(true);
+    });
+
+    it('returns undefined when the WebCodecs API is absent', async () => {
+        vi.stubGlobal('VideoDecoder', undefined);
+        await expect(probeDecodeSupport('h264')).resolves.toBeUndefined();
+    });
+
+    it('returns undefined when isConfigSupported is missing', async () => {
+        vi.stubGlobal('VideoDecoder', {});
+        await expect(probeDecodeSupport('h264')).resolves.toBeUndefined();
+    });
+
+    it('returns undefined for a codec it has no probe strings for', async () => {
+        stubVideoDecoder(async () => ({ supported: true }));
+        await expect(probeDecodeSupport('theora')).resolves.toBeUndefined();
+    });
+
+    it('covers every streamable codec with at least one probe string', () => {
+        for (const codec of ['h264', 'h265', 'av1', 'vp8', 'vp9']) {
+            expect(CODEC_PROBE_STRINGS[codec]?.length ?? 0).toBeGreaterThan(0);
+        }
+    });
+});

--- a/src/app/player/__tests__/webCodecsPlayerWatchdog.test.ts
+++ b/src/app/player/__tests__/webCodecsPlayerWatchdog.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Guard for issue #498: a decoder that configures cleanly, accepts every chunk,
+ * and then never emits a frame used to fail completely silently — no error
+ * callback, no console output, just a black canvas forever. That shape cost
+ * three round trips with a reporter to identify.
+ *
+ * The `error` callback already covers decoders that fault. These tests cover
+ * the other shape: configured, fed, and mute.
+ */
+
+type DecoderInit = {
+    output: (frame: unknown) => void;
+    error: (error: unknown) => void;
+};
+
+let capturedInit: DecoderInit | undefined;
+
+class FakeVideoDecoder {
+    public state = 'unconfigured';
+    constructor(init: DecoderInit) {
+        capturedInit = init;
+    }
+    configure() {
+        this.state = 'configured';
+    }
+    decode() {
+        /* accepts everything, emits nothing */
+    }
+    flush() {
+        return Promise.resolve();
+    }
+    close() {
+        this.state = 'closed';
+    }
+    static isConfigSupported() {
+        return Promise.resolve({ supported: true });
+    }
+}
+
+class FakeEncodedVideoChunk {
+    public type: string;
+    public timestamp: number;
+    public data: Uint8Array;
+    constructor(init: { type: string; timestamp: number; data: Uint8Array }) {
+        this.type = init.type;
+        this.timestamp = init.timestamp;
+        this.data = new Uint8Array(init.data);
+    }
+}
+
+// Minimal H.264 config frame (SPS NAL type 7 after the 00 00 00 01 start code).
+const H264_CONFIG = new Uint8Array([
+    0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1e, 0x8c, 0x8d, 0x40, 0xa0, 0x2f, 0xf9, 0x70, 0x11, 0x00, 0x00, 0x00, 1, 0x68, 0xce,
+    0x3c, 0x80,
+]);
+
+const WELL_PAST_THE_DEADLINE_MS = 30_000;
+
+function fakeFrame() {
+    return { displayWidth: 1280, displayHeight: 720, codedWidth: 1280, codedHeight: 720, close: vi.fn() };
+}
+
+describe('WebCodecsPlayer decode watchdog (issue #498)', () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        capturedInit = undefined;
+        vi.stubGlobal('VideoDecoder', FakeVideoDecoder);
+        vi.stubGlobal('EncodedVideoChunk', FakeEncodedVideoChunk);
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+            drawImage: vi.fn(),
+            clearRect: vi.fn(),
+            fillRect: vi.fn(),
+            measureText: () => ({ actualBoundingBoxLeft: 0, actualBoundingBoxRight: 0 }),
+            fillText: vi.fn(),
+            save: vi.fn(),
+            restore: vi.fn(),
+        } as unknown as CanvasRenderingContext2D);
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    function watchdogMessages(): string[] {
+        return errorSpy.mock.calls
+            .map((args: unknown[]) => args.map(String).join(' '))
+            .filter((message: string) => message.includes('no frames'));
+    }
+
+    it('reports a decoder that configures but never produces a frame', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-watchdog-1');
+        player.setMetadataSize(1280, 720);
+
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        expect(watchdogMessages()).toHaveLength(0);
+
+        vi.advanceTimersByTime(WELL_PAST_THE_DEADLINE_MS);
+
+        const messages = watchdogMessages();
+        expect(messages).toHaveLength(1);
+        // The message has to be actionable, not just "something went wrong".
+        expect(messages[0]).toMatch(/h264/i);
+        expect(messages[0]).toMatch(/codec|browser/i);
+    });
+
+    it('stays quiet when a frame arrives before the deadline', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-watchdog-2');
+        player.setMetadataSize(1280, 720);
+
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        capturedInit?.output(fakeFrame());
+
+        vi.advanceTimersByTime(WELL_PAST_THE_DEADLINE_MS);
+        expect(watchdogMessages()).toHaveLength(0);
+    });
+
+    it('stays quiet when the stream is stopped before the deadline', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-watchdog-3');
+        player.setMetadataSize(1280, 720);
+
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        player.stop();
+
+        vi.advanceTimersByTime(WELL_PAST_THE_DEADLINE_MS);
+        expect(watchdogMessages()).toHaveLength(0);
+    });
+
+    it('reports once, not once per config frame', async () => {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-watchdog-4');
+        player.setMetadataSize(1280, 720);
+
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+
+        vi.advanceTimersByTime(WELL_PAST_THE_DEADLINE_MS);
+        expect(watchdogMessages()).toHaveLength(1);
+    });
+});

--- a/src/app/player/webCodecsConfig.ts
+++ b/src/app/player/webCodecsConfig.ts
@@ -33,6 +33,56 @@ export const WEBCODECS_CODEC_STRING: Record<string, string> = {
 };
 
 /**
+ * Candidate codec strings to probe for support, per scrcpy codec name.
+ *
+ * H.264 carries three profiles because Firefox answers a definite `false` for
+ * individual profile strings it can in fact decode; probing baseline alone
+ * under-reports. Any one candidate reporting `supported` proves the codec is
+ * usable, so the list only has to contain something the browser will admit to.
+ */
+export const CODEC_PROBE_STRINGS: Record<string, readonly string[]> = {
+    h264: ['avc1.42E01E', 'avc1.4D401E', 'avc1.640028'],
+    h265: ['hev1.1.6.L93.B0'],
+    av1: ['av01.0.04M.08'],
+    vp8: ['vp8'],
+    vp9: ['vp09.00.10.08'],
+};
+
+/**
+ * Ask the browser whether it can decode `codec`.
+ *
+ * `true` / `false` are real answers from `VideoDecoder.isConfigSupported()`.
+ * `undefined` means no answer was obtainable — WebCodecs is missing, or every
+ * candidate string threw — and the caller decides what to assume, because the
+ * two call sites want different fallbacks.
+ *
+ * A definite `false` is authoritative and must never be overridden. Both call
+ * sites used to special-case H.264 to "supported" without asking, which meant a
+ * machine with no H.264 decoder at all (Windows N lacking the Media Feature
+ * Pack, for instance) still got h264 auto-selected, fed to a decoder that
+ * emitted nothing, and shown a black screen with no error. See issue #498.
+ */
+export async function probeDecodeSupport(codec: string): Promise<boolean | undefined> {
+    const candidates = CODEC_PROBE_STRINGS[codec];
+    if (!candidates || candidates.length === 0) return undefined;
+    if (typeof VideoDecoder === 'undefined' || typeof VideoDecoder.isConfigSupported !== 'function') {
+        return undefined;
+    }
+    let answered = false;
+    for (const codecString of candidates) {
+        try {
+            const result = await VideoDecoder.isConfigSupported({ codec: codecString });
+            answered = true;
+            if (result.supported) return true;
+        } catch {
+            // A throw is a refusal to answer (malformed string, unimplemented
+            // path), not a "no" — keep asking about the remaining candidates.
+        }
+    }
+    return answered ? false : undefined;
+}
+
+/**
  * Codecs that never produce a config packet.
  *
  * scrcpy sets its config flag straight from MediaCodec's


### PR DESCRIPTION
Fixes the black screen reported in #498, and makes the next one like it diagnose itself.

## What was wrong

Both codec-support checks — `browserSupportsCodec` in `StreamClientScrcpy.ts` and `filterSupportedCodecs` in `ConfigureScrcpy.ts` — special-cased H.264 to "supported" without asking the browser at all:

```js
// H.264 is universally supported — skip the check (Firefox isConfigSupported
// returns false for some H.264 profile strings despite decoding fine)
if (codec === 'h264') return true;
```

The reasoning was sound — Firefox does report a definite `false` for individual H.264 profile strings it plays perfectly well — but the remedy couldn't tell that case apart from a machine that genuinely has no H.264 decoder. On such a machine the browser answers honestly, we override it, auto-detection picks H.264 because it's second in the preference order, and the decoder accepts every chunk while emitting nothing. Black canvas, empty console, nothing to go on.

Firefox on Windows is where this surfaces: it delegates H.264 to the operating system while bundling its own AV1 decoder. That's exactly the reporter's symptom matrix — AV1 fine, H.264 black, H.265 correctly declined.

## What changed

**One shared probe replaces both copies.** `probeDecodeSupport()` in `webCodecsConfig.ts` tries several profile strings per codec and returns a tri-state:

- `true` — some candidate is supported
- `false` — every candidate gave a definite no
- `undefined` — no answer obtainable (WebCodecs absent, or all candidates threw)

Probing three H.264 profiles absorbs the Firefox pessimism the old workaround was reaching for, without having to lie about the answer. The tri-state exists because the two call sites want genuinely different fallbacks for "don't know": `StreamClientScrcpy` treats it as `false` so its preference loop runs out and lands on the plain h264 default, while `ConfigureScrcpy` treats it as "keep" so the dropdown doesn't hide something that might work.

**One deliberate behaviour change worth flagging:** a probe that *throws* used to exclude the codec, and now leaves it on offer. A refusal to answer isn't a no. The watchdog below covers the case where that optimism turns out to be misplaced.

**And a decode watchdog.** The decoder's `error` callback covers faults, not muteness — a decoder that configures cleanly, accepts everything and emits nothing had no path to the console at all. It now logs 5s after configure, naming the codec and what's worth trying instead. Cleared on the first decoded frame and on `stop()`.

## Testing

- `decodeSupportProbe.test.ts` — 10 cases: definite-no is honoured, a later candidate rescuing an earlier no, throws vs. definite answers, missing API, unknown codec, and that every streamable codec has at least one probe string
- `webCodecsPlayerWatchdog.test.ts` — 4 cases on fake timers: fires when mute, silent when a frame arrives, silent after `stop()`, and fires once rather than once per config frame

Full suite 1574 passed / 5 skipped, `tsc --noEmit` clean, biome clean.

One thing to note if you see it in CI: `ServiceApi.test.ts > schedules process.exit(0) after 5s` flaked once across six full-suite runs here. It passes in isolation, shares no modules with anything in this PR, and that file self-documents a `process.exit`-spy timing hazard at line 2217. Pre-existing, not from this change — but it's a real flake and probably wants its own issue.

## What this doesn't do

It doesn't give the reporter H.264 back. If their machine has no H.264 decoder, nothing here installs one — the app just stops pretending otherwise and falls through to a codec that works, instead of showing a black rectangle. Whether that's the actual cause on their box is still pending their reply on #498; this fix is correct regardless of how that lands.
