### PR TITLE
fix(codec): resolve the probe table before logging a rejected codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Tightened the codec-support check after a static-analysis finding.** The rewrite in the previous release removed a table lookup that had implicitly proven a codec name was one of a fixed set before it reached a log line, and the security scanner correctly flagged the result as an unconstrained value reaching a log format. The value was never attacker-controlled — it can only ever be one of five fixed codec names, chosen by the app rather than supplied by the device — but the check now resolves each codec against its own table first and passes the name as a separate log argument, so that guarantee is explicit instead of incidental. A dead fallback branch left over from the same rewrite is gone as well. Nothing behaves differently.
+
 ## [0.1.30-beta.77] - 2026-08-26
 
 ### Fixed

--- a/src/app/googDevice/client/ConfigureScrcpy.ts
+++ b/src/app/googDevice/client/ConfigureScrcpy.ts
@@ -269,13 +269,21 @@ export class ConfigureScrcpy extends Modal {
     private async filterSupportedCodecs(codecs: string[]): Promise<string[]> {
         const supported: string[] = [];
         for (const codec of codecs) {
+            // A codec we have no probe strings for is unanswerable by
+            // definition, so keep it on offer. Resolving the list up front also
+            // keeps everything below working from this map's own contents
+            // rather than from the caller's string.
+            const probeStrings = CODEC_PROBE_STRINGS[codec];
+            if (!probeStrings) {
+                supported.push(codec);
+                continue;
+            }
             // Only a definite `false` drops a codec from the list. An
             // unanswerable probe leaves it on offer rather than hiding
             // something that might work — but a real "no" is now honoured for
             // H.264 too, which it previously was not. See issue #498.
             if ((await probeDecodeSupport(codec)) === false) {
-                const tried = CODEC_PROBE_STRINGS[codec]?.join(', ') ?? codec;
-                console.log(this.TAG, `Browser does not support decoding ${codec} (tried ${tried})`);
+                console.log(this.TAG, 'Browser does not support decoding', codec, `(tried ${probeStrings.join(', ')})`);
                 continue;
             }
             supported.push(codec);


### PR DESCRIPTION
Closes CodeQL alert #32 — `js/tainted-format-string`, high, at `ConfigureScrcpy.ts:278`. Introduced by #535, caught on that PR and now open on `main`.

## What happened

#535 replaced this shape:

```js
const webCodecStr = WEBCODECS_CODEC_STRING[codec];
if (!webCodecStr) { supported.push(codec); continue; }
// ... later
console.log(this.TAG, `Browser does not support decoding ${codec} (${webCodecStr})`);
```

That lookup-and-bail was doing double duty nobody had noticed: it proved to the taint tracker that `codec` was a key of a hardcoded table before it reached the log. The rewrite dropped it, so the value now flows to the log unconstrained and CodeQL — correctly — stopped being able to bound it.

**Not exploitable.** `filterSupportedCodecs` has exactly one caller, fed by `detectVideoCodecs`, which only ever pushes the literals `h264` / `h265` / `av1` / `vp8` / `vp9`. The device's encoder strings decide *which* literal is pushed, never its contents. So the value is provably one of five constants — but "provable by reading three functions" isn't the same as provable by the analyser, and that's a fair thing for it to insist on.

## The fix

Resolve `CODEC_PROBE_STRINGS` up front and bail when it misses, which makes the guarantee explicit again, and pass the codec as its own `console.log` argument so it isn't in a format-string position at all. Belt and braces, since both are one line each.

It also removes a **dead branch**. The old line read:

```js
const tried = CODEC_PROBE_STRINGS[codec]?.join(', ') ?? codec;
```

That `?? codec` was unreachable. `probeDecodeSupport` returns `undefined` — not `false` — for a codec absent from `CODEC_PROBE_STRINGS`, so the `=== false` arm it sat inside never ran for one. The early bail now handles that case where it belongs, at the top of the loop.

## Testing

Full suite 1574 passed / 5 skipped, `tsc --noEmit` clean, biome clean. No behaviour change, so no new tests — the existing probe and filtering coverage from #535 still applies unchanged.

Version files deliberately untouched; the bump belongs to auto-release Mode 1.
