### PR TITLE
fix(codec): keep the UDID-bearing TAG out of the console.log format slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A diagnostic log line no longer builds its message around the device identifier.** The connection identifier a device supplies was being used as the template for one log message rather than as a value inserted into it, which a security scan flagged. A device that reported a deliberately odd identifier could have produced garbled output in the browser console — nothing more than that, since the value never leaves the console — but the message is now built from a fixed template with the identifier filled in, which is the correct shape regardless. This also completes the previous release's attempt at the same finding, which corrected the wrong value.
+
 ## [0.1.30-beta.78] - 2026-08-26
 
 ### Changed
 
-- **Tightened the codec-support check after a static-analysis finding.** The rewrite in the previous release removed a table lookup that had implicitly proven a codec name was one of a fixed set before it reached a log line, and the security scanner correctly flagged the result as an unconstrained value reaching a log format. The value was never attacker-controlled — it can only ever be one of five fixed codec names, chosen by the app rather than supplied by the device — but the check now resolves each codec against its own table first and passes the name as a separate log argument, so that guarantee is explicit instead of incidental. A dead fallback branch left over from the same rewrite is gone as well. Nothing behaves differently.
+- **Tidied the codec-support check.** The rewrite in the previous release left behind a fallback branch that could never run, and the codec name reaching the "unsupported" log line was no longer resolved against the table that defines it. Both are now handled at the top of the loop. Nothing behaves differently.
+
+  *Correction:* this entry originally described the change as resolving a static-analysis finding about the codec name. That was a misreading — the scanner was flagging the log message's device identifier, not the codec, and the finding was not resolved by this release. It is fixed in the next one.
 
 ## [0.1.30-beta.77] - 2026-08-26
 

--- a/src/app/googDevice/client/ConfigureScrcpy.ts
+++ b/src/app/googDevice/client/ConfigureScrcpy.ts
@@ -283,7 +283,17 @@ export class ConfigureScrcpy extends Modal {
             // something that might work — but a real "no" is now honoured for
             // H.264 too, which it previously was not. See issue #498.
             if ((await probeDecodeSupport(codec)) === false) {
-                console.log(this.TAG, 'Browser does not support decoding', codec, `(tried ${probeStrings.join(', ')})`);
+                // `this.TAG` embeds the device UDID, so it is externally
+                // influenced and must not occupy argument 0 — console.log
+                // treats that as the format string, which CodeQL flags as
+                // js/tainted-format-string. Keep a literal there and pass
+                // every variable through a %s substitution instead.
+                console.log(
+                    '%s Browser does not support decoding %s (tried %s)',
+                    this.TAG,
+                    codec,
+                    probeStrings.join(', '),
+                );
                 continue;
             }
             supported.push(codec);


### PR DESCRIPTION
Fixes CodeQL alert #33 — `js/tainted-format-string`, high, `ConfigureScrcpy.ts:286`. This is the second attempt at this finding; the first one misread it, so the diagnosis is worth spelling out.

## What the alert actually points at

The alert's location is line 286, **columns 29–37**. Counting along that line, those columns are `this.TAG` — not the codec name.

```js
this.TAG = `ConfigureScrcpy[${this.udid}]`;   // line 78
```

`this.udid` comes from the device descriptor, so `TAG` carries a device-supplied value. `console.log` treats argument 0 as its format string, and `TAG` was sitting in argument 0.

## Why the previous attempt failed

#537 read the finding as being about `codec` losing a map-key guard and split `codec` out into its own `console.log` argument. That made it strictly worse: **adding substitution arguments is what puts argument 0 in an active format-string role.** Alert #32 closed because its line no longer existed, and #33 immediately opened on the replacement line.

The guard and the dead-branch removal from #537 were still correct on their own merits — `probeDecodeSupport` returns `undefined` rather than `false` for a codec missing from the table, so that `?? codec` fallback genuinely could not run. They just had nothing to do with the alert. Both stay.

## The fix

```js
console.log(
    '%s Browser does not support decoding %s (tried %s)',
    this.TAG,
    codec,
    probeStrings.join(', '),
);
```

Argument 0 is a string literal, so it is untainted by construction — there's no heuristic left to misjudge, which is the point after getting it wrong once. Every variable moves to a `%s` substitution, which is what substitution is for.

## Impact

Low, and worth being accurate about rather than overstating: the value never leaves the browser console. A device reporting a UDID containing format specifiers could garble one console message. It is still the wrong shape for the code to have, and it is one line to correct.

## CHANGELOG

The beta.78 entry described the wrong root cause and implied the finding was resolved when it wasn't. This corrects that entry in place and adds a short note recording the correction, rather than quietly rewriting history.

The published beta.78 release description still carries the original wording — left alone deliberately, since published releases are immutable by project convention.

## Testing

Full suite 1574 passed / 5 skipped, `tsc --noEmit` clean, biome clean. No behaviour change, so no new tests.

**Not setting auto-merge on this one.** The last two attempts merged before I could confirm the alert was actually resolved. This should sit until CodeQL reports on the PR and alert #33 is confirmed closed.
