### PR TITLE
test(service-api): stop a real exit timer leaking between tests

### DIFF
--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -81,6 +81,34 @@ describe('ServiceApi', () => {
     };
 
     beforeEach(() => {
+        // Fake timers for EVERY test in this file, so no test can leave a real
+        // pending timer behind.
+        //
+        // `ServiceApi`'s default `scheduleExit` (constructor param 5) is
+        // `setTimeout(fn, ms).unref()` — a real 5s timer that calls
+        // `process.exit(0)`. `unref()` stops it holding the process open; it
+        // does NOT stop it firing while vitest is still working through the
+        // rest of the suite. Any test that reaches an exit-scheduling path
+        // without overriding that default leaves a live timer that fires ~5s
+        // later, inside whatever test happens to be running by then.
+        //
+        // When that landed on "schedules process.exit(0) after 5s", the foreign
+        // exit tripped its `expect(exitSpy).not.toHaveBeenCalled()` and the
+        // suite failed for reasons unrelated to the test — roughly one run in
+        // eight, and always green in isolation.
+        //
+        // Nine `POST /install` tests were doing this. Earlier attempts to fix it
+        // added `vi.useFakeTimers()` to three *uninstall* tests, which is why
+        // the comments there blamed the uninstall path — the leak was actually
+        // on install, which also calls `scheduleExit`. Doing it here covers
+        // every path at once, and pending fake timers are discarded at the end
+        // of each test rather than escaping into the next one.
+        //
+        // Safe file-wide: nothing here depends on real timer progression, and
+        // fake timers don't touch promises or microtasks, so `await` still
+        // behaves normally.
+        vi.useFakeTimers();
+
         const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-svc-api-'));
         tmpDirs.push(tmpRoot);
         const configPath = path.join(tmpRoot, 'config.json');
@@ -105,6 +133,10 @@ describe('ServiceApi', () => {
     });
 
     afterEach(() => {
+        // Discard any timer this test scheduled and hand the next one real
+        // timers to start from. See the beforeEach note.
+        vi.useRealTimers();
+
         // Capture paths that need cleanup BEFORE resetting the Config singleton.
         let uninstallMarkerPath: string | undefined;
         try {
@@ -2214,17 +2246,6 @@ describe('ServiceApi', () => {
     // ── reason discriminator + no-direct-uninstall guard (v0.1.25) ──────────
 
     it('service+LocalSystem uninstall writes marker and returns shutting-down (Phase 4 replaces handoff)', async () => {
-        // Use fake timers to prevent the hardcoded setTimeout(process.exit, 5000) in
-        // the LocalSystem uninstall path from leaking a real pending timer that fires
-        // during later tests (specifically the "schedules process.exit(0) after 5s"
-        // test that uses a global process.exit spy).
-        vi.useFakeTimers();
-        using _restoreTimers = {
-            [Symbol.dispose]() {
-                vi.useRealTimers();
-            },
-        };
-
         const uninstallSpy = vi.fn(async () => undefined);
         const client = fakeClient({
             uninstall: uninstallSpy,
@@ -2347,16 +2368,6 @@ describe('ServiceApi', () => {
 
     describe('handleUninstall — operation-server flow (Phase 4)', () => {
         it('writes uninstall-pending marker when service+LocalSystem on Windows', async () => {
-            // Use fake timers to prevent the hardcoded setTimeout(process.exit, 5000) in
-            // the LocalSystem uninstall path from leaking a real pending timer that fires
-            // during the "schedules process.exit(0) after 5s" test's global spy window.
-            vi.useFakeTimers();
-            using _restoreTimers = {
-                [Symbol.dispose]() {
-                    vi.useRealTimers();
-                },
-            };
-
             const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
             const factoryResult: ServiceClientFactoryResult = {
                 client,
@@ -2380,16 +2391,6 @@ describe('ServiceApi', () => {
         });
 
         it('returns 200 with status=shutting-down and no redirectTo', async () => {
-            // Use fake timers to prevent the hardcoded setTimeout(process.exit, 5000) in
-            // the LocalSystem uninstall path from leaking a real pending timer that fires
-            // during the "schedules process.exit(0) after 5s" test's global spy window.
-            vi.useFakeTimers();
-            using _restoreTimers = {
-                [Symbol.dispose]() {
-                    vi.useRealTimers();
-                },
-            };
-
             const client = fakeClient({ status: vi.fn(async () => 'running' as const) });
             const factoryResult: ServiceClientFactoryResult = {
                 client,


### PR DESCRIPTION
Fixes the intermittent `ServiceApi.test.ts` failure that showed up during #535 — roughly one full-suite run in eight, always green in isolation, which is what made it easy to wave away as "just a flake".

## The failure

```
FAIL src/server/__tests__/ServiceApi.test.ts > ServiceApi
     > handleUninstall — operation-server flow (Phase 4)
     > schedules process.exit(0) after 5s
```

It always failed at `expect(exitSpy).not.toHaveBeenCalled()` — the *first* assertion, before timers were advanced. The spy had already been called. So the test wasn't wrong about its own behaviour; something else was calling `process.exit` inside its spy window.

## Root cause

`ServiceApi`'s default `scheduleExit` (constructor param 5, `ServiceApi.ts:167`):

```js
private scheduleExit: (fn: () => void, ms: number) => void = (fn, ms) => {
    setTimeout(fn, ms).unref();
},
```

A real 5-second timer that calls `process.exit(0)`. The `.unref()` stops it holding the process open — it does **not** stop it firing while vitest is still working through the remaining ~1500 tests. Any test that reaches an exit-scheduling path without overriding that default leaves a live timer that goes off ~5s later, inside whatever test is running by then. When that happened to be the exit-spy test, the foreign exit tripped its first assertion.

That also explains the shape: it needs the leak and the spy window to overlap, which depends on suite timing. Hence intermittent, and never reproducible alone.

## Finding the offenders

Rather than guess, I made the default throw under an env flag and ran the file:

```js
if (process.env['LEAK_PROBE']) { throw new Error('REAL_EXIT_TIMER_SCHEDULED'); }
```

Nine tests hit it — **all of them `POST /install`**, none of them uninstall. (Instrumentation reverted; it isn't in this diff.)

That's the part worth flagging: three *uninstall* tests already carried `vi.useFakeTimers()` with comments explaining they were preventing exactly this leak. Those comments named the LocalSystem uninstall path as the source. It wasn't — install calls `scheduleExit` too, and that was the actual leak the whole time. A previous pass fixed three tests that weren't the problem and left nine that were.

## The fix

Fake timers in the top-level `beforeEach`, real timers restored in `afterEach`. One place, covering every path, and pending fake timers are discarded at each test boundary instead of escaping into the next test.

Doing it file-wide rather than per-test is deliberate: the per-test approach has already been tried and missed, and a new test reaching an exit path would silently reintroduce the leak. This makes that impossible.

Safe here — nothing in this file depends on real timer progression (no `setTimeout`, no timed promises), and fake timers leave promises and microtasks alone, so `await` is unaffected.

The three now-redundant ad-hoc blocks are removed along with their misleading comments, since leaving a wrong explanation in place is worse than leaving nothing.

## Verification

- **8 consecutive full-suite runs** green — 1574 passed / 5 skipped. Against a ~1-in-8 baseline that's the part that matters.
- 6 runs of `ServiceApi.test.ts` alone — 75/75 each.
- `tsc --noEmit` clean, biome clean.

`release:none` — test-only, nothing user-facing to ship.
