### PR TITLE
docs: retire the H.264 bypass write-ups that outlived the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ npm run build
 node dist/index.js
 ```
 
-Server listens on port 8000. Open `http://localhost:8000/` in a Chromium browser (Chrome, Edge, Brave). Firefox works, with one gap: its `VideoDecoder.isConfigSupported` rejects hardware-encoded HEVC, so **H.265 streams won't play there** — H.264, AV1, VP8, and VP9 do. Firefox also returns a false `supported: false` for some H.264 profile strings it can actually decode; see `docs/TECHNICAL_GUIDE.md` §11.5 for the workaround already in the codebase.
+Server listens on port 8000. Open `http://localhost:8000/` in a Chromium browser (Chrome, Edge, Brave). Firefox works, with one gap: it cannot decode HEVC at all, so **H.265 streams won't play there** — H.264, AV1, VP8, and VP9 do. Firefox also returns a false `supported: false` for some H.264 profile strings it can actually decode, which the app handles by probing several profiles rather than one; see `docs/TECHNICAL_GUIDE.md` §8.3.
+
+One thing worth knowing if you test on Firefox/Windows: it asks the operating system to decode H.264 while carrying its own AV1 decoder. On a machine with no OS-level H.264 decoder, H.264 genuinely will not play there while AV1 still does — that is the browser telling the truth, not a bug in the app.
 
 ## Development Workflow
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -890,16 +890,13 @@ Applied in both `ScrcpyConnection.ts` and `DeviceProbe.ts`.
 
 **Problem:** Firefox's `VideoDecoder.isConfigSupported()` returns `{ supported: false }` for the H.264 profile string `avc1.42E01E`, despite being fully capable of decoding H.264 content. This caused the auto-detection algorithm to skip H.264 and fall back to worse options on Firefox.
 
-**Fix:** The `browserSupportsCodec()` function unconditionally returns `true` for H.264, bypassing the `isConfigSupported` check:
+**First fix (beta.75 era) — since removed.** `browserSupportsCodec()` unconditionally returned `true` for H.264, bypassing the check entirely, on the reasoning that H.264 support is universal across browsers implementing WebCodecs.
 
-```typescript
-async function browserSupportsCodec(codec: string): Promise<boolean> {
-    if (codec === 'h264') return true;
-    // ...
-}
-```
+**That reasoning was wrong, and it caused issue #498.** H.264 support is *not* universal: Firefox on Windows delegates H.264 decoding to the operating system while bundling its own AV1 decoder, so a machine without an OS-level H.264 decoder — a Windows N edition lacking the Media Feature Pack, for instance — answers `supported: false` truthfully. The bypass could not tell that apart from Firefox's spurious rejection, so it overrode a correct refusal: H.264 was auto-selected, handed to a decoder that emitted nothing, and rendered as a black canvas with no error anywhere.
 
-This is safe because H.264 baseline profile support is universal across all browsers that implement WebCodecs.
+**Current fix (beta.77):** `probeDecodeSupport()` probes **several** H.264 profile strings and treats the codec as supported if any one of them is accepted, which absorbs Firefox's per-profile pessimism without discarding the answer. A definite `false` across every candidate is now honoured for H.264 exactly as it is for every other codec. See [8.3](#83-codec-support-probing-and-the-firefox-quirk) for the full contract and [3.7](#37-decode-watchdog) for the watchdog that reports a decoder which accepts data and produces nothing.
+
+**The general lesson:** a workaround that suppresses a capability check cannot distinguish a browser being wrong from a browser being right. Widen the probe instead of ignoring the result.
 
 ---
 


### PR DESCRIPTION
Found by the wrap-up doc sweep — two docs still describing the removed `if (codec === 'h264') return true;` workaround as current. Neither is a file the beta.77–79 work had any reason to open, which is the gap a session-wide sweep exists to catch.

**`TECHNICAL_GUIDE` §11.5** was the worse one. It carried a code sample of the deleted bypass and asserted:

> This is safe because H.264 baseline profile support is universal across all browsers that implement WebCodecs.

That is the exact assumption that caused #498. Rewritten to keep the Firefox false-rejection problem (still real — it's why the probe tries several profile strings), record that the bypass was wrong and why, and cross-reference §8.3 and §3.7 for the current contract. It closes on the general lesson: a workaround that suppresses a capability check can't tell a browser being wrong from a browser being right.

**`CONTRIBUTING.md`** pointed contributors at §11.5 "for the workaround already in the codebase," and blamed Firefox's HEVC gap on `isConfigSupported` rejecting hardware-encoded HEVC — Firefox has no HEVC decoder at all. Corrected, plus a note that Firefox/Windows rides the OS decoder for H.264 while bundling its own AV1, so H.264 failing there while AV1 works is the browser being honest rather than an app bug.

Docs only — `release:none`.