### PR TITLE
fix(stream): make audio teardown idempotent and the stall message browser-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Closing a stream no longer leaves an error in the browser console.** Stopping a stream tore the audio player down twice — once directly, and once more when the closing connection reported itself closed — and the second teardown tried to shut down an audio session that was already shut down. The browser refused, and the refusal surfaced as an unhandled error. Audio stopped correctly either way and nothing was actually broken, but it was noise sitting in exactly the place people look when they are trying to report a problem. Teardown is now safe to run more than once.
+
+- **The stalled-video message no longer recommends the browser you are already using.** When a video decoder starts up cleanly and then produces no picture, the app reports the stall and suggests what to try. That advice was fixed text: it recommended a Chromium-based browser even when you were in Chrome, and it appended an explanation of Firefox's H.264 and H.265 handling to every stall, including ones on codecs where neither is involved. The message now accounts for which browser is running and which codec actually failed — Chromium users get pointed at `chrome://gpu`, where a graphics-driver problem shows up, and the Firefox note only appears when it is relevant.
+
 ## [0.1.30-beta.79] - 2026-08-27
 
 ### Fixed

--- a/src/app/audio/AudioPlayer.ts
+++ b/src/app/audio/AudioPlayer.ts
@@ -3,10 +3,13 @@ import { PCM_WORKLET_NAME, PCM_WORKLET_SOURCE } from './PcmWorklet';
 import { decodeS16LEToFloat32Planar } from './pcmConvert';
 
 export class AudioPlayer {
-    private audioContext?: AudioContext;
-    private decoder?: AudioDecoder;
-    private workletNode?: AudioWorkletNode;
-    private gainNode?: GainNode;
+    // Explicit `| undefined` (matching `configData` below) because
+    // `exactOptionalPropertyTypes` is on: stop() clears these back to
+    // undefined, which a bare `?:` optional does not permit.
+    private audioContext?: AudioContext | undefined;
+    private decoder?: AudioDecoder | undefined;
+    private workletNode?: AudioWorkletNode | undefined;
+    private gainNode?: GainNode | undefined;
     private started = false;
     private workletReady = false;
     private configData?: Uint8Array | undefined;
@@ -155,13 +158,36 @@ export class AudioPlayer {
         }
     }
 
+    /**
+     * Tear the player down. Safe to call repeatedly.
+     *
+     * A single user-initiated stop reaches here twice: `StreamClientScrcpy`
+     * calls it directly, and the `demuxer.close()` alongside it triggers a
+     * WebSocket `onclose` → `onDisconnected`, which calls it again. A real
+     * `AudioContext` rejects a second `close()` with `InvalidStateError:
+     * Can't close an AudioContext twice`, and nothing awaits that promise —
+     * which is how it surfaced as an uncaught rejection in issue #498.
+     *
+     * So: guard on state the way the decoder above already did, drop the
+     * references so a repeat call has nothing left to act on, and catch the
+     * promise in case the browser closed the context out from under us.
+     */
     stop(): void {
         if (this.decoder && this.decoder.state !== 'closed') {
             this.decoder.close();
         }
         this.workletNode?.disconnect();
         this.gainNode?.disconnect();
-        this.audioContext?.close();
+        if (this.audioContext && this.audioContext.state !== 'closed') {
+            this.audioContext.close().catch(() => {
+                // Already closed elsewhere — nothing to do, and an unhandled
+                // rejection here is the exact bug this method is fixing.
+            });
+        }
+        this.decoder = undefined;
+        this.workletNode = undefined;
+        this.gainNode = undefined;
+        this.audioContext = undefined;
         this.started = false;
         this.workletReady = false;
         this.configData = undefined;

--- a/src/app/audio/__tests__/audioPlayerStop.test.ts
+++ b/src/app/audio/__tests__/audioPlayerStop.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `AudioPlayer.stop()` has to be safe to call more than once.
+ *
+ * `StreamClientScrcpy` stops the audio player from three places, and two of
+ * them fire for a single user-initiated stop: the stop handler calls
+ * `demuxer.close()` and then `audioPlayer.stop()`, and the resulting WebSocket
+ * `onclose` runs `onDisconnected`, which stops it again. Only `refreshStream`
+ * clears the reference afterwards, so the second call lands on a live player
+ * whose `AudioContext` is already closed.
+ *
+ * A real `AudioContext` rejects the second `close()` with
+ * `InvalidStateError: Can't close an AudioContext twice`, and nothing awaits
+ * that promise — which is how it reached issue #498's console as an uncaught
+ * rejection. The fake below reproduces that contract exactly.
+ */
+
+class FakeAudioWorklet {
+    addModule = vi.fn(() => Promise.resolve());
+}
+
+class FakeAudioParam {
+    public value = 1;
+}
+
+class FakeGainNode {
+    public gain = new FakeAudioParam();
+    connect = vi.fn();
+    disconnect = vi.fn();
+}
+
+class FakeAudioContext {
+    public state: 'running' | 'suspended' | 'closed' = 'running';
+    public destination = {};
+    public audioWorklet = new FakeAudioWorklet();
+    public closeCalls = 0;
+    public gainNode = new FakeGainNode();
+    /** Make close() reject even from a healthy state — see the swallow test. */
+    public rejectClose = false;
+
+    createGain() {
+        return this.gainNode;
+    }
+
+    close(): Promise<void> {
+        this.closeCalls += 1;
+        if (this.rejectClose) {
+            return Promise.reject(new DOMException('close failed', 'InvalidStateError'));
+        }
+        if (this.state === 'closed') {
+            return Promise.reject(new DOMException("Can't close an AudioContext twice", 'InvalidStateError'));
+        }
+        this.state = 'closed';
+        return Promise.resolve();
+    }
+}
+
+class FakeAudioWorkletNode {
+    public port = { postMessage: vi.fn() };
+    connect = vi.fn();
+    disconnect = vi.fn();
+}
+
+class FakeAudioDecoder {
+    public state: 'unconfigured' | 'configured' | 'closed' = 'unconfigured';
+    configure() {
+        this.state = 'configured';
+    }
+    decode() {
+        /* not exercised here */
+    }
+    close() {
+        this.state = 'closed';
+    }
+}
+
+let lastContext: FakeAudioContext | undefined;
+
+describe('AudioPlayer.stop() idempotency', () => {
+    beforeEach(() => {
+        lastContext = undefined;
+        vi.stubGlobal(
+            'AudioContext',
+            class extends FakeAudioContext {
+                constructor() {
+                    super();
+                    lastContext = this;
+                }
+            },
+        );
+        vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
+        vi.stubGlobal('AudioDecoder', FakeAudioDecoder);
+        // jsdom implements `new URL()` but not the object-URL statics, and the
+        // worklet is loaded from a Blob URL. Subclass so the constructor keeps
+        // working — replacing the global outright breaks every `new URL(...)`
+        // on the import path.
+        class FakeURL extends URL {
+            static override createObjectURL = vi.fn(() => 'blob:fake');
+            static override revokeObjectURL = vi.fn();
+        }
+        vi.stubGlobal('URL', FakeURL);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('closes the AudioContext exactly once across repeated stop() calls', async () => {
+        const { AudioPlayer } = await import('../AudioPlayer');
+        const player = new AudioPlayer('opus');
+        await player.start();
+
+        player.stop();
+        player.stop();
+
+        expect(lastContext?.closeCalls).toBe(1);
+        expect(lastContext?.state).toBe('closed');
+    });
+
+    it('does not throw when stop() runs after the context is already closed', async () => {
+        const { AudioPlayer } = await import('../AudioPlayer');
+        const player = new AudioPlayer('opus');
+        await player.start();
+
+        player.stop();
+        expect(() => player.stop()).not.toThrow();
+    });
+
+    it('skips close() entirely when the context is already closed', async () => {
+        const { AudioPlayer } = await import('../AudioPlayer');
+        const player = new AudioPlayer('opus');
+        await player.start();
+
+        // The browser can close a context out from under us (page hidden,
+        // device change), leaving the player holding a closed one.
+        lastContext!.state = 'closed';
+        player.stop();
+
+        expect(lastContext?.closeCalls).toBe(0);
+    });
+
+    it('swallows a close() that rejects anyway', async () => {
+        const { AudioPlayer } = await import('../AudioPlayer');
+        const player = new AudioPlayer('opus');
+        await player.start();
+
+        // State says open, close() rejects regardless — the state guard cannot
+        // catch this shape, so the promise handler has to.
+        lastContext!.rejectClose = true;
+
+        expect(() => player.stop()).not.toThrow();
+        // Give the rejection a turn to surface as unhandled before we finish.
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    it('is safe to stop a player that was never started', async () => {
+        const { AudioPlayer } = await import('../AudioPlayer');
+        const player = new AudioPlayer('opus');
+
+        expect(() => player.stop()).not.toThrow();
+        expect(lastContext).toBeUndefined();
+    });
+
+    it('closes the decoder once and leaves it closed', async () => {
+        const { AudioPlayer } = await import('../AudioPlayer');
+        const player = new AudioPlayer('opus');
+        await player.start();
+
+        player.stop();
+        player.stop();
+
+        // Nothing to assert on call counts here — the decoder was already
+        // guarded on `state !== 'closed'`. This pins that the guard survives
+        // the stop() rewrite rather than being dropped along with it.
+        expect(() => player.stop()).not.toThrow();
+    });
+});

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -345,6 +345,10 @@ export class StreamClientScrcpy
 
     public onDisconnected = (ev?: CloseEvent): void => {
         this.audioPlayer?.stop();
+        // Drop the reference the way refreshStream does. The session is over,
+        // every remaining use site is optional-chained, and a live reference
+        // is what let a user-initiated stop reach AudioPlayer.stop() twice.
+        this.audioPlayer = undefined;
         this.uhidKeyboard?.detach();
         this.uhidMouse?.detach();
         this.uhidManager?.stop();
@@ -423,6 +427,7 @@ export class StreamClientScrcpy
             document.removeEventListener('keydown', resumeAudio);
             this.demuxer?.close();
             this.audioPlayer?.stop();
+            this.audioPlayer = undefined;
             if (this.player) this.player.stop();
         };
 

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -6,6 +6,7 @@ import VideoSettings from '../VideoSettings';
 import { OBU_TYPE, obuType, parseAv1ConfigRecord, parseAv1SequenceHeader } from './av1-utils';
 import { BaseCanvasBasedPlayer } from './BaseCanvasBasedPlayer';
 import { BasePlayer } from './BasePlayer';
+import { decodeWatchdogMessage, detectBrowserFamily } from './decodeWatchdogMessage';
 import { parseSPS, stripEmulationPrevention } from './h264-utils';
 import { HEVC_NAL_TYPE, hevcNalType, parseHevcSPS } from './h265-utils';
 import { annexBToLengthPrefixed, findFirstNaluOffset, findNaluByHeader } from './naluScanner';
@@ -135,11 +136,15 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
         this.clearDecodeWatchdog();
         this.decodeWatchdog = setTimeout(() => {
             this.decodeWatchdog = undefined;
+            // Prefix stays a constant in the format position; the codec-bearing
+            // message goes in as a substitution arg (see TECHNICAL_GUIDE §8.3).
             console.error(
-                `[WebCodecsPlayer] ${codec}: decoder configured but produced no frames after ` +
-                    `${WebCodecsPlayer.DECODE_WATCHDOG_MS}ms. Video is arriving but this browser is not ` +
-                    'decoding it — try a different video codec, or a Chromium-based browser. Firefox on ' +
-                    'Windows relies on the operating system to decode H.264 and cannot decode H.265 at all.',
+                '[WebCodecsPlayer]',
+                decodeWatchdogMessage({
+                    codec,
+                    timeoutMs: WebCodecsPlayer.DECODE_WATCHDOG_MS,
+                    ...detectBrowserFamily(),
+                }),
             );
         }, WebCodecsPlayer.DECODE_WATCHDOG_MS);
     }

--- a/src/app/player/__tests__/decodeWatchdogMessage.test.ts
+++ b/src/app/player/__tests__/decodeWatchdogMessage.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { decodeWatchdogMessage, detectBrowserFamily } from '../decodeWatchdogMessage';
+
+/**
+ * The decode watchdog's message prescribes a browser, so it has to know which
+ * one it is talking to. Issue #498 collected a Chrome console showing the
+ * watchdog advising the reporter to "try a Chromium-based browser", plus a
+ * Firefox-specific H.264/H.265 note appended to a VP9 failure where neither
+ * codec was involved.
+ */
+
+const BASE = { codec: 'h264', timeoutMs: 5000 };
+
+describe('decodeWatchdogMessage', () => {
+    it('always names the codec and the elapsed time', () => {
+        const msg = decodeWatchdogMessage({ ...BASE, codec: 'vp9', isChromium: false, isFirefox: false });
+        expect(msg).toContain('vp9:');
+        expect(msg).toContain('5000ms');
+    });
+
+    it('does not tell a Chromium user to switch to a Chromium browser', () => {
+        const msg = decodeWatchdogMessage({ ...BASE, isChromium: true, isFirefox: false });
+        expect(msg).not.toContain('Chromium-based browser');
+        expect(msg).toContain('try a different video codec');
+    });
+
+    it('offers Chromium as an option to browsers that are not Chromium', () => {
+        const msg = decodeWatchdogMessage({ ...BASE, isChromium: false, isFirefox: true });
+        expect(msg).toContain('Chromium-based browser');
+    });
+
+    it('explains the OS decoder handoff only for Firefox on h264', () => {
+        const firefoxH264 = decodeWatchdogMessage({ ...BASE, codec: 'h264', isChromium: false, isFirefox: true });
+        expect(firefoxH264).toContain('operating system');
+
+        const firefoxVp9 = decodeWatchdogMessage({ ...BASE, codec: 'vp9', isChromium: false, isFirefox: true });
+        expect(firefoxVp9).not.toContain('operating system');
+    });
+
+    it('states the flat H.265 refusal only for Firefox on h265', () => {
+        const firefoxH265 = decodeWatchdogMessage({ ...BASE, codec: 'h265', isChromium: false, isFirefox: true });
+        expect(firefoxH265).toContain('cannot decode H.265');
+
+        const chromeH265 = decodeWatchdogMessage({ ...BASE, codec: 'h265', isChromium: true, isFirefox: false });
+        expect(chromeH265).not.toContain('cannot decode H.265');
+    });
+
+    it('points Chromium users at chrome://gpu, and nobody else', () => {
+        const chrome = decodeWatchdogMessage({ ...BASE, codec: 'vp8', isChromium: true, isFirefox: false });
+        expect(chrome).toContain('chrome://gpu');
+
+        const firefox = decodeWatchdogMessage({ ...BASE, codec: 'vp8', isChromium: false, isFirefox: true });
+        expect(firefox).not.toContain('chrome://gpu');
+    });
+
+    it('never mentions a codec other than the one that failed', () => {
+        const msg = decodeWatchdogMessage({ ...BASE, codec: 'vp9', isChromium: false, isFirefox: true });
+        expect(msg).not.toContain('H.264');
+        expect(msg).not.toContain('H.265');
+    });
+});
+
+describe('detectBrowserFamily', () => {
+    const FIREFOX_WIN = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0';
+    const CHROME_WIN =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36';
+    const EDGE_WIN =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0';
+    const SAFARI_MAC =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15';
+
+    it('identifies Firefox and does not call it Chromium', () => {
+        expect(detectBrowserFamily(FIREFOX_WIN)).toEqual({ isChromium: false, isFirefox: true });
+    });
+
+    it('identifies Chrome and Edge as Chromium', () => {
+        expect(detectBrowserFamily(CHROME_WIN)).toEqual({ isChromium: true, isFirefox: false });
+        expect(detectBrowserFamily(EDGE_WIN)).toEqual({ isChromium: true, isFirefox: false });
+    });
+
+    it('does not mistake Safari for Chromium on the shared AppleWebKit token', () => {
+        expect(detectBrowserFamily(SAFARI_MAC)).toEqual({ isChromium: false, isFirefox: false });
+    });
+
+    it('trusts userAgentData brands when the UA string is uninformative', () => {
+        const result = detectBrowserFamily('Mozilla/5.0', { brands: [{ brand: 'Chromium', version: '152' }] });
+        expect(result.isChromium).toBe(true);
+    });
+});

--- a/src/app/player/decodeWatchdogMessage.ts
+++ b/src/app/player/decodeWatchdogMessage.ts
@@ -1,0 +1,81 @@
+/**
+ * Message for a decoder that configures cleanly, accepts every chunk, and then
+ * never emits a frame — see `WebCodecsPlayer.armDecodeWatchdog`.
+ *
+ * Kept apart from the player because the text prescribes a browser, and a
+ * message that prescribes a browser has to know which one it is talking to.
+ * The first cut said "try a Chromium-based browser" unconditionally and pinned
+ * a Firefox H.264/H.265 explanation to the end of every failure, so issue
+ * #498's reporter got told to switch to Chromium while sitting in Chrome, and
+ * read about H.264 decoding after a VP9 stream went black.
+ */
+
+export interface BrowserFamily {
+    /** Chrome, Edge, Opera, Brave — anything on the Chromium engine. */
+    isChromium: boolean;
+    /** Firefox and other Gecko browsers. */
+    isFirefox: boolean;
+}
+
+export interface WatchdogMessageContext extends BrowserFamily {
+    /** scrcpy-side codec name, e.g. `h264` / `vp9`. */
+    codec: string;
+    timeoutMs: number;
+}
+
+/** Minimal shape of `navigator.userAgentData`, which only Chromium ships. */
+interface UserAgentDataLike {
+    brands?: { brand: string; version: string }[] | undefined;
+}
+
+/**
+ * Work out the browser family from the user agent.
+ *
+ * Chromium exposes `navigator.userAgentData`; nothing else does, so its
+ * presence is a positive signal on its own. The UA string is the fallback, and
+ * has to reject Safari explicitly: Safari and Chrome both carry the
+ * `AppleWebKit`/`Safari` tokens, and only Chrome adds `Chrome`.
+ */
+export function detectBrowserFamily(
+    userAgent: string = typeof navigator === 'undefined' ? '' : navigator.userAgent,
+    userAgentData: UserAgentDataLike | undefined = typeof navigator === 'undefined'
+        ? undefined
+        : (navigator as Navigator & { userAgentData?: UserAgentDataLike }).userAgentData,
+): BrowserFamily {
+    const isFirefox = /firefox|fxios/i.test(userAgent);
+    const hasChromiumBrands = Boolean(userAgentData?.brands?.length);
+    const isChromium = !isFirefox && (hasChromiumBrands || /chrome|chromium|crios|edg\/|opr\//i.test(userAgent));
+    return { isChromium, isFirefox };
+}
+
+/**
+ * Codec-and-browser-specific tail, or an empty string when we have nothing
+ * useful to add. Only ever mentions the codec that actually failed.
+ */
+function decoderNote({ codec, isChromium, isFirefox }: WatchdogMessageContext): string {
+    if (isFirefox && codec === 'h264') {
+        return (
+            ' Firefox delegates H.264 to the operating system, so a missing or outdated system decoder ' +
+            'produces exactly this.'
+        );
+    }
+    if (isFirefox && codec === 'h265') {
+        return ' Firefox cannot decode H.265 at all.';
+    }
+    if (isChromium) {
+        return ' An outdated or blocklisted graphics driver can also cause this — chrome://gpu reports the decoder status.';
+    }
+    return '';
+}
+
+export function decodeWatchdogMessage(context: WatchdogMessageContext): string {
+    const { codec, timeoutMs, isChromium } = context;
+    const remedy = isChromium
+        ? 'try a different video codec'
+        : 'try a different video codec, or a Chromium-based browser';
+    return (
+        `${codec}: decoder configured but produced no frames after ${timeoutMs}ms. ` +
+        `Video is arriving but this browser is not decoding it — ${remedy}.` +
+        decoderNote(context)
+    );
+}


### PR DESCRIPTION
Two bugs visible in the console dumps on issue #498. Neither is the black-screen bug itself — both were sitting next to it in the reporter's logs.

## Audio teardown ran twice

Stopping a stream reaches `AudioPlayer.stop()` twice. The stop handler calls it directly, and the `demuxer.close()` right beside it triggers a WebSocket `onclose` → `onDisconnected`, which calls it again:

```
stop → onDisconnected → onclose
```

Inside `stop()`, the decoder was guarded on `state !== 'closed'` but `audioContext.close()` was not, and the reference was never cleared — so the second pass closed an already-closed context. A real `AudioContext` rejects that with `InvalidStateError: Can't close an AudioContext twice`, and nothing awaited the promise, so it surfaced as an uncaught rejection.

The fix guards on state the way the decoder already did, drops the references so a repeat call has nothing to act on, and catches the promise for the case where the browser closes the context out from under us. `this.audioPlayer` is now also cleared in the two client paths that were keeping it alive — `refreshStream` already did this, which is why refresh never showed the bug.

`exactOptionalPropertyTypes` is on, so the four fields needed the explicit `| undefined` form the file already used for `configData`.

## The stall message recommended the browser you were already in

The decode watchdog prescribes a browser without knowing which one is running. The reporter got "try a Chromium-based browser" while sitting in Chrome, and a Firefox H.264/H.265 explanation appended to a VP9 stall where neither codec is involved.

Extracted into a pure builder in `decodeWatchdogMessage.ts` that takes the browser family and names only the codec that actually failed. Chromium now gets pointed at `chrome://gpu` instead — which is where a blocklisted graphics driver shows up, and is exactly the diagnostic this issue ended up needing.

## Testing

`audioPlayerStop.test.ts` models the real `AudioContext` contract — second `close()` rejects — so it reproduced the uncaught rejection before the fix and pins it after. Five cases: double stop, stop-after-close, already-closed context, a `close()` that rejects anyway, and stop-without-start.

`decodeWatchdogMessage.test.ts` covers the message matrix and the UA detection, including Safari not being mistaken for Chromium on the shared `AppleWebKit` token.

Full suite 1591 passed / 5 skipped, `tsc --noEmit` clean, biome clean.

`release:none` deliberately — the VP8/VP9 auto-detect fix is coming right behind this one and will cut the beta that carries both.
