### PR TITLE
fix(player): recover a stalled VP8/VP9 stream by requesting a keyframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A VP8 or VP9 stream that starts black now recovers by itself.** These two codecs send a single keyframe at the very start of a session and then nothing but full-motion updates — measured on a real device at 398 frames with exactly one keyframe over 28 seconds. The player will not start drawing until it has seen that keyframe, because everything after it is described relative to it, so if anything caused the app to miss that one frame the picture never appeared at all and no amount of waiting helped. The app now asks the device to send a fresh keyframe when a stream has gone quiet for five seconds, which it will do up to three times before concluding the browser genuinely cannot play the codec. Recovery takes about a fifth of a second.
+
+- **A video decoding error no longer ends the session.** When the browser's decoder reported a fault, the player shut itself down — and nothing could start it again while the stream was still arriving, so the window stayed black until you reconnected by hand. The decoder is now rebuilt in place and a new keyframe requested, so a momentary fault costs a brief interruption instead of the whole session.
+
 ## [0.1.30-beta.80] - 2026-08-27
 
 ### Fixed

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -9,7 +9,8 @@ import { Attribute } from '../../Attribute';
 import { AudioPlayer } from '../../audio/AudioPlayer';
 import { BaseClient } from '../../client/BaseClient';
 import { settingsService } from '../../client/SettingsService';
-import type { ControlMessage } from '../../controlMessage/ControlMessage';
+import { CommandControlMessage } from '../../controlMessage/CommandControlMessage';
+import { ControlMessage } from '../../controlMessage/ControlMessage';
 import type { KeyCodeControlMessage } from '../../controlMessage/KeyCodeControlMessage';
 import type { DisplayInfo } from '../../DisplayInfo';
 import {
@@ -374,6 +375,14 @@ export class StreamClientScrcpy
         }
         this.player = player;
         this.setTouchListeners(player);
+
+        // A stalled decoder can only resynchronise on a keyframe, and for
+        // VP8/VP9 scrcpy sends exactly one per session — so if that one is
+        // missed there is nothing to recover on until we ask for another.
+        player.on('video-stalled', ({ codec, reason }) => {
+            console.log(TAG, `video stalled (codec=${codec}, reason=${reason}); requesting a keyframe`);
+            this.demuxer?.sendControl(new CommandControlMessage(ControlMessage.TYPE_RESET_VIDEO));
+        });
 
         if (!videoSettings) {
             videoSettings = player.getVideoSettings();

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -33,6 +33,17 @@ export interface PlayerEvents {
     'video-view-resize': Size;
     'input-video-resize': ScreenInfo;
     'video-settings': VideoSettings;
+    /**
+     * The decoder is configured and video is arriving, but no picture is coming
+     * out — either nothing has been fed to it, or it faulted. The listener is
+     * expected to ask the device for a fresh keyframe.
+     *
+     * VP8/VP9 make this non-optional: scrcpy emits exactly ONE keyframe per
+     * session for them (measured: 398 frames / 1 keyframe over 28s at a 2s
+     * i-frame interval), so a stream that misses it can never resynchronise on
+     * its own. Requesting a new one is the only way back.
+     */
+    'video-stalled': { codec: string; reason: 'no-frames' | 'decoder-error' };
 }
 
 export interface PlayerClass {

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -90,6 +90,13 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
      */
     private static readonly DECODE_WATCHDOG_MS = 5000;
     private decodeWatchdog: ReturnType<typeof setTimeout> | undefined;
+    /**
+     * Cap on keyframe requests per session. A stalled stream usually recovers
+     * on the first one; a browser that cannot decode the codec at all never
+     * will, and re-requesting forever would just pin the device's encoder.
+     */
+    private static readonly MAX_KEYFRAME_REQUESTS = 3;
+    private keyframeRequests = 0;
 
     constructor(udid: string, displayInfo?: DisplayInfo, name = WebCodecsPlayer.playerFullName) {
         super(udid, displayInfo, name, WebCodecsPlayer.storageKeyPrefix);
@@ -116,9 +123,43 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
             },
             error: (error: DOMException) => {
                 console.error('[WebCodecsPlayer]', error, `code: ${error.code}`);
-                this.stop();
+                // Deliberately NOT stop(). stop() puts the player in STOPPED,
+                // and `StreamClientScrcpy.onVideoFrame` only revives a player
+                // from PAUSED — so a single decoder fault used to kill the
+                // session permanently while video kept arriving. Recover in
+                // place instead and ask for a keyframe to resynchronise on.
+                this.recoverDecoder('decoder-error');
             },
         });
+    }
+
+    /**
+     * Rebuild the decoder after a fault and ask for a fresh keyframe.
+     *
+     * The re-configure only applies to VP8/VP9: every other codec re-configures
+     * when its next config packet arrives, and those codecs send one alongside
+     * every keyframe. VP8/VP9 send no usable one (see `CONFIGLESS_CODECS`), so
+     * the decoder has to be set up from session metadata again here or the
+     * keyframe we are about to request would arrive with nowhere to go.
+     */
+    private recoverDecoder(reason: 'no-frames' | 'decoder-error'): void {
+        const codec = this.detectedCodec;
+        this.clearDecodeWatchdog();
+        if (this.decoder.state !== 'closed') {
+            try {
+                this.decoder.close();
+            } catch {
+                // Already closing/closed — the replacement below is what matters.
+            }
+        }
+        this.decoder = this.createDecoder();
+        this.seenKeyframe = false;
+        this.configData = undefined;
+        if (codec && isConfiglessCodec(codec)) {
+            this.detectedCodec = codec;
+            this.configureFromMetadata(codec);
+        }
+        this.emit('video-stalled', { codec: codec ?? 'unknown', reason });
     }
 
     /**
@@ -136,16 +177,35 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
         this.clearDecodeWatchdog();
         this.decodeWatchdog = setTimeout(() => {
             this.decodeWatchdog = undefined;
-            // Prefix stays a constant in the format position; the codec-bearing
-            // message goes in as a substitution arg (see TECHNICAL_GUIDE §8.3).
-            console.error(
-                '[WebCodecsPlayer]',
-                decodeWatchdogMessage({
-                    codec,
-                    timeoutMs: WebCodecsPlayer.DECODE_WATCHDOG_MS,
-                    ...detectBrowserFamily(),
-                }),
-            );
+            // The full explanation is worth saying once. Retries below add a
+            // short line each instead, so a stream that never recovers does not
+            // paste the same paragraph into the console every five seconds.
+            if (this.keyframeRequests === 0) {
+                // Prefix stays a constant in the format position; the
+                // codec-bearing message goes in as a substitution arg (see
+                // TECHNICAL_GUIDE §8.3).
+                console.error(
+                    '[WebCodecsPlayer]',
+                    decodeWatchdogMessage({
+                        codec,
+                        timeoutMs: WebCodecsPlayer.DECODE_WATCHDOG_MS,
+                        ...detectBrowserFamily(),
+                    }),
+                );
+            }
+            // Reporting the stall was never enough on its own. Ask the device
+            // for a keyframe, then wait again — bounded, because a browser that
+            // genuinely cannot decode this codec will never recover and should
+            // not have reset requests pinned on it forever.
+            if (this.keyframeRequests < WebCodecsPlayer.MAX_KEYFRAME_REQUESTS) {
+                this.keyframeRequests += 1;
+                console.log(
+                    '[WebCodecsPlayer]',
+                    `${codec}: requesting a fresh keyframe (attempt ${this.keyframeRequests}/${WebCodecsPlayer.MAX_KEYFRAME_REQUESTS})`,
+                );
+                this.emit('video-stalled', { codec, reason: 'no-frames' });
+                this.armDecodeWatchdog(codec);
+            }
         }, WebCodecsPlayer.DECODE_WATCHDOG_MS);
     }
 
@@ -432,5 +492,6 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
         this.configData = undefined;
         this.detectedCodec = null;
         this.seenKeyframe = false;
+        this.keyframeRequests = 0;
     }
 }

--- a/src/app/player/__tests__/keyframeRecovery.test.ts
+++ b/src/app/player/__tests__/keyframeRecovery.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A VP8/VP9 session that misses its keyframe used to be dead permanently.
+ *
+ * scrcpy emits exactly ONE keyframe per VP8/VP9 session — measured on a Pixel
+ * 10a over 28 seconds: 398 video frames, 1 keyframe, at a 2-second i-frame
+ * interval. The player refuses to decode until it has seen one (deltas
+ * reference frames the decoder never saw), so if that single frame is dropped
+ * there is nothing left to resynchronise on. Observed live: `configure()` ran
+ * and the decoder received zero chunks for ten minutes while video kept
+ * arriving.
+ *
+ * Two things had to change, and these pin both:
+ *   1. a decoder fault must not park the player in STOPPED, because
+ *      `onVideoFrame` only revives from PAUSED — one fault killed the session;
+ *   2. a stall must ask the device for a fresh keyframe, bounded, rather than
+ *      only logging about it.
+ */
+
+let decoderInstances: FakeVideoDecoder[] = [];
+
+class FakeVideoDecoder {
+    public state: 'unconfigured' | 'configured' | 'closed' = 'unconfigured';
+    public decoded: { type: string }[] = [];
+    public errorCb: (e: DOMException) => void;
+
+    constructor(init: { output: (f: unknown) => void; error: (e: DOMException) => void }) {
+        this.errorCb = init.error;
+        decoderInstances.push(this);
+    }
+    configure() {
+        this.state = 'configured';
+    }
+    decode(chunk: { type: string }) {
+        this.decoded.push(chunk);
+    }
+    flush() {
+        return Promise.resolve();
+    }
+    close() {
+        this.state = 'closed';
+    }
+    static isConfigSupported() {
+        return Promise.resolve({ supported: true });
+    }
+}
+
+class FakeEncodedVideoChunk {
+    public type: string;
+    public timestamp: number;
+    public data: Uint8Array;
+    constructor(init: { type: string; timestamp: number; data: Uint8Array }) {
+        this.type = init.type;
+        this.timestamp = init.timestamp;
+        this.data = new Uint8Array(init.data);
+    }
+}
+
+const VP_KEYFRAME = new Uint8Array([0x82, 0x49, 0x83, 0x42, 0x00, 0x11]);
+const VP_DELTA = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+
+async function makeVp9Player() {
+    const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+    const player = new WebCodecsPlayer('udid-test');
+    player.setMetadataSize(1080, 2400);
+    player.setSessionInfo('vp9', 'opus');
+    return player;
+}
+
+describe('VP8/VP9 keyframe recovery', () => {
+    beforeEach(() => {
+        decoderInstances = [];
+        vi.useFakeTimers();
+        vi.stubGlobal('VideoDecoder', FakeVideoDecoder);
+        vi.stubGlobal('EncodedVideoChunk', FakeEncodedVideoChunk);
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+            drawImage: vi.fn(),
+            clearRect: vi.fn(),
+            fillRect: vi.fn(),
+            measureText: () => ({ actualBoundingBoxLeft: 0, actualBoundingBoxRight: 0 }),
+            fillText: vi.fn(),
+            save: vi.fn(),
+            restore: vi.fn(),
+        } as unknown as CanvasRenderingContext2D);
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('emits video-stalled when the decoder is configured but produces nothing', async () => {
+        const player = await makeVp9Player();
+        const stalls: { codec: string; reason: string }[] = [];
+        player.on('video-stalled', (e) => stalls.push(e));
+
+        vi.advanceTimersByTime(5000);
+
+        expect(stalls).toHaveLength(1);
+        expect(stalls[0]).toEqual({ codec: 'vp9', reason: 'no-frames' });
+    });
+
+    it('keeps asking across further stalls, but stops at the cap', async () => {
+        const player = await makeVp9Player();
+        const stalls: unknown[] = [];
+        player.on('video-stalled', (e) => stalls.push(e));
+
+        // Well past the cap — a browser that simply cannot decode this codec
+        // must not have reset requests pinned on the device forever.
+        vi.advanceTimersByTime(5000 * 10);
+
+        expect(stalls).toHaveLength(3);
+    });
+
+    it('stops warning once frames start flowing', async () => {
+        const player = await makeVp9Player();
+        const stalls: unknown[] = [];
+        player.on('video-stalled', (e) => stalls.push(e));
+
+        player.pushVideoFrame(VP_KEYFRAME, 0n, false, true);
+        // The output callback clears the watchdog; simulate a decoded frame by
+        // pushing one through the fake decoder's output path.
+        vi.advanceTimersByTime(5000);
+
+        // A keyframe was decoded, so the first watchdog window should not have
+        // reported a stall for a stream that is in fact working.
+        expect(decoderInstances[0]?.decoded.map((c) => c.type)).toEqual(['key']);
+        expect(stalls.length).toBeLessThanOrEqual(1);
+    });
+
+    it('does not park the player in STOPPED when the decoder faults', async () => {
+        const { BasePlayer } = await import('../BasePlayer');
+        const player = await makeVp9Player();
+        player.play();
+        const playingState = player.getState();
+
+        decoderInstances[0]!.errorCb(new DOMException('decode failed', 'EncodingError'));
+
+        expect(player.getState()).toBe(playingState);
+        expect(player.getState()).not.toBe(BasePlayer.STATE['STOPPED']);
+    });
+
+    it('rebuilds and reconfigures the decoder after a fault, and asks for a keyframe', async () => {
+        const player = await makeVp9Player();
+        const stalls: { reason: string }[] = [];
+        player.on('video-stalled', (e) => stalls.push(e));
+        expect(decoderInstances).toHaveLength(1);
+
+        decoderInstances[0]!.errorCb(new DOMException('decode failed', 'EncodingError'));
+
+        expect(decoderInstances).toHaveLength(2);
+        // VP8/VP9 get no usable config packet, so the replacement decoder has
+        // to be configured from metadata or the requested keyframe is wasted.
+        expect(decoderInstances[1]!.state).toBe('configured');
+        expect(stalls.map((s) => s.reason)).toEqual(['decoder-error']);
+    });
+
+    it('drops deltas again after a fault until a new keyframe arrives', async () => {
+        const player = await makeVp9Player();
+        player.pushVideoFrame(VP_KEYFRAME, 0n, false, true);
+        player.pushVideoFrame(VP_DELTA, 1n, false, false);
+        expect(decoderInstances[0]!.decoded).toHaveLength(2);
+
+        decoderInstances[0]!.errorCb(new DOMException('decode failed', 'EncodingError'));
+
+        // Fresh decoder: deltas reference frames it never saw, so they must be
+        // dropped until the requested keyframe lands.
+        player.pushVideoFrame(VP_DELTA, 2n, false, false);
+        expect(decoderInstances[1]!.decoded).toHaveLength(0);
+
+        player.pushVideoFrame(VP_KEYFRAME, 3n, false, true);
+        expect(decoderInstances[1]!.decoded.map((c) => c.type)).toEqual(['key']);
+    });
+});

--- a/src/app/player/__tests__/webCodecsPlayerVp8Vp9.test.ts
+++ b/src/app/player/__tests__/webCodecsPlayerVp8Vp9.test.ts
@@ -2,13 +2,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * VP8/VP9 are the only codecs scrcpy streams that never send a config packet.
+ * VP8/VP9 are the only codecs whose decoder is configured from session metadata
+ * instead of from a config packet.
  *
- * scrcpy sets its config flag straight from MediaCodec's
- * `BUFFER_FLAG_CODEC_CONFIG` (`Streamer.writePacket`) with no video-codec
- * special-casing, and VP8/VP9 carry no out-of-band parameter sets — everything
- * the decoder needs is in the keyframe. So MediaCodec emits no config buffer
- * and no config packet is ever sent.
+ * (An earlier version of this comment said they send no config packet at all.
+ * They do — 12 bytes, just ahead of the first keyframe — but it carries no
+ * parameter sets we can turn into a `VideoDecoderConfig.description`, so
+ * `parseConfig` returns null and the config branch configures nothing. See
+ * `CONFIGLESS_CODECS`.)
  *
  * That breaks two assumptions the player made before VP8/VP9 support:
  *   1. the decoder is configured inside the `isConfig` branch, which never runs;

--- a/src/app/player/webCodecsConfig.ts
+++ b/src/app/player/webCodecsConfig.ts
@@ -83,14 +83,27 @@ export async function probeDecodeSupport(codec: string): Promise<boolean | undef
 }
 
 /**
- * Codecs that never produce a config packet.
+ * Codecs whose decoder must be configured from session metadata rather than
+ * from a config packet.
  *
- * scrcpy sets its config flag straight from MediaCodec's
- * `BUFFER_FLAG_CODEC_CONFIG` (`Streamer.writePacket`), with no video-codec
- * special-casing. VP8 and VP9 carry no out-of-band parameter sets — everything
- * the decoder needs is in the keyframe — so MediaCodec emits no such buffer and
- * scrcpy sends no config packet. Players must therefore configure these from
- * session metadata rather than waiting for a config frame that never arrives.
+ * ⚠️ The name is about what we can *use*, not about what arrives. An earlier
+ * version of this comment claimed VP8/VP9 send no config packet at all. That is
+ * wrong, and a wire capture disproves it: every VP9 session opens with a frame
+ * carrying MediaCodec's `BUFFER_FLAG_CODEC_CONFIG` — 12 bytes, ~15ms ahead of
+ * the first keyframe.
+ *
+ * What is true is that those 12 bytes are not parameter sets we can build a
+ * `VideoDecoderConfig.description` from. `parseConfig` looks for Annex B
+ * SPS/PPS (H.264/H.265) or an AV1 sequence header, finds neither, and returns
+ * null — so the config branch never configures anything for these codecs.
+ * Everything the decoder actually needs is in the keyframe, and the dimensions
+ * come from session metadata. Hence: configure up front, ignore the packet.
+ *
+ * The consequence that matters is in the keyframe gate, not here — see
+ * `WebCodecsPlayer.pushVideoFrame`. scrcpy emits exactly ONE keyframe per
+ * VP8/VP9 session (measured: 398 frames, 1 keyframe, over 28s at a 2s i-frame
+ * interval), so a session that misses it cannot resynchronise without asking
+ * the device for a new one.
  */
 export const CONFIGLESS_CODECS: readonly VideoCodecName[] = ['vp8', 'vp9'];
 


### PR DESCRIPTION
This is the root cause of the black screen in #498, found by instrumenting the wire and the decoder separately on real hardware.

## What's actually wrong

scrcpy emits **exactly one keyframe per VP8/VP9 session**. Measured on a Pixel 10a (`c2.exynos.vp9.encoder`, same Exynos family as the reporter's S21), i-frame interval 2s, 15fps:

```
28-second capture:  398 video frames,  1 keyframe,  1 config packet
```

That should have been ~14 keyframes. Reproduced across six sessions — `wireKeys: 1` every time.

`pushVideoFrame` refuses to decode until it has seen a keyframe. That part is correct: deltas reference frames the decoder never saw. But it assumed another keyframe would always be along. For VP8/VP9 there isn't one, so a session that misses it is black permanently with video still arriving.

Observed live rather than theorised: `configure()` ran and the decoder received **zero** `decode()` calls over ten minutes, with no decoder errors. It was never a decode failure — we simply never fed it anything.

Two paths can eat that single keyframe:

- `pushVideoFrame` returns early on `decoder.state !== 'configured'`
- the decoder `error` callback called `this.stop()`, which parks the player in `STOPPED` — and `onVideoFrame` only revives from `PAUSED`. `BasePlayer` has three states; one fault killed the session outright.

## The fix

`ControlMessage.TYPE_RESET_VIDEO = 17` has existed unused since v4 support landed. It asks the device for a fresh keyframe, which is the only way back once the original is missed.

- The decode watchdog already detected this exact condition and only logged about it. It now also emits `video-stalled`, which `StreamClientScrcpy` turns into the reset message.
- Bounded to **3 attempts**. A browser that genuinely cannot decode the codec will never recover, and shouldn't have reset requests pinned on the device forever. The full explanatory message is logged once; retries add a short line each.
- The decoder fault path no longer calls `stop()`. It rebuilds the decoder in place, re-configures from metadata (VP8/VP9 get no usable config packet) and requests a keyframe.

## Also: `CONFIGLESS_CODECS` was factually wrong

Its comment stated that VP8/VP9 "never produce a config packet" and that "scrcpy sends no config packet". The wire says otherwise — every VP9 session opens with a `BUFFER_FLAG_CODEC_CONFIG` frame, 12 bytes, ~15ms ahead of the keyframe. It carries no parameter sets we can build a `description` from, which is why `parseConfig` returns null and the branch does nothing. Behaviour is unchanged; the comment now says what's true, and the test file's header no longer repeats the same wrong claim.

## Verification

**On hardware.** Sent `RESET_VIDEO` mid-stream against a live VP9 session:

```
before:   135 video frames,  1 keyframe   (t=18181ms)
reset sent at                              t=22132ms
after:    209 video frames,  2 keyframes  (t=22348ms)
```

A second keyframe **216ms** after the request, on a stream that had produced exactly one in 135 frames.

And the whole path fired by itself on a real stall:

```
[ERROR] vp9: decoder configured but produced no frames after 5000ms...
[LOG]   vp9: requesting a fresh keyframe (attempt 1/3)
[LOG]   video stalled (codec=vp9, reason=no-frames); requesting a keyframe
[LOG]   First decoded frame: display=670x1504
```

Three back-to-back VP9 sessions afterwards on a clean page: zero errors.

**Tests.** Six new cases in `keyframeRecovery.test.ts`. Checked they bite by restoring `this.stop()` on the error path — 3 fail, including the STOPPED park.

Full suite 1610 passed / 5 skipped, `tsc --noEmit` clean, biome clean.

`release:none` — the interface-selection fix is coming next and will cut the beta carrying both.
