### PR TITLE
fix(device): prefer the LAN interface over cellular when building the stream URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A video decoding error no longer ends the session.** When the browser's decoder reported a fault, the player shut itself down — and nothing could start it again while the stream was still arriving, so the window stayed black until you reconnected by hand. The decoder is now rebuilt in place and a new keyframe requested, so a momentary fault costs a brief interruption instead of the whole session.
 
+- **Phones with mobile data switched on are no longer offered under their cellular address.** A device can report more than one network address, and the app picked between them by asking Android which one was Wi-Fi — a question current versions of Android no longer answer. With no answer it fell back to whichever address came first alphabetically, and on a phone that is the mobile-data one, which nothing on your network can reach. The app now recognises Wi-Fi and wired connections by name, prefers a genuine home-network address, and pushes cellular, tunnel and USB-tethering addresses to the back. Devices with only one address — most TV boxes — are unaffected, which is why this went unnoticed.
+
 ## [0.1.30-beta.80] - 2026-08-27
 
 ### Fixed

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -14,6 +14,7 @@ import type { Tool } from '../../client/Tool';
 import Util from '../../Util';
 import { html } from '../../ui/HtmlTag';
 import SvgImage from '../../ui/SvgImage';
+import { pickDeviceInterface } from './pickDeviceInterface';
 import { StreamClientScrcpy } from './StreamClientScrcpy';
 
 // ---------- capability gating ----------
@@ -315,9 +316,7 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         // Auto-select best interface: prefer wifi/direct IP, fallback to proxy
         let selectedInterfaceUrl = '';
         if (isActive) {
-            const wifiInterface = device.interfaces.find((i) => i.name === device['wifi.interface']);
-            const firstInterface = device.interfaces[0];
-            const bestInterface = wifiInterface || firstInterface;
+            const bestInterface = pickDeviceInterface(device.interfaces, device['wifi.interface']);
             if (bestInterface) {
                 const params = {
                     ...this.params,

--- a/src/app/googDevice/client/__tests__/pickDeviceInterface.test.ts
+++ b/src/app/googDevice/client/__tests__/pickDeviceInterface.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { isPrivateLanAddress, pickDeviceInterface } from '../pickDeviceInterface';
+
+/**
+ * The exact device state that produced the bug: a Pixel 10a with mobile data
+ * on, reporting its cellular interface alongside Wi-Fi, and an empty
+ * `wifi.interface` property.
+ *
+ *   rmnet16  100.90.22.137/32   <- carrier CGNAT, not routable from the LAN
+ *   wlan0    192.168.86.190/24  <- what we want
+ *
+ * The old picker fell back to `interfaces[0]` of an alphabetically sorted list,
+ * so `rmnet16` won and the stream URL pointed at an unreachable address.
+ */
+
+const WLAN = { name: 'wlan0', ipv4: '192.168.86.190' };
+const CELLULAR = { name: 'rmnet16', ipv4: '100.90.22.137' };
+const ETH = { name: 'eth0', ipv4: '192.168.86.43' };
+const TUN = { name: 'tun0', ipv4: '100.90.22.137' };
+const USB = { name: 'rndis0', ipv4: '192.168.42.129' };
+
+describe('pickDeviceInterface', () => {
+    it('prefers wlan over cellular even when cellular sorts first', () => {
+        // Alphabetical order, exactly as the server hands it over.
+        expect(pickDeviceInterface([CELLULAR, WLAN])).toEqual(WLAN);
+    });
+
+    it('still prefers wlan when wifi.interface is empty', () => {
+        expect(pickDeviceInterface([CELLULAR, WLAN], '')).toEqual(WLAN);
+        expect(pickDeviceInterface([CELLULAR, WLAN], undefined)).toEqual(WLAN);
+    });
+
+    it('honours wifi.interface when the device actually reports one', () => {
+        // Device naming its own Wi-Fi interface beats any heuristic, even one
+        // pointing at an interface the ranking would not have chosen.
+        expect(pickDeviceInterface([CELLULAR, WLAN], 'rmnet16')).toEqual(CELLULAR);
+    });
+
+    it('ignores a wifi.interface naming an interface that is not present', () => {
+        expect(pickDeviceInterface([CELLULAR, WLAN], 'wlan9')).toEqual(WLAN);
+    });
+
+    it('picks the only interface on a single-homed device', () => {
+        // The Google TV Streamer — why this bug stayed hidden.
+        expect(pickDeviceInterface([ETH])).toEqual(ETH);
+    });
+
+    it('prefers wlan over wired when both are present', () => {
+        expect(pickDeviceInterface([ETH, WLAN])).toEqual(WLAN);
+    });
+
+    it('prefers wired over cellular', () => {
+        expect(pickDeviceInterface([CELLULAR, ETH])).toEqual(ETH);
+    });
+
+    it('prefers a real network interface over USB tethering', () => {
+        expect(pickDeviceInterface([USB, WLAN])).toEqual(WLAN);
+    });
+
+    it('deprioritises tunnels, which share the CGNAT range with carriers', () => {
+        expect(pickDeviceInterface([TUN, WLAN])).toEqual(WLAN);
+    });
+
+    it('returns undefined when the device reports no interfaces', () => {
+        expect(pickDeviceInterface([])).toBeUndefined();
+    });
+
+    it('falls back to a private address when no name family is recognised', () => {
+        const odd = { name: 'zz-unknown0', ipv4: '10.0.0.5' };
+        const oddCgnat = { name: 'aa-unknown0', ipv4: '100.70.1.2' };
+        expect(pickDeviceInterface([oddCgnat, odd])).toEqual(odd);
+    });
+
+    it('keeps the device ordering when candidates tie', () => {
+        const first = { name: 'wlan0', ipv4: '192.168.1.2' };
+        const second = { name: 'wlan1', ipv4: '192.168.1.3' };
+        expect(pickDeviceInterface([first, second])).toEqual(first);
+    });
+});
+
+describe('isPrivateLanAddress', () => {
+    it('accepts the RFC1918 ranges', () => {
+        expect(isPrivateLanAddress('10.0.0.1')).toBe(true);
+        expect(isPrivateLanAddress('192.168.86.190')).toBe(true);
+        expect(isPrivateLanAddress('172.16.0.1')).toBe(true);
+        expect(isPrivateLanAddress('172.31.255.254')).toBe(true);
+    });
+
+    it('rejects CGNAT, which is what carriers and Tailscale both use', () => {
+        expect(isPrivateLanAddress('100.90.22.137')).toBe(false);
+        expect(isPrivateLanAddress('100.64.0.1')).toBe(false);
+    });
+
+    it('rejects addresses just outside the 172.16/12 block', () => {
+        expect(isPrivateLanAddress('172.15.0.1')).toBe(false);
+        expect(isPrivateLanAddress('172.32.0.1')).toBe(false);
+    });
+
+    it('rejects public addresses and malformed input', () => {
+        expect(isPrivateLanAddress('8.8.8.8')).toBe(false);
+        expect(isPrivateLanAddress('not-an-ip')).toBe(false);
+        expect(isPrivateLanAddress('192.168.1')).toBe(false);
+        expect(isPrivateLanAddress('192.168.1.999')).toBe(false);
+    });
+});

--- a/src/app/googDevice/client/pickDeviceInterface.ts
+++ b/src/app/googDevice/client/pickDeviceInterface.ts
@@ -1,0 +1,109 @@
+import type { NetInterface } from '../../../types/NetInterface';
+
+/**
+ * Choose which of a device's network interfaces to advertise as the stream
+ * host.
+ *
+ * The old rule was `interfaces.find(i => i.name === device['wifi.interface'])
+ * || interfaces[0]`, with `interfaces` sorted alphabetically by name. Two
+ * things go wrong with that on a modern phone:
+ *
+ *   - `getprop wifi.interface` is a legacy property and returns **empty** on
+ *     current Android (verified on a Pixel 10a, Android 17), so the lookup
+ *     misses and the fallback runs; and
+ *   - the fallback is alphabetical, and `rmnet16` sorts before `wlan0`.
+ *
+ * So a phone with mobile data on advertised its **cellular** address —
+ * `100.90.22.137`, a carrier CGNAT address that nothing on the LAN can route
+ * to. (That range is shared with Tailscale, which is what made it look like a
+ * VPN address at first.) Single-homed devices such as the Google TV Streamer
+ * hid the bug completely, since `eth0` was the only candidate.
+ *
+ * Alphabetical order carries no meaning here, so this ranks candidates instead.
+ */
+
+/** Interface-name families, best first. Matched case-insensitively as prefixes. */
+const NAME_RANK: readonly { prefixes: readonly string[]; score: number }[] = [
+    // Wi-Fi: what a phone on the same network as the server should use.
+    { prefixes: ['wlan', 'wifi', 'ap'], score: 100 },
+    // Wired: the Google TV Streamer and most set-top boxes.
+    { prefixes: ['eth', 'enp', 'ens', 'eno'], score: 90 },
+    // USB tethering / reverse tethering — routable, but rarely what is wanted
+    // when a real network interface exists.
+    { prefixes: ['rndis', 'usb', 'ncm'], score: 40 },
+    // Tunnels and VPNs. Reachable in principle, but the far side is somebody
+    // else's network and the address is not the device's LAN identity.
+    { prefixes: ['tun', 'tap', 'wg', 'ppp'], score: 20 },
+    // Cellular. `rmnet` is the Qualcomm/Exynos modem interface; `ccmni` is
+    // MediaTek's; `pdp_ip` is the older name. Never routable from the LAN.
+    { prefixes: ['rmnet', 'ccmni', 'pdp_ip', 'clat'], score: 10 },
+];
+
+const DEFAULT_NAME_SCORE = 50;
+
+function nameScore(name: string): number {
+    const lower = name.toLowerCase();
+    for (const { prefixes, score } of NAME_RANK) {
+        if (prefixes.some((p) => lower.startsWith(p))) return score;
+    }
+    return DEFAULT_NAME_SCORE;
+}
+
+/**
+ * RFC1918 private space — the address families a device on our LAN actually
+ * has. Deliberately does NOT include 100.64.0.0/10 (CGNAT): that is what
+ * carriers hand out to phones on mobile data, and it is the exact address this
+ * function exists to stop picking.
+ */
+export function isPrivateLanAddress(ipv4: string): boolean {
+    const octets = ipv4.split('.').map((o) => Number.parseInt(o, 10));
+    if (octets.length !== 4 || octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+        return false;
+    }
+    const [a, b] = octets as [number, number, number, number];
+    if (a === 10) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    return false;
+}
+
+function score(iface: NetInterface): number {
+    // A private-LAN address is a strong signal on its own: it survives an
+    // interface name nobody has enumerated here, and it is precisely what
+    // separates wlan0's 192.168.x from rmnet's 100.x.
+    return nameScore(iface.name) + (isPrivateLanAddress(iface.ipv4) ? 25 : 0);
+}
+
+/**
+ * Pick the interface to build the stream URL from, or `undefined` when the
+ * device reported none.
+ *
+ * `wifiInterfaceName` is the device's `wifi.interface` property. When it is set
+ * AND matches a reported interface it still wins outright — the device naming
+ * its own Wi-Fi interface is better evidence than any heuristic. It is simply
+ * no longer the only thing standing between us and an alphabetical guess.
+ */
+export function pickDeviceInterface(
+    interfaces: readonly NetInterface[],
+    wifiInterfaceName?: string | undefined,
+): NetInterface | undefined {
+    if (interfaces.length === 0) return undefined;
+
+    if (wifiInterfaceName) {
+        const named = interfaces.find((i) => i.name === wifiInterfaceName);
+        if (named) return named;
+    }
+
+    let best = interfaces[0]!;
+    let bestScore = score(best);
+    for (const candidate of interfaces.slice(1)) {
+        const candidateScore = score(candidate);
+        // Strictly greater, so an equal-scoring tie keeps the device's own
+        // ordering rather than reshuffling on every poll.
+        if (candidateScore > bestScore) {
+            best = candidate;
+            bestScore = candidateScore;
+        }
+    }
+    return best;
+}


### PR DESCRIPTION
Noticed while testing a Pixel: its `connect` link advertised `ws://100.90.22.137/` instead of the phone's LAN address.

100.64.0.0/10 is CGNAT, which Tailscale and every mobile carrier both use — so it read as a VPN address at first. It isn't. It's the phone's cellular interface:

```
rmnet16  100.90.22.137/32   <- carrier CGNAT, mobile data on
wlan0    192.168.86.190/24  <- the address we want
```

## Why it picked that

`DeviceTracker` chose the host with:

```ts
interfaces.find((i) => i.name === device['wifi.interface']) || interfaces[0]
```

over a list `Device.getNetInterfaces` sorts **alphabetically by name**. Both halves fail on a current phone:

- `getprop wifi.interface` is a legacy property and returns **empty** (verified on a Pixel 10a, Android 17), so the lookup misses and the fallback runs;
- the fallback is alphabetical, and `rmnet16` sorts before `wlan0`.

So we advertised an address nothing on the LAN can route to. It stayed hidden because every device tested until now was single-homed — the Google TV Streamer reports only `eth0`, so there was nothing to choose between. It also doesn't bite when you connect through the config modal, which uses `window.location.hostname`; only the plain `connect` link carries the bad host.

## The change

Alphabetical order carries no meaning here, so `pickDeviceInterface` ranks candidates instead:

- `wlan*` / `wifi*` first, then `eth*` / `enp*`
- USB tethering (`rndis*`, `usb*`) well below a real network interface
- tunnels (`tun*`, `tap*`, `wg*`, `ppp*`) below that
- cellular last — `rmnet*` (Qualcomm/Exynos), `ccmni*` (MediaTek), `pdp_ip*`
- plus a bonus for an RFC1918 address, which catches interface names nobody here has enumerated

`isPrivateLanAddress` deliberately excludes 100.64/10. Treating CGNAT as private would defeat the whole point.

An explicit `wifi.interface` that matches a reported interface still wins outright — the device naming its own Wi-Fi interface is better evidence than any heuristic. It's just no longer the only thing standing between us and a guess. Ties keep the device's own ordering so the choice doesn't reshuffle between polls.

I left `Device.interfacesSort` alone: it feeds change detection in `updateInterfaces`, where a stable order is the point, and the ranking no longer depends on input order.

## Testing

16 cases. Verified they bite by restoring the `interfaces[0]` fallback — 8 fail, including the exact Pixel pair.

Covers: the real rmnet-vs-wlan case, empty and absent `wifi.interface`, an explicit `wifi.interface` overriding the ranking, one naming an interface that isn't present, single-homed devices, wlan-over-eth, eth-over-cellular, USB tethering, tunnels, tie stability, and the RFC1918 boundaries either side of 172.16/12.

**On hardware:** the Pixel's link is now `ws://192.168.86.190/`; the TV Streamer is unchanged at `ws://192.168.86.43/`.

Full suite 1620 passed / 5 skipped, `tsc --noEmit` clean, biome clean.

`release:beta` — cuts the beta carrying this and the VP8/VP9 keyframe recovery in #547.
