### PR TITLE
fix(stream): send the advanced codec settings, and correct the keyframe claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The advanced stream settings now actually reach the device.** The "i-frame interval" and "codec options" boxes were collected, saved with the rest of your settings, and then dropped on the way to the device — so the codec-options box, which exists to pass any encoder setting the device understands, did nothing at all. Both are now sent. **One caveat, because it would be misleading to leave it out:** Android encoders very often ignore a requested keyframe interval, and on the hardware tested here changing it made no observable difference. The setting is delivered faithfully; whether the device honours it is up to the device.
+
 ## [0.1.30-beta.81] - 2026-08-27
 
 ### Fixed
@@ -26,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **An error reported by the server no longer interrupts the page.** The same underlying fault had a second, quieter form: when the server sent an error message about the list of hosts, handling it raised an internal error part-way through and abandoned the rest of that update. The message itself was always written to the browser console first, so nothing was lost, but the interruption was needless. Server-reported errors are now delivered without stopping the work around them.
 
 - **A VP8 or VP9 stream that starts black now recovers by itself.** These two codecs send a single keyframe at the very start of a session and then nothing but full-motion updates — measured on a real device at 398 frames with exactly one keyframe over 28 seconds. The player will not start drawing until it has seen that keyframe, because everything after it is described relative to it, so if anything caused the app to miss that one frame the picture never appeared at all and no amount of waiting helped. The app now asks the device to send a fresh keyframe when a stream has gone quiet for five seconds, which it will do up to three times before concluding the browser genuinely cannot play the codec. Recovery takes about a fifth of a second.
+
+  *Correction:* this entry describes the scarce-keyframe behaviour as specific to VP8 and VP9. It is not — measuring every codec afterwards found H.264 sending a single keyframe across 307 frames, and H.265, AV1 and VP9 two apiece, over comparable windows. The recovery described above was never codec-specific and applies to all of them, so this release fixes more than the entry claims rather than less.
 
 - **A video decoding error no longer ends the session.** When the browser's decoder reported a fault, the player shut itself down — and nothing could start it again while the stream was still arriving, so the window stayed black until you reconnected by hand. The decoder is now rebuilt in place and a new keyframe requested, so a momentary fault costs a brief interruption instead of the whole session.
 

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -227,6 +227,8 @@ export class StreamClientScrcpy
                       maxFps: vs.maxFps,
                       bounds: vs.bounds ? { width: vs.bounds.width, height: vs.bounds.height } : undefined,
                       displayId: vs.displayId,
+                      iFrameInterval: vs.iFrameInterval,
+                      codecOptions: vs.codecOptions,
                   }
                 : undefined,
         );
@@ -376,9 +378,10 @@ export class StreamClientScrcpy
         this.player = player;
         this.setTouchListeners(player);
 
-        // A stalled decoder can only resynchronise on a keyframe, and for
-        // VP8/VP9 scrcpy sends exactly one per session — so if that one is
-        // missed there is nothing to recover on until we ask for another.
+        // A stalled decoder can only resynchronise on a keyframe, and keyframes
+        // are scarce for every codec — h264 measured 1 in 307 frames over 24s,
+        // the others 2 apiece. So if one is missed there is nothing to recover
+        // on until we ask for another.
         player.on('video-stalled', ({ codec, reason }) => {
             console.log(TAG, `video stalled (codec=${codec}, reason=${reason}); requesting a keyframe`);
             this.demuxer?.sendControl(new CommandControlMessage(ControlMessage.TYPE_RESET_VIDEO));

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -38,10 +38,13 @@ export interface PlayerEvents {
      * out — either nothing has been fed to it, or it faulted. The listener is
      * expected to ask the device for a fresh keyframe.
      *
-     * VP8/VP9 make this non-optional: scrcpy emits exactly ONE keyframe per
-     * session for them (measured: 398 frames / 1 keyframe over 28s at a 2s
-     * i-frame interval), so a stream that misses it can never resynchronise on
-     * its own. Requesting a new one is the only way back.
+     * This is not optional, and not a VP8/VP9 quirk — keyframes are scarce for
+     * every codec. Measured on a Pixel 10a over ~24s each: h264 gave 1 keyframe
+     * in 307 frames; h265, av1 and vp9 gave 2 apiece, against the ~12 a
+     * 2-second interval implies. Asking for a shorter interval does not help
+     * (Android encoders largely ignore it — see `buildVideoCodecOptions`), so a
+     * stream that misses its keyframe cannot resynchronise on its own and
+     * requesting one is the only way back.
      */
     'video-stalled': { codec: string; reason: 'no-frames' | 'decoder-error' };
 }

--- a/src/app/player/WebCodecsPlayer.ts
+++ b/src/app/player/WebCodecsPlayer.ts
@@ -136,10 +136,13 @@ export class WebCodecsPlayer extends BaseCanvasBasedPlayer {
     /**
      * Rebuild the decoder after a fault and ask for a fresh keyframe.
      *
-     * The re-configure only applies to VP8/VP9: every other codec re-configures
-     * when its next config packet arrives, and those codecs send one alongside
-     * every keyframe. VP8/VP9 send no usable one (see `CONFIGLESS_CODECS`), so
-     * the decoder has to be set up from session metadata again here or the
+     * The re-configure only applies to VP8/VP9. For the other codecs a
+     * `TYPE_RESET_VIDEO` brings a fresh config packet back with the keyframe —
+     * verified on hardware, h264 returned config at +180ms and keyframe at
+     * +188ms — so their replacement decoder configures itself on arrival. (Not
+     * every keyframe carries a config packet; a reset-triggered one does.)
+     * VP8/VP9 send no usable config packet at all (see `CONFIGLESS_CODECS`), so
+     * their decoder has to be set up from session metadata again here, or the
      * keyframe we are about to request would arrive with nowhere to go.
      */
     private recoverDecoder(reason: 'no-frames' | 'decoder-error'): void {

--- a/src/app/player/__tests__/keyframeRecovery.test.ts
+++ b/src/app/player/__tests__/keyframeRecovery.test.ts
@@ -2,15 +2,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * A VP8/VP9 session that misses its keyframe used to be dead permanently.
+ * A session that misses its keyframe used to be dead permanently.
  *
- * scrcpy emits exactly ONE keyframe per VP8/VP9 session — measured on a Pixel
- * 10a over 28 seconds: 398 video frames, 1 keyframe, at a 2-second i-frame
- * interval. The player refuses to decode until it has seen one (deltas
- * reference frames the decoder never saw), so if that single frame is dropped
- * there is nothing left to resynchronise on. Observed live: `configure()` ran
- * and the decoder received zero chunks for ten minutes while video kept
- * arriving.
+ * Keyframes are scarce for every codec, not just VP8/VP9 — measured on a Pixel
+ * 10a over ~24 seconds each: h264 gave 1 keyframe in 307 frames; h265, av1 and
+ * vp9 gave 2 apiece, against the ~12 a 2-second i-frame interval implies.
+ * Asking for a shorter interval does not help, because Android encoders
+ * largely ignore `KEY_I_FRAME_INTERVAL` (an I-frame is not necessarily an IDR
+ * frame, and only IDR frames carry `BUFFER_FLAG_KEY_FRAME`).
+ *
+ * The player refuses to decode until it has seen a keyframe (deltas reference
+ * frames the decoder never saw), so if that one frame is dropped there is
+ * nothing left to resynchronise on. Observed live: `configure()` ran and the
+ * decoder received zero chunks for ten minutes while video kept arriving.
  *
  * Two things had to change, and these pin both:
  *   1. a decoder fault must not park the player in STOPPED, because
@@ -69,31 +73,31 @@ async function makeVp9Player() {
     return player;
 }
 
-describe('VP8/VP9 keyframe recovery', () => {
-    beforeEach(() => {
-        decoderInstances = [];
-        vi.useFakeTimers();
-        vi.stubGlobal('VideoDecoder', FakeVideoDecoder);
-        vi.stubGlobal('EncodedVideoChunk', FakeEncodedVideoChunk);
-        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-            drawImage: vi.fn(),
-            clearRect: vi.fn(),
-            fillRect: vi.fn(),
-            measureText: () => ({ actualBoundingBoxLeft: 0, actualBoundingBoxRight: 0 }),
-            fillText: vi.fn(),
-            save: vi.fn(),
-            restore: vi.fn(),
-        } as unknown as CanvasRenderingContext2D);
-        vi.spyOn(console, 'error').mockImplementation(() => {});
-        vi.spyOn(console, 'log').mockImplementation(() => {});
-    });
+beforeEach(() => {
+    decoderInstances = [];
+    vi.useFakeTimers();
+    vi.stubGlobal('VideoDecoder', FakeVideoDecoder);
+    vi.stubGlobal('EncodedVideoChunk', FakeEncodedVideoChunk);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+        drawImage: vi.fn(),
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        measureText: () => ({ actualBoundingBoxLeft: 0, actualBoundingBoxRight: 0 }),
+        fillText: vi.fn(),
+        save: vi.fn(),
+        restore: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+});
 
-    afterEach(() => {
-        vi.useRealTimers();
-        vi.unstubAllGlobals();
-        vi.restoreAllMocks();
-    });
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
 
+describe('keyframe recovery (config-less codecs)', () => {
     it('emits video-stalled when the decoder is configured but produces nothing', async () => {
         const player = await makeVp9Player();
         const stalls: { codec: string; reason: string }[] = [];
@@ -174,6 +178,95 @@ describe('VP8/VP9 keyframe recovery', () => {
         expect(decoderInstances[1]!.decoded).toHaveLength(0);
 
         player.pushVideoFrame(VP_KEYFRAME, 3n, false, true);
+        expect(decoderInstances[1]!.decoded.map((c) => c.type)).toEqual(['key']);
+    });
+});
+
+/**
+ * h264 takes a materially different route through the same recovery, and it was
+ * untested: its decoder is configured from the config packet rather than from
+ * session metadata, so `recoverDecoder` deliberately does NOT re-configure it.
+ *
+ * That only works because a `TYPE_RESET_VIDEO` brings a fresh config packet
+ * back alongside the keyframe. Verified on a Pixel 10a: after the reset the
+ * config packet arrived at +180ms and the keyframe at +188ms, taking the
+ * session from 1 config / 2 keyframes to 2 configs / 3 keyframes.
+ */
+describe('keyframe recovery (codecs with a config packet)', () => {
+    // Annex B SPS for 1080x2400 baseline — enough for parseConfig to identify
+    // h264 and build a decoder config.
+    const H264_CONFIG = new Uint8Array([
+        0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0xc0, 0x1f, 0xda, 0x02, 0x80, 0xf6, 0xc0, 0x5a, 0x80, 0x80, 0x80, 0xa0,
+        0x00, 0x00, 0x00, 0x01, 0x68, 0xce, 0x3c, 0x80,
+    ]);
+    const H264_KEYFRAME = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84, 0x00]);
+    const H264_DELTA = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x41, 0x9a, 0x00, 0x01]);
+
+    async function makeH264Player() {
+        const { WebCodecsPlayer } = await import('../WebCodecsPlayer');
+        const player = new WebCodecsPlayer('udid-h264');
+        player.setMetadataSize(1080, 2400);
+        player.setSessionInfo('h264', 'opus');
+        return player;
+    }
+
+    it('does not configure up front — it waits for the config packet', async () => {
+        await makeH264Player();
+        expect(decoderInstances[0]?.state).toBe('unconfigured');
+    });
+
+    it('stalls and asks for a keyframe when the config packet brings no frames', async () => {
+        const player = await makeH264Player();
+        const stalls: { codec: string; reason: string }[] = [];
+        player.on('video-stalled', (e) => stalls.push(e));
+
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        vi.advanceTimersByTime(5000);
+
+        expect(stalls).toHaveLength(1);
+        expect(stalls[0]?.reason).toBe('no-frames');
+    });
+
+    it('does not park the player in STOPPED when the decoder faults', async () => {
+        const { BasePlayer } = await import('../BasePlayer');
+        const player = await makeH264Player();
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        player.play();
+
+        decoderInstances[0]!.errorCb(new DOMException('decode failed', 'EncodingError'));
+
+        expect(player.getState()).not.toBe(BasePlayer.STATE['STOPPED']);
+    });
+
+    it('leaves the replacement decoder unconfigured, ready for the reset config packet', async () => {
+        const player = await makeH264Player();
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        expect(decoderInstances[0]!.state).toBe('configured');
+
+        decoderInstances[0]!.errorCb(new DOMException('decode failed', 'EncodingError'));
+
+        // Unlike VP8/VP9, this one must NOT be configured from metadata — the
+        // config packet that comes back with the requested keyframe does it.
+        expect(decoderInstances).toHaveLength(2);
+        expect(decoderInstances[1]!.state).toBe('unconfigured');
+    });
+
+    it('recovers once the reset returns a config packet and a keyframe', async () => {
+        const player = await makeH264Player();
+        player.pushVideoFrame(H264_CONFIG, 0n, true, false);
+        player.pushVideoFrame(H264_KEYFRAME, 1n, false, true);
+        expect(decoderInstances[0]!.decoded).toHaveLength(1);
+
+        decoderInstances[0]!.errorCb(new DOMException('decode failed', 'EncodingError'));
+
+        // Deltas alone cannot restart it.
+        player.pushVideoFrame(H264_DELTA, 2n, false, false);
+        expect(decoderInstances[1]!.decoded).toHaveLength(0);
+
+        // The reset brings both back, in this order.
+        player.pushVideoFrame(H264_CONFIG, 3n, true, false);
+        player.pushVideoFrame(H264_KEYFRAME, 4n, false, true);
+        expect(decoderInstances[1]!.state).toBe('configured');
         expect(decoderInstances[1]!.decoded.map((c) => c.type)).toEqual(['key']);
     });
 });

--- a/src/app/player/webCodecsConfig.ts
+++ b/src/app/player/webCodecsConfig.ts
@@ -100,10 +100,11 @@ export async function probeDecodeSupport(codec: string): Promise<boolean | undef
  * come from session metadata. Hence: configure up front, ignore the packet.
  *
  * The consequence that matters is in the keyframe gate, not here — see
- * `WebCodecsPlayer.pushVideoFrame`. scrcpy emits exactly ONE keyframe per
- * VP8/VP9 session (measured: 398 frames, 1 keyframe, over 28s at a 2s i-frame
- * interval), so a session that misses it cannot resynchronise without asking
- * the device for a new one.
+ * `WebCodecsPlayer.pushVideoFrame`. Keyframes are extremely scarce, and that
+ * is NOT a VP8/VP9 trait: measured on a Pixel 10a over ~24s each, h264 gave 1
+ * keyframe in 307 frames, and h265/av1/vp9 gave 2 apiece — where the configured
+ * 2-second interval implies about twelve. So any codec that misses its keyframe
+ * is stuck until the device is asked for a new one.
  */
 export const CONFIGLESS_CODECS: readonly VideoCodecName[] = ['vp8', 'vp9'];
 

--- a/src/common/StreamUrlParams.ts
+++ b/src/common/StreamUrlParams.ts
@@ -12,6 +12,64 @@ export interface VideoSettingsInput {
     maxFps?: number | undefined;
     bounds?: { width: number; height: number } | undefined;
     displayId?: number | undefined;
+    /**
+     * Seconds between keyframes. Reaches the device as a MediaFormat codec
+     * option rather than a top-level scrcpy argument — see
+     * {@link buildVideoCodecOptions}.
+     */
+    iFrameInterval?: number | undefined;
+    /** Free-form `key[:type]=value` codec options entered by the user. */
+    codecOptions?: string | undefined;
+}
+
+/** MediaFormat key for the keyframe interval (`MediaFormat.KEY_I_FRAME_INTERVAL`). */
+const I_FRAME_INTERVAL_KEY = 'i-frame-interval';
+
+/**
+ * Build scrcpy's `video_codec_options` value.
+ *
+ * scrcpy has no top-level argument for the keyframe interval; it is passed
+ * through to `MediaFormat` as a codec option in `key:type=value` form. The UI
+ * collects an i-frame interval and a free-form codec-options string
+ * separately, so they have to be merged into the one argument scrcpy accepts.
+ *
+ * A user-supplied `i-frame-interval` wins — if someone typed it into the
+ * codec-options box explicitly, that is a deliberate override of the slider,
+ * and emitting the key twice would be ambiguous.
+ *
+ * ⚠️ Sending the interval does NOT reliably change how often keyframes arrive.
+ * scrcpy applies codec options after its own `KEY_I_FRAME_INTERVAL` default of
+ * 10s, so the value does reach `MediaFormat` — verified on the device command
+ * line — but Android encoders commonly ignore it, because an I-frame is not
+ * necessarily an IDR frame and only IDR frames carry
+ * `BUFFER_FLAG_KEY_FRAME`. Measured on a Pixel 10a: keyframe spacing stayed
+ * around 14s whether the interval was sent as 2 or left at scrcpy's default.
+ * Upstream reports the same (Genymobile/scrcpy issues 3260 and 4857).
+ *
+ * So this exists to stop silently discarding settings the UI collected, not as
+ * a lever on keyframe cadence. The only reliable way to obtain a keyframe on
+ * demand is `TYPE_RESET_VIDEO` — see `WebCodecsPlayer`'s decode watchdog.
+ */
+export function buildVideoCodecOptions(
+    iFrameInterval?: number | undefined,
+    codecOptions?: string | undefined,
+): string | undefined {
+    const parts: string[] = [];
+    const user = codecOptions?.trim();
+    const userSetsIFrame = user ? user.split(',').some((p) => p.trim().startsWith(`${I_FRAME_INTERVAL_KEY}:`)) : false;
+
+    if (
+        !userSetsIFrame &&
+        typeof iFrameInterval === 'number' &&
+        Number.isFinite(iFrameInterval) &&
+        iFrameInterval > 0
+    ) {
+        parts.push(`${I_FRAME_INTERVAL_KEY}:int=${Math.round(iFrameInterval)}`);
+    }
+    if (user) {
+        parts.push(user);
+    }
+    return parts.length > 0 ? parts.join(',') : undefined;
 }
 
 /**
@@ -35,6 +93,13 @@ export function applyStreamParams(url: URL, params: StreamParamsInput, videoSett
             if (maxDim > 0) url.searchParams.set('maxSize', maxDim.toString());
         }
         if (videoSettings.displayId) url.searchParams.set('displayId', videoSettings.displayId.toString());
+        // Both were collected by the advanced UI and persisted in
+        // VideoSettings, then silently dropped here — so the codec-options box,
+        // which is scrcpy's documented escape hatch, did nothing at all.
+        const videoCodecOptions = buildVideoCodecOptions(videoSettings.iFrameInterval, videoSettings.codecOptions);
+        if (videoCodecOptions) {
+            url.searchParams.set('videoCodecOptions', videoCodecOptions);
+        }
     }
 
     if (params.videoCodec && params.videoCodec !== 'h264') {

--- a/src/common/__tests__/videoCodecOptions.test.ts
+++ b/src/common/__tests__/videoCodecOptions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { applyStreamParams, buildVideoCodecOptions } from '../StreamUrlParams';
+
+/**
+ * The advanced settings collected an i-frame interval and a free-form codec
+ * options string, stored both in `VideoSettings`, and then never sent them:
+ * `applyStreamParams` had no field for either. The codec-options box — which
+ * is scrcpy's documented escape hatch for arbitrary `MediaFormat` keys — did
+ * nothing whatsoever.
+ *
+ * scrcpy has no dedicated argument for the keyframe interval; it travels as a
+ * codec option, so the two UI fields have to merge into the one value scrcpy
+ * accepts. That merge is what these tests pin.
+ *
+ * ⚠️ Deliberately NOT claimed here: that sending the interval changes keyframe
+ * cadence. It does not, measurably — see `buildVideoCodecOptions` for the
+ * evidence and the reason (I-frame ≠ IDR frame).
+ */
+
+describe('buildVideoCodecOptions', () => {
+    it('turns an interval into a MediaFormat codec option', () => {
+        expect(buildVideoCodecOptions(2, undefined)).toBe('i-frame-interval:int=2');
+    });
+
+    it('passes user codec options through untouched', () => {
+        expect(buildVideoCodecOptions(undefined, 'profile:int=8')).toBe('profile:int=8');
+    });
+
+    it('merges the interval with user options', () => {
+        expect(buildVideoCodecOptions(2, 'profile:int=8')).toBe('i-frame-interval:int=2,profile:int=8');
+    });
+
+    it('lets an explicit user i-frame-interval win, without emitting the key twice', () => {
+        // Typing the key by hand is a deliberate override of the slider, and
+        // scrcpy would have no way to resolve the key appearing twice.
+        const result = buildVideoCodecOptions(2, 'i-frame-interval:int=10');
+        expect(result).toBe('i-frame-interval:int=10');
+        expect(result?.match(/i-frame-interval/g)).toHaveLength(1);
+    });
+
+    it('still merges when the user sets a different key that merely contains the name', () => {
+        const result = buildVideoCodecOptions(2, 'my-i-frame-interval-ish:int=1');
+        expect(result).toBe('i-frame-interval:int=2,my-i-frame-interval-ish:int=1');
+    });
+
+    it('returns undefined when there is nothing to send', () => {
+        expect(buildVideoCodecOptions(undefined, undefined)).toBeUndefined();
+        expect(buildVideoCodecOptions(0, '')).toBeUndefined();
+    });
+
+    it('ignores a nonsensical interval rather than sending it', () => {
+        expect(buildVideoCodecOptions(-1, undefined)).toBeUndefined();
+        expect(buildVideoCodecOptions(Number.NaN, undefined)).toBeUndefined();
+    });
+
+    it('rounds a fractional interval, since MediaFormat wants an int', () => {
+        expect(buildVideoCodecOptions(2.4, undefined)).toBe('i-frame-interval:int=2');
+        expect(buildVideoCodecOptions(2.6, undefined)).toBe('i-frame-interval:int=3');
+    });
+
+    it('trims surrounding whitespace from user options', () => {
+        expect(buildVideoCodecOptions(undefined, '  profile:int=8  ')).toBe('profile:int=8');
+    });
+});
+
+describe('applyStreamParams video codec options', () => {
+    const url = () => new URL('ws://localhost:8001/');
+
+    it('sends the i-frame interval that the UI collected', () => {
+        const u = url();
+        applyStreamParams(u, { udid: 'dev' }, { iFrameInterval: 2 });
+        expect(u.searchParams.get('videoCodecOptions')).toBe('i-frame-interval:int=2');
+    });
+
+    it('sends nothing when the settings carry neither', () => {
+        const u = url();
+        applyStreamParams(u, { udid: 'dev' }, { bitrate: 8000000 });
+        expect(u.searchParams.has('videoCodecOptions')).toBe(false);
+    });
+
+    it('leaves the existing params alone', () => {
+        const u = url();
+        applyStreamParams(u, { udid: 'dev', videoCodec: 'vp9' }, { bitrate: 8000000, maxFps: 15, iFrameInterval: 2 });
+        expect(u.searchParams.get('udid')).toBe('dev');
+        expect(u.searchParams.get('videoCodec')).toBe('vp9');
+        expect(u.searchParams.get('bitrate')).toBe('8000000');
+        expect(u.searchParams.get('maxFps')).toBe('15');
+        expect(u.searchParams.get('videoCodecOptions')).toBe('i-frame-interval:int=2');
+    });
+});

--- a/src/server/ScrcpyOptions.ts
+++ b/src/server/ScrcpyOptions.ts
@@ -17,9 +17,15 @@ export interface ScrcpyOptions {
     tunnelForward?: boolean;
     cleanup?: boolean;
     videoEncoder?: string;
+    /**
+     * MediaFormat codec options as `key[:type]=value[,...]`, e.g.
+     * `i-frame-interval:int=2`. scrcpy has no dedicated argument for the
+     * keyframe interval, so it travels here.
+     */
+    videoCodecOptions?: string;
 }
 
-const DEFAULTS: Omit<Required<ScrcpyOptions>, 'scid' | 'videoEncoder'> = {
+const DEFAULTS: Omit<Required<ScrcpyOptions>, 'scid' | 'videoEncoder' | 'videoCodecOptions'> = {
     videoCodec: 'h264',
     audioCodec: 'opus',
     audioSource: 'output',
@@ -53,6 +59,9 @@ export function serializeOptions(options: ScrcpyOptions): string[] {
     args.push(`scid=${options.scid}`);
     if (options.videoEncoder) {
         args.push(`video_encoder=${options.videoEncoder}`);
+    }
+    if (options.videoCodecOptions) {
+        args.push(`video_codec_options=${options.videoCodecOptions}`);
     }
     return args;
 }

--- a/src/server/__tests__/scrcpyCodecOptions.test.ts
+++ b/src/server/__tests__/scrcpyCodecOptions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { serializeOptions } from '../ScrcpyOptions';
+import { scrcpyOptionsFromQuery } from '../scrcpyOptionsFromQuery';
+import { isSafeCodecOptions } from '../security/deviceInput';
+
+/**
+ * `videoCodecOptions` is browser input that ends up inside the
+ * `CLASSPATH=... app_process ...` string executed via `adb shell`, exactly like
+ * `videoEncoder`. It is allowlisted rather than escaped, so the allowlist is
+ * the security boundary and gets tested as one.
+ */
+
+describe('isSafeCodecOptions', () => {
+    it('accepts the shapes scrcpy actually takes', () => {
+        expect(isSafeCodecOptions('i-frame-interval:int=2')).toBe(true);
+        expect(isSafeCodecOptions('i-frame-interval:int=2,profile:int=8')).toBe(true);
+        expect(isSafeCodecOptions('bitrate-mode:int=1')).toBe(true);
+        expect(isSafeCodecOptions('some_key:string=baseline')).toBe(true);
+    });
+
+    it('rejects shell metacharacters', () => {
+        expect(isSafeCodecOptions('a:int=1; rm -rf /')).toBe(false);
+        expect(isSafeCodecOptions('a:int=$(id)')).toBe(false);
+        expect(isSafeCodecOptions('a:int=`id`')).toBe(false);
+        expect(isSafeCodecOptions("a:int=1'")).toBe(false);
+        expect(isSafeCodecOptions('a:int=1 && whoami')).toBe(false);
+        expect(isSafeCodecOptions('a:int=1|tee /tmp/x')).toBe(false);
+        expect(isSafeCodecOptions('a:int=1\nb:int=2')).toBe(false);
+    });
+
+    it('rejects empty, non-string and over-long values', () => {
+        expect(isSafeCodecOptions('')).toBe(false);
+        expect(isSafeCodecOptions(undefined)).toBe(false);
+        expect(isSafeCodecOptions(42)).toBe(false);
+        expect(isSafeCodecOptions(`a:int=${'1'.repeat(300)}`)).toBe(false);
+    });
+});
+
+describe('scrcpyOptionsFromQuery videoCodecOptions', () => {
+    const q = (s: string) => new URLSearchParams(s);
+
+    it('accepts a well-formed value', () => {
+        const o = scrcpyOptionsFromQuery(q('videoCodecOptions=i-frame-interval%3Aint%3D2'), 'scid1');
+        expect(o.videoCodecOptions).toBe('i-frame-interval:int=2');
+    });
+
+    it('drops a value that fails the allowlist rather than passing it on', () => {
+        const o = scrcpyOptionsFromQuery(q('videoCodecOptions=a%3Aint%3D1%3B%20id'), 'scid1');
+        expect(o.videoCodecOptions).toBeUndefined();
+    });
+
+    it('is absent when not supplied', () => {
+        const o = scrcpyOptionsFromQuery(q('videoCodec=vp9'), 'scid1');
+        expect(o.videoCodecOptions).toBeUndefined();
+    });
+});
+
+describe('serializeOptions', () => {
+    it('emits video_codec_options for scrcpy', () => {
+        const args = serializeOptions({ scid: 'abc', videoCodecOptions: 'i-frame-interval:int=2' });
+        expect(args).toContain('video_codec_options=i-frame-interval:int=2');
+    });
+
+    it('omits it when unset', () => {
+        const args = serializeOptions({ scid: 'abc' });
+        expect(args.some((a) => a.startsWith('video_codec_options='))).toBe(false);
+    });
+
+    it('does not disturb the existing arguments', () => {
+        const args = serializeOptions({ scid: 'abc', videoCodec: 'vp9', videoEncoder: 'c2.exynos.vp9.encoder' });
+        expect(args).toContain('video_codec=vp9');
+        expect(args).toContain('video_encoder=c2.exynos.vp9.encoder');
+        expect(args).toContain('scid=abc');
+    });
+});

--- a/src/server/scrcpyOptionsFromQuery.ts
+++ b/src/server/scrcpyOptionsFromQuery.ts
@@ -1,5 +1,5 @@
 import type { ScrcpyOptions } from './ScrcpyOptions';
-import { isSafeEncoderName } from './security/deviceInput';
+import { isSafeCodecOptions, isSafeEncoderName } from './security/deviceInput';
 
 /**
  * Pure translation from the stream WebSocket's query string to a ScrcpyOptions
@@ -52,6 +52,15 @@ export function scrcpyOptionsFromQuery(params: URLSearchParams, scid: string): S
     const videoEncoder = params.get('videoEncoder');
     if (videoEncoder && isSafeEncoderName(videoEncoder)) {
         options.videoEncoder = videoEncoder;
+    }
+
+    // Carries the keyframe interval, which scrcpy has no top-level argument for
+    // — it goes to MediaFormat as `i-frame-interval:int=N`. Serialized into the
+    // same `app_process ...` string as videoEncoder, so it gets the same
+    // allowlist treatment rather than being escaped.
+    const videoCodecOptions = params.get('videoCodecOptions');
+    if (videoCodecOptions && isSafeCodecOptions(videoCodecOptions)) {
+        options.videoCodecOptions = videoCodecOptions;
     }
 
     return options;

--- a/src/server/security/deviceInput.ts
+++ b/src/server/security/deviceInput.ts
@@ -33,6 +33,17 @@ export function assertSerial(serial: unknown): string {
     return serial;
 }
 
+// scrcpy codec options are a comma-separated list of `key[:type]=value`, e.g.
+// `i-frame-interval:int=2,profile:int=8`. Values are MediaFormat keys, type
+// names and numbers — never paths, quotes or shell metacharacters. Like the
+// encoder name, this is browser input that ends up inside the `app_process ...`
+// string run via `adb shell`, so it is allowlisted rather than escaped.
+const CODEC_OPTIONS_RE = /^[A-Za-z0-9_.:,=-]{1,256}$/;
+
+export function isSafeCodecOptions(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && CODEC_OPTIONS_RE.test(value);
+}
+
 // Encoder names look like `OMX.qcom.video.encoder.avc` / `c2.android.avc.encoder`.
 const ENCODER_RE = /^[A-Za-z0-9_.-]{1,128}$/;
 


### PR DESCRIPTION
Two things: a genuinely inert pair of settings, and a correction to the scope of what beta.81 claimed to fix.

## The advanced settings never reached the device

`ConfigureScrcpy` collects an i-frame interval and a free-form codec-options string. `VideoSettings` persists both. And `applyStreamParams` had a field for neither, so both were dropped on the way out — `scrcpyOptionsFromQuery` and `ScrcpyOptions` had nowhere to put them either.

The consequence worth caring about is the **codec-options box**: that is scrcpy's documented escape hatch for passing arbitrary `MediaFormat` keys to the encoder, and it did nothing whatsoever.

Both now travel as scrcpy's `video_codec_options`, merged into the one argument it accepts. An `i-frame-interval` typed explicitly into the codec-options box beats the slider, since emitting the key twice would be ambiguous.

Verified on the live device command line, not just in a test:

```
app_process / com.genymobile.scrcpy.Server 4.1 max_size=1504 video_bit_rate=7864320
  max_fps=15 scid=329c91ba video_encoder=c2.android.avc.encoder
  video_codec_options=i-frame-interval:int=2
```

It is allowlisted rather than escaped, matching `videoEncoder`, because it ends up inside the `adb shell` string.

## What this does NOT do

**It does not change how often keyframes arrive**, and I want that on the record rather than discovered later.

scrcpy applies `video_codec_options` *after* its own `KEY_I_FRAME_INTERVAL` default of 10s, so our value genuinely reaches `MediaFormat`. But Android encoders commonly ignore it: an I-frame is not necessarily an IDR frame, and only IDR frames carry `BUFFER_FLAG_KEY_FRAME`. Measured on a Pixel 10a, keyframe spacing stayed around 14s whether the interval was sent as 2 or left at scrcpy's default. Upstream reports the same behaviour (Genymobile/scrcpy [#3260](https://github.com/Genymobile/scrcpy/issues/3260), [#4857](https://github.com/Genymobile/scrcpy/issues/4857)).

I originally justified this PR as defence-in-depth for the black-screen bug — keyframes every 2s meaning a missed one self-heals. That was wrong, and the source comment now says so plainly. `TYPE_RESET_VIDEO` remains the only reliable way to get a keyframe on demand.

## Correcting beta.81's scope

The keyframe-recovery fix described the scarcity as a VP8/VP9 trait. Measuring every codec over ~24s each disproved it:

```
h264   307 frames  ->  1 keyframe
h265   706 frames  ->  2 keyframes
av1    720 frames  ->  2 keyframes
vp9    718 frames  ->  2 keyframes
```

Against roughly twelve that a 2-second interval implies. The recovery mechanism was never codec-specific, so beta.81 fixed *more* than its entry claimed — but five source comments and the CHANGELOG asserted otherwise, and those comments exist precisely to stop the next reader re-deriving this. Corrected in place, with a `*Correction:*` note on the shipped entry following the beta.78 precedent.

I also verified the measurement itself rather than trusting it: `FrameReader`'s flag constants match scrcpy's `Streamer.java` exactly (`PACKET_FLAG_SESSION = 1L << 63`, `CONFIG = 1L << 62`, `KEY_FRAME = 1L << 61`, sourced from `BUFFER_FLAG_KEY_FRAME`), so the scarcity is real and not a parsing artefact.

## Filling the h264 test gap

`keyframeRecovery.test.ts` only covered VP8/VP9. h264 takes a materially different route: `recoverDecoder` deliberately does *not* re-configure it, relying instead on the reset returning a config packet alongside the keyframe. Confirmed on hardware — after the reset, config at +180ms and keyframe at +188ms, taking the session from 1 config / 2 keyframes to 2 / 3.

Five new cases pin that: no up-front configure, stall detection, no STOPPED park on fault, the replacement decoder left unconfigured on purpose, and full recovery once config + keyframe return. Shared setup hoisted to file scope so both describes get it.

## Testing

Full suite 1666 passed / 5 skipped, `tsc --noEmit` clean, biome clean.

New: 12 cases for the option merge and `applyStreamParams`, 9 for the server-side allowlist and serialization (including shell-metacharacter rejection, since that value reaches `adb shell`), 5 for h264 recovery.

`release:none` — the last PR in this batch will carry the beta.
