### PR TITLE
fix(stream): tell the user the device is locked instead of reconnecting blindly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A locked phone now says so, instead of showing you a black screen.** Android does not allow anything to capture the lock screen — not this app, not any other, not even the phone's own screenshot tool. It hands over a black image instead. So a phone that locked itself while you were watching, or was locked when you connected, produced a completely black window with no explanation, which is indistinguishable from the app being broken. The stream window now tells you the device is locked and clears the message the moment you unlock it.
+
+- **The app no longer reconnects the stream over and over when the picture is not moving.** It watched for the video "degrading" and reconnected when frames became small — but a still screen legitimately produces small frames, and a locked one produces almost nothing at all. The result was a stream that interrupted itself every thirty seconds, achieved nothing (the picture was still black afterwards), and explained none of it. It now asks the device what is actually going on rather than guessing, and reconnects only when you ask it to.
+
 - **The advanced stream settings now actually reach the device.** The "i-frame interval" and "codec options" boxes were collected, saved with the rest of your settings, and then dropped on the way to the device — so the codec-options box, which exists to pass any encoder setting the device understands, did nothing at all. Both are now sent. **One caveat, because it would be misleading to leave it out:** Android encoders very often ignore a requested keyframe interval, and on the hardware tested here changing it made no observable difference. The setting is delivered faithfully; whether the device honours it is up to the device.
 
 ## [0.1.30-beta.81] - 2026-08-27

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -47,6 +47,35 @@ type StartParams = {
 
 const TAG = '[StreamClientScrcpy]';
 
+/**
+ * Average encoded frame size below which there is almost certainly no picture.
+ * A black screen measured 13 bytes per frame on a Pixel 10a against 30-50KB
+ * once unlocked, so even a still photo sits far above this.
+ */
+export const NO_PICTURE_FRAME_BYTES = 1000;
+
+/**
+ * Whether the stream appears to have stopped showing anything, which is the cue
+ * to ask the device whether its keyguard is up.
+ *
+ * Two independent conditions, because one alone is not enough:
+ *
+ * - **Relative** catches a stream that *becomes* static, i.e. the phone locking
+ *   part-way through a session.
+ * - **Absolute** catches one that starts that way. Connecting to an
+ *   already-locked phone builds the baseline out of black frames, so nothing
+ *   can ever look small relative to it — that is exactly what a reconnect onto
+ *   a locked phone does, and the case that left issue #498's reporter staring
+ *   at black with no explanation.
+ *
+ * Being liberal here is safe: crossing the line only prompts a question to the
+ * device, and the banner is driven by its answer rather than by this guess.
+ */
+export function looksLikeNoPicture(averageFrameBytes: number, baselineFrameBytes: number): boolean {
+    const relativeDrop = baselineFrameBytes > 0 && averageFrameBytes < baselineFrameBytes * 0.1;
+    return relativeDrop || averageFrameBytes < NO_PICTURE_FRAME_BYTES;
+}
+
 async function browserSupportsCodec(codec: string): Promise<boolean> {
     // An unanswerable probe (no WebCodecs API) resolves to false so the caller
     // exhausts its preference loop and falls through to its plain h264 default,
@@ -106,7 +135,11 @@ export class StreamClientScrcpy
     private frameSampleCount = 0;
     private baselineFrameSize = 0;
     private degradationCount = 0;
-    private lastRefreshTime = 0;
+    /** Banner shown over the video while the device reports its keyguard is up. */
+    private lockedNotice?: HTMLElement | undefined;
+    private lastLockCheckTime = 0;
+    /** Each check is an adb round trip, so do not ask more often than this. */
+    private static readonly LOCK_CHECK_INTERVAL_MS = 5000;
     private stopFn?: (() => void) | undefined;
 
     /** Public hook — fires after session metadata is parsed. Used by the public startStream API. */
@@ -418,6 +451,14 @@ export class StreamClientScrcpy
         deviceView.appendChild(this.controlButtons);
         const video = document.createElement('div');
         video.className = 'video';
+        // Overlay for "this device is locked". Android refuses to capture the
+        // keyguard, so the stream is genuinely black through no fault of ours —
+        // without this the app looks broken (see issue #498).
+        this.lockedNotice = document.createElement('div');
+        this.lockedNotice.className = 'stream-locked-notice';
+        this.lockedNotice.hidden = true;
+        this.lockedNotice.textContent = 'device is locked — unlock it to see the screen';
+        video.appendChild(this.lockedNotice);
         deviceView.appendChild(video);
         player.setParent(video);
         player.pause();
@@ -499,38 +540,75 @@ export class StreamClientScrcpy
         this.demuxer?.sendControl(message);
     }
 
+    /**
+     * Watch for the frames going very small, and find out why.
+     *
+     * This used to conclude "the stream has degraded" and force a reconnect.
+     * That premise was wrong: small frames mean the *picture is not changing*,
+     * which is a perfectly healthy stream of a static screen. The thresholds
+     * had already been loosened twice (10s → 30s, 25% → 10%) chasing false
+     * positives rather than questioning the idea.
+     *
+     * The dominant cause is a locked phone. Android will not let anything
+     * capture the keyguard, so it hands scrcpy a black surface, which encodes
+     * to almost nothing — measured at 13 bytes per frame against 30-50KB once
+     * unlocked. Reconnecting could never have fixed that; it just interrupted
+     * the video for a second and landed on the same black screen, repeatedly
+     * and without explanation. Issue #498 spent days on it.
+     *
+     * So the small-frame signal is now a prompt to *ask the device* what is
+     * going on, rather than a verdict about the stream.
+     */
     private checkForDegradation(): void {
-        if (this.baselineFrameSize === 0) return;
-        const now = Date.now();
-        // Don't check within 30s of a refresh (was 10s — too aggressive)
-        if (now - this.lastRefreshTime < 30000) return;
-        // Need at least 10 samples for a reliable average
         if (this.frameSizes.count < 10) return;
 
         const avg = this.frameSizes.average();
-        // If average frame size drops below 10% of baseline for sustained period
-        // (was 25% — too sensitive for static content like screensavers)
-        if (avg < this.baselineFrameSize * 0.1) {
+        if (looksLikeNoPicture(avg, this.baselineFrameSize)) {
             this.degradationCount++;
             if (this.degradationCount >= 5) {
-                console.log(
-                    TAG,
-                    `Quality degradation detected (avg=${Math.round(avg)} vs baseline=${Math.round(this.baselineFrameSize)}), refreshing stream`,
-                );
                 this.degradationCount = 0;
-                this.frameSizes.clear();
-                this.frameSampleCount = 0;
-                this.baselineFrameSize = 0;
-                this.refreshStream();
+                void this.refreshLockedNotice();
             }
         } else {
             this.degradationCount = 0;
+            // Picture is moving again, so whatever it was has passed.
+            this.setLockedNotice(false);
+        }
+    }
+
+    /**
+     * Ask the device whether its keyguard is up, and show or hide the notice.
+     *
+     * Throttled because it costs an adb round trip, and deliberately fails
+     * quiet: if we cannot get an answer we say nothing rather than accusing a
+     * working device of being locked.
+     */
+    private async refreshLockedNotice(): Promise<void> {
+        const now = Date.now();
+        if (now - this.lastLockCheckTime < StreamClientScrcpy.LOCK_CHECK_INTERVAL_MS) return;
+        this.lastLockCheckTime = now;
+        try {
+            const response = await fetch(`/api/devices/screen-state?udid=${encodeURIComponent(this.params.udid)}`);
+            if (!response.ok) return;
+            const state = (await response.json()) as { awake?: boolean; locked?: boolean };
+            this.setLockedNotice(state.locked === true);
+        } catch {
+            // Offline, server restarting, endpoint unavailable — stay silent.
+        }
+    }
+
+    private setLockedNotice(locked: boolean): void {
+        if (!this.lockedNotice) return;
+        const alreadyCorrect = this.lockedNotice.hidden === !locked;
+        if (alreadyCorrect) return;
+        this.lockedNotice.hidden = !locked;
+        if (locked) {
+            console.log(TAG, 'device reports its keyguard is up; screen capture will be black until it is unlocked');
         }
     }
 
     public refreshStream(): void {
         console.log(TAG, 'Refreshing stream (reconnect for fresh keyframe)');
-        this.lastRefreshTime = Date.now();
         this.frameSizes.clear();
         this.frameSampleCount = 0;
         this.baselineFrameSize = 0;

--- a/src/app/googDevice/client/__tests__/looksLikeNoPicture.test.ts
+++ b/src/app/googDevice/client/__tests__/looksLikeNoPicture.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { looksLikeNoPicture, NO_PICTURE_FRAME_BYTES } from '../StreamClientScrcpy';
+
+/**
+ * Sizes taken from a Pixel 10a with a stream running across a lock/unlock:
+ *
+ *   locked    15 fps    13 bytes/frame
+ *   unlocked  15 fps    30,000-50,000 bytes/frame
+ *
+ * Android refuses to let anything capture the keyguard, so it hands scrcpy a
+ * black surface which encodes to almost nothing. This predicate is the cue to
+ * go *ask* the device whether it is locked — it never decides the answer.
+ *
+ * The code this replaced treated the same signal as proof the stream had
+ * degraded and forced a reconnect, which could not possibly help: the next
+ * frame was black too. It just interrupted the video every ~30s and said
+ * nothing, which is what issue #498 spent days chasing.
+ */
+
+const BLACK = 13;
+const LIVE = 40000;
+
+describe('looksLikeNoPicture', () => {
+    it('spots a stream that goes black part-way through, against a live baseline', () => {
+        expect(looksLikeNoPicture(BLACK, LIVE)).toBe(true);
+    });
+
+    it('spots a stream that was already black when it started', () => {
+        // Connecting to a locked phone builds the baseline out of black frames,
+        // so 13 is not "small relative to" 13. Without the absolute floor this
+        // case is invisible — and it is the one a reconnect produces.
+        expect(looksLikeNoPicture(BLACK, BLACK)).toBe(true);
+    });
+
+    it('spots black even with no baseline established yet', () => {
+        expect(looksLikeNoPicture(BLACK, 0)).toBe(true);
+    });
+
+    it('leaves a live picture alone', () => {
+        expect(looksLikeNoPicture(LIVE, LIVE)).toBe(false);
+        expect(looksLikeNoPicture(35000, 40000)).toBe(false);
+    });
+
+    it('leaves a quiet but real screen alone', () => {
+        // A mostly-static app is still well above the floor and within range of
+        // its own baseline; it must not be mistaken for a locked device.
+        expect(looksLikeNoPicture(9000, 40000)).toBe(false);
+    });
+
+    it('still catches a severe relative collapse that stays above the floor', () => {
+        // 2,000 bytes against a 40,000 baseline is a 95% drop: not black, but
+        // worth asking about.
+        expect(looksLikeNoPicture(2000, 40000)).toBe(true);
+    });
+
+    it('treats the absolute floor as exclusive', () => {
+        expect(looksLikeNoPicture(NO_PICTURE_FRAME_BYTES - 1, 0)).toBe(true);
+        expect(looksLikeNoPicture(NO_PICTURE_FRAME_BYTES, 0)).toBe(false);
+    });
+});

--- a/src/server/__tests__/deviceScreenState.test.ts
+++ b/src/server/__tests__/deviceScreenState.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { parseScreenState, SCREEN_STATE_COMMAND } from '../deviceScreenState';
+
+/**
+ * Real captures from a Pixel 10a (Android 17), taken either side of an unlock
+ * while a stream was running. The locked capture is the state in which Android
+ * hands scrcpy a black surface and the stream appears broken.
+ */
+const LOCKED = ['  mWakefulness=Awake', '    isKeyguardShowing=true'].join('\n');
+const UNLOCKED = ['  mWakefulness=Awake', '    isKeyguardShowing=false'].join('\n');
+const ASLEEP = ['  mWakefulness=Asleep', '    isKeyguardShowing=true'].join('\n');
+
+describe('parseScreenState', () => {
+    it('reads a locked-but-awake device, which is the black-screen case', () => {
+        // The display is fully on and the user is looking at the lock screen.
+        // Capture is black anyway — this is the combination that matters.
+        expect(parseScreenState(LOCKED)).toEqual({ awake: true, locked: true });
+    });
+
+    it('reads an unlocked device', () => {
+        expect(parseScreenState(UNLOCKED)).toEqual({ awake: true, locked: false });
+    });
+
+    it('reads a sleeping device', () => {
+        expect(parseScreenState(ASLEEP)).toEqual({ awake: false, locked: true });
+    });
+
+    it('tolerates the fields arriving in either order', () => {
+        const reversed = ['    isKeyguardShowing=true', '  mWakefulness=Awake'].join('\n');
+        expect(parseScreenState(reversed)).toEqual({ awake: true, locked: true });
+    });
+
+    it('is case-insensitive about the keyguard field name', () => {
+        expect(parseScreenState('mWakefulness=Awake\nmIsKeyguardShowing=true').locked).toBe(true);
+    });
+
+    it('does not claim "locked" when the keyguard line is missing', () => {
+        // This drives a user-facing banner. Telling someone their phone is
+        // locked when it is not is worse than staying quiet, so an unparseable
+        // dumpsys must read as unlocked.
+        expect(parseScreenState('  mWakefulness=Awake')).toEqual({ awake: true, locked: false });
+        expect(parseScreenState('')).toEqual({ awake: true, locked: false });
+    });
+
+    it('does not claim "asleep" when the wakefulness line is missing', () => {
+        expect(parseScreenState('isKeyguardShowing=false').awake).toBe(true);
+    });
+
+    it('treats Dreaming and Dozing as not awake', () => {
+        expect(parseScreenState('mWakefulness=Dreaming').awake).toBe(false);
+        expect(parseScreenState('mWakefulness=Dozing').awake).toBe(false);
+    });
+});
+
+describe('SCREEN_STATE_COMMAND', () => {
+    it('greps on the device so only matched lines cross the wire', () => {
+        // `dumpsys window` alone is hundreds of KB; the -m1 greps keep this to
+        // two short lines per poll.
+        expect(SCREEN_STATE_COMMAND).toContain('grep -m1');
+        expect(SCREEN_STATE_COMMAND).toContain('mWakefulness');
+        expect(SCREEN_STATE_COMMAND).toContain('isKeyguardShowing');
+    });
+
+    it('asks for both readings in a single round trip', () => {
+        expect(SCREEN_STATE_COMMAND.split(';')).toHaveLength(2);
+    });
+});

--- a/src/server/api/DeviceDiscoveryApi.ts
+++ b/src/server/api/DeviceDiscoveryApi.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { AdbClient, parseSerialFromMdnsName } from '../AdbClient';
 import { resolveUserId } from '../auth/currentUser';
 import { Config } from '../Config';
+import { parseScreenState, SCREEN_STATE_COMMAND } from '../deviceScreenState';
 import { Logger } from '../Logger';
 import { resolveMac } from '../network/MacResolver';
 import { detectSubnet } from '../network/SubnetDetector';
@@ -144,10 +145,12 @@ export class DeviceDiscoveryApi {
                     res.end(JSON.stringify({ error: 'udid is required' }));
                     return true;
                 }
-                const output = await this.adbClient.shell(udid, 'dumpsys power 2>/dev/null | grep mWakefulness');
-                const awake = output.includes('Awake');
+                // Also reports `locked`: while the keyguard is up Android hands
+                // scrcpy a black surface, so a locked phone is otherwise
+                // indistinguishable from a broken stream (see issue #498).
+                const output = await this.adbClient.shell(udid, SCREEN_STATE_COMMAND);
                 res.writeHead(200);
-                res.end(JSON.stringify({ awake }));
+                res.end(JSON.stringify(parseScreenState(output)));
                 return true;
             }
 

--- a/src/server/deviceScreenState.ts
+++ b/src/server/deviceScreenState.ts
@@ -1,0 +1,44 @@
+/**
+ * Device screen state, as reported by `dumpsys`.
+ *
+ * `locked` is the field that matters for streaming: **Android will not let
+ * anything capture the screen while the keyguard is up.** scrcpy receives a
+ * black surface, encodes it faithfully, and the browser decodes and paints
+ * black — measured at 13 bytes per frame at a steady 15fps, next to 30-50KB
+ * once unlocked. The device's own `screencap` returns black under the same
+ * conditions, which is how we know the capture path is not at fault.
+ *
+ * Without this, a locked phone is indistinguishable from a broken stream. That
+ * cost issue #498 several rounds: every "this codec is black" result was really
+ * "the phone locked itself", and the codec matrix built on top was meaningless.
+ */
+export interface DeviceScreenState {
+    /** The display is on (`mWakefulness=Awake`). */
+    awake: boolean;
+    /** The keyguard is up, so screen capture yields black. */
+    locked: boolean;
+}
+
+/**
+ * One shell round trip for both readings. `grep` runs on the device, so only
+ * the matched lines cross the wire rather than the whole dumpsys output.
+ */
+export const SCREEN_STATE_COMMAND =
+    'dumpsys power 2>/dev/null | grep -m1 mWakefulness; dumpsys window 2>/dev/null | grep -m1 -i isKeyguardShowing';
+
+/**
+ * Parse the combined output of {@link SCREEN_STATE_COMMAND}.
+ *
+ * Both fields default to a "nothing is wrong" reading when absent, because
+ * this drives a warning banner: a device whose dumpsys we cannot parse should
+ * not be reported as locked. A false "your phone is locked" on a working
+ * stream is worse than saying nothing.
+ */
+export function parseScreenState(output: string): DeviceScreenState {
+    const awakeMatch = /mWakefulness=(\w+)/i.exec(output);
+    const keyguardMatch = /isKeyguardShowing=(true|false)/i.exec(output);
+    return {
+        awake: awakeMatch ? awakeMatch[1]!.toLowerCase() === 'awake' : true,
+        locked: keyguardMatch ? keyguardMatch[1]!.toLowerCase() === 'true' : false,
+    };
+}

--- a/src/style/ws-scrcpy.css
+++ b/src/style/ws-scrcpy.css
@@ -72,6 +72,30 @@
     max-height: 100vh;
 }
 
+/* Shown over the canvas while the device reports its keyguard is up. Android
+ * will not let anything capture the lock screen, so the stream is legitimately
+ * black and there is nothing to fix on our side — the point is to say so
+ * instead of leaving a black rectangle with no explanation. */
+.stream-locked-notice {
+    grid-area: 1 / 1;
+    align-self: center;
+    justify-self: center;
+    z-index: 2;
+    padding: 0.6rem 1rem;
+    border: 1px solid var(--warning-color);
+    border-radius: 4px;
+    background-color: var(--controls-bg-color);
+    color: var(--warning-color);
+    font-size: 0.85rem;
+    text-align: center;
+    /* Never swallow touches meant for the device. */
+    pointer-events: none;
+}
+
+.stream-locked-notice[hidden] {
+    display: none;
+}
+
 .control-wrapper > input[type="checkbox"] {
     display: none;
 }


### PR DESCRIPTION
This is the actual explanation for issue #498, and most of it turns out not to be a bug in this app at all.

## Android will not let anything capture a locked screen

Not us, not scrcpy, not the phone's own screenshot tool. It hands over a black image. Confirmed from the device side rather than inferred — `screencap` on the phone itself returns black while `isKeyguardShowing=true`, with `mScreenOnFully=true`.

Measured across an unlock, with a stream running the whole time:

```
locked     15 fps    13 bytes/frame
locked     15 fps    13 bytes/frame
UNLOCK     15 fps    47,078 bytes/frame
unlocked   15 fps    30-50 KB/frame
```

The frame rate never dips. The decode path stays perfectly healthy — it is faithfully decoding and painting black frames, because black is what Android supplied. Which means a locked phone was indistinguishable from a broken stream, and the app said nothing either way.

That accounts for the reporter's whole account: a session that worked until they raised the shade to type their passcode; AV1 dying "after 20 minutes" (the phone auto-locked); reconnects staying black; and their own guess that it needed a "cooldown" — what actually cleared it was unlocking the phone.

It also means their entire codec matrix was confounded. Whether any given test showed a picture depended on whether the phone happened to be locked, not on the codec.

## What was genuinely wrong here

`checkForDegradation` treated exactly this as evidence the stream had degraded, and forced a reconnect.

The premise is wrong. Small frames mean *the picture is not changing* — a static app, a screensaver, a locked phone — which is a healthy stream, not a failing one. And the remedy could never work: reconnecting lands on the same black screen, because the phone is still locked.

The comments show it had already been loosened twice chasing the false positives:

```ts
// Don't check within 30s of a refresh (was 10s — too aggressive)
// (was 25% — too sensitive for static content like screensavers)
```

Net effect: the video interrupted itself every ~30 seconds, fixed nothing, and explained nothing.

## The change

The small-frame signal now prompts a **question** rather than a verdict. When the picture stops changing, ask the device whether its keyguard is up, and if so show a banner over the video.

The banner is driven by the device's answer, never by the frame-size guess. An unparseable `dumpsys` reads as *unlocked* — telling someone their phone is locked when it isn't would be worse than saying nothing.

Two trigger conditions, and the second is not optional:

- **Relative drop** catches a stream that *becomes* static — the phone locking mid-session.
- **Absolute floor** catches one that starts that way. Connecting to an already-locked phone builds the baseline out of black frames, so nothing can ever be "small relative to" it. That is precisely the reconnect-onto-a-locked-phone case, and it is invisible to the relative test alone.

Reuses the existing `/api/devices/screen-state` endpoint, which already ran `dumpsys power`; it now returns `locked` alongside `awake` from a single shell round trip, with both greps running on-device so only two short lines cross the wire.

`refreshStream()` itself is unchanged and still available from the toolbar button — it is only the automatic, unexplained invocation that is gone, along with the now-dead `lastRefreshTime` throttle.

## Verification

**On hardware.** The endpoint returns `{awake:true, locked:false}` unlocked and `{awake:true, locked:true}` locked. Connecting to a locked phone, the banner appears after ~6 seconds and stays:

```
 2s  hidden
 4s  hidden
 6s  visible   <- device asked and answered
 8s+ visible
```

Screenshot confirms it renders over the video without swallowing touches (`pointer-events: none`).

**Tests.** 10 cases on the dumpsys parser using real captures from either side of an unlock, including the fail-quiet behaviour when fields are missing. 7 on the trigger predicate, covering the already-black-at-connect case that the relative test alone misses.

Full suite 1683 passed / 5 skipped, `tsc --noEmit` clean, biome clean.

## Not addressed here

Several of the reporter's tests say "phone unlocked" and still failed. Those remain unexplained and are not covered by this change.

`release:none` — the last PR in this batch carries the beta.
