### PR TITLE
Cover the embed consent flow with an end-to-end suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,31 @@ jobs:
       - run: cargo test --workspace
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: npm run build
+
+      # End-to-end suite. Deliberately steps inside build-and-test rather than a
+      # separate job: main's ruleset requires a check named exactly
+      # `build-and-test`, so a new job would not be required and could rot
+      # unnoticed. It also reuses the `npm run build` above -- the suite runs the
+      # built `dist/index.js`, so a second job would have to rebuild it.
+      #
+      # Chromium only. The suite asserts on server behaviour and app DOM, not on
+      # rendering differences, so a second browser would buy coverage the specs
+      # do not actually exercise.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: E2E typecheck
+        # tests/ sits outside the root tsconfig's rootDir, so `npx tsc --noEmit`
+        # above does not see it. Without this the e2e sources are never typechecked.
+        run: npm run test:e2e:types
+      - run: npm run test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
       - name: Bump/blob sync
         # The auto-release bump commit is assembled from an explicit blob list.
         # Fail here if it no longer matches what bump-version.mjs writes -- the

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ ws-scrcpy-web.log.1
 
 # Visual Studio local IDE state — local-only, never share
 .vs/
+
+# Playwright e2e artifacts
+/test-results/
+/playwright-report/
+/blob-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Playwright end-to-end suite (`npm run test:e2e`).** Fourteen specs covering the embed-consent protocol, the framing headers and Settings → Embedding, running against a real server process rather than mocks. This is the layer the existing vitest suite cannot reach: `frameGuard` and `embedRequests` are already covered as pure functions, but a header that never reaches the wire, or an approval that rewrites `config.json` and drops `webPort` out from under the running server, both look fine to a unit test. Every consent spec asserts the keys it must not have touched.
+
+  The suite is fully isolated — its own port (8123) and its own throwaway data root, via `PROGRAMDATA`/`DATA_ROOT`, `WS_SCRCPY_CONFIG` and `WS_SCRCPY_WEB_PORT` — so it never reads or writes an installed config or `wsscrcpy.db`, and it can run while a normal instance is up on 8000. It runs serially by design: the server holds one pending embed request at a time, so parallel specs would cancel each other's prompts. Wired into `build-and-test` (steps, not a new job, so the ruleset's required check name is unchanged) along with a `test:e2e:types` typecheck, since `tests/` sits outside the root tsconfig's `rootDir` and was otherwise never typechecked. See `tests/e2e/README.md`.
+
 ### Fixed
 
 - **`PRIVACY.md` said "No cookies of any kind"; the app sets two.** The published policy asserted in four places that no cookies are used, while the project's own `SECURITY.md` documents a per-launch `HttpOnly; SameSite=Strict` instance token handed to every browser that loads a page, and smoke Module 18 exercises an `HttpOnly` session cookie that survives restart. The policy now describes both — a per-launch instance token that exists only as a CSRF / DNS-rebinding defence and carries no identity, and a session cookie present only when the optional login is enabled — while keeping the claim that actually matters and is true: no tracking cookies, no third-party cookies, nothing that leaves your machine. The stale "no login" line is corrected to "no project-operated account" (the opt-in login shipped in beta.67), the §"Web UI storage (no cookies)" heading is retitled, and the Effective date is bumped per the policy's own §Changes rule.

--- a/biome.json
+++ b/biome.json
@@ -60,7 +60,7 @@
         }
     },
     "files": {
-        "includes": ["src/**", "webpack/**"]
+        "includes": ["src/**", "webpack/**", "tests/**", "playwright.config.ts"]
     },
     "overrides": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.11",
+        "@playwright/test": "^1.62.1",
         "@swc/core": "^1.16.1",
         "@types/node": "^24.13.3",
         "@types/ws": "^8",
@@ -934,6 +935,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -3695,6 +3712,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "package:linux": "node scripts/package-linux.mjs",
     "package:pack": "node -e \"if (process.platform !== 'win32') { console.log('package:pack is Windows-only; use package:linux for AppImage'); process.exit(0); } require('child_process').spawnSync('vpk', ['pack','--packId','WsScrcpyWeb','--packVersion',process.env.npm_package_version,'--packDir','publish','--mainExe','ws-scrcpy-web-launcher.exe','--packTitle','ws-scrcpy-web','--packAuthors','ws-scrcpy-web contributors','--channel','stable','-o','Releases'], {stdio:'inherit',shell:true});\"",
     "test:update-flow": "pwsh scripts/test-update-flow.ps1",
-    "release-notes": "node scripts/extract-changelog.mjs $npm_package_version"
+    "release-notes": "node scripts/extract-changelog.mjs $npm_package_version",
+    "test:e2e": "playwright test",
+    "test:e2e:types": "tsc -p tests/e2e --noEmit"
   },
   "dependencies": {
     "velopack": "^1.2.0",
@@ -56,6 +58,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.11",
+    "@playwright/test": "^1.62.1",
     "@swc/core": "^1.16.1",
     "@types/node": "^24.13.3",
     "@types/ws": "^8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
 import {
     E2E_BASE_URL,
@@ -46,6 +47,22 @@ import {
 if (process.env['TEST_WORKER_INDEX'] === undefined) {
     mkdirSync(E2E_DATA_ROOT, { recursive: true });
     writeFileSync(E2E_CONFIG_PATH, JSON.stringify(SEED_CONFIG, null, 4), 'utf8');
+
+    /**
+     * Decline the Linux system-wide install offer up front.
+     *
+     * On Linux `SystemWideInstallModal` opens on first load unless this marker
+     * exists (`offerMachineWide` in `src/app/index.ts` gates on
+     * `systemInstallDeclined`, which `ServiceApi` derives from the file's presence
+     * rather than from a setting). Like the bookmark reminder it is a plain
+     * <dialog> stacked over the consent prompt, so it swallows the clicks meant for
+     * it — and being Linux-only it passes locally on Windows and fails only in CI.
+     *
+     * Name mirrors DECLINE_MARKER_NAME in `src/server/service/SystemdClient.ts`;
+     * copied rather than imported to keep server modules out of this config.
+     */
+    mkdirSync(join(E2E_DATA_ROOT, 'control'), { recursive: true });
+    writeFileSync(join(E2E_DATA_ROOT, 'control', 'system-install-declined'), '', 'utf8');
 }
 
 export default defineConfig({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { defineConfig, devices } from '@playwright/test';
+import {
+    E2E_BASE_URL,
+    E2E_CONFIG_PATH,
+    E2E_DATA_ROOT,
+    E2E_PORT,
+    E2E_PROGRAM_DATA,
+    SEED_CONFIG,
+} from './tests/e2e/support/paths';
+
+/**
+ * End-to-end suite.
+ *
+ * This complements the vitest tests rather than repeating them. Those exercise pure
+ * functions (`frameGuard`, `embedRequests`) with no I/O; these drive a real server
+ * process over a real socket and assert on the file it writes — the layer where the
+ * interesting failures actually live.
+ *
+ * Isolation is the load-bearing part of this config, for two reasons that both bite:
+ *
+ *   1. The consent specs approve and revoke embedding origins, and an approval
+ *      REWRITES config.json. Aimed at an installed `<dataRoot>/config.json` that
+ *      would edit a developer's live install; and since `webPort` lives in the same
+ *      file, a careless write moves the running server to another port.
+ *   2. A developer normally has the app up on 8000. Binding the suite there would
+ *      collide with it, or worse, silently attach and mutate it.
+ *
+ * So the suite runs its own server, on its own port, against its own throwaway
+ * config: WS_SCRCPY_CONFIG overrides the config path (see `src/server/Config.ts`)
+ * and WS_SCRCPY_WEB_PORT overrides the port (see `src/server/index.ts`). Neither the
+ * installed config nor anything under the real data root is touched.
+ */
+/**
+ * Seed the throwaway config before anything else.
+ *
+ * This cannot live in `globalSetup`: Playwright starts `webServer` FIRST and only
+ * then runs globalSetup, and the server throws outright when WS_SCRCPY_CONFIG names
+ * a file that does not exist (an explicit override calls `loadFile` directly rather
+ * than falling back to defaults the way the unset path does). Config load is the
+ * last hook that genuinely precedes the server.
+ *
+ * Guarded to the runner process because worker processes re-import this module, and
+ * re-seeding mid-run would wipe the state the specs had just written.
+ */
+if (process.env['TEST_WORKER_INDEX'] === undefined) {
+    mkdirSync(E2E_DATA_ROOT, { recursive: true });
+    writeFileSync(E2E_CONFIG_PATH, JSON.stringify(SEED_CONFIG, null, 4), 'utf8');
+}
+
+export default defineConfig({
+    testDir: 'tests/e2e',
+    globalSetup: './tests/e2e/global-setup.ts',
+
+    /**
+     * Serial on purpose, not as a workaround for flake.
+     *
+     * The server holds exactly ONE pending embed request at a time (`current` is
+     * module-level state in `security/embedRequests.ts`) and every consent spec also
+     * mutates the single shared config file. Run concurrently, specs would cancel
+     * each other's prompts and race each other's writes.
+     */
+    fullyParallel: false,
+    workers: 1,
+
+    forbidOnly: !!process.env['CI'],
+    retries: process.env['CI'] ? 1 : 0,
+    timeout: 30_000,
+    expect: { timeout: 10_000 },
+    reporter: process.env['CI'] ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+    use: {
+        baseURL: process.env['PLAYWRIGHT_BASE_URL'] || E2E_BASE_URL,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+    },
+
+    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+
+    webServer: {
+        command: 'node dist/index.js',
+        url: `${E2E_BASE_URL}/`,
+        /**
+         * Never reuse. A server already listening on this port is not necessarily
+         * ours, and attaching to someone else's would write to their config — the
+         * exact accident this whole config exists to prevent.
+         */
+        reuseExistingServer: false,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        timeout: 120_000,
+        env: {
+            /**
+             * Isolate the whole data root, not just the config file. Per-user
+             * settings (the bookmark-reminder flags among them) live in
+             * `<dataRoot>/wsscrcpy.db`, so overriding only the config path would
+             * leave the suite reading and writing a developer's real database.
+             * PROGRAMDATA is the Windows lever, DATA_ROOT the one used elsewhere.
+             */
+            PROGRAMDATA: E2E_PROGRAM_DATA,
+            DATA_ROOT: E2E_DATA_ROOT,
+            WS_SCRCPY_CONFIG: E2E_CONFIG_PATH,
+            WS_SCRCPY_WEB_PORT: String(E2E_PORT),
+        },
+    },
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,76 @@
+# End-to-end tests
+
+Playwright suite covering the embed-consent protocol, the framing headers and the
+Settings → Embedding surface.
+
+```bash
+npm run test:e2e            # run the suite
+npm run test:e2e:types      # typecheck it (tests/ is outside the root tsconfig)
+npx playwright test --ui    # pick through it interactively
+```
+
+`npm run build` must have run at least once: the suite starts the built
+`dist/index.js`, not a dev server.
+
+## What this covers that the unit tests do not
+
+`src/server/security/frameGuard.test.ts` and `embedRequests.test.ts` already cover
+the pure functions. These specs exist for the layer underneath that: a real server
+process, real sockets, and the config file it actually writes. Two failures that a
+unit test cannot see, and that this suite would:
+
+- `securityHeaders()` once applied only to the static handler, so the login page and
+  its 401 shipped with no framing headers at all. The function was fine; the wiring
+  was not.
+- An approval that rebuilt `config.json` instead of amending it would drop `webPort`
+  and move the running server to another port. Every consent spec asserts the
+  untouched keys for that reason.
+
+## Isolation
+
+The suite never touches a real install. It runs its own server on **port 8123**
+against a **throwaway data root** under the OS temp directory:
+
+| Variable | Effect |
+|---|---|
+| `PROGRAMDATA` / `DATA_ROOT` | Redirects the whole data root, including `wsscrcpy.db` |
+| `WS_SCRCPY_CONFIG` | Points `config.json` at the throwaway root |
+| `WS_SCRCPY_WEB_PORT` | Binds 8123 instead of the configured port |
+
+Isolating only the config file is not enough — per-user settings live in
+`<dataRoot>/wsscrcpy.db`, so the suite would otherwise read and write a developer's
+real database. And `reuseExistingServer` is off: a server already on this port is not
+necessarily ours, and attaching to someone else's would write to their config.
+
+Because of that isolation you can run the suite while your normal instance is up on
+8000.
+
+## Two ordering facts worth knowing before editing the config
+
+1. **Playwright starts `webServer` before `globalSetup`.** The server throws when
+   `WS_SCRCPY_CONFIG` names a missing file, so the seed config is written at
+   *config-load* time in `playwright.config.ts`, guarded to the runner process
+   (workers re-import that module and would otherwise re-seed mid-run).
+2. **`globalSetup` therefore has a live server to talk to**, which is where the
+   bookmark reminder gets switched off. `PortChangeModal` opens on every page load
+   for an unacknowledged port — every load, against a virgin data root — and being a
+   plain `<dialog>` it stacks over the consent prompt and swallows its clicks.
+   Symptom is `subtree intercepts pointer events`, which points nowhere near the
+   cause. Dismissing it per-spec raced the async fetch that opens it, so it is
+   disabled once via the same `PATCH /api/settings` its own checkbox uses.
+
+## Why it runs serially
+
+`workers: 1` and `fullyParallel: false` are deliberate, not a flake workaround. The
+server holds exactly **one** pending embed request at a time (`current` is
+module-level state in `security/embedRequests.ts`), and every consent spec also
+mutates the single shared config file. Run concurrently, specs would cancel each
+other's prompts and race each other's writes.
+
+## Still manual
+
+- **A LAN client is refused.** Verified by hand (all three embed endpoints return
+  their loopback refusals from a non-loopback address). Automating it needs a second
+  host or a second interface, which CI does not have.
+- **Locked mode.** `/embed-request` and `/embed-request/` are allow-listed in
+  `AuthGate` so the flow survives `authEnabled`; untested either way.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -51,7 +51,13 @@ Because of that isolation you can run the suite while your normal instance is up
    `WS_SCRCPY_CONFIG` names a missing file, so the seed config is written at
    *config-load* time in `playwright.config.ts`, guarded to the runner process
    (workers re-import that module and would otherwise re-seed mid-run).
-2. **`globalSetup` therefore has a live server to talk to**, which is where the
+2. **Four first-run dialogs must be suppressed, by three different mechanisms.**
+   `ServiceFirstRunModal` (gated by `installMode`) and `WelcomeModal` (by
+   `firstRunComplete`) are handled by the seed config. `SystemWideInstallModal` is
+   **Linux-only** and gated by a marker *file*, `<dataRoot>/control/system-install-declined`,
+   so it passes locally on Windows and fails only in CI — it is written at seed time.
+   `PortChangeModal` is gated by per-user settings, covered below.
+3. **`globalSetup` therefore has a live server to talk to**, which is where the
    bookmark reminder gets switched off. `PortChangeModal` opens on every page load
    for an unacknowledged port — every load, against a virgin data root — and being a
    plain `<dialog>` it stacks over the consent prompt and swallows its clicks.

--- a/tests/e2e/embed-consent.spec.ts
+++ b/tests/e2e/embed-consent.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+import { askToEmbed, gotoHome, readServerConfig, revokeAllOrigins, waitForPrompt } from './support/consent';
+import { SEED_CONFIG } from './support/paths';
+
+const ORIGIN = 'http://localhost:5159';
+
+/**
+ * The consent protocol end to end.
+ *
+ * The split it enforces is the design, not an implementation detail:
+ *   asking      — unauthenticated, loopback-only, touches no config
+ *   granting    — admin AND loopback, human click only
+ *   cancelling  — loopback-only, and retract-only: it can never undo a decision
+ */
+test.describe('embed consent', () => {
+    test.afterEach(async ({ page }) => {
+        await gotoHome(page);
+        await revokeAllOrigins(page);
+    });
+
+    test('asking for permission writes nothing to config', async ({ request }) => {
+        const before = readServerConfig();
+
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+
+        // Asking raises a prompt and does nothing else. If this ever fails, an
+        // unauthenticated caller has gained the ability to change stored config.
+        expect(readServerConfig()).toEqual(before);
+    });
+
+    test('approving stores the origin and leaves unrelated keys untouched', async ({ page, request }) => {
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+
+        const prompt = await waitForPrompt(page);
+        await expect(prompt).toContainText(ORIGIN);
+        await expect(prompt).toContainText('Control Menu');
+        await prompt.getByRole('button', { name: 'approve', exact: true }).click();
+
+        await expect.poll(() => readServerConfig().frameAncestors).toContain(ORIGIN);
+
+        // The assertion with real teeth. `webPort` shares this file, so a write that
+        // rebuilt the config instead of amending it would move the running server to
+        // a different port — a failure that looks like "the app died" from outside.
+        const after = readServerConfig();
+        expect(after.webPort).toBe(SEED_CONFIG.webPort);
+        expect(after.installMode).toBe(SEED_CONFIG.installMode);
+        expect(after.firstRunComplete).toBe(SEED_CONFIG.firstRunComplete);
+    });
+
+    test('denying grants nothing', async ({ page, request }) => {
+        const id = await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+
+        await (await waitForPrompt(page)).getByRole('button', { name: 'deny', exact: true }).click();
+
+        await expect
+            .poll(async () => (await request.get(`/embed-request/${id}`)).json())
+            .toMatchObject({
+                status: 'denied',
+            });
+        expect(readServerConfig().frameAncestors).not.toContain(ORIGIN);
+    });
+
+    test('withdrawing replaces the prompt instead of leaving it decidable', async ({ page, request }) => {
+        const id = await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        const prompt = await waitForPrompt(page);
+
+        const res = await request.post(`/embed-request/${id}/cancel`);
+        expect(await res.json()).toMatchObject({ cancelled: true, status: 'cancelled' });
+
+        // Leaving an abandoned prompt on screen would be worse than closing it:
+        // approving it would grant permission to an app that stopped waiting.
+        await expect(prompt).toContainText('withdrew this request');
+        await expect(prompt.getByRole('button', { name: 'approve', exact: true })).toHaveCount(0);
+        await expect(prompt.getByRole('button', { name: 'deny', exact: true })).toHaveCount(0);
+    });
+
+    test('a cancel after approval is refused, and the approval stands', async ({ page, request }) => {
+        const id = await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        await (await waitForPrompt(page)).getByRole('button', { name: 'approve', exact: true }).click();
+        await expect.poll(() => readServerConfig().frameAncestors).toContain(ORIGIN);
+
+        const res = await request.post(`/embed-request/${id}/cancel`);
+
+        // Retract-only. The asking app may withdraw a request nobody has answered;
+        // it may never reach back and undo a human's decision.
+        expect(await res.json()).toMatchObject({ cancelled: false, status: 'approved' });
+        expect(readServerConfig().frameAncestors).toContain(ORIGIN);
+    });
+
+    test('a web page cannot raise a prompt, even from this machine', async ({ request }) => {
+        const res = await request.post('/embed-request', {
+            headers: { Origin: 'http://evil.example' },
+            data: { origin: 'http://evil.example', appName: 'Evil' },
+        });
+
+        // A browser always sends Origin and it will never match ours, which is what
+        // stops a random page from raising a consent prompt on this desktop. A
+        // native local app sends none, and is allowed — see askToEmbed.
+        expect(res.status()).toBe(403);
+        expect(await res.json()).toMatchObject({ reason: 'cross-origin request rejected' });
+    });
+
+    test('an unknown request id reports unknown rather than failing', async ({ request }) => {
+        const res = await request.get('/embed-request/not-a-real-id');
+
+        expect(res.status()).toBe(200);
+        expect(await res.json()).toMatchObject({ status: 'unknown' });
+    });
+});

--- a/tests/e2e/framing-headers.spec.ts
+++ b/tests/e2e/framing-headers.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import { askToEmbed, gotoHome, revokeAllOrigins, waitForPrompt } from './support/consent';
+
+const ORIGIN = 'http://localhost:5159';
+
+/**
+ * The framing headers as a browser actually receives them.
+ *
+ * `frameGuard.test.ts` already covers the header-building function itself, so this
+ * file deliberately covers what a unit test cannot: whether those headers survive
+ * the real response path. That distinction is not academic — a past regression had
+ * `securityHeaders()` applied only by the static handler, so the login page and its
+ * 401 shipped with no framing headers at all.
+ */
+test.describe('framing headers', () => {
+    test.afterEach(async ({ page }) => {
+        await gotoHome(page);
+        await revokeAllOrigins(page);
+    });
+
+    test('sends X-Frame-Options and omits the CSP when nothing is allow-listed', async ({ request }) => {
+        const res = await request.get('/');
+
+        expect(res.status()).toBe(200);
+        expect(res.headers()['x-frame-options']).toBe('SAMEORIGIN');
+        // An empty allow-list has nothing to permit, so the CSP header is omitted
+        // entirely and X-Frame-Options alone governs. Its absence here is the
+        // designed behaviour, not a header that failed to be emitted.
+        expect(res.headers()['content-security-policy']).toBeUndefined();
+    });
+
+    test('adds an approved origin to frame-ancestors and keeps X-Frame-Options', async ({ page, request }) => {
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        await (await waitForPrompt(page)).getByRole('button', { name: 'approve', exact: true }).click();
+
+        await expect
+            .poll(async () => (await request.get('/')).headers()['content-security-policy'])
+            .toBe(`frame-ancestors 'self' ${ORIGIN}`);
+
+        // Both headers ship together on purpose: a browser that understands
+        // frame-ancestors must ignore X-Frame-Options when both are present (CSP
+        // Level 2), so the allow-list wins where it is understood while older
+        // browsers keep the stricter same-origin behaviour.
+        expect((await request.get('/')).headers()['x-frame-options']).toBe('SAMEORIGIN');
+    });
+
+    test('drops the CSP again once the origin is revoked', async ({ page, request }) => {
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        await (await waitForPrompt(page)).getByRole('button', { name: 'approve', exact: true }).click();
+        await expect.poll(async () => (await request.get('/')).headers()['content-security-policy']).toBeTruthy();
+
+        await revokeAllOrigins(page);
+
+        // Revocation applies to the running server, with no restart.
+        await expect.poll(async () => (await request.get('/')).headers()['content-security-policy']).toBeUndefined();
+    });
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,36 @@
+import { request } from '@playwright/test';
+import { E2E_BASE_URL } from './support/paths';
+
+/**
+ * Switch off the bookmark reminder before any spec runs.
+ *
+ * `PortChangeModal` ("this app lives at: ...") opens on every page load for a port
+ * the user has not acknowledged, and the suite deliberately runs against a virgin
+ * data root — so that is every load. It is a plain <dialog> stacked above the
+ * consent prompt, and it silently swallows the clicks aimed at the prompt beneath
+ * it. Specs then fail with "subtree intercepts pointer events", which points
+ * nowhere near the actual cause.
+ *
+ * Dismissing it inside each spec raced the async config+settings fetch that opens
+ * it, so it is switched off exactly once, here, through the same endpoint the
+ * modal's own "don't show again" checkbox writes to.
+ *
+ * Note the ordering this relies on: Playwright starts `webServer` BEFORE globalSetup,
+ * which is why the seed config is written at config-load time instead (see
+ * playwright.config.ts) while this — which needs a live server — belongs here.
+ */
+export default async function globalSetup(): Promise<void> {
+    const ctx = await request.newContext({ baseURL: E2E_BASE_URL });
+    try {
+        // A document GET is what mints the per-instance token cookie that gates /api.
+        await ctx.get('/');
+        const res = await ctx.patch('/api/settings', {
+            data: { bookmarkDismissedGlobally: true, serviceFirstRunSeen: true },
+        });
+        if (!res.ok()) {
+            throw new Error(`could not pre-dismiss the bookmark reminder: ${res.status()} ${await res.text()}`);
+        }
+    } finally {
+        await ctx.dispose();
+    }
+}

--- a/tests/e2e/settings-embedding.spec.ts
+++ b/tests/e2e/settings-embedding.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+import { askToEmbed, gotoHome, readServerConfig, revokeAllOrigins, waitForPrompt } from './support/consent';
+import { SEED_CONFIG } from './support/paths';
+
+const ORIGIN = 'http://localhost:5159';
+
+/** Open Settings and return its Embedding section. */
+async function openEmbeddingSettings(page: import('@playwright/test').Page) {
+    await page.getByRole('button', { name: 'Open settings' }).click();
+    const settings = page.locator('dialog.settings-modal');
+    await expect(settings).toBeVisible();
+    return settings;
+}
+
+/**
+ * Settings -> Embedding: the only place an operator can withdraw a permission they
+ * previously granted, without hand-editing config.json.
+ */
+test.describe('settings / embedding', () => {
+    test.afterEach(async ({ page }) => {
+        await gotoHome(page);
+        await revokeAllOrigins(page);
+    });
+
+    test('says so plainly when no origin is allow-listed', async ({ page }) => {
+        await gotoHome(page);
+        const settings = await openEmbeddingSettings(page);
+
+        await expect(settings).toContainText('No other origins may embed this app.');
+    });
+
+    test('lists an approved origin with a way to revoke it', async ({ page, request }) => {
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        await (await waitForPrompt(page)).getByRole('button', { name: 'approve', exact: true }).click();
+        await expect.poll(() => readServerConfig().frameAncestors).toContain(ORIGIN);
+
+        const settings = await openEmbeddingSettings(page);
+
+        await expect(settings).toContainText(ORIGIN);
+        await expect(settings.getByRole('button', { name: 'revoke' })).toBeVisible();
+    });
+
+    test('asks for confirmation before revoking, and the origin survives a cancel', async ({ page, request }) => {
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        await (await waitForPrompt(page)).getByRole('button', { name: 'approve', exact: true }).click();
+        await expect.poll(() => readServerConfig().frameAncestors).toContain(ORIGIN);
+
+        const settings = await openEmbeddingSettings(page);
+        await settings.getByRole('button', { name: 'revoke' }).click();
+
+        // Revoking breaks whatever that origin is currently displaying, so it is a
+        // confirmed action rather than a single click.
+        const confirm = page.locator('dialog.confirm-modal');
+        await expect(confirm).toBeVisible();
+        await expect(confirm).toContainText(ORIGIN);
+
+        await confirm.getByRole('button', { name: 'cancel', exact: true }).click();
+        expect(readServerConfig().frameAncestors).toContain(ORIGIN);
+    });
+
+    test('revoking removes the origin from the list and from config', async ({ page, request }) => {
+        await askToEmbed(request, ORIGIN, 'Control Menu');
+        await gotoHome(page);
+        await (await waitForPrompt(page)).getByRole('button', { name: 'approve', exact: true }).click();
+        await expect.poll(() => readServerConfig().frameAncestors).toContain(ORIGIN);
+
+        const settings = await openEmbeddingSettings(page);
+        await settings.getByRole('button', { name: 'revoke' }).click();
+        await page.locator('dialog.confirm-modal').getByRole('button', { name: 'ok', exact: true }).click();
+
+        await expect(settings).toContainText('No other origins may embed this app.');
+        await expect.poll(() => readServerConfig().frameAncestors).not.toContain(ORIGIN);
+
+        // Same integrity guarantee as approving: revoking amends the file, it does
+        // not rewrite it and lose the keys the server booted from.
+        const after = readServerConfig();
+        expect(after.webPort).toBe(SEED_CONFIG.webPort);
+        expect(after.installMode).toBe(SEED_CONFIG.installMode);
+        expect(after.firstRunComplete).toBe(SEED_CONFIG.firstRunComplete);
+    });
+});

--- a/tests/e2e/support/consent.ts
+++ b/tests/e2e/support/consent.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import { type APIRequestContext, expect, type Page } from '@playwright/test';
+import { E2E_CONFIG_PATH } from './paths';
+
+export interface ServerConfig {
+    installMode?: string;
+    webPort?: number;
+    firstRunComplete?: boolean;
+    frameAncestors?: string[];
+    [key: string]: unknown;
+}
+
+/**
+ * Navigate to the app and clear the bookmark reminder out of the way.
+ *
+ * `PortChangeModal` ("this app lives at: ...") fires on every page load for a port
+ * the user has not acknowledged, and the suite runs against a virgin data root, so
+ * that is every load. It is a plain <dialog> stacked above the consent prompt, and
+ * it silently swallows clicks aimed at the prompt underneath — the specs then fail
+ * with "subtree intercepts pointer events", which points nowhere near the cause.
+ *
+ * Dismissed with "got it" and no checkbox, which closes it WITHOUT persisting the
+ * flag, so this stays a UI step rather than hidden state the next run inherits.
+ * Tolerant of absence: a developer who has dismissed it globally never sees it.
+ */
+export async function gotoHome(page: Page): Promise<void> {
+    await page.goto('/');
+    const reminder = page.locator('dialog.port-change-modal');
+    if (await reminder.isVisible().catch(() => false)) {
+        await reminder.getByRole('button', { name: 'got it', exact: true }).click();
+        await expect(reminder).toBeHidden();
+    }
+}
+
+/** Read the config file the running e2e server is actually bound to. */
+export function readServerConfig(): ServerConfig {
+    return JSON.parse(readFileSync(E2E_CONFIG_PATH, 'utf8')) as ServerConfig;
+}
+
+/**
+ * Raise a consent prompt the way another local app does: an unauthenticated,
+ * loopback POST carrying no Origin header. Playwright's request context does not
+ * set Origin, which is precisely how a native app behaves and why this is allowed
+ * where a browser page would be rejected.
+ */
+export async function askToEmbed(request: APIRequestContext, origin: string, appName: string): Promise<string> {
+    const res = await request.post('/embed-request', { data: { origin, appName } });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { id: string; status: string };
+    expect(body.status).toBe('pending');
+    return body.id;
+}
+
+/** The consent prompt raised by {@link askToEmbed}, once the page's poller has picked it up. */
+export function consentPrompt(page: Page) {
+    return page.locator('dialog.confirm-modal').filter({ hasText: 'allow embedding?' });
+}
+
+/**
+ * Wait for the prompt to surface.
+ *
+ * The generous timeout is not padding: the prompt is discovered by a poll rather
+ * than pushed, so worst case is a full poll interval after the request lands.
+ */
+export async function waitForPrompt(page: Page) {
+    const prompt = consentPrompt(page);
+    await expect(prompt).toBeVisible({ timeout: 15_000 });
+    return prompt;
+}
+
+/**
+ * Withdraw every approved origin through the app's own API.
+ *
+ * Deliberately NOT a file write. `frameAncestors` is applied to the live server as
+ * it changes (`Config.removeFrameAncestor` calls through to `setFrameAncestors`), so
+ * editing config.json behind the server's back would leave the file and the
+ * in-memory allowlist disagreeing — and the next header assertion would then fail
+ * for a reason that has nothing to do with the behaviour under test.
+ *
+ * Runs inside the page so the per-instance token cookie is attached to both calls.
+ */
+export async function revokeAllOrigins(page: Page): Promise<void> {
+    await page.evaluate(async () => {
+        const listed = await fetch('/api/embed-origins');
+        if (!listed.ok) return;
+        const { origins } = (await listed.json()) as { origins: string[] };
+        for (const origin of origins) {
+            await fetch('/api/embed-origins/revoke', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ origin }),
+            });
+        }
+    });
+}

--- a/tests/e2e/support/paths.ts
+++ b/tests/e2e/support/paths.ts
@@ -1,0 +1,40 @@
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * A throwaway data root for the end-to-end server.
+ *
+ * Deterministic rather than a random `mkdtemp` name on purpose: the Playwright
+ * config and each spec worker import this module in a SEPARATE process, so a random
+ * path would hand each of them a different directory and the file assertions would
+ * read a config the server never wrote.
+ *
+ * The server resolves its data root per platform — `PROGRAMDATA/WsScrcpyWeb` on
+ * Windows, `DATA_ROOT` elsewhere (see `resolveDataRoot` in `src/server/Config.ts`) —
+ * so the suite sets both and works either way.
+ */
+export const E2E_PROGRAM_DATA = path.join(tmpdir(), 'ws-scrcpy-web-e2e');
+export const E2E_DATA_ROOT = path.join(E2E_PROGRAM_DATA, 'WsScrcpyWeb');
+export const E2E_CONFIG_PATH = path.join(E2E_DATA_ROOT, 'config.json');
+
+/**
+ * Deliberately not 8000 — that is where a developer's real instance listens, and
+ * binding there would either collide with it or silently drive it.
+ */
+export const E2E_PORT = 8123;
+export const E2E_BASE_URL = `http://localhost:${E2E_PORT}`;
+
+/**
+ * The state every run starts from.
+ *
+ * `installMode`, `webPort` and `firstRunComplete` are here so the consent specs can
+ * prove an approval preserves keys it has no business touching. That is not
+ * hypothetical: `webPort` shares this file, so a rewrite rather than an amend would
+ * move the running server to a different port.
+ */
+export const SEED_CONFIG = {
+    installMode: 'user',
+    webPort: E2E_PORT,
+    firstRunComplete: true,
+    frameAncestors: [] as string[],
+};

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "../..",
+        "noEmit": true,
+        "types": ["node"]
+    },
+    "include": ["**/*.ts", "../../playwright.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
         __PATHNAME__: '""',
     },
     test: {
+        // The Playwright suite lives in tests/e2e and uses `@playwright/test`, whose
+        // `test.describe` throws outright when a different runner imports it
+        // ("Playwright Test did not expect test.describe() to be called here").
+        // Vitest's default spec glob would otherwise collect those files and report
+        // three failures that have nothing to do with the code under test.
+        exclude: ['**/node_modules/**', '**/dist/**', 'tests/e2e/**'],
         // CSS imports are stubbed out (no stylesheet processing needed in tests)
         css: false,
         // The default 5s per-test timeout is too tight for tests that lazily


### PR DESCRIPTION
Adds a Playwright suite (`npm run test:e2e`) covering the embed-consent protocol, the framing headers, and Settings → Embedding. Closes the todo item open since 2026-04-30.

Labelled `release:none` — test infrastructure only, no user-facing change to release. The CHANGELOG entry rides along in the next real release.

## Why this layer

The consent flow already has unit coverage of `frameGuard` and `embedRequests` as pure functions. The two failures that actually happened on this feature were not function bugs:

- `securityHeaders()` was once applied only by the static handler, so the login page and its 401 shipped with **no framing headers at all**. The function was fine; the wiring was not.
- An approval that rebuilt `config.json` instead of amending it would drop `webPort` and move the running server to a port nobody is listening on.

Both look correct to a unit test and to a reading of the code. These specs drive a real server over a real socket and assert on the file it writes.

## What it covers

**Consent** — asking touches no config · approving stores the origin and leaves `installMode`/`webPort`/`firstRunComplete` untouched · denying grants nothing · a withdrawal replaces the prompt rather than leaving it decidable · a cancel after a decision is refused and the approval stands · a cross-origin caller cannot raise a prompt · an unknown id reports `unknown` rather than erroring.

**Headers** — `X-Frame-Options` always; no CSP when nothing is allow-listed (correct, not a header that failed to send); the exact `frame-ancestors` value once approved; and the CSP gone again after revocation, with no restart.

**Settings → Embedding** — the empty state, the listed origin, confirmation before revoking, the origin surviving a cancelled confirm, and removal from both list and config.

## Isolation

The specs revoke and approve for real, so the suite runs its own server on **8123** against a **throwaway data root**. Overriding `WS_SCRCPY_CONFIG` alone is not enough — per-user settings live in `<dataRoot>/wsscrcpy.db` — so `PROGRAMDATA`/`DATA_ROOT` are overridden too, and `reuseExistingServer` is off so it can never attach to whatever is already on the port. Nothing real is read or written, and it runs happily while a normal instance is up on 8000.

Serial by design (`workers: 1`): the server keeps one pending request at a time, so parallel specs would cancel each other's prompts.

## Two ordering facts, recorded rather than left to be rediscovered

1. Playwright starts `webServer` **before** `globalSetup`, and the server throws on a missing `WS_SCRCPY_CONFIG` — so the seed is written at config-load time, guarded to the runner because workers re-import that module.
2. The bookmark reminder (`PortChangeModal`) opens on every load against a virgin data root. Being a plain `<dialog>` it stacks over the consent prompt and swallows its clicks, surfacing as `subtree intercepts pointer events` — nowhere near the cause. Dismissing it per-spec raced the fetch that opens it, so it is switched off once via the same `PATCH /api/settings` its own checkbox uses. That is the difference between a suite that times out for five minutes and one that passes in **13 seconds**.

## Plumbing

- Wired into `build-and-test` as **steps, not a new job** — main's ruleset requires that exact check name, so a separate job would not be required and could rot unnoticed. It also reuses the existing `npm run build`.
- **Vitest now excludes `tests/e2e`**: its default spec glob was collecting the Playwright files and reporting three failures unrelated to the code under test.
- `tests/` added to biome, plus a dedicated `tests/e2e/tsconfig.json` and `test:e2e:types` — it sits outside the root tsconfig's `rootDir` and was otherwise neither linted nor typechecked.

## Verification

`tsc` clean · `test:e2e:types` clean · biome clean (497 src + 8 harness) · **1,729 unit tests pass, 190 files** · `npm run build` succeeds · **14/14 e2e pass in 13s**. Confirmed the real `C:\ProgramData\WsScrcpyWeb\config.json` was untouched across every run.

## Still manual

- **A LAN client is refused** — verified by hand today (all three embed endpoints return their loopback refusals from a non-loopback address). Automating needs a second host or interface, which CI does not have.
- **Locked mode** — `/embed-request` is allow-listed in `AuthGate` so the flow survives `authEnabled`; untested either way.

Both are noted in `tests/e2e/README.md` with the reasoning.
