### PR TITLE
Make the app aware it is running in a container (SP4 E4)

### DIFF
--- a/docs/smoke-tests/automation-coverage.md
+++ b/docs/smoke-tests/automation-coverage.md
@@ -1,0 +1,50 @@
+# Automation coverage register
+
+Per-row automation status for `smoke-test.md`. **Seeded by P3 task 5; the full
+127-row triage lands in task 16.** Until then this file holds only the container
+findings task 5 was required to record rather than fix silently.
+
+Companion to `smoke-test.md`, not a replacement: that document remains the
+canonical list of rows and their steps.
+
+---
+
+## Module 20 — container (Docker) behaviour
+
+New module. Modules run 1–19 with 17 a deliberate tombstone, so 20 is the next
+free number.
+
+### Gated in task 5 (SP4 E4)
+
+| # | Affordance | Container behaviour | Status |
+|---|---|---|---|
+| 20.1 | Settings → Service | replaced by *"service install not applicable — this instance runs in a container."* | automated (`settingsModal.dockerGating.test.ts`; container smoke in task 11) |
+| 20.2 | Settings → Updates | replaced by *"update via `docker pull bilbospocketses/ws-scrcpy-web:latest`."* | automated (same) |
+| 20.3 | libfuse2 banner | **nothing to hide — the gate no longer exists** | n/a, see below |
+
+**20.3 is satisfied by deletion, not by gating.** SP4 decision 4 requires the
+libfuse2 banner hidden in Docker, but the libfuse2 first-run gate was removed
+end-to-end in an earlier release — `isLibfuse2Installed` / `ensureLibfuse2`
+(`SystemdClient.ts`), the `/api/updates/install-libfuse2` endpoint, the
+`libfuse2Installed` status field, **and the Settings prompt in
+`SettingsModal.ts`** (see CHANGELOG, "Removed the libfuse2 first-run gate").
+`grep -ri libfuse src/` returns nothing today. The requirement is moot rather
+than outstanding, and is recorded here so a future reader does not go looking
+for a gate to implement.
+
+### Findings — surfaced by task 5 step 3, deliberately NOT fixed there
+
+Task 5's grep for host-assuming affordances surfaced three more, all in the
+**Server** section, which task 5 does not gate. Recorded rather than fixed,
+because gating the Server section is a scoped decision and not part of SP4
+decision 4's locked list.
+
+| # | Affordance | In a container | Assessment |
+|---|---|---|---|
+| 20.4 | **"install for all users"** (Linux-only) | POSTs `/api/service/install-system-wide`, which runs `pkexec`, relocates to `/opt` and re-execs | **Finding.** A container has no polkit and relocating inside the image is meaningless; the row is already Linux-gated but not container-gated. Needs a decision: hide it in Docker, or leave it and let it fail loudly. |
+| 20.5 | **"uninstall ws-scrcpy-web"** | tears down a service/install that does not exist here | **Finding.** The container equivalent is `docker rm`. Same decision as 20.4. |
+| 20.6 | **"stop server & exit"** | graceful shutdown — `adb kill-server`, service release, exit 0 | **Correct in a container, and load-bearing.** This is exactly what smoke row 12.1 asserts against `docker stop` (SIGTERM reaching node *through* `start.sh` via `tini -g`). Must NOT be gated. |
+
+20.4 and 20.5 are the two rows a container-aware Server section would cover. They
+are listed as one decision because they share a cause: both are install-lifecycle
+affordances whose lifecycle the container owns instead.

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -416,9 +416,67 @@ export function buildResetControl(opts: { reload: () => void }): {
  * with the inputs they affect, so the right column stays a clean
  * "value column" across all rows.
  */
+/**
+ * The container replacements for the Service and Updates sections (SP4 E4).
+ *
+ * Exported and free-standing so the gating is unit-testable without standing up
+ * the whole modal, and so the locked copy has exactly one definition.
+ *
+ * The copy is LOCKED — reproduced verbatim from the SP4 design §8 and
+ * `todo_ws_scrcpy_web` item 2 decision 4. Do not reword it casually; the
+ * container smoke asserts on it.
+ *
+ * `.settings-status` is the shared Settings-note convention (modal.css: indented
+ * 1.25rem, italic, weight 600), so these read as sub-notes rather than as
+ * settings — which is what the SP4 branch's 730e521 exists to specify.
+ */
+function buildDockerNoteSection(title: string, kind: 'service' | 'updates', text: string): HTMLElement {
+    const section = document.createElement('section');
+    section.className = 'settings-section';
+    section.dataset['dockerNote'] = kind; // stable hook for the container smoke
+    const heading = document.createElement('h3');
+    heading.className = 'settings-section-heading';
+    heading.textContent = title;
+    section.appendChild(heading);
+    const body = document.createElement('div');
+    body.className = 'settings-section-body';
+    const note = document.createElement('p');
+    note.className = 'settings-status';
+    note.style.gridColumn = '1 / -1';
+    note.textContent = text;
+    body.appendChild(note);
+    section.appendChild(body);
+    return section;
+}
+
+export function buildDockerServiceNote(): HTMLElement {
+    return buildDockerNoteSection(
+        'Service',
+        'service',
+        'service install not applicable — this instance runs in a container.',
+    );
+}
+
+export function buildDockerUpdatesNote(): HTMLElement {
+    return buildDockerNoteSection(
+        'Updates',
+        'updates',
+        'update via `docker pull bilbospocketses/ws-scrcpy-web:latest`.',
+    );
+}
+
 export class SettingsModal extends Modal {
     private role: Role | null = null;
     private authEnabled = false;
+    /**
+     * True when the server reported WS_SCRCPY_DOCKER=1 (SP4 E4). Read from the
+     * /api/config runtime envelope, never from AppConfig — the flag is an env
+     * implication and is deliberately never persisted to config.json.
+     */
+    private docker = false;
+    /** Set by fillBody so applyDockerGating() can swap them once docker mode lands. */
+    private updatesSectionEl: HTMLElement | null = null;
+    private serviceSectionEl: HTMLElement | null = null;
     private serviceSection!: HTMLElement;
     private embedOriginsBody: HTMLElement | null = null;
     private webPortInput: HTMLInputElement | null = null;
@@ -463,6 +521,13 @@ export class SettingsModal extends Modal {
             void (async () => {
                 let role: Role | null = 'admin';
                 let authEnabled = false;
+                // SP4 E4. Start the container-mode probe now, but deliberately do
+                // NOT await it before fillBody. Blocking the body on a second fetch
+                // means a hung /api/config renders a permanently EMPTY Settings
+                // dialog — this modal's own tests stub fetch as a never-resolving
+                // promise precisely to pin "the body still renders", and that is a
+                // real guarantee, not a test artifact.
+                const dockerProbe = this.probeDockerMode();
                 try {
                     const me = await authClient.me();
                     role = me.user?.role ?? null;
@@ -473,9 +538,26 @@ export class SettingsModal extends Modal {
                 this.role = role;
                 this.authEnabled = authEnabled;
                 this.fillBody(this.bodyEl);
-                if (canSeeSection(role, 'service')) void this.refreshService();
-                if (canSeeSection(role, 'updates')) void this.refreshUpdates();
                 void this.refreshServer(); // server section always present (has the user-level reset row)
+                // The Service and Updates refreshes are HELD until container mode is
+                // known. That is what the plan's build-site gating was really for:
+                // in a container neither endpoint describes anything actionable, and
+                // firing them anyway would draw "couldn't reach server" underneath
+                // the informational copy. Holding them costs nothing on the desktop
+                // (the sections already render a "loading…" placeholder) and means
+                // no inapplicable request is ever made in a container.
+                void (async () => {
+                    // Fail-open to "not a container": the desktop answer, and the one
+                    // that shows MORE, so a transient error cannot silently strip a
+                    // host user's Service and Updates sections.
+                    this.docker = await dockerProbe;
+                    if (this.docker) {
+                        this.applyDockerGating();
+                        return;
+                    }
+                    if (canSeeSection(this.role, 'service')) void this.refreshService();
+                    if (canSeeSection(this.role, 'updates')) void this.refreshUpdates();
+                })();
             })();
         });
     }
@@ -496,8 +578,18 @@ export class SettingsModal extends Modal {
         if (canSeeSection(this.role, 'users')) container.appendChild(this.buildUsersSection());
         // Next to Users: both answer "who is allowed to do what with this server".
         if (canSeeSection(this.role, 'embedOrigins')) container.appendChild(this.buildEmbedOriginsSection());
-        if (canSeeSection(this.role, 'updates')) container.appendChild(this.buildUpdatesSection());
-        if (canSeeSection(this.role, 'service')) container.appendChild(this.buildServiceSection());
+        // Built unconditionally; applyDockerGating() swaps them for the locked
+        // container copy if the probe comes back true. Their refresh calls are
+        // held until then, so a container never issues an inapplicable request
+        // and never renders an error under the copy. See the constructor.
+        if (canSeeSection(this.role, 'updates')) {
+            this.updatesSectionEl = this.buildUpdatesSection();
+            container.appendChild(this.updatesSectionEl);
+        }
+        if (canSeeSection(this.role, 'service')) {
+            this.serviceSectionEl = this.buildServiceSection();
+            container.appendChild(this.serviceSectionEl);
+        }
         container.appendChild(this.buildServerSection()); // always (contains the user-level reset row)
     }
 
@@ -975,6 +1067,49 @@ export class SettingsModal extends Modal {
         }
 
         return section;
+    }
+
+    /**
+     * Replace the Service and Updates sections with the locked container copy
+     * (SP4 E4). Called only once the probe has confirmed container mode, and
+     * before either section's refresh has been allowed to run — so nothing here
+     * is racing a half-rendered async result.
+     *
+     * The stale body references are dropped as well. `refreshService()` writes
+     * into `this.serviceSection` unconditionally; leaving it pointing at a
+     * detached node would let any later call render service UI into nothing,
+     * which is the kind of bug that only shows up as "the section is blank".
+     */
+    private applyDockerGating(): void {
+        this.updatesSectionEl?.replaceWith(buildDockerUpdatesNote());
+        this.serviceSectionEl?.replaceWith(buildDockerServiceNote());
+        this.updatesSectionEl = null;
+        this.serviceSectionEl = null;
+        this.updatesBody = null;
+        this.updatesStatusEl = null;
+        this.updatesCheckNowBtn = null;
+    }
+
+    /**
+     * Ask the server whether it is running in a container (SP4 E4).
+     *
+     * Reads `runtime.docker` off the /api/config envelope — the runtime side, not
+     * `config`, because the flag is an env implication the server deliberately
+     * never persists to config.json.
+     *
+     * Fails open to `false`. That is the desktop answer and the one that shows
+     * MORE, matching the role fail-open in the constructor: a transient fetch
+     * error should not silently strip a host user's Service and Updates sections.
+     */
+    private async probeDockerMode(): Promise<boolean> {
+        try {
+            const r = await fetch('/api/config');
+            if (!r.ok) return false;
+            const env = (await r.json()) as AppConfigEnvelope;
+            return env.runtime.docker === true;
+        } catch {
+            return false;
+        }
     }
 
     private async refreshServer(): Promise<void> {

--- a/src/app/client/__tests__/settingsModal.dockerGating.test.ts
+++ b/src/app/client/__tests__/settingsModal.dockerGating.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+/**
+ * SP4 E4 — the Settings gating for container mode.
+ *
+ * Each assertion runs in BOTH states. The second half is the one that matters:
+ * a gate that hides a section unconditionally passes every "it is absent in
+ * Docker" check and is still completely broken on the desktop.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authClient } from '../AuthClient';
+import { buildDockerServiceNote, buildDockerUpdatesNote, SettingsModal } from '../SettingsModal';
+
+// The locked copy, verbatim from SP4 design §8 / todo_ws_scrcpy_web item 2
+// decision 4. Written out here rather than imported so a silent reword of the
+// source string fails this test instead of travelling with it.
+const SERVICE_COPY = 'service install not applicable — this instance runs in a container.';
+const UPDATES_COPY = 'update via `docker pull bilbospocketses/ws-scrcpy-web:latest`.';
+
+describe('container replacements for Service and Updates', () => {
+    beforeEach(() => {
+        document.body.replaceChildren();
+    });
+
+    it('renders the Service note with the locked copy, in the shared note style', () => {
+        const el = buildDockerServiceNote();
+        document.body.appendChild(el);
+
+        expect(el.dataset['dockerNote']).toBe('service');
+        expect(el.querySelector('.settings-section-heading')?.textContent).toBe('Service');
+
+        const note = el.querySelector('.settings-status');
+        expect(note).not.toBeNull();
+        expect(note?.textContent).toBe(SERVICE_COPY);
+    });
+
+    it('renders the Updates note with the locked copy, in the shared note style', () => {
+        const el = buildDockerUpdatesNote();
+        document.body.appendChild(el);
+
+        expect(el.dataset['dockerNote']).toBe('updates');
+        expect(el.querySelector('.settings-section-heading')?.textContent).toBe('Updates');
+
+        const note = el.querySelector('.settings-status');
+        expect(note).not.toBeNull();
+        expect(note?.textContent).toBe(UPDATES_COPY);
+    });
+
+    it('carries none of the interactive affordances the real sections have', () => {
+        // The point of replacing rather than hiding: nothing here can be clicked,
+        // so nothing triggers refreshService()/refreshUpdates() and no
+        // "couldn't reach server" error can render under the copy.
+        for (const el of [buildDockerServiceNote(), buildDockerUpdatesNote()]) {
+            expect(el.querySelectorAll('button').length).toBe(0);
+            expect(el.querySelectorAll('input').length).toBe(0);
+            expect(el.querySelectorAll('select').length).toBe(0);
+        }
+    });
+
+    it('uses the settings-status class, which is what supplies the indent and bold-italic', () => {
+        // modal.css gives .settings-status padding-left 1.25rem / italic / 600.
+        // Asserting the class rather than computed style keeps this a contract
+        // about the convention (730e521) rather than about jsdom's CSS support.
+        for (const el of [buildDockerServiceNote(), buildDockerUpdatesNote()]) {
+            const note = el.querySelector('p');
+            expect(note?.className).toContain('settings-status');
+        }
+    });
+
+    it('produces two DISTINCT sections, so one gate cannot stand in for the other', () => {
+        const a = buildDockerServiceNote();
+        const b = buildDockerUpdatesNote();
+        expect(a.dataset['dockerNote']).not.toBe(b.dataset['dockerNote']);
+        expect(a.querySelector('.settings-status')?.textContent).not.toBe(
+            b.querySelector('.settings-status')?.textContent,
+        );
+    });
+});
+
+/**
+ * The gating as the modal actually applies it. The builder tests above prove the
+ * copy; these prove the SWAP — and, more importantly, that it happens only in a
+ * container and that a container issues no inapplicable request.
+ */
+describe('SettingsModal applies the gating only in a container', () => {
+    const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+    function stubMeAsAdmin(): void {
+        vi.spyOn(authClient, 'me').mockResolvedValue({
+            authEnabled: false,
+            user: { username: 'admin', role: 'admin' },
+        });
+    }
+
+    /** A fetch that answers /api/config with the given runtime, and stalls the rest. */
+    function stubConfigFetch(runtime: Record<string, unknown>): ReturnType<typeof vi.fn> {
+        const f = vi.fn((url: string) => {
+            if (typeof url === 'string' && url.startsWith('/api/config')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ config: { webPort: 8000 }, runtime }),
+                });
+            }
+            return new Promise(() => undefined); // never settles — nothing should need it
+        });
+        vi.stubGlobal('fetch', f);
+        return f as unknown as ReturnType<typeof vi.fn>;
+    }
+
+    beforeEach(() => {
+        document.body.replaceChildren();
+        HTMLDialogElement.prototype.showModal = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('swaps both sections for the notes when runtime.docker is true', async () => {
+        stubMeAsAdmin();
+        const f = stubConfigFetch({ firstRunComplete: true, portWasAutoShifted: false, webPort: 8000, docker: true });
+        new SettingsModal();
+        await flush();
+
+        expect(document.querySelector('[data-docker-note="service"]')).not.toBeNull();
+        expect(document.querySelector('[data-docker-note="updates"]')).not.toBeNull();
+
+        // And the inapplicable endpoints were never asked. This is the whole
+        // reason the refreshes are held until docker mode is known: firing them
+        // would draw "couldn't reach server" underneath the copy.
+        const urls = f.mock.calls.map((c) => String(c[0]));
+        expect(urls.some((u) => u.startsWith('/api/service/status'))).toBe(false);
+        expect(urls.some((u) => u.startsWith('/api/updates/status'))).toBe(false);
+    });
+
+    it('leaves the real sections alone when runtime.docker is absent', async () => {
+        // The half that matters: a gate that fires unconditionally passes the
+        // test above and is completely broken on the desktop.
+        stubMeAsAdmin();
+        const f = stubConfigFetch({ firstRunComplete: true, portWasAutoShifted: false, webPort: 8000 });
+        new SettingsModal();
+        await flush();
+
+        expect(document.querySelector('[data-docker-note="service"]')).toBeNull();
+        expect(document.querySelector('[data-docker-note="updates"]')).toBeNull();
+
+        const headings = Array.from(document.querySelectorAll<HTMLElement>('.settings-section-heading')).map(
+            (el) => el.textContent ?? '',
+        );
+        expect(headings).toContain('Service');
+        expect(headings).toContain('Updates');
+
+        // And on the desktop those endpoints ARE asked.
+        const urls = f.mock.calls.map((c) => String(c[0]));
+        expect(urls.some((u) => u.startsWith('/api/service/status'))).toBe(true);
+        expect(urls.some((u) => u.startsWith('/api/updates/status'))).toBe(true);
+    });
+
+    it('still renders the body when /api/config never answers', async () => {
+        // The guarantee the modal's own suite already pins, restated here because
+        // this feature is what would have broken it: blocking the render on the
+        // docker probe leaves a permanently EMPTY Settings dialog.
+        stubMeAsAdmin();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(() => new Promise(() => undefined)),
+        );
+        new SettingsModal();
+        await flush();
+
+        const headings = Array.from(document.querySelectorAll<HTMLElement>('.settings-section-heading')).map(
+            (el) => el.textContent ?? '',
+        );
+        expect(headings.length).toBeGreaterThan(0);
+        expect(headings).toContain('Server');
+    });
+});

--- a/src/common/ConfigEvents.ts
+++ b/src/common/ConfigEvents.ts
@@ -40,6 +40,16 @@ export interface FirstRunStatus {
     firstRunComplete: boolean;
     portWasAutoShifted: boolean;
     webPort: number;
+    /**
+     * True when the server was started with WS_SCRCPY_DOCKER=1.
+     *
+     * Optional so a pre-SP4 server and a post-SP4 frontend interoperate: an
+     * absent field reads as false everywhere, which is the desktop answer.
+     * Carried on the runtime envelope rather than in AppConfig deliberately —
+     * AppConfig is what gets written to config.json, and this must never
+     * persist into a /data volume that could later be mounted elsewhere.
+     */
+    docker?: boolean;
 }
 
 /** Envelope shape returned by GET /api/config. */

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -37,6 +37,20 @@ export interface ServiceStatusResponse {
      */
     servedByService?: boolean;
     /**
+     * True when the server was started with WS_SCRCPY_DOCKER=1.
+     *
+     * Mirrored here rather than only on the config envelope so the Settings
+     * modal can gate its Service section from the status call it already
+     * makes, instead of adding a second probe (SP4 E4).
+     *
+     * Optional so a pre-SP4 server and a post-SP4 frontend interoperate: an
+     * absent field reads as false everywhere, which is the desktop answer.
+     * Deliberately NOT part of AppConfig — AppConfig is what gets written to
+     * config.json, and this must never persist into a /data volume that could
+     * later be mounted elsewhere.
+     */
+    docker?: boolean;
+    /**
      * Snapshot of `AppConfig.installMode` at status time. Lets the frontend
      * tell which service scope is active (`user-service` vs `system-service`)
      * without poking a second endpoint. `null` when never installed. Present

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -433,6 +433,12 @@ export class Config {
     private _appConfig: AppConfig;
     private _configFilePath: string;
     private _firstRunStatus: FirstRunStatus;
+    /**
+     * Whether firstRunComplete was stated explicitly (by the file at boot, or by a
+     * later updateAppConfig). Only meaningful in Docker mode, where an unstated
+     * value is implied true and a stated one is honoured as written.
+     */
+    private _firstRunExplicit: boolean;
 
     private static loadFile(configPath: string): FlatConfig {
         const isAbsolute = configPath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(configPath);
@@ -545,6 +551,31 @@ export class Config {
             // Prompt-dismissal flags are no longer part of AppConfig — they live
             // in user_settings and are read by the frontend via GET /api/settings.
             const appConfig = composeAppConfig(fileConfig, globals, warn);
+
+            // SP4 E4: a container presents as already-configured. WS_SCRCPY_DOCKER=1
+            // implies firstRunComplete + installMode 'user', so the WelcomeModal and
+            // the Linux SystemWideInstallModal never open — on the host those are
+            // seeded by Velopack's hooks.rs::on_install, and no such hook exists in
+            // Docker.
+            //
+            // Compared against the literal '1'. Boolean(process.env.X) makes the
+            // STRING '0' true, so a compose file that disables the flag by setting
+            // it to 0 would silently leave it enabled.
+            //
+            // The implication is applied as a READ-TIME OVERLAY (effectiveAppConfig)
+            // and is never written into _appConfig. saveToDisk() persists
+            // installMode + firstRunComplete straight out of _appConfig, and is
+            // reached from setActualWebPort() on any port shift — so baking it in
+            // would write firstRunComplete:true into /data/config.json on first
+            // boot. It would then outlive WS_SCRCPY_DOCKER and suppress the welcome
+            // modal on any host that later mounted that volume.
+            const dockerMode = process.env['WS_SCRCPY_DOCKER'] === '1';
+
+            // Whether the FILE stated firstRunComplete. composeAppConfig turns an
+            // absent value into `false`, which is indistinguishable from an explicit
+            // false — and the overlay must defer to a user who wrote one.
+            const firstRunExplicit = fileConfig.firstRunComplete !== undefined;
+
             const servers = Config.buildServers(fileConfig, appConfig.webPort);
 
             // An app_settings override of dependenciesPath/adbPath is overlaid for
@@ -594,6 +625,8 @@ export class Config {
                 allowedHosts,
                 frameAncestors,
                 db,
+                dockerMode,
+                firstRunExplicit,
             );
         }
         return this.instance;
@@ -619,13 +652,41 @@ export class Config {
         private readonly _allowedHosts: string[],
         private readonly _frameAncestors: string[],
         private readonly _db: Db,
+        private readonly _dockerMode: boolean = false,
+        firstRunExplicit: boolean = false,
     ) {
         this._appConfig = appConfig;
         this._configFilePath = configFilePath;
+        this._firstRunExplicit = firstRunExplicit;
         this._firstRunStatus = {
-            firstRunComplete: appConfig.firstRunComplete,
+            firstRunComplete: this.effectiveAppConfig().firstRunComplete,
             portWasAutoShifted: false,
             webPort: appConfig.webPort,
+            ...(this._dockerMode ? { docker: true } : {}),
+        };
+    }
+
+    /** True when the server was started with WS_SCRCPY_DOCKER=1. */
+    public get dockerMode(): boolean {
+        return this._dockerMode;
+    }
+
+    /**
+     * The effective config as READ. The Docker implication lives here and only
+     * here: `_appConfig` stays exactly what the file and the store said, so
+     * `saveToDisk()` — which writes installMode + firstRunComplete straight out of
+     * `_appConfig`, and is reached from `setActualWebPort()` on any port shift —
+     * can never persist it. See the note in getInstance().
+     *
+     * `?? 'user'` rather than an unconditional override: the implication is a
+     * DEFAULT, so a user who wrote an installMode keeps it.
+     */
+    private effectiveAppConfig(): AppConfig {
+        if (!this._dockerMode) return this._appConfig;
+        return {
+            ...this._appConfig,
+            firstRunComplete: this._firstRunExplicit ? this._appConfig.firstRunComplete : true,
+            installMode: this._appConfig.installMode ?? 'user',
         };
     }
 
@@ -845,9 +906,12 @@ export class Config {
         return [];
     }
 
-    /** Returns the resolved AppConfig (with defaults filled in). */
+    /**
+     * Returns the resolved AppConfig (with defaults filled in, and the Docker
+     * implication overlaid when WS_SCRCPY_DOCKER=1 — see effectiveAppConfig).
+     */
     public getAppConfig(): AppConfig {
-        return { ...this._appConfig };
+        return { ...this.effectiveAppConfig() };
     }
 
     /** Path on disk where config.json lives (or will live on first save). */
@@ -892,12 +956,17 @@ export class Config {
         }
         const restartRequired = merged.webPort !== this._appConfig.webPort;
         this._appConfig = merged;
+        // A caller that writes firstRunComplete has stated it, so the Docker
+        // implication must stop supplying a value for it from here on.
+        if (partial.firstRunComplete !== undefined) {
+            this._firstRunExplicit = true;
+        }
         this._firstRunStatus = {
             ...this._firstRunStatus,
-            firstRunComplete: merged.firstRunComplete,
+            firstRunComplete: this.effectiveAppConfig().firstRunComplete,
         };
         this.saveToDisk();
-        return { config: { ...merged }, restartRequired };
+        return { config: { ...this.effectiveAppConfig() }, restartRequired };
     }
 
     /**
@@ -947,9 +1016,10 @@ export class Config {
             this.saveToDisk();
         }
         this._firstRunStatus = {
-            firstRunComplete: this._appConfig.firstRunComplete,
+            firstRunComplete: this.effectiveAppConfig().firstRunComplete,
             portWasAutoShifted: shifted,
             webPort: actualPort,
+            ...(this._dockerMode ? { docker: true } : {}),
         };
     }
 }

--- a/src/server/__tests__/config.dockerMode.test.ts
+++ b/src/server/__tests__/config.dockerMode.test.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Config } from '../Config';
+import { EnvName } from '../EnvName';
+
+// Same CONFIG_PATH + DEPS_PATH temp harness as config.storeBacked.test.ts: the
+// DB co-locates with config.json, so each test is isolated in its own temp dir.
+const tmpDirs: string[] = [];
+const saved = {
+    CONFIG: process.env[EnvName.CONFIG_PATH],
+    DEPS: process.env['DEPS_PATH'],
+    DOCKER: process.env['WS_SCRCPY_DOCKER'],
+};
+
+function setup(initial: unknown, docker?: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-cfg-docker-'));
+    tmpDirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify(initial));
+    process.env[EnvName.CONFIG_PATH] = configPath;
+    process.env['DEPS_PATH'] = path.join(dir, 'deps');
+    if (docker === undefined) delete process.env['WS_SCRCPY_DOCKER'];
+    else process.env['WS_SCRCPY_DOCKER'] = docker;
+    Config._resetForTest();
+    return configPath;
+}
+
+afterEach(() => {
+    Config._resetForTest();
+    for (const [k, v] of [
+        [EnvName.CONFIG_PATH, saved.CONFIG],
+        ['DEPS_PATH', saved.DEPS],
+        ['WS_SCRCPY_DOCKER', saved.DOCKER],
+    ] as const) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+    while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('WS_SCRCPY_DOCKER runtime implication (SP4 E4)', () => {
+    it('presents a container as already-configured: firstRunComplete + installMode user', () => {
+        // A container has no Velopack hooks.rs::on_install to seed the trio, so
+        // without this the WelcomeModal and the Linux SystemWideInstallModal
+        // would open on every boot of a perfectly good image.
+        setup({}, '1');
+        const c = Config.getInstance();
+        expect(c.getFirstRunStatus().firstRunComplete).toBe(true);
+        expect(c.getAppConfig().installMode).toBe('user');
+        expect(c.getFirstRunStatus().docker).toBe(true);
+    });
+
+    it('changes nothing when the flag is unset', () => {
+        setup({});
+        const c = Config.getInstance();
+        expect(c.getFirstRunStatus().firstRunComplete).toBe(false);
+        expect(c.getAppConfig().installMode).toBeNull();
+        expect(c.getFirstRunStatus().docker ?? false).toBe(false);
+    });
+
+    it('NEVER persists the implication to config.json, even when a port shift forces a save', () => {
+        // The trap. Config composes the effective config and then PERSISTS:
+        // setActualWebPort() calls saveToDisk() on a shift, and saveToDisk writes
+        // installMode + firstRunComplete straight out of _appConfig. If the Docker
+        // implication were baked into that object, the container would write
+        // firstRunComplete:true into /data/config.json on first boot and the flag
+        // would stop being an env implication and become persisted state -- which
+        // outlives WS_SCRCPY_DOCKER and would suppress the welcome modal on any
+        // host that later mounted the same volume.
+        const configPath = setup({ webPort: 8000 }, '1');
+        const c = Config.getInstance();
+        c.setActualWebPort(8123); // differs from webPort -> saveToDisk()
+
+        const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+        expect(onDisk['webPort']).toBe(8123); // the shift itself SHOULD persist
+        expect(onDisk['firstRunComplete']).toBe(false); // the implication must NOT
+        expect(onDisk['installMode']).toBeNull();
+
+        // And the live view still reports the container as configured.
+        expect(c.getFirstRunStatus().firstRunComplete).toBe(true);
+        expect(c.getAppConfig().installMode).toBe('user');
+    });
+
+    it.each(['0', '', 'false', 'no'])('does not treat %o as enabling docker mode', (value) => {
+        // Boolean(process.env.X) makes the STRING '0' true, so a compose file that
+        // disables the flag by setting it to 0 would silently leave it enabled.
+        // The comparison is against the literal '1'.
+        setup({}, value);
+        const c = Config.getInstance();
+        expect(c.getFirstRunStatus().docker ?? false).toBe(false);
+        expect(c.getFirstRunStatus().firstRunComplete).toBe(false);
+        expect(c.getAppConfig().installMode).toBeNull();
+    });
+
+    it('lets an explicit installMode in config.json win over the implication', () => {
+        // The implication is a DEFAULT, not an override: a user who wrote a value
+        // meant it, and a container started against an existing volume must not
+        // have its recorded install mode silently rewritten.
+        setup({ installMode: 'system-service', firstRunComplete: false }, '1');
+        const c = Config.getInstance();
+        expect(c.getAppConfig().installMode).toBe('system-service');
+        // Same rule for firstRunComplete: an EXPLICIT false in the file wins, so a
+        // container started against a volume mid-first-run still finishes it.
+        expect(c.getFirstRunStatus().firstRunComplete).toBe(false);
+        // ...but it is still a container, and the UI gating keys off this.
+        expect(c.getFirstRunStatus().docker).toBe(true);
+    });
+});

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -243,6 +243,11 @@ export class ServiceApi {
                 supported: false,
                 platform: result.platform,
                 unsupportedReason: result.unsupportedReason,
+                // Reported on BOTH branches. The Settings modal gates its Service
+                // section on this, and a container on a platform that also reports
+                // unsupported must still gate — otherwise the section would be
+                // hidden for the right reason on Linux and the wrong one elsewhere.
+                ...(Config.getInstance().dockerMode ? { docker: true } : {}),
             };
             res.writeHead(200);
             res.end(JSON.stringify(body));
@@ -289,6 +294,11 @@ export class ServiceApi {
             // install never has it. The post-install poll keys hand-off completion
             // off this positive signal (no mtime-change / dead-window race).
             servedByService: process.env['WS_SCRCPY_SERVICE'] === '1',
+            // SP4 E4: lets the Settings modal hide the Service section from the
+            // status call it already makes, rather than adding a second probe.
+            // Read from Config, not process.env, so there is one place that
+            // decides what "docker mode" means (the literal '1' comparison).
+            ...(Config.getInstance().dockerMode ? { docker: true } : {}),
             ...(scope !== undefined ? { scope } : {}),
             ...(disk.diskWebPort != null ? { diskWebPort: disk.diskWebPort } : {}),
             ...(disk.configMtime != null ? { configMtime: disk.configMtime } : {}),


### PR DESCRIPTION
The container-awareness half of SP4: the server treats `WS_SCRCPY_DOCKER=1` as implying an already-configured install, and Settings replaces the two sections that describe nothing actionable in a container.

Part of `qa-harness` P3 (tasks 4 and 5). The image itself is a separate PR — nothing here sets the env var, so this is inert on the desktop.

## The server side

`WS_SCRCPY_DOCKER=1` implies `firstRunComplete` + `installMode: 'user'`, so the WelcomeModal and the Linux SystemWideInstallModal never open. On the host those are seeded by Velopack's `hooks.rs::on_install`; Docker has no such hook, so without this a perfectly good image shows a first-run wizard on **every** boot.

**The interesting part is where the implication is *not* applied.** `Config` composes the effective config and then persists: `saveToDisk()` writes `installMode` and `firstRunComplete` straight out of `_appConfig`, and `setActualWebPort()` calls it on any port shift — which a container hits routinely, since the resolver shifts when 8000 is taken.

Bake the implication into `_appConfig` and first boot writes `firstRunComplete: true` into `/data/config.json`. The flag then stops being an env implication and becomes **persisted state**: it outlives `WS_SCRCPY_DOCKER`, and a `/data` volume later bind-mounted onto a desktop install would suppress *that* install's welcome modal.

So it is a **read-time overlay**. `_appConfig` stays exactly what the file and store said; `effectiveAppConfig()` applies the implication for reads; `saveToDisk()` is untouched and cannot leak it.

It is a **default, not an override** — `installMode` uses `?? 'user'`, so a user who wrote one keeps it. `firstRunComplete` can't use the same trick (its default is `false`, making absent indistinguishable from explicit), so the constructor is told whether the *file* stated it, and `updateAppConfig` flips that the moment a caller writes it.

Compared against the literal `'1'`: `Boolean(process.env.X)` makes the **string `'0'` true**, so a compose file disabling the flag with `0` would silently leave it on.

## The UI side

Service → *"service install not applicable — this instance runs in a container."*
Updates → *"update via `docker pull bilbospocketses/ws-scrcpy-web:latest`."*

Both use `.settings-status`, the shared indented bold-italic Settings-note convention.

**A deviation from the plan, and why.** The plan called for gating at the *build* sites, which requires knowing container mode before the body renders. This modal's own suite stubs `fetch` as a **never-resolving promise** in three tests, specifically to pin *"the body still renders"* — and awaiting a second fetch before `fillBody` makes a hung `/api/config` produce a permanently **empty** Settings dialog: no sections, no error, nothing to retry. Those tests encode a real guarantee, so they were left alone.

What build-site gating was actually *for* is the refresh calls — a hidden-after-render section still fires `refreshService()`/`refreshUpdates()`, whose error paths draw "couldn't reach server" under the copy. That reason is preserved exactly: sections render immediately, the probe runs concurrently, and **both refreshes are held until it answers**. A container issues neither request at all.

## Verification

- **1745 tests pass / 5 skipped across 192 files**, `tsc --noEmit` clean, biome clean over 507 files.
- Every new test was watched failing first. Two failure directions were then proven specifically:
  - Implementing the overlay the obvious way (assigning the effective config back into `_appConfig`) fails **only** the persistence guard, with `expected true to be false` on the on-disk `firstRunComplete`.
  - Forcing the UI gate unconditionally fails **only** "leaves the real sections alone when `runtime.docker` is absent" — the check that a hide-everything gate would otherwise sail straight through.

## Two findings recorded, not silently fixed

In a new `docs/smoke-tests/automation-coverage.md` under module 20:

- **The libfuse2 requirement is moot, not outstanding.** SP4 decision 4 asks for the banner hidden in Docker, but that gate was removed end-to-end in an earlier release — endpoint, status field, and the Settings prompt itself. `grep -ri libfuse src/` returns nothing. Noted so nobody goes looking for a gate to implement.
- **The Server section still carries "install for all users" (pkexec → /opt → re-exec) and "uninstall"**, neither of which means anything in a container. They need a scoped decision and are not part of decision 4's locked list. **"stop server & exit" is deliberately not flagged** — it is correct in a container and is exactly what smoke row 12.1 asserts against `docker stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ntNnppxZf5Yet6yDb3HHL