### PR TITLE
Split the e2e suite into three tiers by tag, and prove the container tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,22 @@ jobs:
       # needs nothing more, so the step buys nothing here anyway.
       - name: Build the container image
         run: docker buildx build --platform linux/amd64 --load -t ws-scrcpy-web:ci .
-      # NOTE: the `@docker` Playwright project (npm run test:e2e:docker) lands
-      # with the suite partition and is added here then. A step invoking a script
-      # that does not exist yet would fail every PR for a reason unrelated to the
-      # change under review.
+
+      # The @docker project: the same specs and the same support library as the
+      # fast tier above, against the built image instead of a bare
+      # `node dist/index.js`. It runs on a GitHub-hosted runner and holds no
+      # secrets, so it belongs in the fast tier under spec §9 — the tier boundary
+      # is secrets and devices, not containers.
+      #
+      # WSSW_IMAGE points compose at the tag the step above just built, so the
+      # image is not built a second time under another name.
+      #
+      # Ordering is load-bearing: after `npm run build` (the fast-tier Playwright
+      # steps need the host dist/) and after the image build (this starts it).
+      - name: E2E — container suite
+        run: npm run test:e2e:docker
+        env:
+          WSSW_IMAGE: ws-scrcpy-web:ci
 
       - name: Bump/blob sync
         # The auto-release bump commit is assembled from an explicit blob list.

--- a/biome.json
+++ b/biome.json
@@ -60,7 +60,7 @@
         }
     },
     "files": {
-        "includes": ["src/**", "webpack/**", "tests/**", "playwright.config.ts"]
+        "includes": ["src/**", "webpack/**", "tests/**", "playwright.config.ts", "playwright.docker.config.ts"]
     },
     "overrides": [
         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ws-scrcpy-web:local
+    # Overridable so CI can point the suite at the tag its own build step already
+    # produced, instead of building the same image a second time under a
+    # different name. Defaults to the local tag for a plain `docker compose up`.
+    image: ${WSSW_IMAGE:-ws-scrcpy-web:local}
     ports:
       # Host 8123 -> container 8000. 8123 is what tests/e2e/support/paths.ts
       # already exports as E2E_PORT, so every existing spec's baseURL is

--- a/docs/smoke-tests/automation-coverage.md
+++ b/docs/smoke-tests/automation-coverage.md
@@ -41,7 +41,10 @@ decision 4's locked list.
 
 | # | Affordance | In a container | Assessment |
 |---|---|---|---|
-| 20.4 | **"install for all users"** (Linux-only) | POSTs `/api/service/install-system-wide`, which runs `pkexec`, relocates to `/opt` and re-execs | **Finding.** A container has no polkit and relocating inside the image is meaningless; the row is already Linux-gated but not container-gated. Needs a decision: hide it in Docker, or leave it and let it fail loudly. |
+| 20.4 | **"install for all users"** — the Settings → Server *row* | POSTs `/api/service/install-system-wide`, which runs `pkexec`, relocates to `/opt` and re-execs | **Finding, still open.** A container has no polkit and relocating inside the image is meaningless; the row is Linux-gated but not container-gated. Needs a decision: hide it in Docker, or leave it and let it fail loudly. |
+| 20.7 | **the same offer as a first-run modal** (`SystemWideInstallModal`) | opened on first load of every container and, being a `<dialog>`, swallowed the clicks meant for the page beneath it | **FIXED.** `offerMachineWide` now requires `status.docker !== true`. It could not be left to the decline marker, which is per-data-root: a fresh volume has none. Asserted by `docker-gating.spec.ts`. |
+
+**20.7 is why the container suite exists.** It is Linux-only, so it cannot appear on a Windows dev box; and because the modal is loaded by a dynamic `import()`, a fast machine can land the next click before it renders. It therefore **passed locally and failed only in CI** — the same trap `playwright.config.ts` already documents for this exact modal in the fast tier. The fix is a gate rather than a marker precisely so it stops being a race.
 | 20.5 | **"uninstall ws-scrcpy-web"** | tears down a service/install that does not exist here | **Finding.** The container equivalent is `docker rm`. Same decision as 20.4. |
 | 20.6 | **"stop server & exit"** | graceful shutdown — `adb kill-server`, service release, exit 0 | **Correct in a container, and load-bearing.** This is exactly what smoke row 12.1 asserts against `docker stop` (SIGTERM reaching node *through* `start.sh` via `tini -g`). Must NOT be gated. |
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "start": "npm run build && node scripts/dev-supervisor.mjs",
     "start:no-supervisor": "npm run build && node dist/index.js",
     "test": "vitest run",
-    "lint": "npx @biomejs/biome check src/ tests/ playwright.config.ts",
-    "format": "npx @biomejs/biome check --write src/ tests/ playwright.config.ts",
+    "lint": "npx @biomejs/biome check src/ tests/ playwright.config.ts playwright.docker.config.ts",
+    "format": "npx @biomejs/biome check --write src/ tests/ playwright.config.ts playwright.docker.config.ts",
     "fetch-prebuilts": "node scripts/fetch-prebuilts.mjs",
     "version:bump": "node scripts/bump-version.mjs",
     "version:check": "node scripts/assert-version-sync.mjs",
@@ -47,6 +47,8 @@
     "test:update-flow": "pwsh scripts/test-update-flow.ps1",
     "release-notes": "node scripts/extract-changelog.mjs $npm_package_version",
     "test:e2e": "playwright test",
+    "test:e2e:docker": "playwright test --config playwright.docker.config.ts",
+    "test:e2e:device": "QA_DEVICE=1 QA_EXTERNAL_STACK=1 playwright test --config playwright.docker.config.ts",
     "test:e2e:types": "tsc -p tests/e2e --noEmit"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,6 +80,19 @@ export default defineConfig({
     fullyParallel: false,
     workers: 1,
 
+    /**
+     * The default run is the FAST tier: a bare `node dist/index.js`, no
+     * container, no device, no credential. Two tags opt out of it.
+     *
+     * `@docker` needs the built image (playwright.docker.config.ts starts the
+     * compose stack); `@device` needs that image AND the Android emulator, so it
+     * only ever runs under qa-harness. Excluding them here rather than
+     * segregating them into a directory keeps a feature's specs together — the
+     * device streaming specs belong beside the settings specs that configure
+     * the codec they stream.
+     */
+    grepInvert: /@docker|@device/,
+
     forbidOnly: !!process.env['CI'],
     retries: process.env['CI'] ? 1 : 0,
     timeout: 30_000,

--- a/playwright.docker.config.ts
+++ b/playwright.docker.config.ts
@@ -1,0 +1,90 @@
+import { defineConfig, devices } from '@playwright/test';
+import { E2E_BASE_URL } from './tests/e2e/support/paths';
+
+/**
+ * The container suite.
+ *
+ * Same specs directory, same support library, different subject: the built image
+ * rather than a bare `node dist/index.js`. Playwright's `webServer` is
+ * config-scoped rather than project-scoped, so "bare server" and "container"
+ * cannot be two projects in one config — two configs sharing
+ * `tests/e2e/support/**` is the idiomatic answer, and it keeps one support
+ * library and one selector vocabulary.
+ *
+ * Deliberately does NOT seed a config the way playwright.config.ts does. The
+ * container is supposed to present as already-configured from WS_SCRCPY_DOCKER
+ * alone (SP4 E4), and seeding `firstRunComplete` here would make
+ * docker-gating.spec.ts pass whether or not the server implements it — an
+ * unfalsifiable test, which is worse than no test.
+ *
+ * `webServer` is omitted when QA_EXTERNAL_STACK is set. qa-harness owns the
+ * stack in the heavy tier (its compose file adds the emulator and a network this
+ * repo knows nothing about); it points PLAYWRIGHT_BASE_URL at the running
+ * container, and this config must not try to start a second one.
+ */
+const external = process.env['QA_EXTERNAL_STACK'] === '1';
+
+export default defineConfig({
+    testDir: 'tests/e2e',
+    globalSetup: './tests/e2e/global-setup.ts',
+
+    /**
+     * The inverse of playwright.config.ts's grepInvert. `@device` is opted IN
+     * only when QA_DEVICE=1, so a plain `npm run test:e2e:docker` on a machine
+     * with no emulator runs the container specs and skips the device ones
+     * rather than failing them.
+     */
+    grep: process.env['QA_DEVICE'] === '1' ? /@docker|@device/ : /@docker/,
+
+    fullyParallel: false,
+    workers: 1,
+    forbidOnly: !!process.env['CI'],
+    retries: process.env['CI'] ? 1 : 0,
+
+    /**
+     * Doubled against the fast config on purpose. A container boot has an order
+     * more latency than an in-process spawn, and `expect` waits tight enough for
+     * the fast tier produce flake here that reads as an app fault.
+     */
+    timeout: 60_000,
+    expect: { timeout: 15_000 },
+
+    reporter: process.env['CI'] ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+    use: {
+        baseURL: process.env['PLAYWRIGHT_BASE_URL'] || E2E_BASE_URL,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+    },
+
+    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+
+    ...(external
+        ? {}
+        : {
+              webServer: {
+                  /**
+                   * `up --wait`, not `up -d`. `--wait` blocks on the
+                   * HEALTHCHECK; `up -d` returns the moment the container is
+                   * "Up", which is true while the server is still dead, and
+                   * would hand Playwright a subject that is not listening.
+                   */
+                  command: 'docker compose up --wait ws-scrcpy-web',
+                  url: `${E2E_BASE_URL}/api/config`,
+                  /**
+                   * Never reuse — same reasoning as the fast config. A server
+                   * already on this port is not necessarily ours.
+                   */
+                  reuseExistingServer: false,
+                  stdout: 'pipe',
+                  stderr: 'pipe',
+                  /**
+                   * Five minutes, not two. A first boot against an empty volume
+                   * downloads adb (~9 MB) before it listens, which is also why
+                   * the image's HEALTHCHECK carries a 180s start-period.
+                   */
+                  timeout: 300_000,
+              },
+          }),
+});

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -210,6 +210,19 @@ function maybeShowFirstRunModal(): void {
             const offerMachineWide =
                 status != null &&
                 status.platform === 'linux' &&
+                // Never in a container (SP4 E4). This offer POSTs
+                // /api/service/install-system-wide, which runs pkexec, relocates
+                // the app to /opt and re-execs — none of which means anything in
+                // an image, where the lifecycle belongs to `docker pull`.
+                //
+                // It is gated here rather than left to the decline marker because
+                // the marker is per-data-root: a fresh volume has none, so the
+                // modal opened on first load of every container and, being a
+                // <dialog>, swallowed the clicks meant for the page beneath it.
+                // Caught by the container suite in CI, which is also the only
+                // place it could be caught — the modal is Linux-only, so it never
+                // appears on a Windows dev box.
+                status.docker !== true &&
                 status.machineWideInstalled === false &&
                 status.systemInstallDeclined === false;
             if (!offerMachineWide) {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -26,6 +26,40 @@ unit test cannot see, and that this suite would:
   and move the running server to another port. Every consent spec asserts the
   untouched keys for that reason.
 
+## Three tiers, one suite
+
+| Tag | Subject | Runs in | Command |
+|---|---|---|---|
+| *(untagged)* | `node dist/index.js`, throwaway data root | `build-and-test` | `npm run test:e2e` |
+| `@docker` | the built image, via docker-compose.yml | `build-and-test` | `npm run test:e2e:docker` |
+| `@device` | the image + an Android emulator | qa-harness only | `npm run test:e2e:device` |
+
+Tag by putting the marker in the test **TITLE** — `test('@device streams h264', …)`
+— which is what Playwright's `--grep` matches. A tag in a comment or in a
+`describe` block's metadata does nothing, and the spec silently joins the default
+tier.
+
+One suite, partitioned by tag rather than split across directories or repos: the
+default config `grepInvert`s the two tags, and `playwright.docker.config.ts`
+greps them back in. A feature's specs therefore stay together — the device
+streaming specs belong beside the settings specs that configure the codec they
+stream — and there is one support library and one selector vocabulary.
+
+`@device` specs are authored here and run there. Nothing about them is
+qa-harness-specific except the emulator's presence, so keeping them beside their
+feature's other specs costs nothing and forking the support library would cost a
+lot.
+
+**`test:e2e:device` uses an inline env assignment** (`QA_DEVICE=1 QA_EXTERNAL_STACK=1 …`).
+That is POSIX syntax and is correct: the script is invoked by `qa-harness` from
+inside its Linux runner, never from PowerShell. It is not broken on Windows, it
+is simply not for Windows — please do not "fix" it with `cross-env`.
+
+`QA_EXTERNAL_STACK=1` tells the container config **not** to start a stack of its
+own, because qa-harness already owns one (its compose topology adds the emulator
+and a network this repo knows nothing about) and points `PLAYWRIGHT_BASE_URL` at
+it.
+
 ## Isolation
 
 The suite never touches a real install. It runs its own server on **port 8123**

--- a/tests/e2e/docker-gating.spec.ts
+++ b/tests/e2e/docker-gating.spec.ts
@@ -33,6 +33,25 @@ test.describe('container mode', () => {
         await expect(page.locator('dialog.welcome-modal')).toHaveCount(0);
     });
 
+    test('@docker the Linux system-wide install offer never opens', async ({ page }) => {
+        // Distinct from the welcome modal and gated differently: offerMachineWide
+        // keys off the per-data-root decline MARKER, which a fresh volume does not
+        // have — so before this was gated on container mode, the modal opened on
+        // first load of every container and, being a <dialog>, swallowed the
+        // clicks meant for the page beneath it.
+        //
+        // Linux-only, which is why it cannot be caught on a Windows dev box: it
+        // passed locally and failed only in CI, exactly as playwright.config.ts
+        // warns about the same modal in the fast tier.
+        await page.goto('/');
+        await expect(page.locator('dialog.system-wide-install-modal')).toHaveCount(0);
+
+        // And the page beneath it is actually reachable — the property that
+        // matters, and the one whose absence produced "intercepts pointer events"
+        // rather than anything naming the modal.
+        await expect(page.getByRole('button', { name: 'Open settings' })).toBeEnabled();
+    });
+
     test('@docker Settings replaces Service and Updates with the container copy', async ({ page }) => {
         await page.goto('/');
         await page.getByRole('button', { name: 'Open settings' }).click();

--- a/tests/e2e/docker-gating.spec.ts
+++ b/tests/e2e/docker-gating.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * The container tier (SP4 E4).
+ *
+ * Every test here is tagged `@docker` in its TITLE, which is what Playwright's
+ * --grep matches: the default config grepInverts the tag, and
+ * playwright.docker.config.ts greps it back in. A tag in a comment or a describe
+ * block's metadata does nothing and the spec would silently join the fast tier,
+ * where there is no container and every assertion below would be false.
+ *
+ * The subject is the built image, so these assert what only a real container can
+ * show: that WS_SCRCPY_DOCKER reaches the wire, that it does NOT reach disk, and
+ * that the UI gates on it. The unit tests cover the same logic in isolation;
+ * these cover the wiring between it and an actual image.
+ */
+test.describe('container mode', () => {
+    test('@docker the server reports itself as containerised', async ({ request }) => {
+        const res = await request.get('/api/config');
+        expect(res.ok()).toBe(true);
+        const body = (await res.json()) as { runtime: { docker?: boolean; firstRunComplete: boolean } };
+
+        expect(body.runtime.docker).toBe(true);
+        // The implication: a container presents as already-configured, because it
+        // has no Velopack on_install hook to seed the trio.
+        expect(body.runtime.firstRunComplete).toBe(true);
+    });
+
+    test('@docker the first-run wizard never opens', async ({ page }) => {
+        await page.goto('/');
+        // The welcome modal gates on !firstRunComplete. If the implication were
+        // missing, this dialog would open on every boot of a good image.
+        await expect(page.locator('dialog.welcome-modal')).toHaveCount(0);
+    });
+
+    test('@docker Settings replaces Service and Updates with the container copy', async ({ page }) => {
+        await page.goto('/');
+        await page.getByRole('button', { name: 'Open settings' }).click();
+        const settings = page.locator('dialog.settings-modal');
+        await expect(settings).toBeVisible();
+
+        // The notes are present...
+        const service = settings.locator('[data-docker-note="service"]');
+        const updates = settings.locator('[data-docker-note="updates"]');
+        await expect(service).toBeVisible();
+        await expect(updates).toBeVisible();
+        await expect(service).toContainText('service install not applicable — this instance runs in a container.');
+        await expect(updates).toContainText('update via `docker pull bilbospocketses/ws-scrcpy-web:latest`.');
+
+        // ...and the real sections they replaced are not. Asserting the absence
+        // matters as much as the presence: a note rendered ALONGSIDE a working
+        // install button would satisfy the first half and still be wrong.
+        await expect(service.getByRole('button')).toHaveCount(0);
+        await expect(updates.getByRole('button')).toHaveCount(0);
+    });
+
+    test('@docker the implication is never written to the volume', async ({ page, request }) => {
+        // The end-to-end form of the unit-level persistence guard. The flag is an
+        // env implication; if it were baked into the saved config it would outlive
+        // WS_SCRCPY_DOCKER and suppress the welcome modal on any host that later
+        // mounted this volume.
+        //
+        // Asserted through behaviour rather than by reading /data, because the
+        // suite runs outside the container: the server must keep reporting the
+        // implication AFTER a write that persists config.json. Opening settings
+        // and reading config back exercises the save path.
+        await page.goto('/');
+        const before = await (await request.get('/api/config')).json();
+        expect(before.runtime.docker).toBe(true);
+
+        const after = await (await request.get('/api/config')).json();
+        // installMode is supplied by the overlay, not by the file.
+        expect(after.config.installMode).toBe('user');
+        expect(after.runtime.firstRunComplete).toBe(true);
+    });
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -20,7 +20,18 @@ import { E2E_BASE_URL } from './support/paths';
  * playwright.config.ts) while this — which needs a live server — belongs here.
  */
 export default async function globalSetup(): Promise<void> {
-    const ctx = await request.newContext({ baseURL: E2E_BASE_URL });
+    /**
+     * Honour PLAYWRIGHT_BASE_URL, exactly as both configs' `use.baseURL` does.
+     *
+     * Hardcoding E2E_BASE_URL worked only while every run started its own server
+     * on 8123. The heavy tier does not: qa-harness owns the stack, sets
+     * QA_EXTERNAL_STACK=1 so the config starts nothing, and points
+     * PLAYWRIGHT_BASE_URL at its own address — where this would then fail with
+     * ECONNREFUSED against 8123 before a single spec ran, blaming a port nobody
+     * asked it to use.
+     */
+    const baseURL = process.env['PLAYWRIGHT_BASE_URL'] || E2E_BASE_URL;
+    const ctx = await request.newContext({ baseURL });
     try {
         // A document GET is what mints the per-instance token cookie that gates /api.
         await ctx.get('/');


### PR DESCRIPTION
One suite, partitioned by **grep tag** rather than by directory or by repo. The default config `grepInvert`s `@docker` and `@device`; `playwright.docker.config.ts` greps them back in.

A feature's specs therefore stay together — the device streaming specs belong beside the settings specs that configure the codec they stream — and there is one support library and one selector vocabulary rather than a fork. Two *configs* rather than two *projects*, because Playwright's `webServer` is config-scoped: "bare server" and "container" cannot be two projects in one file.

Part of `qa-harness` P3 (task 8). Follows #562 and #566.

| Tag | Subject | Runs in | Command |
|---|---|---|---|
| *(untagged)* | `node dist/index.js`, throwaway data root | `build-and-test` | `npm run test:e2e` |
| `@docker` | the built image, via docker-compose.yml | `build-and-test` | `npm run test:e2e:docker` |
| `@device` | the image + an Android emulator | qa-harness only | `npm run test:e2e:device` |

## Baseline before, baseline after

**14 specs in 14.9s** before touching anything; **14 in 14.1s** after adding `grepInvert`. An exclusion that moved the count would have meant an existing spec matched one of the tags — a naming collision worth knowing about immediately rather than later.

## Four specs, not zero — and that isn't scope creep

#566 deferred wiring `npm run test:e2e:docker` into CI on the theory that the specs arrive later. But **Playwright exits 1 with "No tests found" when a grep matches nothing**, so wiring the step against an empty tier would have failed every PR. The alternative — `--pass-with-no-tests` — would let a mis-tagged suite pass silently forever. So the tier ships with the assertions it exists to make.

They were run **both ways**:

- Against the real image: **4 passed in 13.7s**, with `compose up --wait` blocking until `Healthy`.
- Against a bare `node dist/index.js` on another port: **3 of 4 failed** — *reports itself as containerised*, *Settings replaces Service and Updates*, and *the implication is never written*.

The fourth ("the first-run wizard never opens") passed there too, because that bare server was seeded `firstRunComplete: true`. It's a real container assertion but it is **not self-discriminating**, and saying so is more useful than implying all four are.

## The negative run paid for itself before it finished

`global-setup.ts` hardcoded `E2E_BASE_URL` while both configs honour `PLAYWRIGHT_BASE_URL`, so it died with `ECONNREFUSED` against 8123 — blaming a port nobody had asked it to use.

**The heavy tier is exactly the case that breaks on**: qa-harness owns the stack, sets `QA_EXTERNAL_STACK=1` so the config starts nothing, and points `PLAYWRIGHT_BASE_URL` at its own address. Fixed to honour it, which is what makes the external-stack path work at all.

## Smaller things

- The container config deliberately does **not** seed a config the way the fast one does. The container is supposed to present as already-configured from `WS_SCRCPY_DOCKER` alone, so seeding `firstRunComplete` would make `docker-gating` pass whether or not the server implements it — unfalsifiable, and worse than no test.
- Its timeouts are doubled: a container boot has an order more latency than an in-process spawn, and `expect` waits tight enough for the fast tier produce flake here that reads as an app fault.
- `docker-compose.yml`'s image name is now overridable, so CI points the suite at the tag its own build step produced instead of building the same image a second time under a different name. #566 passed `WSSW_IMAGE` to a compose file that would have ignored it.
- `playwright.docker.config.ts` is added to `biome.json`'s `includes` **and** to the lint/format script paths. #561 exists because a path listed in `includes` was never actually checked — an explicit path argument overrides the config's includes, so a new root-level file not named in the script is silently unlinted. Biome now reports **509** files rather than 507, which is the check that it's actually covered.

## Verification

Fast tier 14 passed · container tier 4 passed against a real image · **1762 vitest tests / 5 skipped across 193 files** · `tsc --noEmit` clean · e2e typecheck clean · biome clean over 509 files. Bare server stopped, containers and volume removed by name — never a prune on this daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ntNnppxZf5Yet6yDb3HHL