### PR TITLE
Fire the Docker publish on the tag push, because release:published can never reach it

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,17 @@
 name: Docker publish
 
-# release:published, not tag push. The Velopack legs in release.yml own the tag;
-# this reuses the published release's tag name and stays decoupled from them, so
-# a Docker failure never blocks an installer release or vice versa.
+# Tag push, NOT release:published -- and this is a correction. release.yml
+# publishes the GitHub Release through softprops/action-gh-release with the
+# default GITHUB_TOKEN, and GitHub never triggers other workflows from events
+# that token creates, so a `release: published` trigger here could never fire.
+# It did not: no run exists for v0.1.30-beta.84 or beta.85, and Docker Hub has
+# no repository. The tag itself is pushed by auto-release with a GitHub App
+# token, whose events DO trigger workflows, so this listens to the same tag
+# push release.yml does. Still decoupled -- a separate workflow -- so a Docker
+# failure never blocks an installer release or vice versa.
 on:
-  release:
-    types: [published]
+  push:
+    tags: ['v*']
 
 permissions:
   contents: read
@@ -45,7 +51,7 @@ jobs:
         # The rule that matters is the negative one: a beta must never become
         # :latest. That is unit-tested rather than first exercised on a real
         # release, because it reaches every user who follows the default tag.
-        run: node .github/scripts/docker-tags.mjs "${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+        run: node .github/scripts/docker-tags.mjs "${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Docker Hub publish could never run.** The workflow listened for `release: published`, but the release is created by `release.yml` through `action-gh-release` with the default `GITHUB_TOKEN`, whose events never trigger other workflows — so no image was published for beta.84 or beta.85, and the Docker Hub repository does not exist yet. It now fires on the same `v*` tag push as `release.yml`, which auto-release pushes with an App token.
+
 ## [0.1.30-beta.85] - 2026-09-03
 
 ## [0.1.30-beta.84] - 2026-09-03


### PR DESCRIPTION
The Docker Hub publish workflow from #566 **could never fire.** It listened for `release: published`, but `release.yml` creates the release with `action-gh-release` under the default `GITHUB_TOKEN` — and GitHub never triggers other workflows from events that token creates.

Evidence: no `docker-publish` run exists for beta.84 or beta.85 (the workflow's only runs are April's, from the old placeholder), and Docker Hub returns *object not found* for `bilbospocketses/ws-scrcpy-web`. **No image has ever been published.**

The tag is pushed by auto-release with a GitHub App token, whose events *do* trigger workflows — that is why `release.yml` runs at all. This workflow now listens to the same `v*` tag push and reads the version from `github.ref_name`. It stays a separate workflow, so a Docker failure never blocks an installer release or vice versa.

`release:none` on purpose: the real proof is the **next** tag push, so this should merge before #570 — whose `release:beta` will then cut a beta whose tag exercises the repaired trigger end to end. That run also fills the digest `qa-harness` task 14's lock file is waiting on.

Verified: the file parses, `push.tags == ['v*']`, and `github.event.release` no longer appears anywhere in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ntNnppxZf5Yet6yDb3HHL
