### PR TITLE
Attach the Playwright suite bundle and qa-manifest.json to every release (task 12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
         # tests/ sits outside the root tsconfig's rootDir, so `npx tsc --noEmit`
         # above does not see it. Without this the e2e sources are never typechecked.
         run: npm run test:e2e:types
+      - name: Suite bundle round-trip
+        # Build the bundle qa-harness consumes, extract it, and typecheck the
+        # suite from inside the extracted copy. A bundle missing a file fails
+        # here, not in the harness as a Playwright module-resolution error a
+        # long way from its cause. Also refuses a qa-manifest.json whose
+        # runner.playwrightVersion drifted from the lockfile.
+        run: node scripts/build-suite-bundle.mjs --out "${{ runner.temp }}/wssw-suite" --verify
       - run: npm run test:e2e
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,10 +243,20 @@ jobs:
         with:
           path: artifacts/
 
+      # The Playwright suite bundle qa-harness mounts into its Linux runner
+      # (P3 §8 artifacts 2 and 3): tests/, both Playwright configs, the manifest
+      # and the lockfile — no app source, no dist. No `npm ci` here: the script
+      # needs only node built-ins and the system tar (absolute path, never $PATH).
+      # The manifest's runner.playwrightVersion is checked against the lockfile
+      # before anything is archived, so a stale manifest fails this job rather
+      # than the harness.
+      - name: Build the QA suite bundle
+        run: node scripts/build-suite-bundle.mjs --out artifacts/suite
+
       - name: Generate SHA256SUMS
         run: |
           cd artifacts
-          find . -type f \( -name '*.msi' -o -name '*.AppImage' -o -name '*.AppImage.sig' -o -name '*-Portable.zip' -o -name '*.nupkg' \) -exec sha256sum {} \; > ../SHA256SUMS
+          find . -type f \( -name '*.msi' -o -name '*.AppImage' -o -name '*.AppImage.sig' -o -name '*-Portable.zip' -o -name '*.nupkg' -o -name '*.tar.gz' \) -exec sha256sum {} \; > ../SHA256SUMS
           cd ..
           cat SHA256SUMS
 
@@ -293,4 +303,6 @@ jobs:
             artifacts/linux-final/*.AppImage.sig
             artifacts/linux-final/*.nupkg
             artifacts/linux-final/releases.linux-${{ needs.prepare.outputs.channel }}.json
+            artifacts/suite/*.tar.gz
+            artifacts/suite/*.tar.gz.sha256
             SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ ws-scrcpy-web.log.1
 /test-results/
 /playwright-report/
 /blob-report/
+
+# Suite bundle round-trip scratch (scripts/build-suite-bundle.mjs --verify)
+/.suite-check/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The QA suite bundle.** Every release now attaches `wssw-suite-<version>.tar.gz` (and its
+  sha256): `tests/`, both Playwright configs, `qa-manifest.json`, `tsconfig.json`, `package.json`
+  and `package-lock.json` — the Playwright suite as an artefact the qa-harness Linux runner
+  mounts and runs against the published image, with no app source and no build output inside.
+  `qa-manifest.json` declares the subject, the image, the three suites and the exact Playwright
+  version the runner must carry; `scripts/build-suite-bundle.mjs` refuses to build if that
+  version drifts from the lockfile, and CI extracts every bundle and typechecks the suite from
+  inside the copy.
+
 ## [0.1.30-beta.88] - 2026-09-03
 
 ### Added

--- a/qa-manifest.json
+++ b/qa-manifest.json
@@ -1,0 +1,22 @@
+{
+    "schemaVersion": 1,
+    "subject": "ws-scrcpy-web",
+    "kind": "container-linux",
+    "artifact": {
+        "type": "container-image",
+        "registry": "docker.io",
+        "repository": "bilbospocketses/ws-scrcpy-web"
+    },
+    "suites": [
+        { "name": "fast", "command": "npm run test:e2e", "services": [] },
+        { "name": "docker", "command": "npm run test:e2e:docker", "services": [] },
+        { "name": "device", "command": "npm run test:e2e:device", "services": ["android-emulator"] }
+    ],
+    "suiteMap": {
+        "fast": "tests/e2e"
+    },
+    "runner": {
+        "playwrightVersion": "1.62.1",
+        "browsers": ["chromium"]
+    }
+}

--- a/scripts/build-suite-bundle.mjs
+++ b/scripts/build-suite-bundle.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+// scripts/build-suite-bundle.mjs
+//
+// Build the Playwright suite bundle qa-harness mounts into its Linux runner
+// (P3 §8 artifacts 2 and 3): `wssw-suite-<version>.tar.gz` carrying `tests/`,
+// the two Playwright configs, `qa-manifest.json`, `tsconfig.json`,
+// `package.json` and `package-lock.json` — and nothing else. The runner drives
+// a *published image*; a bundle carrying `src/` or `dist/` would invite exactly
+// the source coupling §8 forbids, one convenience at a time. `tsconfig.json`
+// rides along because `tests/e2e/tsconfig.json` extends it; without it the
+// suite cannot be typechecked from inside the bundle.
+//
+//   node scripts/build-suite-bundle.mjs [--out <dir>] [--verify]
+//
+// `--out` defaults to `Releases/` (gitignored). `--verify` extracts the finished
+// archive into `.suite-check/` and typechecks the suite from inside the copy,
+// so a bundle missing a file fails here, not in the harness as a Playwright
+// module-resolution error a long way from its cause.
+//
+// The manifest is checked before anything is archived: `runner.playwrightVersion`
+// must equal the version `package-lock.json` locks for `@playwright/test`. The
+// runner refuses a bundle whose version differs from the one baked into its
+// image, so a stale manifest would fail at run time with a browser error that
+// names neither version. Every suite's `command` must be an npm script, and
+// every `suiteMap` entry must point into the bundle.
+//
+// tar is invoked by absolute path only — `C:\Windows\System32\tar.exe` on
+// Windows, `resolvePosixTar()` elsewhere — never the bare name $PATH would
+// resolve (Local-Dependencies-Only, the same policy as fetch-node.mjs).
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolvePosixTar } from './posix-tar.mjs';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const WINDOWS_TAR = 'C:\\Windows\\System32\\tar.exe';
+
+/** Top-level members of the bundle, relative to the repo root. Nothing else goes in. */
+export const BUNDLE_MEMBERS = [
+    'tests',
+    'playwright.config.ts',
+    'playwright.docker.config.ts',
+    'qa-manifest.json',
+    'tsconfig.json',
+    'package.json',
+    'package-lock.json',
+];
+
+/** Directory names skipped anywhere under a member: build outputs and run artefacts. */
+export const EXCLUDED_DIRS = new Set([
+    'node_modules',
+    'dist',
+    'build',
+    'test-results',
+    'playwright-report',
+    'blob-report',
+    '__pycache__',
+]);
+
+/** File names skipped anywhere under a member. */
+export const EXCLUDED_FILE_PATTERNS = [/\.log(\.\d+)?$/, /\.tsbuildinfo$/, /^\.DS_Store$/];
+
+/** Whether a bundle-relative POSIX path belongs in the archive. */
+export function includeEntry(relPath) {
+    const parts = relPath.split('/');
+    if (parts.slice(0, -1).some((p) => EXCLUDED_DIRS.has(p))) {
+        return false;
+    }
+    const base = parts[parts.length - 1] ?? '';
+    return !EXCLUDED_FILE_PATTERNS.some((re) => re.test(base));
+}
+
+/** The archive's file name for a package version. */
+export function bundleName(version) {
+    return `wssw-suite-${version}.tar.gz`;
+}
+
+/**
+ * Every file the bundle will carry, as sorted bundle-relative POSIX paths.
+ * Throws if a member is missing: a bundle built without, say, the manifest is
+ * not a bundle with a warning, it is the wrong artefact.
+ */
+export function collectBundleFiles(root, fsApi = fs) {
+    const files = [];
+    const walk = (rel) => {
+        const abs = path.join(root, rel);
+        for (const entry of fsApi.readdirSync(abs, { withFileTypes: true })) {
+            const childRel = `${rel}/${entry.name}`;
+            if (entry.isDirectory()) {
+                if (!EXCLUDED_DIRS.has(entry.name)) {
+                    walk(childRel);
+                }
+            } else if (includeEntry(childRel)) {
+                files.push(childRel);
+            }
+        }
+    };
+    for (const member of BUNDLE_MEMBERS) {
+        const st = fsApi.statSync(path.join(root, member), { throwIfNoEntry: false });
+        if (!st) {
+            throw new Error(`bundle member missing: ${member}`);
+        }
+        if (st.isDirectory()) {
+            walk(member);
+        } else {
+            files.push(member);
+        }
+    }
+    return files.sort();
+}
+
+/**
+ * Problems with the manifest, as human-readable strings. Empty means it is fit
+ * to ship. `lock` is the parsed package-lock.json, `pkg` the parsed package.json,
+ * `files` the bundle file list.
+ */
+export function checkManifest(manifest, { lock, pkg, files }) {
+    const problems = [];
+    if (manifest.schemaVersion !== 1) {
+        problems.push(`schemaVersion must be 1, is ${JSON.stringify(manifest.schemaVersion)}`);
+    }
+    if (manifest.subject !== pkg.name) {
+        problems.push(`subject must be the package name '${pkg.name}', is ${JSON.stringify(manifest.subject)}`);
+    }
+    const locked = lock?.packages?.['node_modules/@playwright/test']?.version;
+    if (!locked) {
+        problems.push('package-lock.json does not lock @playwright/test');
+    } else if (manifest.runner?.playwrightVersion !== locked) {
+        problems.push(
+            `runner.playwrightVersion is ${JSON.stringify(manifest.runner?.playwrightVersion)} ` +
+                `but package-lock.json locks @playwright/test ${locked} — the runner refuses a skew`,
+        );
+    }
+    const suites = Array.isArray(manifest.suites) ? manifest.suites : [];
+    if (suites.length === 0) {
+        problems.push('suites is empty');
+    }
+    for (const suite of suites) {
+        const m = /^npm run (\S+)$/.exec(suite.command ?? '');
+        if (!m || !pkg.scripts?.[m[1]]) {
+            problems.push(`suite '${suite.name}' command ${JSON.stringify(suite.command)} is not an npm script of this package`);
+        }
+    }
+    for (const [name, dir] of Object.entries(manifest.suiteMap ?? {})) {
+        if (!suites.some((s) => s.name === name)) {
+            problems.push(`suiteMap.${name} names a suite that is not declared in suites`);
+        }
+        if (!files.some((f) => f === dir || f.startsWith(`${dir}/`))) {
+            problems.push(`suiteMap.${name} -> ${dir} is not in the bundle`);
+        }
+    }
+    return problems;
+}
+
+/** The tar to run: absolute path, per platform, never a bare name. */
+export function resolveTar(platform = process.platform, existsSync = fs.existsSync) {
+    if (platform === 'win32') {
+        if (!existsSync(WINDOWS_TAR)) {
+            throw new Error(`expected bsdtar at ${WINDOWS_TAR}`);
+        }
+        return WINDOWS_TAR;
+    }
+    return resolvePosixTar(existsSync);
+}
+
+function readJson(rel) {
+    return JSON.parse(fs.readFileSync(path.join(REPO, rel), 'utf8'));
+}
+
+function sha256(file) {
+    return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+/** Build the archive into `outDir`; returns { archive, sha256, name, files }. */
+export function build({ outDir }) {
+    const pkg = readJson('package.json');
+    const lock = readJson('package-lock.json');
+    const manifest = readJson('qa-manifest.json');
+    const files = collectBundleFiles(REPO);
+    const problems = checkManifest(manifest, { lock, pkg, files });
+    if (problems.length > 0) {
+        throw new Error(`qa-manifest.json is not fit to ship:\n  - ${problems.join('\n  - ')}`);
+    }
+
+    // Stage a copy so the archive holds exactly the listed files under clean
+    // top-level names, whichever tar builds it.
+    const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'wssw-suite-'));
+    try {
+        for (const rel of files) {
+            const dest = path.join(staging, rel);
+            fs.mkdirSync(path.dirname(dest), { recursive: true });
+            fs.copyFileSync(path.join(REPO, rel), dest);
+        }
+        fs.mkdirSync(outDir, { recursive: true });
+        const name = bundleName(pkg.version);
+        const archive = path.resolve(outDir, name);
+        fs.rmSync(archive, { force: true });
+        execFileSync(resolveTar(), ['-czf', archive, '-C', staging, ...BUNDLE_MEMBERS], { stdio: 'inherit' });
+        const digest = sha256(archive);
+        fs.writeFileSync(`${archive}.sha256`, `${digest}  ${name}\n`);
+        return { archive, sha256: digest, name, files };
+    } finally {
+        fs.rmSync(staging, { recursive: true, force: true });
+    }
+}
+
+/**
+ * Extract the archive into `<repo>/.suite-check` and typecheck the suite from
+ * inside the copy. Under the repo on purpose: TypeScript resolves
+ * `@playwright/test` and `@types/node` by walking up to the repo's
+ * node_modules, the way the runner's NODE_PATH does for the real bundle.
+ */
+export function verify(archive) {
+    const check = path.join(REPO, '.suite-check');
+    fs.rmSync(check, { recursive: true, force: true });
+    fs.mkdirSync(check, { recursive: true });
+    execFileSync(resolveTar(), ['-xzf', archive, '-C', check], { stdio: 'inherit' });
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(check, 'qa-manifest.json'), 'utf8'));
+    if (typeof manifest.runner?.playwrightVersion !== 'string') {
+        throw new Error('extracted qa-manifest.json has no runner.playwrightVersion — the runner would exit 40');
+    }
+    for (const dir of Object.values(manifest.suiteMap ?? {})) {
+        if (!fs.existsSync(path.join(check, dir))) {
+            throw new Error(`extracted bundle lacks suiteMap target ${dir}`);
+        }
+    }
+
+    const tsc = path.join(REPO, 'node_modules', 'typescript', 'bin', 'tsc');
+    try {
+        execFileSync(process.execPath, [tsc, '-p', path.join(check, 'tests', 'e2e'), '--noEmit'], { stdio: 'inherit' });
+    } catch (err) {
+        throw new Error(`the suite does not typecheck from inside the bundle (left in ${check} for inspection): ${err.message}`);
+    }
+    fs.rmSync(check, { recursive: true, force: true });
+}
+
+function parseArgs(argv) {
+    const opts = { outDir: path.join(REPO, 'Releases'), verify: false };
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--out') {
+            const value = argv[++i];
+            if (!value) {
+                throw new Error('--out needs a directory');
+            }
+            opts.outDir = path.resolve(value);
+        } else if (arg === '--verify') {
+            opts.verify = true;
+        } else {
+            throw new Error(`unknown argument ${arg}`);
+        }
+    }
+    return opts;
+}
+
+function main() {
+    const opts = parseArgs(process.argv.slice(2));
+    const result = build(opts);
+    console.error(`[suite-bundle] ${result.files.length} files -> ${result.archive}`);
+    if (opts.verify) {
+        verify(result.archive);
+        console.error('[suite-bundle] verified: the suite typechecks from inside the extracted bundle');
+    }
+    // stdout carries exactly the sha256sum-format line, for the release step to record.
+    process.stdout.write(`${result.sha256}  ${result.name}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+    try {
+        main();
+    } catch (err) {
+        console.error(`[suite-bundle] ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+    }
+}

--- a/scripts/build-suite-bundle.test.mjs
+++ b/scripts/build-suite-bundle.test.mjs
@@ -1,0 +1,119 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+    BUNDLE_MEMBERS,
+    bundleName,
+    checkManifest,
+    collectBundleFiles,
+    includeEntry,
+    resolveTar,
+} from './build-suite-bundle.mjs';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => JSON.parse(fs.readFileSync(path.join(REPO, rel), 'utf8'));
+
+describe('includeEntry', () => {
+    it('keeps suite sources and configs', () => {
+        expect(includeEntry('tests/e2e/auth.spec.ts')).toBe(true);
+        expect(includeEntry('tests/docker/compose.offline.yml')).toBe(true);
+        expect(includeEntry('playwright.config.ts')).toBe(true);
+    });
+
+    it('drops build outputs and run artefacts wherever they sit under a member', () => {
+        expect(includeEntry('tests/e2e/dist/auth.spec.js')).toBe(false);
+        expect(includeEntry('tests/node_modules/x/index.js')).toBe(false);
+        expect(includeEntry('tests/e2e/test-results/run.txt')).toBe(false);
+        expect(includeEntry('tests/e2e/ws-scrcpy-web.log')).toBe(false);
+        expect(includeEntry('tests/e2e/ws-scrcpy-web.log.1')).toBe(false);
+        expect(includeEntry('tests/.DS_Store')).toBe(false);
+    });
+});
+
+describe('bundleName', () => {
+    it('names the archive after the package version', () => {
+        expect(bundleName('0.1.30-beta.88')).toBe('wssw-suite-0.1.30-beta.88.tar.gz');
+    });
+});
+
+describe('collectBundleFiles', () => {
+    it('lists every member and nothing outside them, sorted', () => {
+        const files = collectBundleFiles(REPO);
+        expect(files).toEqual([...files].sort());
+        for (const member of BUNDLE_MEMBERS) {
+            expect(files.some((f) => f === member || f.startsWith(`${member}/`)), member).toBe(true);
+        }
+        // The runner drives a published image: no app source, no build output.
+        expect(files.some((f) => f.startsWith('src/') || f.startsWith('dist/'))).toBe(false);
+        expect(files).toContain('tests/e2e/tsconfig.json');
+        expect(files).toContain('tsconfig.json');
+    });
+
+    it('refuses to build without a member rather than shipping a smaller bundle', () => {
+        const fsApi = {
+            ...fs,
+            statSync: (p, opts) => (p.endsWith('qa-manifest.json') ? undefined : fs.statSync(p, opts)),
+        };
+        expect(() => collectBundleFiles(REPO, fsApi)).toThrow(/bundle member missing: qa-manifest.json/);
+    });
+});
+
+describe('checkManifest', () => {
+    const pkg = read('package.json');
+    const lock = read('package-lock.json');
+    const manifest = read('qa-manifest.json');
+    const files = collectBundleFiles(REPO);
+
+    it('accepts the committed manifest against the committed lockfile', () => {
+        // This is the drift guard: bump @playwright/test and this test names the
+        // manifest line to change, before the runner refuses the bundle.
+        expect(checkManifest(manifest, { lock, pkg, files })).toEqual([]);
+    });
+
+    it('names a Playwright version skew with both versions', () => {
+        const skewed = { ...manifest, runner: { ...manifest.runner, playwrightVersion: '1.0.0' } };
+        const problems = checkManifest(skewed, { lock, pkg, files });
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toMatch(/"1\.0\.0"/);
+        expect(problems[0]).toContain(lock.packages['node_modules/@playwright/test'].version);
+    });
+
+    it('rejects a suite whose command is not an npm script', () => {
+        const bad = { ...manifest, suites: [{ name: 'fast', command: 'npm run no-such-script', services: [] }] };
+        expect(checkManifest(bad, { lock, pkg, files })).toEqual([
+            expect.stringMatching(/suite 'fast' command "npm run no-such-script" is not an npm script/),
+        ]);
+    });
+
+    it('rejects a suiteMap entry that points outside the bundle or at an undeclared suite', () => {
+        const bad = { ...manifest, suiteMap: { fast: 'src/server', ghost: 'tests/e2e' } };
+        const problems = checkManifest(bad, { lock, pkg, files });
+        expect(problems).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/suiteMap\.fast -> src\/server is not in the bundle/),
+                expect.stringMatching(/suiteMap\.ghost names a suite that is not declared/),
+            ]),
+        );
+    });
+
+    it('rejects an empty suite list and a foreign subject', () => {
+        const bad = { ...manifest, subject: 'someone-else', suites: [] };
+        const problems = checkManifest(bad, { lock, pkg, files });
+        expect(problems).toEqual(
+            expect.arrayContaining([expect.stringMatching(/subject must be/), expect.stringMatching(/suites is empty/)]),
+        );
+    });
+});
+
+describe('resolveTar', () => {
+    it('uses the System32 bsdtar on Windows and refuses if it is absent — never a bare name', () => {
+        expect(resolveTar('win32', (p) => p === 'C:\\Windows\\System32\\tar.exe')).toBe('C:\\Windows\\System32\\tar.exe');
+        expect(() => resolveTar('win32', () => false)).toThrow(/System32/);
+    });
+
+    it('uses the canonical POSIX tar elsewhere', () => {
+        expect(resolveTar('linux', (p) => p === '/usr/bin/tar')).toBe('/usr/bin/tar');
+        expect(() => resolveTar('linux', () => false)).toThrow(/canonical system path/);
+    });
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -166,6 +166,31 @@ Both resolve `docker` from the shell, as `playwright.docker.config.ts`'s
 `docker compose up --wait` already does: the daemon is the tier's execution
 environment, not an app dependency.
 
+## The suite as an artefact: the bundle and the manifest
+
+qa-harness does not check this repo out. It mounts `wssw-suite-<version>.tar.gz` — attached to
+every release next to the installers — into a Linux runner and runs the suite against the
+*published image*. `scripts/build-suite-bundle.mjs` builds it from `tests/`, both Playwright
+configs, `qa-manifest.json`, `tsconfig.json`, `package.json` and `package-lock.json`, and
+nothing else: no `src/`, no `dist/`, no `node_modules/`. `tsconfig.json` is there because
+`tests/e2e/tsconfig.json` extends it; the runner never builds the app.
+
+`qa-manifest.json` is what the runner reads. `runner.playwrightVersion` must equal the version
+the runner image was built with, or it refuses to start (a skew otherwise surfaces later as
+"browser was downloaded by a different version of Playwright", which names the browser and
+not the skew). The bundle script checks that field against `package-lock.json`, and
+`scripts/build-suite-bundle.test.mjs` fails on the same drift, so bumping `@playwright/test`
+names the manifest line to change. `suites` declares the three tiers with their `npm run`
+commands; `suiteMap` is what today's runner actually consults — a spec path it hands to
+`playwright test` — and it lists only `fast`, because the runner cannot select a config and a
+`docker` or `device` entry would run the fast config's filter and report the wrong specs as
+passed. Running the other two tiers from the bundle is the harness's run-lifecycle work
+(P3 task 14), which executes each suite's `command` from the bundle root.
+
+Locally: `node scripts/build-suite-bundle.mjs --out Releases --verify` builds the archive,
+prints its sha256, extracts it into `.suite-check/` and typechecks the suite from inside the
+copy — the same round-trip CI runs on every PR.
+
 ## Still manual
 
 - **A LAN client is refused.** Verified by hand (all three embed endpoints return


### PR DESCRIPTION
`qa-harness` P3 task 12: the Playwright suite as an artefact. Every release now attaches `wssw-suite-<version>.tar.gz` (plus its sha256, and a line in `SHA256SUMS`), and `qa-manifest.json` tells the harness's Linux runner what it is running.

## What is in the bundle, and what is not

`tests/`, `playwright.config.ts`, `playwright.docker.config.ts`, `qa-manifest.json`, `tsconfig.json`, `package.json`, `package-lock.json`. Nothing else: no `src/`, no `dist/`, no `node_modules/`. The runner drives a *published image* and never builds the app; a bundle carrying source would invite the coupling §8 forbids one convenience at a time.

`tsconfig.json` is the one addition to the plan's list. `tests/e2e/tsconfig.json` extends it, so without it the suite cannot be typechecked from inside the bundle — which is exactly what the round-trip step does. The plan flagged that step as the thing to verify before promising; this is what it needed.

## The manifest

Per the plan's sketch (`schemaVersion`, `subject`, `kind`, `artifact`, `suites` with their `npm run` commands, `runner.playwrightVersion`), with two honest edits:

- **`suiteMap: { fast: "tests/e2e" }`** — the field today's runner (`images/linux-runner/run-suite.sh`) actually reads: a spec path it hands to `playwright test`. It lists only `fast`, because the runner cannot select a config, and a `docker` or `device` entry would run the fast config's `grepInvert` and report the wrong specs as passed — a pass with no evidence behind it. Running the other two tiers from the bundle is task 14's run-lifecycle work, which executes each suite's `command` from the bundle root.
- **`browsers: ["chromium"]`**, not the sketch's `["chromium", "chrome"]`: the config has one project and it is Chromium.

`runner.playwrightVersion` is `1.62.1` — the version `package-lock.json` locks, not the `^1.62.1` range `package.json` declares. The runner compares it as a string against the version baked into its image and refuses a skew (exit 41), so this value has to be exact and has to stay exact.

## The script, and what keeps the manifest honest

`scripts/build-suite-bundle.mjs` checks the manifest before archiving anything: `runner.playwrightVersion` equals the lockfile's `@playwright/test`, every suite `command` is an npm script of this package, every `suiteMap` target is inside the bundle, the subject is the package name. It stages the file list into a temp dir and runs tar by absolute path — `C:\Windows\System32\tar.exe` on Windows, `resolvePosixTar()` elsewhere, the precedent `fetch-node.mjs` and `posix-tar.mjs` set (the pre-edit hook flagged the `execFileSync` calls; that is the answer). It prints the `sha256sum`-format line on stdout and writes `<name>.sha256` beside the archive.

`--verify` extracts the archive into `.suite-check/` (gitignored) and runs `tsc -p tests/e2e --noEmit` from inside the copy, resolving `@playwright/test` and `@types/node` by walking up to the repo's `node_modules` the way the runner's `NODE_PATH` does for the real bundle.

`scripts/build-suite-bundle.test.mjs` (vitest, 12 tests) covers the include filter, the member list, the manifest checks, and the tar resolution; its first manifest test runs the committed manifest against the committed lockfile, so bumping `@playwright/test` names the manifest line to change before the runner refuses the bundle.

## Wiring

- `release.yml`, `publish` job: builds the bundle into `artifacts/suite/` before `SHA256SUMS` (whose `find` now includes `*.tar.gz`), and the release's `files:` list gains the archive and its sha256. No `npm ci` in that job and none needed: the script uses node built-ins and the system tar.
- `ci.yml`, `build-and-test`: a **Suite bundle round-trip** step after the e2e typecheck runs the script with `--verify` into `runner.temp`. Inside the required check on purpose, for the reason #560 recorded: a separate job would not be required and could rot unnoticed.
- `tests/e2e/README.md` gets the section that explains all of the above; `CHANGELOG.md` `[Unreleased]` has the Added entry.

## Verified locally (Windows tree)

- vitest: `scripts/build-suite-bundle.test.mjs` + `scripts/posix-tar.test.mjs` — 17 passed.
- `node scripts/build-suite-bundle.mjs --out <scratch> --verify`: 28 files, 106 KB archive, typecheck from inside the extracted copy passed, `.suite-check/` removed afterwards. The archive lists only the seven members.
- Failing direction: a bundle built from the same files minus `tsconfig.json` is refused by `verify` with the check dir named for inspection.
- biome clean. The Linux path of the script (posix tar, the release job) is exercised by this PR's CI round-trip and by the beta this merge cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ntNnppxZf5Yet6yDb3HHL
