### PR TITLE
Docker image: install the production tree in the runtime stage, drop the base's npm (clears the Scout gate)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,20 @@ updates:
       actions:
         patterns:
           - "*"
+
+  # docker: tracks the digest-pinned base image in the Dockerfile
+  # (`ARG NODE_IMAGE=node:24-trixie-slim@sha256:…`). Without this entry the pin
+  # never moved: the Docker Scout gate in docker-publish.yml found the base's
+  # bundled npm carrying fixable high CVEs (tar, brace-expansion, ip-address)
+  # that a fresh base would have cleared once upstream rebuilt. Dependabot keys
+  # on the tag in the ARG and rewrites the digest beside it.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(docker)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Docker image no longer ships the dev toolchain or the base image's npm.** The runtime stage
+  now installs its production tree from the lockfile (`npm ci --omit=dev --ignore-scripts`) instead of
+  copying the build stage's pruned `node_modules`, because that prune had never taken effect: beta.91's
+  image carried Playwright, vitest, webpack, swc, biome and TypeScript 7's native compiler — 372 MB —
+  and the compiler's Go standard library is where the Docker Scout gate's one critical CVE lived. The
+  base image's bundled npm, npx, corepack and yarn are removed in the same layer; the app runs
+  `node dist/index.js` and never invokes any of them, and npm's own `tar`, `brace-expansion` and
+  `ip-address` were the gate's other four highs. Dependabot gains a `docker` ecosystem so the base
+  image's digest pin moves on its own.
+
 ## [0.1.30-beta.92] - 2026-09-04
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,19 @@ COPY . .
 # stage an x86-64 ELF at seed/node/node — which start.sh's `[ -x ]` probe would
 # happily select, producing "exec format error" at container start. The runtime
 # stage symlinks the image's own node instead (design amendment 16.2).
+#
+# No `npm prune --omit=dev` at the end: the runtime stage installs its own
+# production tree from the lockfile (below), so nothing from this stage's
+# node_modules is copied. The prune used to be here and did not work — the
+# published beta.91 image carried the whole dev tree (Playwright, vitest,
+# webpack, TypeScript 7's native compiler, swc, biome: 372 MB), which is how a
+# Go-stdlib CVE inside `@typescript/typescript-linux-x64/lib/tsc` reached the
+# Docker Scout gate.
 RUN node scripts/fetch-prebuilts.mjs \
  && node scripts/stage-seed-node-pty.mjs \
  && node scripts/stage-seed-scrcpy-server.mjs \
  && npm run build \
- && node scripts/fetch-tini.mjs /out/tini \
- && npm prune --omit=dev
+ && node scripts/fetch-tini.mjs /out/tini
 
 # -------------------------------------------------------------- runtime ------
 FROM ${NODE_IMAGE} AS runtime
@@ -71,10 +78,30 @@ RUN test -x /usr/bin/setpriv || (echo 'setpriv missing from base image; vendor g
 
 WORKDIR /app
 COPY --from=build /out/tini            /usr/local/bin/tini
+COPY --from=build /src/package.json /src/package-lock.json ./
+
+# The production tree is installed HERE, from the lockfile, rather than copied
+# from the build stage: `npm ci --omit=dev` cannot carry a devDependency or one
+# of its optional platform packages, where a prune of the build tree provably
+# did (see the build stage). --ignore-scripts for the same reason as above —
+# node-pty's install script would compile; the runtime never loads node-pty from
+# this tree anyway, NodePtyResolver copies it from seed/node-pty-pkg.
+#
+# Then the base image's package managers go. The app runs `node dist/index.js`
+# and nothing in start.sh, entrypoint.sh or src/ ever invokes npm, npx, corepack
+# or yarn — and the bundled npm is where Scout found tar, brace-expansion and
+# ip-address with fixable high CVEs that no base rebuild had cleared. One RUN,
+# so the tree and the removals land in one layer and the npm cache never ships.
+RUN npm ci --omit=dev --ignore-scripts \
+ && rm -rf /root/.npm \
+           /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+           /opt/yarn-v* /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+ && test ! -e /app/node_modules/@typescript \
+ && test ! -e /app/node_modules/@playwright \
+ && test ! -e /usr/local/lib/node_modules/npm
+
 COPY --from=build /src/dist            ./dist
-COPY --from=build /src/node_modules    ./node_modules
 COPY --from=build /src/seed            ./seed
-COPY --from=build /src/package.json    ./package.json
 COPY start.sh                          ./start.sh
 COPY docker/entrypoint.sh              /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
The Docker Scout gate (#583) was going to fail its first live run on ten fixable CVEs in beta.90's image. This is the fix, and it turned out to be bigger than a version bump: the image was shipping the entire development toolchain.

## What was wrong

`Dockerfile`'s build stage ended with `npm prune --omit=dev` and the runtime stage copied that tree. The prune never took effect. Inspected in the published beta.91 image (`sha256:ec909c85…`): `/app/node_modules` was 372 MB and contained `@playwright/test`, `vitest`, `webpack`, `@swc/core`, `@biomejs/biome`, `typescript`, `tsx`, `esbuild`, `@types/*` — and `@typescript/typescript-linux-x64/lib/tsc`, TypeScript 7's native compiler, whose Go standard library (1.26.4) was the gate's one critical and five of its highs. The other four highs were in the base image's bundled npm (`tar`, `brace-expansion`, `ip-address`), which the app never invokes and which no current `node:24` slim tag has cleared.

## What changed

- **The runtime stage installs its own production tree** from the lockfile: `npm ci --omit=dev --ignore-scripts`. A fresh install cannot carry a devDependency or one of its optional platform packages. `--ignore-scripts` for the same reason the build stage uses it (node-pty's install script compiles); the runtime never loads node-pty from this tree — `NodePtyResolver` copies it from `seed/node-pty-pkg`, which the build stage still produces and the runtime still copies.
- **The base image's npm, npx, corepack and yarn are removed** in the same `RUN`, so the tree, the removals and the absence of an npm cache land in one layer. Nothing in `start.sh`, `docker/entrypoint.sh` or `src/` invokes any of them; the app runs `node dist/index.js`.
- **The `RUN` asserts** that `@typescript`, `@playwright` and the global npm are absent, so a regression fails the build rather than the gate.
- **Dependabot gains a `docker` ecosystem** (weekly, two PRs max) so the digest-pinned `node:24-trixie-slim` base moves on its own. It never had.
- The build stage's dead `npm prune` is gone, with a comment recording why.

## Verified

- **The gate's exact rule against the fixed image**, built locally as `ws-scrcpy-web:cvefix` from this branch: `docker scout cves local://ws-scrcpy-web:cvefix --only-severity critical,high --only-fixed --exit-code` → **exit 0, "No vulnerable package detected", 0C 0H 0M 0L**. Unfiltered, for the record: 25 advisories in 11 packages, 0 critical, 0 high, 1 medium, 24 low, none of them fixable at critical or high.
- **Size:** 936 MB → **546 MB**. `/app/node_modules` 372 MB → **82 MB, five top-level entries**. Inside the image: `@typescript`, `@playwright`, `@swc`, `@biomejs`, `typescript`, `webpack`, `vitest`, `tsx` all absent; `velopack`, `ws`, `node-pty` present; `/usr/local/lib/node_modules` and `/opt/yarn-*` gone; `/usr/local/bin` holds `node`, `tini` and the two entrypoints; `seed/{node,node-pty-pkg,scrcpy-server}` intact; `node --version` v24.20.0.
- **The harness docker tier against the fixed image** (`scripts/run-linux-suite.ps1 -Suite docker -ImageOverride ws-scrcpy-web:cvefix`, the pinned beta.91 bundle): run `lin-wssw-20260904T003421Z-0bd4`, **6 passed, 0 errors, exit 0** — the container boots on the fresh production tree, hydrates its dependencies onto the volume and answers every container row; the run removed itself cleanly.
- **The gate's own red run, for the record:** beta.92's publish (run 33821353090) failed at the step `Docker Scout gate (fixable critical/high CVEs fail the publish)` with `1C 9H` in exactly the four packages named above, and the push step was **skipped** — nothing reached Docker Hub. That is the gate working; this PR's beta is its green counterpart.
- `.github/dependabot.yml` parses with the three ecosystems (`npm`, `github-actions`, `docker`).
- Not exercised in CI yet: `docker-publish.yml` runs on tag push only. This PR carries `release:beta`; its beta's publish is the green run that follows the red one beta.92 produced by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ntNnppxZf5Yet6yDb3HHL
