### PR TITLE
docs: the README's Docker section describes the shipped image; register row 20.8 is no longer blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,20 @@ See `docs/TECHNICAL_GUIDE.md` section 15 for details on the Logger utility and a
 
 ## Docker
 
-A legacy `Dockerfile` exists in the repo but is not actively maintained and targets an older Node version. Docker-based deployment is planned but has not shipped yet. For now, use the MSI, AppImage, or portable ZIP.
+The image is published to Docker Hub as [`jchapz30/ws-scrcpy-web`](https://hub.docker.com/r/jchapz30/ws-scrcpy-web) on every release: `:beta` follows the beta channel (every `0.1.30-beta.N` also gets its own immutable tag), and `:latest` / `:stable` will follow the first stable release. `linux/amd64` only for now — Google publishes no arm64 Linux `platform-tools`, so an arm64 image would start and then fail on the first device.
+
+```bash
+docker run -d --name ws-scrcpy-web -p 127.0.0.1:8000:8000 -v wsdata:/data jchapz30/ws-scrcpy-web:beta
+```
+
+(Bound to loopback on purpose; see the second note below before publishing it on a LAN interface.) The repo's `docker-compose.yml` is the developer and CI quickstart instead — it builds the image from source and publishes it on `127.0.0.1:8123`. Everything mutable lives on `/data` — `config.json`, the SQLite store, and the dependencies the container downloads on first boot (adb, ~9 MB; the health check allows 180 s for that). Update with `docker pull` and re-create the container; the volume carries your state across.
+
+Two things to know before relying on it:
+
+- **Wireless ADB only.** The container connects to devices over the network (`adb connect <ip>:<port>`); there is no USB pass-through, by design.
+- **Streaming needs a secure context.** The browser's video decoder (WebCodecs) is only available on `https://` or `localhost`, so opening the container over plain `http://<lan-ip>:8000` shows the device list but no connect link — and, today, no explanation (tracked as a known issue). Open it on the serving machine, or put it behind a TLS reverse proxy.
+
+Every published image passes a [Docker Scout](https://docs.docker.com/scout/) gate in the publish workflow — a fixable critical or high CVE fails the publish — and the Hub repository has Scout analysis enabled, so already-published images are re-evaluated as advisories land. For now, use the MSI, AppImage, or portable ZIP.
 
 ## Acknowledgments
 

--- a/docs/smoke-tests/automation-coverage.md
+++ b/docs/smoke-tests/automation-coverage.md
@@ -206,7 +206,7 @@ Sorted by module, then by row number, which is not the doc's execution order.
 | 20.5 | `[Both]` | "uninstall ws-scrcpy-web" row in a container | residual: un-automatable | Blocked on an open product decision, not on automation: what "uninstall ws-scrcpy-web" should do in a container is undecided (register 20.5). |
 | 20.6 | `[Both]` | "stop server & exit" in a container | no spec yet - container | Automatable as a `@docker-host` spec that drives `docker stop` from outside the container. The bare-server half is already covered by 12.1. |
 | 20.7 | `[Both]` | Linux system-wide-install offer in a container | container | `docker-gating.spec.ts` |
-| 20.8 | `[Both]` | Pull `:beta` from Docker Hub | no spec yet - container | Automatable as a pull-and-compare check once a `:beta` tag exists. Blocked today only because the publish workflow's Docker Hub token is unset. |
+| 20.8 | `[Both]` | Pull `:beta` from Docker Hub | no spec yet - container | Automatable as a pull-and-compare check against `jchapz30/ws-scrcpy-web:beta`, which publishes on every beta since beta.90 (2026-09-03) and passes the Scout gate since beta.94; nothing blocks the spec now. |
 | 20.9 | `[Both]` | First-boot hydrate on a fresh `/data` volume | container | `docker-gating.spec.ts` |
 | 20.10 | `[Both]` | Wireless connect from a container | no spec yet - device | Automatable by pointing the device tier at the container subject instead of the bare server. Needs the emulator and the container on one network. |
 | 20.11 | `[Both]` | Persistence across `docker rm` + re-run | no spec yet - container | Automatable as a `@docker-host` spec. The log half cannot pass until finding 20.14 is fixed - the container writes no server log at all. |


### PR DESCRIPTION
Two stale lines the wrap-up doc sweep's refutation pass found after the first sweep reported none, both narrative claims a keyword grep could not see.

- **README \## Docker\** said a legacy Dockerfile was unmaintained and Docker deployment had not shipped. The image publishes to \jchapz30/ws-scrcpy-web\ on every release and is Scout-gated since beta.94, so the section now gives the pull/run shape (bound to loopback on purpose), the \/data\ volume and first-boot hydrate, wireless-ADB-only, the secure-context caveat (register finding 8.10, tracked), what \docker-compose.yml\ is for, and the gate.
- **Register row 20.8** said its spec was blocked only because the publish workflow's Docker Hub token was unset; nothing blocks it now.

Docs only, \elease:none\.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ntNnppxZf5Yet6yDb3HHL