### PR TITLE
Docs: the embed/consent model, the LAN trust boundary, and what §NN actually means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The docs describe the security model the code actually has.** The README still said the app has no
+  login, listed three defences with no framing layer, never mentioned `frameAncestors`, and documented
+  the iframe protocol without saying cross-origin framing is refused by default — follow it as written
+  and you got "localhost refused to connect". `SECURITY.md` and the technical guide now also state
+  plainly what open mode is: the LAN is trusted, the per-instance token is handed to anything that can
+  fetch a page so it is not an authenticator, and enabling login is what makes a boundary. No behaviour
+  changed; the documentation was describing an older app.
+
 ## [0.1.30-beta.102] - 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ ws-scrcpy-web can run as a background **service** that starts at boot/login and 
 
 ## Embedding
 
+> **Cross-origin framing is refused by default.** A page that tries to iframe ws-scrcpy-web without being allow-listed gets a browser refusal ("localhost refused to connect") — the response carries
+> `X-Frame-Options: SAMEORIGIN` and no CSP `frame-ancestors` entry for it. Everything below assumes you have opted the host origin in first, either by adding it to `frameAncestors` in `config.json` or
+> by approving the consent prompt the embedding app raises. Settings → Embedding shows what is currently approved and can revoke it.
+
 ### Embedding: theme bridge
 
-When ws-scrcpy-web is embedded in a cross-origin iframe, the host page can sync
+When ws-scrcpy-web is embedded in a cross-origin iframe (once allow-listed, per the note above), the host page can sync
 its dark/light theme via `postMessage`. ws-scrcpy-web's listener and handshake
 fire automatically on load — no extra wiring needed inside ws-scrcpy-web.
 
@@ -310,6 +314,8 @@ Almost all configuration is managed through the in-app **Settings** panel (gear 
 | `updateCheckIntervalMinutes` | `60` | Settings → Updates → Check interval |
 | `channel` | `stable` | Settings → Updates → Channel |
 | `githubOwner` | `bilbospocketses` | Settings → Updates → GitHub owner (override for forks) |
+| `frameAncestors` | `[]` (nothing may frame the app) | Settings → Embedding, or edit `config.json` |
+| `allowedHosts` | `[]` (localhost + IP literals only) | `config.json` only — server-only, never exposed via the API |
 
 Not a stored field, but reached the same way: **Settings → Server → stop the server and close the app** cleanly stops the server and quits the app — the primary clean-exit path on Linux (no tray there), disabled in service mode.
 
@@ -325,12 +331,20 @@ A few advanced switches are only available via environment variables:
 
 ### Access control
 
-ws-scrcpy-web has **no login** — anyone who can reach the port can control connected devices, so run it only on a trusted local/LAN network. The server blocks cross-site (CSRF) and DNS-rebinding attacks with a Host allowlist, an Origin check, and a per-launch token cookie; by default it accepts only `localhost` and IP-literal hosts.
+ws-scrcpy-web is **open by default** — with login off, anyone who can reach the port can control connected devices, so run it only on a trusted local/LAN network. **Opt-in login is available** (Settings → Users): add a user with a password and the app requires a session from then on.
+
+With login off, the LAN is trusted. The server blocks cross-site (CSRF) and DNS-rebinding attacks with a Host allowlist, an Origin check, a per-launch token cookie, and a framing policy; by default it accepts only `localhost` and IP-literal hosts, and refuses cross-origin framing outright. Those defences stop a malicious *web page* and a rebound *domain name*. They are not a login: the token cookie is handed to anything that can fetch the page, so a client already on your network can use the API. **Turning login on is what makes that a boundary.**
 
 To serve it on a domain name behind a TLS-terminating reverse proxy, add the domain(s) to a server-only `allowedHosts` array in `config.json` (read at startup, never exposed via the in-app API), and make sure the proxy forwards the original `Host` header:
 
 ```json
 { "allowedHosts": ["devices.example.com"] }
+```
+
+To let another local app embed this one in an iframe, add its origin to `frameAncestors` in `config.json`, or approve the consent prompt the embedding app can raise (Settings → Embedding lists and revokes what you have approved). Cross-origin framing is refused until you do:
+
+```json
+{ "frameAncestors": ["http://localhost:5159"] }
 ```
 
 See [`SECURITY.md`](SECURITY.md) and `docs/TECHNICAL_GUIDE.md` §24 for the full access-control model.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ ESM consumers can `import` the same names from the package entry.
 
 **Security: `allowedOrigins`.** The default listener accepts theme messages
 from any origin (`allowedOrigins: '*'`). This is permissive by design so the
-helper is drop-in for any embedder. Locked-down deployments should call
+helper is drop-in for any embedder — note that the ws-scrcpy-web app itself
+does **not** use that default: it scopes its own listener to same-origin plus
+whatever `frameAncestors` permits. `allowedOrigins` also accepts a function,
+evaluated per message, for callers that do not know their allowlist at install
+time. Locked-down deployments should call
 
 ```javascript
 WsScrcpy.installThemeEmbedListener({

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,15 @@ ws-scrcpy-web is **open (no login) by default**, intended for a trusted local or
 - **Origin match** — for the API / WebSocket surface, a present `Origin` must be same-origin (CSRF defense).
 - **Per-instance token** — a random per-launch `HttpOnly; SameSite=Strict` cookie gates the API and the WebSocket upgrade, so a non-browser client that never loaded the page is refused.
 
+**What these layers do not do.** They defend against a *cross-site page* and a *rebound domain name*. They are not authentication, and in open mode the whole LAN is trusted:
+
+- the server binds all interfaces, and any IP literal passes the Host allowlist;
+- the Origin match is skipped when the header is absent, which a non-browser client decides;
+- the per-instance token is handed to **any** unauthenticated GET of an extensionless path, so anything that can fetch `/` can obtain one — it raises the cost of a blind attack, it does not identify a caller;
+- with login disabled, `requireAdmin` resolves to the implicit admin.
+
+Together that means a client already on your network can fetch `/`, take a token, and reach the admin API — users, config, shutdown. **`authEnabled` is the boundary**: enable login (Settings → Users) if the network is not one you trust. The embed-consent endpoints do not rely on this and are additionally restricted to loopback, which is why granting an embed permission cannot be done over the network.
+
 **Serving on a domain / behind a reverse proxy.** Because the default rejects domain `Host` headers, a TLS-terminating reverse proxy on a domain name must be opted in via the server-only `allowedHosts` array in `config.json`:
 
 ```json

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -10,6 +10,14 @@ This document covers the internal architecture of ws-scrcpy-web -- a browser-bas
 
 ## Table of Contents
 
+> **On `§NN` in source comments.** This guide has sections **1-25**, and a comment citing one
+> in that range means this document. Comments citing **§26 and above** -- `§27`, `§30`, `§32`,
+> `§34`, `§36`, `§39`, `§40`, `§49` -- do **not**: they are historical references to numbered
+> items in the maintainer's internal planning file, which is not part of this repository, and
+> several of those numbers were reassigned or archived as that file evolved. They are left in
+> place because they still carry provenance for the maintainer, but do not go looking for a
+> section here that matches -- there has never been one.
+
 1. [Directory Structure](#1-directory-structure)
 2. [Communication Protocol](#2-communication-protocol)
 3. [Video Pipeline](#3-video-pipeline)
@@ -34,6 +42,7 @@ This document covers the internal architecture of ws-scrcpy-web -- a browser-bas
 22. [In-App Updater (Velopack)](#22-in-app-updater-velopack)
 23. [First-Run Modal Gating](#23-first-run-modal-gating)
 24. [Access Control & Request Gating](#24-access-control--request-gating)
+25. [Why the Screen Is Black](#25-why-the-screen-is-black)
 
 ---
 
@@ -1949,6 +1958,8 @@ Windows and the Windows-service apply path are unchanged (Velopack `waitExitThen
 
 `src/app/client/firstRunGate.ts` orchestrates the first-run experience, ensuring the user sees the right modal on the right instance.
 
+> **Not the only modal that can appear unbidden.** `startEmbedRequestWatch()` (raised from `src/app/index.ts`, home page only) polls `GET /embed-request` every 5 s, and shows the embed-consent prompt when another local app asks to frame this one. It is **non-dismissible** — the user must Approve or Deny — and it can appear over an idle home page with no action from them. It is not part of the first-run gate and is not sequenced against it. `stopEmbedRequestWatch()` tears the poller down on page teardown. See `SECURITY.md` §Framing.
+
 ### 23.1 Decision Flow
 
 On page load, `src/app/index.ts` reads `installMode` + `firstRunComplete` from `GET /api/config` and the per-user prompt flags from the settings store (`SettingsService.loadGlobal()`), then evaluates:
@@ -2013,11 +2024,17 @@ The **Settings** modal's reset control — **"reset all my settings"** — now c
 
 ## 24. Access Control & Request Gating
 
-ws-scrcpy-web serves an **unauthenticated** API + WebSocket surface (anyone who can reach the port can drive connected devices). It is designed for a trusted local/LAN network — there is no user login (an opt-in auth subsystem is a separate, future workstream). The server defends that surface against *cross-network* and *cross-site* attackers with three layers, evaluated in order in `src/server/security/requestGate.ts`:
+ws-scrcpy-web serves an API + WebSocket surface that is **unauthenticated by default**: anyone who can reach the port can drive connected devices. An **opt-in login subsystem has shipped** (smoke Module 18 — users, roles, sessions, `AuthGate`); while `authEnabled` is false the app runs in *open mode* and every request resolves to the implicit admin.
+
+**Open mode trusts the entire LAN, and `authEnabled` is the boundary.** The layers below stop a *cross-site* page and a *rebound DNS name* from reaching the API. They do not stop a direct client on the network: `server.listen(port)` binds all interfaces, `isHostAllowed` accepts any IP literal, the Origin match is skipped when the header is absent (which a non-browser client controls), and in open mode `requireAdmin` resolves to the implicit admin. A LAN client can therefore fetch `/`, collect the per-instance token from the response, and reach the admin API — `UsersApi`, `ConfigApi` PATCH, `ServerShutdownApi`. Turn login on to have a real boundary; the embed-consent endpoints are additionally loopback-gated for exactly this reason (§Framing in `SECURITY.md`).
+
+Against cross-network and cross-site attackers the server applies four layers, the first three evaluated in order in `src/server/security/requestGate.ts`:
 
 1. **Host allowlist (DNS-rebinding defense)** — `originGuard.isHostAllowed`. The `Host` header's hostname must be `localhost`, an IP literal (e.g. `192.168.1.5`, `[::1]`), or an operator-configured `allowedHosts` entry. A bare domain name is rejected, because DNS-rebinding attacks require a domain the attacker can re-point at a loopback/LAN address. This check is **universal** — it applies even to document / static-asset requests, so a rebound page never loads.
 2. **Origin match (CSRF defense)** — `originGuard.isRequestAllowed`. For the sensitive surface (`/api/*` and any state-changing method), a present `Origin` header must equal the request's own origin (`http(s)://<host>`). A *missing* Origin is allowed here (non-browser clients and top-level navigations omit it); the token layer closes that gap.
-3. **Per-instance token** — `instanceToken.ts`. A 256-bit random token is minted once per server launch and handed to the browser as an `HttpOnly; SameSite=Strict` cookie when it loads a document. Every `/api/*` call (except the launcher's `GET /api/config` discovery probe) and every WebSocket upgrade must present it, compared in constant time. A non-browser LAN client that never loaded the page has no token and is refused.
+3. **Per-instance token** — `instanceToken.ts`. A 256-bit random token is minted once per server launch and handed to the browser as an `HttpOnly; SameSite=Strict` cookie when it loads a document. Every `/api/*` call (except the launcher's `GET /api/config` discovery probe) and every WebSocket upgrade must present it, compared in constant time. Read that as the `/api` prefix, not as an inventory of the whole surface: `/embed-request` and `/embed-request/{id}/cancel` sit **outside** `/api` deliberately, so an app that wants to ask for embed permission can do so without first holding a token — and they are loopback-only precisely because they are ungated. A non-browser LAN client that never loaded the page has no token and is refused.
+   **It is not an authenticator.** `shouldSetTokenCookie` returns true for any GET/HEAD of an extensionless non-`/api` path, and the cookie is attached with no authentication at all, so anything that can fetch `/` can have one. It raises the cost of a *blind* cross-site or rebinding attack; it does not identify a caller. Only `authEnabled` does that.
+4. **Framing policy (clickjacking)** — `security/frameGuard.ts`. Every response carries `X-Frame-Options: SAMEORIGIN` and, when `frameAncestors` is configured, a matching CSP `frame-ancestors` header. Cross-origin framing is **refused by default**; an operator opts in per origin, either by editing `config.json` or by approving a consent prompt raised by the embedding app (`embedRequests.ts`, `EmbedRequestApi.ts`). See `SECURITY.md` §Framing.
 
 ### 24.1 `allowedHosts` — serving on a domain / behind a reverse proxy
 
@@ -2039,7 +2056,11 @@ By default only `localhost` + IP literals pass layer 1, so terminating TLS at a 
 | File | Purpose |
 |------|---------|
 | `src/server/security/originGuard.ts` | Host allowlist (`isHostAllowed`, `setAllowedHosts`) + Origin match (`isRequestAllowed`) |
-| `src/server/security/requestGate.ts` | Composes the three layers for HTTP (`evaluateHttpRequest`) and WS (`evaluateWsConnection`) |
+| `src/server/security/requestGate.ts` | Composes the Host/Origin/token layers for HTTP (`evaluateHttpRequest`) and WS (`evaluateWsConnection`) |
+| `src/server/security/frameGuard.ts` | `securityHeaders()` + the CSP `frame-ancestors` list (`setFrameAncestors`) — layer 4 |
+| `src/server/embedRequests.ts` | Pending embed-consent request store (one at a time, five-minute expiry) |
+| `src/server/api/EmbedRequestApi.ts` | `/embed-request` ask + `/api/embed-request/decision` grant; both loopback-gated |
+| `src/server/auth/authState.ts` | `authEnabled` — the actual authentication boundary — plus the gate's allow-list |
 | `src/server/security/instanceToken.ts` | Per-launch token mint, cookie build, constant-time validation |
 | `src/server/Config.ts` | Reads + sanitizes `allowedHosts` from config.json (`sanitizeAllowedHosts`, `Config.allowedHosts`) |
 | `src/server/index.ts` | Applies `allowedHosts` at boot via `setAllowedHosts(config.allowedHosts)` |

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -2194,10 +2194,13 @@ Two live consequences before this was guarded:
   with `Unhandled error. (undefined)` on every reconnect attempt. (`undefined`
   because the `events` polyfill formats `er.message`, and a plain `Event` has
   none — that detail is what identifies this rather than something else.)
-- **`emit`** — `HostTrackerEvents` types `'error'` as a plain `string` and
-  **nothing in the codebase listens for it**, so every `MessageType.ERROR` from
-  the server threw inside `onSocketMessage` and abandoned the rest of the
-  handler.
+- **`emit`** — `HostTrackerEvents` used to type `'error'` as a plain `string`
+  while **nothing in the codebase listened for it**, so every
+  `MessageType.ERROR` from the server threw inside `onSocketMessage` and
+  abandoned the rest of the handler. The guard below fixed the throw; the
+  event itself has since been **removed** (the server sends that message only
+  for "unsupported message", a protocol fault with nothing a user could act
+  on), so the condition is logged and no longer emitted.
 
 Both methods now return `false` instead of emitting when `'error'` has no
 listener. Attaching a listener restores ordinary delivery, which is how


### PR DESCRIPTION
Items **86**, **85** (README + TECHNICAL_GUIDE parts) and **81 option (c)**. Documentation only — no runtime change, no behaviour change. Labelled `release:none` deliberately: there is nothing here to ship, and cutting a beta would move the target out from under the QA harness mid-run.

## 86 — the premise in the todo was wrong, and that is the finding

The item says the `§NN` citations point at TECHNICAL_GUIDE sections that never existed. They don't. **They point at numbered items in the maintainer's internal planning file** — `UpdateService.test.ts:629` says so outright: *"See §32 in todo_ws_scrcpy_web.md"*.

Five of the eight cited numbers resolve in the archived todo:

| Cited | Resolves to |
|---|---|
| §27 | In-app exit modal for Linux (no tray) |
| §34 | Cross-platform device-name database |
| §36 | Single SQLite store |
| §39 | Linux service-mode in-app update apply |
| §40 | Service-mode-fix session follow-ups |

§30, §32 and §49 no longer resolve — that file was renumbered as it grew.

So they are not dangling into nothing, but they *are* unfollowable by anyone who is not the maintainer, because that file is not in this repository. Stripping 40 comments would destroy provenance that is still real; instead the **convention is now stated under the TOC**: §1–25 mean this guide, §26+ mean the planning file and will never resolve here.

## 85 — the docs described a security model the code no longer had

- **README said "no login", full stop.** Opt-in login shipped — it is the entire subject of smoke Module 18.
- **README's Access control** listed three defences with no framing layer, and presented `allowedHosts` as the only server-side opt-in. `frameAncestors` appeared nowhere, including the Configuration table.
- **README's Embedding section** documented ~70 lines of iframe protocol without once saying cross-origin framing is refused by default. Follow it as written and you get *"localhost refused to connect"*.
- **§24** still called the auth subsystem *"a separate, future workstream"*, still said *"three layers"*, and its Key Files table omitted `frameGuard.ts`, `embedRequests.ts`, `EmbedRequestApi.ts` and `auth/authState.ts`.
- **§24's "every `/api/*` call"** now reads as an inventory of the gated surface and is not — `/embed-request` sits outside `/api` deliberately, and is loopback-only *because* it is ungated.
- **§23** lists which modals may appear unbidden and omitted the embed-consent prompt — the only **non-dismissible** one, which can appear over an idle home page with no user action.
- **The TOC ended at §24** while the body has §25.

## 81 (c) — documented, not re-gated

SECURITY.md and §24 now say plainly what open mode is: the server binds all interfaces, any IP literal passes the Host allowlist, the Origin match is skipped when the header is absent (which a non-browser client controls), the per-instance token is handed to **any** unauthenticated GET of an extensionless path — so it raises the cost of a blind attack but does not identify a caller — and `requireAdmin` resolves to the implicit admin.

Consequence, stated: a client already on the network can fetch `/`, take a token, and reach `UsersApi`, `ConfigApi` PATCH and `ServerShutdownApi`. **`authEnabled` is the boundary.** SECURITY.md already said this for the embed endpoints; it now says it in general, which is where it belongs.

**Options (a) and (b) are not closed by this.** Loopback-gating the admin API, or requiring a real session regardless of mode, both change who may call admin routes from off-box — which is exactly what the QA harness does. They need to move in step with it.

## Deliberately not included

**Item 85's `smoke-test.md` rows.** The coverage register is *"derived from `smoke-test.md` at v0.1.30-beta.92, which holds 140 rows"*, and every number in it is keyed to that denominator. Nothing in CI enforces the count, which makes it worse rather than safer — adding rows here would silently desync the harness's coverage arithmetic. That belongs in a change coordinated with qa-harness.

## Verification

Every factual claim added was checked against the code rather than against the prior docs:

| Claim | Verified |
|---|---|
| `frameAncestors` defaults to empty | `Config.ts` |
| `X-Frame-Options: SAMEORIGIN` on every response | `frameGuard.ts` |
| Embed watch polls every 5 s | `EmbedRequestPrompt.ts` |
| `startEmbedRequestWatch()` raised from the home page | `index.ts` |
| `/embed-request` sits outside the `/api` token gate | `instanceToken.ts`, `authState.ts` |
| Login is enabled from Settings → Users | `SettingsModal.ts` |

Suite unchanged and green: 1846 passed, 5 skipped, 205 files. `tsc --noEmit` and `npm run lint` clean.
