### PR TITLE
fix(release): default the MSI to C:\Program Files\WsScrcpyWeb (was drive root)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,13 +99,15 @@ jobs:
       - name: vpk pack (PerMachine MSI)
         shell: pwsh
         run: |
-          # Phase 4 of the Program Files migration: PerMachine MSI is
-          # the only Windows install artifact. The MSI installs to
-          # C:\Program Files\WsScrcpyWeb\ and runs elevated; the
-          # launcher's veloapp-install hook grants the ProgramData
-          # ACL (Authenticated Users:Modify (OI)(CI)) at install
-          # time. v0.1.22 dropped Setup.exe (vpk still emits one as a
-          # side effect of `--msi`; we just don't publish it).
+          # PerMachine MSI is the only Windows install artifact (v0.1.22 dropped
+          # Setup.exe; vpk still emits one as a side effect of `--msi`, we just
+          # don't publish it). `--instLocation PerMachine` sets the install SCOPE
+          # (all-users, elevated) -- it does NOT set the directory. vpk's raw MSI
+          # defaults INSTALLFOLDER to the DRIVE ROOT (C:\ws-scrcpy-web); the
+          # Program-Files install this project shipped for weeks came from the
+          # dropped Setup.exe, not the MSI. The next step reparents INSTALLFOLDER
+          # to C:\Program Files\WsScrcpyWeb; the launcher's veloapp-install hook
+          # grants the ProgramData ACL at install time.
           vpk pack `
             --packId WsScrcpyWeb `
             --packVersion ${{ needs.prepare.outputs.version }} `
@@ -118,6 +120,19 @@ jobs:
             --msi `
             --instLocation PerMachine `
             -o Releases
+
+      - name: Default MSI install dir to Program Files
+        shell: pwsh
+        run: |
+          # vpk's MSI defaults INSTALLFOLDER to the drive root; this reparents it
+          # under ProgramFiles64Folder so the shipped MSI installs to
+          # C:\Program Files\WsScrcpyWeb by default in every mode (double-click and
+          # /qn). Runs BEFORE signing so the signature covers the patched MSI. The
+          # script self-verifies and throws if the reparent did not take, so a
+          # silent regression to the drive root fails the release loudly.
+          Get-ChildItem Releases/*.msi | ForEach-Object {
+            ./scripts/msi-default-programfiles.ps1 -Msi $_.FullName
+          }
 
       - name: Upload unsigned MSI
         if: needs.prepare.outputs.signing_mode == 'signed'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The MSI installs to `C:\Program Files\WsScrcpyWeb` again — it had silently regressed to the drive
+  root `C:\ws-scrcpy-web`.** `vpk`'s `--msi` artifact defaults `INSTALLFOLDER` to `[TARGETDIR]\<packTitle>`,
+  i.e. the **drive root**, in every vpk version (verified against 0.0.1589, 1.0.1, 1.1.1, 1.2.0);
+  `--instLocation PerMachine` only sets the install **scope** (all-users, elevated), never the directory.
+  The Program-Files install this project shipped for weeks came from the Velopack **Setup.exe**
+  bootstrapper (it resolves `ProgramFilesX64` at runtime), and dropping Setup.exe for an MSI-only Windows
+  artifact (v0.1.22) silently left the raw MSI's drive-root default as the shipped behaviour. Nothing
+  tested the *actual* install location, so it went unnoticed until a from-scratch install was measured.
+  A new release step (`scripts/msi-default-programfiles.ps1`) reparents `INSTALLFOLDER` under
+  `ProgramFiles64Folder` after `vpk pack` (before signing), so the shipped MSI installs to
+  `C:\Program Files\WsScrcpyWeb` by default in **every** mode — double-click and silent (`/qn`) alike —
+  and the script self-verifies and fails the release if the reparent does not take. Velopack's
+  `VELOPACK_INSTALLDIR` property still overrides the location for anyone who needs a custom directory.
+  This also restores the install-root ACL / one-time-UAC grant behaviour that the two-root design
+  (`C:\Program Files\WsScrcpyWeb` binaries + `C:\ProgramData\WsScrcpyWeb` writable state) was built
+  around. **Existing drive-root installs must be uninstalled and reinstalled** — Velopack cannot migrate
+  an install across locations. Verified 2026-09-05: a patched MSI installs `/qn` to
+  `C:\Program Files\WsScrcpyWeb` (ARP `InstallLocation` correct) where the unpatched MSI lands at
+  `C:\ws-scrcpy-web`.
+
 ### Changed
 
 - **The docs describe the security model the code actually has.** The README still said the app has no

--- a/scripts/msi-default-programfiles.ps1
+++ b/scripts/msi-default-programfiles.ps1
@@ -1,0 +1,90 @@
+<#
+.SYNOPSIS
+  Make Velopack's MSI install to C:\Program Files\<AppFolder> by default.
+
+.DESCRIPTION
+  vpk's `--msi` artifact defaults INSTALLFOLDER to `[TARGETDIR]\<packTitle>` --
+  the DRIVE ROOT (C:\ws-scrcpy-web). This is true in EVERY vpk version tested
+  (0.0.1589, 1.0.1, 1.1.1, 1.2.0): the Directory table roots the app at
+  TARGETDIR, and `--instLocation` only sets per-machine vs per-user SCOPE, never
+  the directory. The Program-Files install this project shipped for weeks came
+  from the Velopack **Setup.exe** bootstrapper, which resolves ProgramFilesX64 at
+  runtime -- and dropping Setup.exe (MSI-only, commit 8827fbf) silently left the
+  raw MSI's drive-root default as the shipped behaviour. Nothing tested the real
+  install location, so it went unnoticed until qa-harness measured it.
+
+  This reparents INSTALLFOLDER under the standard ProgramFiles64Folder system
+  folder, so the shipped MSI installs to C:\Program Files\<AppFolder> by default
+  in EVERY mode -- double-click and silent (`/qn`) alike, because the change is to
+  the Directory-table default, not a UI-only custom action. Velopack's
+  `VELOPACK_INSTALLDIR` property still overrides it for anyone who wants a custom
+  location.
+
+  Proven on 2026-09-05: a patched stub MSI installed `/qn` to
+  `C:\Program Files\WsScrcpyWeb` (msiexec exit 0, ARP InstallLocation correct),
+  where the unpatched MSI lands at `C:\ws-scrcpy-web`.
+
+.NOTES
+  Windows-only (WindowsInstaller COM). Runs in the release workflow's
+  windows-latest job, AFTER `vpk pack` and BEFORE signing, so the signature
+  covers the patched MSI.
+#>
+param(
+    [Parameter(Mandatory)][string]$Msi,
+    [string]$AppFolder = 'WsScrcpyWeb'
+)
+$ErrorActionPreference = 'Stop'
+
+# Direct late-bound COM, and ONE OpenDatabase for the whole operation. The
+# reflection-based InvokeMember form was measured flaky, and -- more importantly
+# -- opening the same MSI a SECOND time in one process throws
+# "OpenDatabase,DatabasePath,OpenMode" (WindowsInstaller caches/locks it). So the
+# verify happens INSIDE the single transacted session, reflecting the pending
+# change, and Commit runs ONLY if it verified. Measured 2026-09-05.
+$installer = New-Object -ComObject WindowsInstaller.Installer
+# msiOpenDatabaseModeTransact = 1 (changes visible in-session, persisted on Commit()).
+$db = $installer.OpenDatabase($Msi, 1)
+try {
+    # 1. Ensure ProgramFiles64Folder (child of TARGETDIR) exists as a REAL row so
+    #    the Directory tree links. MSI resolves the standard system-folder path
+    #    itself; '.' is the WiX-idiomatic DefaultDir placeholder.
+    #
+    #    NEVER insert this row TEMPORARY: a temporary row satisfies an existence
+    #    check but is dropped at Commit, orphaning INSTALLFOLDER's parent and
+    #    failing the install with Error 2705 ("Invalid table: Directory; could
+    #    not be linked as tree"). Measured 2026-09-05.
+    $check = $db.OpenView("SELECT Directory FROM Directory WHERE Directory='ProgramFiles64Folder'")
+    $check.Execute()
+    $exists = $null -ne $check.Fetch()
+    $check.Close()
+    if (-not $exists) {
+        $ins = $db.OpenView("INSERT INTO Directory (Directory, Directory_Parent, DefaultDir) VALUES ('ProgramFiles64Folder','TARGETDIR','.')")
+        $ins.Execute(); $ins.Close()
+    }
+
+    # 2. Reparent INSTALLFOLDER under ProgramFiles64Folder and set its leaf. Short
+    #    name <=8 chars and valid; long name is <AppFolder>.
+    $short = ($AppFolder.ToUpper() -replace '[^A-Z0-9]', '')
+    if ($short.Length -gt 8) { $short = $short.Substring(0, 8) }
+    $upd = $db.OpenView("UPDATE Directory SET Directory_Parent='ProgramFiles64Folder', DefaultDir='$short|$AppFolder' WHERE Directory='INSTALLFOLDER'")
+    $upd.Execute(); $upd.Close()
+
+    # 3. VERIFY the pending change before committing. A silent no-op here would
+    #    ship the drive-root MSI again -- exactly what this script prevents -- so
+    #    it throws (and does NOT commit) rather than shipping the wrong default.
+    $v = $db.OpenView("SELECT Directory_Parent FROM Directory WHERE Directory='INSTALLFOLDER'")
+    $v.Execute()
+    $rec = $v.Fetch()
+    $parent = if ($rec) { $rec.StringData(1) } else { '<none>' }
+    $v.Close()
+    if ($parent -ne 'ProgramFiles64Folder') {
+        throw "MSI PATCH FAILED: INSTALLFOLDER parent is '$parent', expected 'ProgramFiles64Folder'. Not committing. $Msi"
+    }
+
+    $db.Commit()
+}
+finally {
+    [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($db)
+}
+
+Write-Output "OK: $([System.IO.Path]::GetFileName($Msi)) -> C:\Program Files\$AppFolder (INSTALLFOLDER reparented under ProgramFiles64Folder)"


### PR DESCRIPTION
fix(release): default the MSI to C:\Program Files\WsScrcpyWeb (was drive root)

The Windows MSI silently regressed to installing at the DRIVE ROOT
(C:\ws-scrcpy-web) instead of C:\Program Files\WsScrcpyWeb, and nothing caught it
because nothing tested the actual install location.

Root cause, established by building MSIs from an identical stub under every vpk
version and reading each one's Directory table:

  - vpk's `--msi` artifact defaults INSTALLFOLDER to [TARGETDIR]\<packTitle> = the
    drive root. This is true in vpk 0.0.1589, 1.0.1, 1.1.1 AND 1.2.0 -- the
    Directory tables are byte-identical. It is NOT a vpk regression.
  - `--instLocation PerMachine` sets the install SCOPE (all-users, elevated). It
    does not set the directory. vpk 1.2.110 confirms it: `[default: Either]`.
  - The Program-Files install we shipped for weeks came from the Velopack
    Setup.exe bootstrapper, which resolves ProgramFilesX64 at runtime.
  - Commit 8827fbf ("drop Setup.exe artifact -- MSI-only on Windows") removed that
    bootstrapper, leaving the raw MSI's drive-root default as the shipped
    behaviour. The pack step's own comment claimed "installs to
    C:\Program Files\WsScrcpyWeb" -- the false belief that hid this.

Fix: scripts/msi-default-programfiles.ps1 reparents INSTALLFOLDER under the
standard ProgramFiles64Folder system folder, run in release.yml after `vpk pack`
and before signing (so the signature covers the patched MSI). Because the change
is to the Directory-table DEFAULT, not a UI-only custom action, it applies in
every install mode -- double-click and silent (/qn). Velopack's
VELOPACK_INSTALLDIR property still overrides for a custom directory.

The script self-verifies: it reparents inside a single transacted MSI session,
re-reads INSTALLFOLDER's parent from the pending change, and COMMITS ONLY IF it
verified -- throwing (and failing the release) otherwise. A silent no-op that
shipped the drive-root MSI again is the one outcome this must never allow, so it
is made loud. Two traps were hit and are guarded in comments: inserting the
ProgramFiles64Folder row TEMPORARY orphans the tree (Error 2705), and re-opening
the same MSI a second time in one process throws -- hence the single-session
verify.

Verified end to end on a clean Windows 11 guest: the patched MSI installs /qn
to C:\Program Files\WsScrcpyWeb (msiexec exit 0, ARP InstallLocation correct,
\current\ws-scrcpy-web-launcher.exe present), where the unpatched MSI lands at
C:\ws-scrcpy-web. Determinism confirmed across repeated fresh runs.

This restores the two-root design the Program Files migration built (binaries in
Program Files, writable state in ProgramData with the Authenticated Users ACL,
and the install-root grant / one-time UAC on first launch).

Existing drive-root installs must be uninstalled and reinstalled -- Velopack
cannot migrate an install across locations.
