### PR TITLE
ci: run the linter in build-and-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
         with:
           components: clippy
       - run: npm ci
+      # Biome. Runs first because it is the cheapest gate here (~2s over 545
+      # files) and the one most likely to trip on a hand-edited file, so a
+      # style-only failure does not cost a tsc + build + Playwright run to
+      # discover.
+      #
+      # `npm run lint` is `biome check` -- formatter, linter and assist
+      # together -- so this pins formatting too; `npm run format` is the fix.
+      # Biome is a pinned devDependency, not a floating npx download, so a
+      # biome release cannot turn this step red on its own.
+      #
+      # build-and-test only, deliberately: macos-node-checks exists to exercise
+      # the darwin code paths, and lint findings are platform-independent, so a
+      # second run of the same check buys nothing.
+      - run: npm run lint
       - run: npx tsc --noEmit
       - run: npm test
       - run: cargo test --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI never ran the linter.** `build-and-test` ran `tsc`, the unit tests, the Rust gates, the build and
+  both Playwright tiers, but never `npm run lint` — so biome was enforced only by whoever remembered to
+  run it locally, and the recent fix that brought `webpack/**` into the linted set held by that same
+  convention. `build-and-test` now runs `npm run lint` immediately after `npm ci`, ahead of the slower
+  gates, so a style-only failure costs seconds rather than a full build. `npm run lint` is `biome check`,
+  which covers formatting as well, and biome is a lockfile-pinned devDependency, so a biome release
+  cannot turn the step red on its own. The step is not repeated in `macos-node-checks`: lint findings do
+  not vary by platform.
+- **`biome.json` pointed at the schema for a biome it no longer runs.** The `$schema` URL still named
+  2.4.12 while the pinned CLI is 2.5.11, so biome reported a version mismatch on every run and editors
+  validated the config against the wrong schema. Now 2.5.11.
+
 ## [0.1.30-beta.104] - 2026-09-06
 
 ### Fixed

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
     "assist": { "actions": { "source": { "organizeImports": "on" } } },
     "formatter": {
         "enabled": true,


### PR DESCRIPTION
Closes the "CI never runs the linter" gap (todo item 106).

`build-and-test` runs `npm ci`, `tsc --noEmit`, `npm test`, `cargo test`, `cargo clippy`, `npm run build`, the e2e typecheck, the suite bundle round-trip and both Playwright tiers — and never `npm run lint`. So biome has been enforced by convention only: whoever remembered to run it locally. The recent fix that brought `webpack/**` into the linted set holds by that same convention, which is to say it doesn't.

**The step goes right after `npm ci`.** Biome checks all 545 files in ~2s, so putting it first means a style-only failure costs seconds instead of a tsc + cargo + build + two-tier Playwright run to discover. `npm run lint` is `biome check` — formatter, linter and assist together — so this pins formatting too; `npm run format` is the fix for a red step.

**Not added to `macos-node-checks`.** That job exists to keep the darwin code paths from shipping unverified; lint findings are platform-independent, so a second run of the same check buys nothing.

**No floating download.** `@biomejs/biome` is a devDependency pinned to 2.5.11 in the lockfile, so `npx @biomejs/biome` resolves the installed copy. A biome release cannot turn this step red on its own.

### Also in here

`biome.json`'s `$schema` still named **2.4.12** while the pinned CLI is **2.5.11**, so biome emitted a version-mismatch diagnostic on every single run and editors were validating the config against the wrong schema. Bumped to 2.5.11.

### Verification

```
$ npm run lint
Checked 545 files in 1714ms. No fixes applied.
Found 1 info.
$ echo $?
0
```

The one remaining info is `linter.rules.recommended`, which biome has deprecated and will remove in its next major. Migrating it to `preset` changes which rules are on — a policy change, so it is deliberately not smuggled into this PR. It does not fail the step today.

One gotcha found while doing this and worth stating: biome checks the **working tree**, and `.gitattributes` normalises these files to LF. A CRLF-rewritten `biome.json` fails the formatter locally while a fresh CI checkout passes. Both files here are LF.
