### PR TITLE
fix: an explicit open-files budget for the server, and a cap on the scan that could spend it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+### Fixed
+
+- **The server now has an explicit open-files budget, and the scan can no longer spend it.** On Linux
+  the process ran on whatever `RLIMIT_NOFILE` it inherited — systemd's 1024-soft default as a service,
+  the shell's `ulimit -n` (also 1024) on a desktop launch — and that budget was shared by the HTTP
+  listener, every browser WebSocket, adb's sockets, the SQLite store, the log and a subnet scan whose
+  `scanConcurrency` accepted any number at all. The budget is now written down in one place
+  (`src/server/fdBudget.ts`, with the arithmetic: a worst case of 768 descriptors against a limit of
+  4096): the systemd unit carries `LimitNOFILE=4096` in both scopes, the Linux launcher raises its own
+  soft limit to the same number before spawning Node so a desktop run inherits it, and
+  `scanConcurrency` is capped at 512 wherever it is set, with a log line when it is brought down. The
+  Rust constant is pinned to the TypeScript one by a test that reads the source, so the two cannot
+  drift. Windows has no per-process descriptor limit and is unchanged; so is the container, whose
+  engine default is 1048576.
+- **`config.json`'s four `scan*` keys did nothing.** `scanConcurrency`, `scanTcpTimeoutMs`,
+  `scanAdbConnectTimeoutMs` and `scanProgressInterval` were documented as `config.json` keys, parsed
+  from the file, and then never consulted — only the env var and the per-user store were. They are now
+  read in the documented order: env var, then the store, then the file, then the default.
+
 ## [0.1.30-beta.106] - 2026-09-06
 
 ### Fixed

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1280,10 +1280,14 @@ Defaults in `src/server/Config.ts`, overridable via env var or `config.json` key
 
 | Key (config.json) | Env var | Default | Purpose |
 |---|---|---|---|
-| `scanConcurrency` | `SCAN_CONCURRENCY` | 64 | Max in-flight TCP connects in the probe pool. |
+| `scanConcurrency` | `SCAN_CONCURRENCY` | 64 | Max in-flight TCP connects in the probe pool. **Capped at 512** by the file-descriptor budget below; a higher value is brought down and logged. |
 | `scanTcpTimeoutMs` | `SCAN_TCP_TIMEOUT_MS` | 300 | Per-host TCP connect timeout. |
 | `scanAdbConnectTimeoutMs` | `SCAN_ADB_CONNECT_TIMEOUT_MS` | 5000 | CNXN handshake reply timeout — needs headroom for slow embedded adbd stacks. |
 | `scanProgressInterval` | `SCAN_PROGRESS_INTERVAL` | 10 | Hosts checked per `scan.progress` emission. Lower = more frequent UI updates, higher = less WS chatter. |
+
+Precedence for all four is env var → per-user store (`app_settings`) → `config.json` → default. (The `config.json` column was parsed but never read until beta.105; a scan key in the file did nothing.)
+
+**File-descriptor budget.** The server is one process, and on Linux its open-file limit is whatever it inherits — systemd's `DefaultLimitNOFILE` (1024 soft) for a service, the shell's `ulimit -n` (1024) for a desktop launch — shared by the HTTP listener, every WebSocket, adb's sockets, the SQLite store, the log, and the subnet scan, which holds `scanConcurrency` connects open at once. `src/server/fdBudget.ts` makes that explicit: the worst case it derives (16 tabs, 16 streamed devices, a scan at the cap) is 768 descriptors; `SERVICE_NOFILE_LIMIT` is 4096, and `MAX_SCAN_CONCURRENCY` is 512. The service unit writes `LimitNOFILE=4096` (`SystemdClient.ts`), the Linux launcher raises its own soft limit to the same number before spawning Node so a desktop run inherits it (`launcher/src/spawn.rs`, pinned to the TypeScript constant by `fdBudget.test.ts`), and `Config` clamps `scanConcurrency` to the cap wherever it came from. Windows has no per-process fd rlimit and needs none; Docker's default `nofile` ulimit is 1048576.
 
 #### 14.2.6 Diagnostic Scripts
 

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -386,7 +386,7 @@ mod tests {
             None => NOFILE_LIMIT,
         };
         assert!(
-            after.current.map_or(true, |soft| soft >= expected),
+            after.current.is_none_or(|soft| soft >= expected),
             "soft limit {:?} below {expected}",
             after.current
         );

--- a/launcher/src/spawn.rs
+++ b/launcher/src/spawn.rs
@@ -169,6 +169,49 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path, open_browser: bool) -> R
     Ok(child)
 }
 
+/// Soft `RLIMIT_NOFILE` a desktop launch grants the Node server. The same
+/// number the systemd unit writes as `LimitNOFILE=` (SystemdClient.ts), and
+/// derived in src/server/fdBudget.ts — read that before changing this. The
+/// TypeScript side pins this constant by reading this file
+/// (src/server/__tests__/fdBudget.test.ts), so the two cannot drift silently.
+#[cfg(target_os = "linux")]
+pub const NOFILE_LIMIT: u64 = 4096;
+
+/// Raise this process's soft `RLIMIT_NOFILE` to `NOFILE_LIMIT`, or to the hard
+/// limit if that is lower, so the Node child inherits it. A desktop launch
+/// starts from the shell's `ulimit -n` — 1024 on every mainstream distro — and
+/// that budget is shared by every WebSocket, adb socket, the store, the log
+/// and the subnet scan. rlimits are inherited across `exec`, and `Command` has
+/// no per-child rlimit API, so the launcher raises its own; it holds a handful
+/// of descriptors itself, so the change costs it nothing. Never lowers a limit
+/// that is already higher, and never touches the hard limit (that would need
+/// privilege). Errors are returned for the caller to log; a failure here is a
+/// degraded launch, not a failed one.
+#[cfg(target_os = "linux")]
+pub fn raise_nofile_soft_limit() -> Result<()> {
+    use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
+    let current = getrlimit(Resource::Nofile);
+    // `None` is RLIM_INFINITY: nothing to raise.
+    let target = match current.maximum {
+        Some(hard) => NOFILE_LIMIT.min(hard),
+        None => NOFILE_LIMIT,
+    };
+    match current.current {
+        None => return Ok(()),
+        Some(soft) if soft >= target => return Ok(()),
+        Some(_) => {}
+    }
+    setrlimit(
+        Resource::Nofile,
+        Rlimit {
+            current: Some(target),
+            maximum: current.maximum,
+        },
+    )
+    .with_context(|| format!("setrlimit(RLIMIT_NOFILE, soft={target})"))?;
+    Ok(())
+}
+
 #[cfg(not(windows))]
 pub fn spawn_server(deps_path: &Path, data_root: &Path, open_browser: bool) -> Result<Child> {
     let exe = std::env::current_exe()?;
@@ -176,6 +219,14 @@ pub fn spawn_server(deps_path: &Path, data_root: &Path, open_browser: bool) -> R
     let deps_str = deps_path.to_str().context("deps_path is not valid UTF-8")?;
     let node = resolve_node_with(Some(deps_str), &work_dir)?;
     let entry = resolve_server_entry_with(&work_dir)?;
+
+    // Before the spawn, so the child inherits it (see raise_nofile_soft_limit).
+    // Best-effort: the server runs on the inherited limit if this fails, which
+    // is exactly what it did before, so say so and carry on.
+    #[cfg(target_os = "linux")]
+    if let Err(e) = raise_nofile_soft_limit() {
+        eprintln!("[launcher] could not raise the open-files limit for the server (continuing on the inherited one): {e:#}");
+    }
 
     let mut cmd = Command::new(&node);
     cmd.arg("--disable-warning=ExperimentalWarning")
@@ -320,6 +371,27 @@ mod tests {
 
         let err = resolve_server_entry_with(&exe_dir).unwrap_err();
         assert!(err.to_string().contains("Server entry not found"));
+    }
+
+    /// After the raise, the soft limit is NOFILE_LIMIT or the hard cap,
+    /// whichever is lower — and a second call is a no-op, not a lowering.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn raise_nofile_soft_limit_reaches_the_budget_and_never_lowers() {
+        use rustix::process::{Resource, getrlimit};
+        raise_nofile_soft_limit().unwrap();
+        let after = getrlimit(Resource::Nofile);
+        let expected = match after.maximum {
+            Some(hard) => NOFILE_LIMIT.min(hard),
+            None => NOFILE_LIMIT,
+        };
+        assert!(
+            after.current.map_or(true, |soft| soft >= expected),
+            "soft limit {:?} below {expected}",
+            after.current
+        );
+        raise_nofile_soft_limit().unwrap();
+        assert_eq!(getrlimit(Resource::Nofile).current, after.current, "second call must not move the limit");
     }
 
     #[test]

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -13,11 +13,12 @@ import type { ServerItem } from '../types/Configuration';
 import { GLOBAL_KEYS } from './db/constants';
 import { Db, dbDir } from './db/Db';
 import { EnvName } from './EnvName';
+import { clampScanConcurrency, DEFAULT_SCAN_CONCURRENCY } from './fdBudget';
 import { Logger } from './Logger';
 import { parseFrameAncestorOrigin, setFrameAncestors } from './security/frameGuard';
 import { writeFileAtomicSync } from './util/atomicFile';
 
-const DEFAULT_SCAN_CONCURRENCY = 64;
+// DEFAULT_SCAN_CONCURRENCY lives in fdBudget.ts, beside the cap it is tuned against.
 const DEFAULT_SCAN_TCP_TIMEOUT_MS = 300;
 const DEFAULT_SCAN_ADB_CONNECT_TIMEOUT_MS = 5000;
 const DEFAULT_SCAN_PROGRESS_INTERVAL = 10;
@@ -606,22 +607,54 @@ export class Config {
             const adbPath = adbResolution.path;
             log.info(`adbPath=${adbPath} (source=${adbResolution.source})`);
 
-            const scanConcurrency =
-                Number.parseInt(process.env['SCAN_CONCURRENCY'] ?? '', 10) ||
-                (globals['scanConcurrency'] as number | undefined) ||
-                DEFAULT_SCAN_CONCURRENCY;
-            const scanTcpTimeoutMs =
-                Number.parseInt(process.env['SCAN_TCP_TIMEOUT_MS'] ?? '', 10) ||
-                (globals['scanTcpTimeoutMs'] as number | undefined) ||
-                DEFAULT_SCAN_TCP_TIMEOUT_MS;
-            const scanAdbConnectTimeoutMs =
-                Number.parseInt(process.env['SCAN_ADB_CONNECT_TIMEOUT_MS'] ?? '', 10) ||
-                (globals['scanAdbConnectTimeoutMs'] as number | undefined) ||
-                DEFAULT_SCAN_ADB_CONNECT_TIMEOUT_MS;
-            const scanProgressInterval =
-                Number.parseInt(process.env['SCAN_PROGRESS_INTERVAL'] ?? '', 10) ||
-                (globals['scanProgressInterval'] as number | undefined) ||
-                DEFAULT_SCAN_PROGRESS_INTERVAL;
+            // env → store → config.json → default: the precedence adbPath uses
+            // just above. The config.json column of these four was documented
+            // (TECHNICAL_GUIDE §14.2.5) and parsed (parseFlatConfig) but never
+            // consulted here, so a scan key in the file silently did nothing.
+            const scanNumber = (
+                envName: string,
+                storeKey: string,
+                fileValue: number | undefined,
+                fallback: number,
+            ): number =>
+                Number.parseInt(process.env[envName] ?? '', 10) ||
+                (globals[storeKey] as number | undefined) ||
+                fileValue ||
+                fallback;
+            // The one scan knob that spends file descriptors is capped by the
+            // budget in fdBudget.ts — a config.json or env var cannot exceed the
+            // limit the service unit and the Linux launcher grant the process.
+            const scanRequested = scanNumber(
+                'SCAN_CONCURRENCY',
+                'scanConcurrency',
+                fileConfig.scanConcurrency,
+                DEFAULT_SCAN_CONCURRENCY,
+            );
+            const scanClamp = clampScanConcurrency(scanRequested);
+            const scanConcurrency = scanClamp.value;
+            if (scanClamp.clamped) {
+                log.warn(
+                    `scanConcurrency ${scanRequested} exceeds the file-descriptor budget; using ${scanConcurrency} (src/server/fdBudget.ts)`,
+                );
+            }
+            const scanTcpTimeoutMs = scanNumber(
+                'SCAN_TCP_TIMEOUT_MS',
+                'scanTcpTimeoutMs',
+                fileConfig.scanTcpTimeoutMs,
+                DEFAULT_SCAN_TCP_TIMEOUT_MS,
+            );
+            const scanAdbConnectTimeoutMs = scanNumber(
+                'SCAN_ADB_CONNECT_TIMEOUT_MS',
+                'scanAdbConnectTimeoutMs',
+                fileConfig.scanAdbConnectTimeoutMs,
+                DEFAULT_SCAN_ADB_CONNECT_TIMEOUT_MS,
+            );
+            const scanProgressInterval = scanNumber(
+                'SCAN_PROGRESS_INTERVAL',
+                'scanProgressInterval',
+                fileConfig.scanProgressInterval,
+                DEFAULT_SCAN_PROGRESS_INTERVAL,
+            );
 
             const allowedHosts = sanitizeAllowedHosts(fileConfig.allowedHosts, warn);
             const frameAncestors = sanitizeFrameAncestors(fileConfig.frameAncestors, warn);

--- a/src/server/__tests__/SystemdClient.test.ts
+++ b/src/server/__tests__/SystemdClient.test.ts
@@ -140,6 +140,9 @@ describe('SystemdClient', () => {
             expect(out).toContain('Environment=DEPS_PATH=/opt/ws-scrcpy-web/dependencies');
             expect(out).toContain('StartLimitBurst=3');
             expect(out).toContain('StartLimitIntervalSec=300');
+            // The fd budget (src/server/fdBudget.ts): without this the service
+            // ran on systemd's 1024 default, shared with an uncapped scan.
+            expect(out).toContain('LimitNOFILE=4096');
             expect(out).toContain('StandardOutput=append:/opt/ws-scrcpy-web/dependencies/service.log');
             expect(out).toContain('StandardError=append:/opt/ws-scrcpy-web/dependencies/service.log');
             expect(out).toContain('WantedBy=default.target');
@@ -148,6 +151,7 @@ describe('SystemdClient', () => {
 
         it('renders system-scope unit with multi-user.target', () => {
             const out = renderUnitFile(baseOpts, 'system');
+            expect(out).toContain('LimitNOFILE=4096');
             expect(out).toContain('WantedBy=multi-user.target');
             expect(out).not.toContain('default.target');
         });

--- a/src/server/__tests__/config.scanConcurrency.test.ts
+++ b/src/server/__tests__/config.scanConcurrency.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Config } from '../Config';
+import { EnvName } from '../EnvName';
+import { DEFAULT_SCAN_CONCURRENCY, MAX_SCAN_CONCURRENCY } from '../fdBudget';
+
+/**
+ * `scanConcurrency` is the one knob that can spend the process's whole
+ * file-descriptor budget (fdBudget.ts). It accepted any number at all; now it
+ * is capped, at the single site where env, config.json and the store are
+ * merged, so every source is covered.
+ */
+const tmpDirs: string[] = [];
+const saved = {
+    CONFIG: process.env[EnvName.CONFIG_PATH],
+    DEPS: process.env['DEPS_PATH'],
+    SCAN: process.env['SCAN_CONCURRENCY'],
+};
+
+function setup(initialConfig: Record<string, unknown> = {}): void {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-cfg-scan-'));
+    tmpDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ webPort: 8000, ...initialConfig }));
+    process.env[EnvName.CONFIG_PATH] = path.join(dir, 'config.json');
+    process.env['DEPS_PATH'] = path.join(dir, 'deps');
+    Config._resetForTest();
+}
+
+afterEach(() => {
+    Config._resetForTest();
+    if (saved.CONFIG === undefined) delete process.env[EnvName.CONFIG_PATH];
+    else process.env[EnvName.CONFIG_PATH] = saved.CONFIG;
+    if (saved.DEPS === undefined) delete process.env['DEPS_PATH'];
+    else process.env['DEPS_PATH'] = saved.DEPS;
+    if (saved.SCAN === undefined) delete process.env['SCAN_CONCURRENCY'];
+    else process.env['SCAN_CONCURRENCY'] = saved.SCAN;
+    while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('Config.scanConcurrency', () => {
+    it('defaults when nothing sets it', () => {
+        delete process.env['SCAN_CONCURRENCY'];
+        setup();
+        expect(Config.getInstance().scanConcurrency).toBe(DEFAULT_SCAN_CONCURRENCY);
+    });
+
+    it('honours an in-range SCAN_CONCURRENCY', () => {
+        process.env['SCAN_CONCURRENCY'] = '128';
+        setup();
+        expect(Config.getInstance().scanConcurrency).toBe(128);
+    });
+
+    it('caps SCAN_CONCURRENCY at the budget ceiling', () => {
+        process.env['SCAN_CONCURRENCY'] = '100000';
+        setup();
+        expect(Config.getInstance().scanConcurrency).toBe(MAX_SCAN_CONCURRENCY);
+    });
+
+    it('caps a config.json scanConcurrency the same way', () => {
+        delete process.env['SCAN_CONCURRENCY'];
+        setup({ scanConcurrency: MAX_SCAN_CONCURRENCY * 10 });
+        expect(Config.getInstance().scanConcurrency).toBe(MAX_SCAN_CONCURRENCY);
+    });
+
+    it('falls back to the default for a value that is not a number', () => {
+        process.env['SCAN_CONCURRENCY'] = 'lots';
+        setup();
+        expect(Config.getInstance().scanConcurrency).toBe(DEFAULT_SCAN_CONCURRENCY);
+    });
+});

--- a/src/server/__tests__/fdBudget.test.ts
+++ b/src/server/__tests__/fdBudget.test.ts
@@ -1,0 +1,73 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+    clampScanConcurrency,
+    DEFAULT_SCAN_CONCURRENCY,
+    MAX_SCAN_CONCURRENCY,
+    SERVICE_NOFILE_LIMIT,
+} from '../fdBudget';
+
+/**
+ * The budget's arithmetic and its two cross-file pins. The numbers in
+ * fdBudget.ts are only worth anything if they stay in the relationship its
+ * header derives, and if the Rust launcher — which cannot import a TypeScript
+ * constant — carries the same one.
+ */
+describe('fdBudget', () => {
+    it('keeps the worst case comfortably inside the limit it grants', () => {
+        // The header's derivation, restated as arithmetic so a future edit to
+        // either number has to reconcile with it here.
+        const base = 32;
+        const perTab = 6;
+        const perDevice = 8;
+        const tabs = 16;
+        const devices = 16;
+        const worstCase = base + tabs * perTab + devices * perDevice + MAX_SCAN_CONCURRENCY;
+        expect(worstCase).toBe(768);
+        expect(SERVICE_NOFILE_LIMIT).toBeGreaterThanOrEqual(worstCase * 4);
+        // Grantable without privilege on every systemd this app targets: the
+        // oldest hard cap in the wild is 4096.
+        expect(SERVICE_NOFILE_LIMIT).toBeLessThanOrEqual(4096);
+        expect(DEFAULT_SCAN_CONCURRENCY).toBeLessThan(MAX_SCAN_CONCURRENCY);
+    });
+
+    it('is the number the Linux launcher raises its soft limit to before spawning Node', () => {
+        // launcher/src/spawn.rs cannot import this module, so its constant is
+        // pinned here by reading the source. A drift fails this test, not a
+        // user's stream.
+        const spawnRs = fs.readFileSync(
+            path.resolve(__dirname, '..', '..', '..', 'launcher', 'src', 'spawn.rs'),
+            'utf8',
+        );
+        const m = /pub const NOFILE_LIMIT: u64 = (\d+);/.exec(spawnRs);
+        expect(m, 'launcher/src/spawn.rs must declare `pub const NOFILE_LIMIT: u64 = <n>;`').not.toBeNull();
+        expect(Number(m![1])).toBe(SERVICE_NOFILE_LIMIT);
+    });
+
+    describe('clampScanConcurrency', () => {
+        it('passes an in-range value through untouched', () => {
+            expect(clampScanConcurrency(64)).toEqual({ value: 64, clamped: false });
+            expect(clampScanConcurrency(MAX_SCAN_CONCURRENCY)).toEqual({ value: MAX_SCAN_CONCURRENCY, clamped: false });
+            expect(clampScanConcurrency(1)).toEqual({ value: 1, clamped: false });
+        });
+
+        it('brings anything above the cap down to it, and says so', () => {
+            expect(clampScanConcurrency(MAX_SCAN_CONCURRENCY + 1)).toEqual({
+                value: MAX_SCAN_CONCURRENCY,
+                clamped: true,
+            });
+            expect(clampScanConcurrency(100_000)).toEqual({ value: MAX_SCAN_CONCURRENCY, clamped: true });
+        });
+
+        it('falls back to the default for anything that is not a positive number', () => {
+            for (const bad of [undefined, 0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+                expect(clampScanConcurrency(bad)).toEqual({ value: DEFAULT_SCAN_CONCURRENCY, clamped: false });
+            }
+        });
+
+        it('floors a fractional value rather than passing it to a loop counter', () => {
+            expect(clampScanConcurrency(12.9)).toEqual({ value: 12, clamped: false });
+        });
+    });
+});

--- a/src/server/fdBudget.ts
+++ b/src/server/fdBudget.ts
@@ -1,0 +1,78 @@
+/**
+ * The file-descriptor budget: how many the server may hold open, and the one
+ * knob that can spend most of them.
+ *
+ * Why this exists. On Linux the server inherits its parent's soft
+ * RLIMIT_NOFILE, and nothing set one: a systemd service got systemd's
+ * DefaultLimitNOFILE (1024 soft on every mainstream distro), a desktop launch
+ * got the shell's `ulimit -n` (1024 there too). That budget is shared by the
+ * HTTP listener, every browser WebSocket, adb's sockets, the SQLite store, the
+ * log, and — the elephant — the subnet scan, which opens `scanConcurrency`
+ * TCP connects at once and accepted any number at all. The review of PR #506
+ * argued publicly that a 1024-socket sweep would collide with the process
+ * limit outright; that was true, and it was true for our own scanner with a
+ * large enough `SCAN_CONCURRENCY`. This module makes the budget explicit and
+ * ties the two numbers together so neither moves without the other.
+ *
+ * The arithmetic, worst case, per process:
+ *
+ *   base                 32   listener, stdio, log, SQLite (db + wal + shm),
+ *                             adb client sockets, Node's own handles
+ *   per browser tab       6   1–2 HTTP keep-alive + up to 4 WebSockets
+ *                             (device tracker, scan, shell, multiplexer)
+ *   per streamed device   8   video / audio / control over adb forward,
+ *                             the stream WebSocket, probes, file listing
+ *   scan                MAX_SCAN_CONCURRENCY
+ *
+ * Sixteen tabs and sixteen devices at once — well past anything the smoke
+ * has ever run — is 32 + 96 + 128 = 256, plus the scan. With the scan capped
+ * at 512 that is 768; SERVICE_NOFILE_LIMIT is 4096, five times the worst
+ * case, and below the hard limit every systemd since v240 grants (524288)
+ * as well as the 4096 hard cap older units shipped with, so it is always
+ * grantable without privilege. The cap on the scan is the load-bearing half:
+ * it is what keeps a config.json or an env var from spending the budget.
+ *
+ * Who reads this:
+ *   - src/server/service/SystemdClient.ts writes `LimitNOFILE=` into both
+ *     unit scopes (service runs).
+ *   - launcher/src/spawn.rs raises the launcher's own soft limit to the same
+ *     number before it spawns Node, which inherits it (desktop runs on Linux).
+ *     The Rust constant is pinned to this one by fdBudget.test.ts.
+ *   - src/server/Config.ts clamps `scanConcurrency` to MAX_SCAN_CONCURRENCY.
+ *
+ * Windows has no equivalent and needs none: there is no per-process fd
+ * rlimit — sockets are kernel handles, and the CRT's `_setmaxstdio` ceiling
+ * covers only C `FILE*` streams, which libuv does not use. Docker: the engine's
+ * default `nofile` ulimit is 1048576, so the container is never the binding
+ * constraint either.
+ */
+
+/** Default in-flight TCP connects in the scan's probe pool. */
+export const DEFAULT_SCAN_CONCURRENCY = 64;
+
+/** Hard ceiling on `scanConcurrency`, whatever config.json or SCAN_CONCURRENCY says. */
+export const MAX_SCAN_CONCURRENCY = 512;
+
+/**
+ * Soft RLIMIT_NOFILE the service unit and the Linux launcher grant the server.
+ * launcher/src/spawn.rs carries the same number as `NOFILE_LIMIT`.
+ */
+export const SERVICE_NOFILE_LIMIT = 4096;
+
+/**
+ * Resolve a requested scan concurrency to one the budget allows. Anything that
+ * is not a positive finite number falls back to the default; anything above the
+ * cap is brought down to it. Returns the value and whether it was changed, so
+ * the caller can say so in the log — a silently halved setting is a support
+ * ticket.
+ */
+export function clampScanConcurrency(requested: number | undefined): { value: number; clamped: boolean } {
+    if (requested === undefined || !Number.isFinite(requested) || requested <= 0) {
+        return { value: DEFAULT_SCAN_CONCURRENCY, clamped: false };
+    }
+    const value = Math.floor(requested);
+    if (value > MAX_SCAN_CONCURRENCY) {
+        return { value: MAX_SCAN_CONCURRENCY, clamped: true };
+    }
+    return { value, clamped: false };
+}

--- a/src/server/service/SystemdClient.ts
+++ b/src/server/service/SystemdClient.ts
@@ -38,6 +38,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
+import { SERVICE_NOFILE_LIMIT } from '../fdBudget';
 import { Logger } from '../Logger';
 import { fileExists } from '../util/fsExists';
 import type { ServiceClient, ServiceInstallOptions, ServiceStatus } from './ServiceClient';
@@ -214,6 +215,12 @@ export function renderUnitFile(opts: ServiceInstallOptions, scope: SystemdScope)
         `WorkingDirectory=${workingDir}`,
         'Restart=on-failure',
         scope === 'system' ? 'RestartSec=2' : 'RestartSec=5',
+        // The fd budget. Without this the service ran on systemd's
+        // DefaultLimitNOFILE (1024 soft), shared by every WebSocket, adb
+        // socket, the store, the log and an uncapped subnet scan. The number and
+        // its derivation live in src/server/fdBudget.ts; the Linux launcher
+        // grants the same one to a desktop run.
+        `LimitNOFILE=${SERVICE_NOFILE_LIMIT}`,
         ...(envLines ? [envLines] : []),
         `StandardOutput=append:${opts.logPath}`,
         `StandardError=append:${opts.logPath}`,


### PR DESCRIPTION
Closes todo item 75, and fixes a dead config knob found on the way.

## The gap

We set no `LimitNOFILE` anywhere, so on Linux the server ran on whatever `RLIMIT_NOFILE` it inherited: systemd's `DefaultLimitNOFILE` (1024 soft) as a service, the shell's `ulimit -n` (also 1024) on a desktop launch. That budget is shared by the HTTP listener, every browser WebSocket, adb's sockets, the SQLite store, the log, and the subnet scan — which holds `scanConcurrency` TCP connects open at once and **accepted any number at all**. The argument made publicly on #506 (a 1024-socket sweep collides with the process limit) was just as true of our own scanner with a large enough `SCAN_CONCURRENCY`.

## What this does

One module owns the numbers and their derivation — `src/server/fdBudget.ts`:

| | |
|---|---|
| base (listener, stdio, log, SQLite ×3, adb sockets, Node) | 32 |
| per browser tab (keep-alive + ≤4 WebSockets) | 6 |
| per streamed device (video/audio/control forwards, WS, probes, file listing) | 8 |
| scan | `MAX_SCAN_CONCURRENCY` = **512** |
| worst case: 16 tabs + 16 devices + scan at the cap | **768** |
| `SERVICE_NOFILE_LIMIT` | **4096** — 5× the worst case, ≤ the oldest hard cap in the wild, so always grantable unprivileged |

Three readers of that module:

1. **`SystemdClient.ts`** writes `LimitNOFILE=4096` into both unit scopes.
2. **`launcher/src/spawn.rs`** raises the launcher's *own* soft limit to `NOFILE_LIMIT` (or the hard cap if lower) before it spawns Node, which inherits it — rlimits survive `exec` and `Command` has no per-child API. Never lowers an already-higher limit, never touches the hard one, logs and continues on failure. `rustix` (`process` feature) was already the Linux dependency; the API is `getrlimit(Resource::Nofile) -> Rlimit { current, maximum }` / `setrlimit(Resource, Rlimit)`, verified against the 1.1.4 crate source, not the docs summary (which has a different, wrong signature).
3. **`Config.ts`** clamps `scanConcurrency` to the cap at the one site where env, store and file are merged, with a `warn` line naming the requested and applied values.

**Cross-language pin:** `fdBudget.test.ts` reads `spawn.rs` and asserts `pub const NOFILE_LIMIT: u64 = 4096;` equals the TypeScript constant. The two cannot drift silently.

**Windows:** no per-process fd rlimit exists (sockets are kernel handles; `_setmaxstdio` covers C `FILE*` only) — unchanged, and the module says why. **Docker:** the engine's default `nofile` ulimit is 1048576 — unchanged.

## Found on the way: `config.json`'s `scan*` keys did nothing

`scanConcurrency`, `scanTcpTimeoutMs`, `scanAdbConnectTimeoutMs` and `scanProgressInterval` are documented as `config.json` keys (TECHNICAL_GUIDE §14.2.5), parsed by `parseFlatConfig`, and were **never consulted** — the merge read only the env var and the per-user store. My "cap a config.json value" test came back with the default and that is how it surfaced. They are now read in the documented order (env → store → file → default), the same precedence `adbPath` already uses at that site. Same call site as the clamp, so it is in this PR rather than logged; the CHANGELOG has its own entry.

## Verification

- `fdBudget.test.ts`: the arithmetic restated as assertions; the Rust pin; clamp edges (in-range, above cap, non-numbers, fractional).
- `config.scanConcurrency.test.ts`: default, in-range env, capped env, capped `config.json`, non-numeric env.
- `SystemdClient.test.ts`: `LimitNOFILE=4096` in both scopes.
- `spawn.rs`: a Linux-only test that the raise reaches the budget and a second call is a no-op.
- Full vitest 209 files / 1874 passed; `tsc`, `test:e2e:types`, `npm run lint` clean; Windows `cargo test` (56 + 141 + 1 + 4) and `cargo clippy -D warnings` clean.
- **The Linux `cfg` block is compiled only by CI's ubuntu Rust leg** — the standing note in the todo's operational block. Watch that step.

No smoke row describes any of this; `docs/smoke-tests/smoke-test.md` is untouched.
