### PR TITLE
docs: Intel-Mac node-pty prebuilts closed as won't-fix (item 70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Intel-Mac (`darwin x64`) node-pty prebuilts are closed as won't-fix**, by decision rather than by
+  omission. TECHNICAL_GUIDE §18.2 now says so beside the existing explanation (Apple-silicon-only
+  runners; Intel Macs no longer sold since 2023). Nothing changes for users: an Intel Mac runs the app
+  with the shell modal reporting `no-prebuilt-for-abi-…`, exactly as before.
+
 ## [0.1.30-beta.107] - 2026-09-06
 
 ### Fixed

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1618,7 +1618,12 @@ shell-disabled UI; everything else keeps working.
 - **`darwin x64` (Intel Macs)** — GitHub's macOS runners are Apple silicon.
   Producing an Intel tarball would mean cross-compiling with
   `npm_config_arch=x64` and publishing a binary no runner can load, let
-  alone test, which is a worse trade than the shell-disabled UI.
+  alone test, which is a worse trade than the shell-disabled UI. **Closed as
+  won't-fix on 2026-09-06** (user decision, todo item 70): Apple stopped
+  selling Intel Macs in 2023, so this population only shrinks. An Intel Mac
+  runs everything except the shell modal, which reports
+  `{ available: false, reason: 'no-prebuilt-for-abi-…' }`; not a gap awaiting
+  hardware.
 
 **The Alpine legs pull a MAJOR Docker tag (`node:24-alpine`), never an exact
 patch.** nodejs.org publishes a release the moment it is cut; the official


### PR DESCRIPTION
Closes todo item 70 by recording the user's decision (option c, 2026-09-06): no `darwin x64` node-pty prebuilt, ever. One sentence in TECHNICAL_GUIDE §18.2 beside the existing why (Apple-silicon-only runners; Intel Macs not sold since 2023), plus a CHANGELOG line under Changed. No code change; behaviour on an Intel Mac is unchanged (shell modal reports `no-prebuilt-for-abi-…`).