### PR TITLE
fix(client): port hand-offs stay on the browser's own origin, never a literal localhost (item 112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Port hand-offs no longer send off-box browsers to their own `localhost`.** A service install
+  (shifting to the service's port), a service uninstall (discovering the fresh local instance), a
+  web-port save and the first-run "install as a service" path all navigated to a literal
+  `http://localhost:<port>/`, which is only right for a browser on the serving machine — a LAN
+  client, a hostname, a reverse proxy or a container runner lost the app. They now keep the origin
+  the browser is already on and change only the port (`sameOriginUrl`); `PATCH /api/config` returns
+  `redirectPort` instead of a server-built `redirectTo` URL, since the server cannot know the
+  client's host. The "this app lives at:" links in the welcome, bookmark and service-first-run
+  reminders show the browser's own address for the same reason. Found by qa-harness Arc 1b
+  (smoke rows 4.3 / 12.2).
+
 ## [0.1.30-beta.108] - 2026-09-06
 
 ### Added

--- a/src/app/client/PortChangeModal.ts
+++ b/src/app/client/PortChangeModal.ts
@@ -1,3 +1,4 @@
+import { sameOriginBase } from '../sameOriginUrl';
 import { Modal } from '../ui/Modal';
 import { ConfirmModal } from './ConfirmModal';
 import { settingsService } from './SettingsService';
@@ -67,7 +68,9 @@ export class PortChangeModal extends Modal {
     }
 
     private fillBody(container: HTMLElement): void {
-        const url = `http://localhost:${this.opts.webPort}`;
+        // The address THIS browser reached the app on, not the serving machine's
+        // loopback — a LAN user bookmarks their own URL.
+        const url = sameOriginBase(this.opts.webPort);
 
         const lead = document.createElement('p');
         lead.style.cssText = 'margin: 0 0 12px;';

--- a/src/app/client/ServiceFirstRunModal.ts
+++ b/src/app/client/ServiceFirstRunModal.ts
@@ -1,3 +1,4 @@
+import { sameOriginBase } from '../sameOriginUrl';
 import { Modal } from '../ui/Modal';
 import { settingsService } from './SettingsService';
 
@@ -75,7 +76,9 @@ export class ServiceFirstRunModal extends Modal {
         );
         container.appendChild(intro);
 
-        const url = `http://localhost:${this.opts.webPort}`;
+        // The address THIS browser reached the app on, not the serving machine's
+        // loopback — a LAN user bookmarks their own URL.
+        const url = sameOriginBase(this.opts.webPort);
         const urlPara = document.createElement('p');
         urlPara.style.cssText = 'margin: 0 0 12px;';
         urlPara.appendChild(document.createTextNode('this page lives at: '));

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -5,6 +5,7 @@ import type {
     ServiceUninstallResponse,
 } from '../../common/ServiceEvents';
 import type { UpdatesConfigPatchRequest, UpdatesStatusResponse } from '../../common/UpdateEvents';
+import { sameOriginUrl } from '../sameOriginUrl';
 import { Modal } from '../ui/Modal';
 import { AdminConfirmModal, type AdminConfirmOptions } from './AdminConfirmModal';
 import { authClient, type Role } from './AuthClient';
@@ -1178,9 +1179,14 @@ export class SettingsModal extends Modal {
             this.currentWebPort = data.config.webPort;
             if (data.restartRequired) {
                 this.setServerStatus('restarting → redirecting…', false);
-                if (data.redirectTo) {
+                // The server names only the PORT; the host is whatever this
+                // browser is already on. It used to send a full
+                // http://localhost:<port> URL, which took off-box clients to
+                // their own machine.
+                const redirectPort = data.redirectPort;
+                if (typeof redirectPort === 'number') {
                     setTimeout(() => {
-                        window.location.href = data.redirectTo!;
+                        window.location.href = sameOriginUrl(redirectPort);
                     }, 4000);
                 }
             } else {
@@ -1924,7 +1930,10 @@ export class SettingsModal extends Modal {
                 switch (outcome.kind) {
                     case 'navigate':
                         clearInterval(poll);
-                        window.location.href = `http://localhost:${outcome.port}/`;
+                        // Same host the browser is on, new port. A literal
+                        // localhost here sent every off-box client to its
+                        // own machine (qa-harness Arc 1b, rows 4.3 / 12.2).
+                        window.location.href = sameOriginUrl(outcome.port);
                         return;
                     case 'reconnect':
                         // Same-port handoff: reload the current URL after a short
@@ -2053,7 +2062,7 @@ export class SettingsModal extends Modal {
                             discoverData.webPort != null
                         ) {
                             clearInterval(poll);
-                            window.location.href = `http://localhost:${discoverData.webPort}/`;
+                            window.location.href = sameOriginUrl(discoverData.webPort);
                         }
                     } catch {
                         if (!serverDied) {

--- a/src/app/client/WelcomeModal.ts
+++ b/src/app/client/WelcomeModal.ts
@@ -1,4 +1,5 @@
 import type { ServiceInstallResponse, ServiceStatusResponse } from '../../common/ServiceEvents';
+import { sameOriginBase, sameOriginUrl } from '../sameOriginUrl';
 import { Modal } from '../ui/Modal';
 import { ServiceOperationModal } from './ServiceOperationModal';
 import { settingsService } from './SettingsService';
@@ -61,7 +62,9 @@ export class WelcomeModal extends Modal {
         intro.style.cssText = 'margin: 0 0 8px;';
         intro.appendChild(document.createTextNode('server is running on '));
         const link = document.createElement('a');
-        const url = `http://localhost:${this.opts.webPort}`;
+        // The address THIS browser reached the app on, not the serving
+        // machine's loopback — a LAN user bookmarks their own URL.
+        const url = sameOriginBase(this.opts.webPort);
         link.href = url;
         link.target = '_blank';
         link.rel = 'noopener';
@@ -358,8 +361,10 @@ export class WelcomeModal extends Modal {
                         clearInterval(poll);
                         modal.close();
                         this.setStatus('service mode active. switching you over…');
+                        const servicePort = statusData.diskWebPort;
                         setTimeout(() => {
-                            window.location.href = `http://localhost:${statusData.diskWebPort}/`;
+                            // Same host, new port — never a literal localhost.
+                            window.location.href = sameOriginUrl(servicePort);
                         }, 500);
                     }
                 } catch {

--- a/src/app/sameOriginUrl.test.ts
+++ b/src/app/sameOriginUrl.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { sameOriginBase, sameOriginUrl } from './sameOriginUrl';
+
+// qa-harness Arc 1b (2026-09-06): every post-install / post-uninstall /
+// port-change hand-off navigated to `http://localhost:<port>/`, so a browser
+// that was not on the serving machine was sent to its own localhost. The port
+// is the only thing a hand-off changes; the host must be whatever the browser
+// is already using.
+describe('sameOriginUrl', () => {
+    it('keeps a LAN host and changes only the port', () => {
+        expect(sameOriginUrl(8001, 'http://192.168.87.3:8000/')).toBe('http://192.168.87.3:8001/');
+    });
+
+    it('never rewrites a non-loopback host to localhost (the reported bug)', () => {
+        for (const base of ['http://192.168.87.3:8000/', 'http://wssw.lan:8000/', 'https://ws.example.com/']) {
+            expect(sameOriginUrl(8001, base)).not.toContain('localhost');
+        }
+    });
+
+    it('lands on the root: path, query and hash are cleared', () => {
+        expect(sameOriginUrl(8001, 'http://wssw.lan:8000/settings?tab=server#service')).toBe('http://wssw.lan:8001/');
+    });
+
+    it('keeps the scheme, so an https deployment stays https', () => {
+        expect(sameOriginUrl(8001, 'https://ws.example.com:8000/')).toBe('https://ws.example.com:8001/');
+    });
+
+    it('drops a port that is the default for the scheme rather than printing it', () => {
+        expect(sameOriginUrl(443, 'https://ws.example.com:8000/')).toBe('https://ws.example.com/');
+        expect(sameOriginUrl(80, 'http://wssw.lan:8000/')).toBe('http://wssw.lan/');
+    });
+
+    it('keeps IPv6 brackets', () => {
+        expect(sameOriginUrl(8001, 'http://[::1]:8000/')).toBe('http://[::1]:8001/');
+        expect(sameOriginUrl(8001, 'http://[fd00::a1]:8000/devices')).toBe('http://[fd00::a1]:8001/');
+    });
+
+    it('is a no-op change of host for the serving machine itself', () => {
+        expect(sameOriginUrl(8001, 'http://localhost:8000/')).toBe('http://localhost:8001/');
+        expect(sameOriginUrl(8001, 'http://127.0.0.1:8000/')).toBe('http://127.0.0.1:8001/');
+    });
+
+    it('defaults its base to the current window location', () => {
+        // jsdom's default location; only the port and the root path are ours.
+        const here = new URL(window.location.href);
+        const out = new URL(sameOriginUrl(9999));
+        expect(out.protocol).toBe(here.protocol);
+        expect(out.hostname).toBe(here.hostname);
+        expect(out.port).toBe('9999');
+        expect(out.pathname).toBe('/');
+    });
+});
+
+describe('sameOriginBase', () => {
+    it('is the origin only, for "this app lives at …" text — no trailing slash', () => {
+        expect(sameOriginBase(8000, 'http://192.168.87.3:8000/devices')).toBe('http://192.168.87.3:8000');
+        expect(sameOriginBase(8001, 'http://localhost:8000/')).toBe('http://localhost:8001');
+    });
+
+    it('drops a default port there too', () => {
+        expect(sameOriginBase(443, 'https://ws.example.com:8000/')).toBe('https://ws.example.com');
+    });
+});

--- a/src/app/sameOriginUrl.ts
+++ b/src/app/sameOriginUrl.ts
@@ -1,0 +1,32 @@
+/**
+ * The same app on another port — same scheme, same host, only the port changed.
+ *
+ * Every hand-off that moves the browser to a different port (service install
+ * shifting to the service's port, uninstall discovering the fresh local
+ * instance, a web-port save, the first-run install) used to navigate to
+ * `http://localhost:<port>/`. That is right only for a browser on the serving
+ * machine: a LAN client, a hostname, a reverse proxy or a container runner was
+ * sent to its OWN localhost and lost the app (qa-harness Arc 1b finding,
+ * 2026-09-06; smoke rows 4.3 / 12.2). The port is the one thing a hand-off
+ * changes, so keep everything else the browser already has.
+ *
+ * `URL` does the fiddly parts: IPv6 hosts keep their brackets, and a port that
+ * is the scheme's default (80 / 443) is dropped rather than printed.
+ */
+
+/** Navigation target: `<scheme>//<host>:<port>/` with path, query and hash cleared. */
+export function sameOriginUrl(port: number, base: string = window.location.href): string {
+    const url = new URL(base);
+    url.port = String(port);
+    url.pathname = '/';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+}
+
+/** Display form for "this app lives at …": the origin only, no trailing slash. */
+export function sameOriginBase(port: number, base: string = window.location.href): string {
+    const url = new URL(base);
+    url.port = String(port);
+    return url.origin;
+}

--- a/src/common/ConfigEvents.ts
+++ b/src/common/ConfigEvents.ts
@@ -75,12 +75,18 @@ export interface AppConfigPatchResponse {
     config: AppConfig;
     restartRequired: boolean;
     /**
-     * v0.1.8: when `restartRequired` is true, the server will request a
-     * supervisor-driven restart shortly after responding. This URL is
-     * where the frontend should redirect the user once the new server
-     * is up. Absent when no restart is needed.
+     * When `restartRequired` is true, the server requests a supervisor-driven
+     * restart shortly after responding and the new server binds THIS port.
+     * The frontend navigates to it on the origin the browser already uses
+     * (`sameOriginUrl`). Absent when no restart is needed.
+     *
+     * Until 2026-09-06 this was `redirectTo`, a full `http://localhost:<port>`
+     * URL built server-side — right only for a browser on the serving machine;
+     * every off-box client was sent to its own localhost (qa-harness Arc 1b).
+     * The server cannot know the client's host reliably, so it names the port
+     * and nothing else.
      */
-    redirectTo?: string;
+    redirectPort?: number;
 }
 
 /**

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -81,25 +81,17 @@ export interface ServiceActionSuccess {
     status: ServiceStatus;
     installMode: 'user' | 'system' | 'user-service' | 'system-service';
     /**
-     * v0.1.8 install-flow auto-redirect: when the install succeeds and
-     * the new service-instance has been verified reachable on a port
-     * different from this (local) instance's port, this field carries
-     * the URL the frontend should navigate to. The local instance
-     * schedules its own shutdown shortly after responding so the user
-     * doesn't end up with two app instances fighting for the tray.
-     *
-     * Absent when no redirect is needed (e.g., service install
-     * succeeded but the new instance is unreachable for some reason —
-     * frontend should fall back to refreshing the home page).
-     */
-    redirectTo?: string;
-    /**
      * v0.1.8 uninstall-flow Path A handoff: present when the request
      * came from a service-context API and the server has spawned a
      * fresh user-session local launcher to take over. Frontend
-     * navigates to `redirectTo` with this token in the URL params; the
-     * new local instance reads `?resume=uninstall-service&token=...`,
+     * navigates to the fresh instance with this token in the URL params;
+     * the new local instance reads `?resume=uninstall-service&token=...`,
      * validates it, and auto-fires the uninstall click.
+     *
+     * (The v0.1.8 `redirectTo` URL that used to sit beside this field was
+     * retired by the §39 mtime-poll discovery — the server stopped
+     * producing it in May 2026 — and the type followed on 2026-09-06 when
+     * every remaining server-built `http://localhost` URL was removed.)
      */
     resumeToken?: string;
     /** config.json mtime snapshot at response time (epoch ms). Frontend uses as baseline for polling. */

--- a/src/server/__tests__/configApi.redirectPort.test.ts
+++ b/src/server/__tests__/configApi.redirectPort.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigApi } from '../api/ConfigApi';
+import { Config } from '../Config';
+import { EnvName } from '../EnvName';
+import { makeReqRes } from './helpers/httpMock';
+
+/**
+ * PATCH /api/config with a port change names the NEW PORT and nothing else.
+ *
+ * Until 2026-09-06 the response carried `redirectTo: "http://localhost:<port>"`,
+ * a URL the server built for the browser to follow. The server cannot know the
+ * host the browser is on — a LAN client, a hostname, a reverse proxy and the
+ * qa-harness container runner were all sent to their own localhost and lost the
+ * app (Arc 1b, smoke rows 4.3 / 12.2). The client now builds the URL itself
+ * from `redirectPort` on the origin it already uses (`sameOriginUrl`).
+ */
+
+const tmpDirs: string[] = [];
+const saved = {
+    CONFIG: process.env[EnvName.CONFIG_PATH],
+    DEPS: process.env['DEPS_PATH'],
+    DATA_ROOT: process.env['DATA_ROOT'],
+};
+
+function setup(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wscfgapi-'));
+    tmpDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ webPort: 8000 }));
+    process.env[EnvName.CONFIG_PATH] = path.join(dir, 'config.json');
+    process.env['DEPS_PATH'] = path.join(dir, 'deps');
+    // The handler writes the `.restart` marker under the data root. Point it at
+    // the temp dir, never at the machine's real ProgramData root.
+    process.env['DATA_ROOT'] = dir;
+    Config._resetForTest();
+    return dir;
+}
+
+function restore(key: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Config._resetForTest();
+    restore(EnvName.CONFIG_PATH, saved.CONFIG);
+    restore('DEPS_PATH', saved.DEPS);
+    restore('DATA_ROOT', saved.DATA_ROOT);
+    while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('PATCH /api/config port change', () => {
+    it('answers a port change with redirectPort and never a server-built URL', async () => {
+        const dir = setup();
+        // The handler schedules process.exit(75) one second after answering so
+        // the supervisor restarts it on the new port. Neither may happen here:
+        // fake the timer so it never fires, and stub exit in case it does.
+        vi.useFakeTimers({ toFake: ['setTimeout'] });
+        const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+        const { req, res, getStatus, getJson } = makeReqRes('PATCH', '/api/config', { webPort: 8011 });
+        expect(await new ConfigApi().handle(req, res)).toBe(true);
+        expect(getStatus()).toBe(200);
+
+        const body = getJson() as Record<string, unknown>;
+        expect(body['restartRequired']).toBe(true);
+        expect(body['redirectPort']).toBe(8011);
+        expect(body).not.toHaveProperty('redirectTo');
+        // The whole contract in one line: nothing in the answer names a host.
+        expect(JSON.stringify(body)).not.toContain('localhost');
+
+        // The restart half still fires: the marker is written, the exit is
+        // scheduled but has not happened.
+        expect(fs.existsSync(path.join(dir, '.restart'))).toBe(true);
+        expect(exit).not.toHaveBeenCalled();
+    });
+
+    it('omits redirectPort when nothing needs a restart', async () => {
+        setup();
+        const { req, res, getStatus, getJson } = makeReqRes('PATCH', '/api/config', { firstRunComplete: true });
+        expect(await new ConfigApi().handle(req, res)).toBe(true);
+        expect(getStatus()).toBe(200);
+        const body = getJson() as Record<string, unknown>;
+        expect(body['restartRequired']).toBe(false);
+        expect(body).not.toHaveProperty('redirectPort');
+        expect(body).not.toHaveProperty('redirectTo');
+    });
+});

--- a/src/server/api/ConfigApi.ts
+++ b/src/server/api/ConfigApi.ts
@@ -62,16 +62,17 @@ export class ConfigApi {
                     };
 
                     // v0.1.8: when a port change requires a restart,
-                    // build the redirect URL pointing at the new port
-                    // and schedule the actual restart via the existing
-                    // .restart marker + exit-75 mechanism. The
-                    // launcher's supervisor will pick up the marker,
-                    // restart Node, and the new server binds the new
-                    // port. The browser redirects 3s after the
-                    // response, by which time the new server should
-                    // be listening.
+                    // name the new port and schedule the actual restart
+                    // via the existing .restart marker + exit-75
+                    // mechanism. The launcher's supervisor will pick up
+                    // the marker, restart Node, and the new server binds
+                    // the new port. The browser navigates to that port on
+                    // its OWN origin a few seconds after the response, by
+                    // which time the new server should be listening.
+                    // (Only the port: a server-built http://localhost URL
+                    // sent every off-box client to its own machine.)
                     if (result.restartRequired) {
-                        response.redirectTo = `http://localhost:${result.config.webPort}`;
+                        response.redirectPort = result.config.webPort;
                         const markerPath = cfg.restartMarkerPath;
                         try {
                             writeFileAtomicSync(markerPath, `restart-requested-${Date.now()}`);


### PR DESCRIPTION
## Why

qa-harness Arc 1b (finding 1, high): after a service install, a service uninstall, a web-port save or the first-run "install as a service" path, the browser was sent to a literal `http://localhost:<port>/`. That is right only for a browser on the serving machine — a LAN client, a hostname, a reverse proxy or the harness's container runner all landed on their own localhost and lost the app. The port shift itself (8000 → 8001 on service install) is correct; only the host was wrong. Smoke rows 4.3 and 12.2 could only be verified guest-side because of it. Todo item 112.

## What

- **`src/app/sameOriginUrl.ts`** — `sameOriginUrl(port)` (navigation) and `sameOriginBase(port)` (display) keep the scheme and host the browser already uses and change only the port; `URL` handles IPv6 brackets and drops a default port. Ten unit tests, including "never yields localhost for a non-loopback host".
- **Call sites** — `SettingsModal` (install navigate, uninstall discover, web-port save), `WelcomeModal` (first-run install). The "this app lives at:" links in the welcome, bookmark and service-first-run reminders now show the browser's own address (`PortChangeModal`, `ServiceFirstRunModal`, `WelcomeModal`).
- **`PATCH /api/config`** returns `redirectPort` (a number) instead of a server-built `redirectTo` URL — the server cannot know the client's host. `configApi.redirectPort.test.ts` pins the contract (no host in the answer; the `.restart` marker still lands; `process.exit(75)` is only scheduled). The never-produced `redirectTo` on `ServiceInstallResponse` is removed with it.
- CHANGELOG under Unreleased.

Not touched on purpose: the launcher's own `http://localhost` browser-opens (`main.rs`, `linux_service.rs`) run on the box and are correct; the operation-server's post-update redirect string has no client consumer (`UpgradingOverlay` polls `window.location.origin`).

## Smoke rows

4.3 and 12.2 keep their wording ("redirects"). No row semantics change.

## Verified

- `npm run lint` clean; `tsc --noEmit` clean; `npm run build` OK.
- vitest: `sameOriginUrl.test.ts` 10/10, `configApi.redirectPort.test.ts` 2/2, plus `ServiceApi`, `settingsApi` and every client modal suite green (80 + 253 tests).
- Fast-tier e2e against the built `dist/`: 46/46.

## For qa-harness

Once this beta is published, re-pin the lock and upgrade rows 4.3 / 12.2 from guest-side-only to full DOM verification. Finding 2 (the blocking reminders) follows in its own beta (todo item 113).
