### PR TITLE
fix(server): the tray's shutdown POST is token-exempt and loopback-only, so Exit works again (item 114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The Windows tray's "Exit" works again.** The tray helper POSTs `/api/server/shutdown` cookielessly —
   it is a process, not a browser — and the per-instance token gate has answered it `403 {"reason":"missing
   or invalid token"}` since that gate shipped, so clicking Exit → Yes killed only the tray icon (the
-  launcher's supervisor put it back within ten seconds) and left the server running. Measured against a
-  real server, both before and after. That POST is now exempt from the token, and `ServerShutdownApi`
-  refuses any caller that is not on loopback (403, with nothing scheduled and nothing exited), the same
-  shape `WhoamiApi` uses. A unit test had encoded the broken behaviour as correct; it now pins the fix.
-  **Locked mode is unchanged and still 401s the tray** — exempting AuthGate would let `requireAdmin` fall
-  back to the implicit admin for a cookieless caller, which that gate's fail-closed rule forbids; whether
-  a loopback process may stop a locked-mode server is an operator policy question, tracked separately.
+  launcher's supervisor put it back within ten seconds) and left the server running. In service mode that
+  Exit is the only stop affordance the product has. The endpoint is now exempt from the token gate and
+  from AuthGate, and `ServerShutdownApi` authorizes callers itself: **on loopback it is allowed** — the
+  operator's own machine, an explicit decision whose trade is that any local process can stop the server,
+  including a system-scope service — while an **off-box caller is treated exactly as before**, needing the
+  instance token (403 without it) and, in locked mode, a signed-in session (401). `requireAdmin` still runs
+  last, so a signed-in non-admin cannot stop the server from anywhere. A unit test had encoded the broken
+  behaviour as correct (`requiresToken('POST', '/api/server/shutdown') === true`); it now pins the fix.
+  New smoke row **15.6**. All five paths measured against a real server, open and locked.
 
 ## [0.1.30-beta.111] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Windows tray's "Exit" works again.** The tray helper POSTs `/api/server/shutdown` cookielessly —
+  it is a process, not a browser — and the per-instance token gate has answered it `403 {"reason":"missing
+  or invalid token"}` since that gate shipped, so clicking Exit → Yes killed only the tray icon (the
+  launcher's supervisor put it back within ten seconds) and left the server running. Measured against a
+  real server, both before and after. That POST is now exempt from the token, and `ServerShutdownApi`
+  refuses any caller that is not on loopback (403, with nothing scheduled and nothing exited), the same
+  shape `WhoamiApi` uses. A unit test had encoded the broken behaviour as correct; it now pins the fix.
+  **Locked mode is unchanged and still 401s the tray** — exempting AuthGate would let `requireAdmin` fall
+  back to the implicit admin for a cookieless caller, which that gate's fail-closed rule forbids; whether
+  a loopback process may stop a locked-mode server is an operator policy question, tracked separately.
+
 ## [0.1.30-beta.111] - 2026-09-06
 
 ### Added

--- a/docs/smoke-tests/automation-coverage.md
+++ b/docs/smoke-tests/automation-coverage.md
@@ -6,32 +6,34 @@ does. Companion to `smoke-test.md`, not a replacement — that document remains 
 canonical list of rows and their steps.
 
 Derived from `smoke-test.md` at `v0.1.30-beta.92`, which held **140 rows**; item 63
-(the Linux tray, 2026-09-06) added rows 14.8 and 14.9, so the doc holds **142**. Row
-ids are stable and gappy; so are the lines here.
+(the Linux tray, 2026-09-06) added 14.8 and 14.9 and item 114 (the tray's Exit, same
+day) added 15.6, so the doc holds **143**. Row ids are stable and gappy; so are the
+lines here.
 
 | | Rows | Where |
 |---|---|---|
 | Automated, fast tier | 30 | `build-and-test`, every PR |
 | Automated, container tier | 11 | `build-and-test`'s docker step, and qa-harness nightly |
 | Automated, device tier | 17 | qa-harness, nightly |
-| Windows guest | 25 | qa-harness, nightly, once P4 lands |
+| Windows guest | 26 | qa-harness, nightly, once P4 lands |
 | Windows guest **and** Linux residual | 2 | Windows half P4; Linux half nobody |
 | Automatable, no spec written yet | 0 | — (the six of 2026-09-04 were written 2026-09-06, item 104) |
 | **Residual — Linux installer and desktop** | **50** | nobody (14.8 / 14.9 are assertable by qa-harness item 14's Linux guests) |
 | **Residual — un-automatable** | **7** | nobody, ever |
-| **Total** | **142** | |
+| **Total** | **143** | |
 
-**Automated today: 58 of 142 = 41 %.** After P4: 83 of 142 = 58 %, plus the
+**Automated today: 58 of 143 = 41 %.** After P4: 84 of 143 = 59 %, plus the
 Windows halves of the two split rows. (52 / 37 % and 77 / 55 % until 2026-09-06,
 when item 104 wrote the six specs this table used to list as "automatable, no
-spec"; the denominator was 140 until item 63 added the two tray rows.)
+spec"; the denominator was 140 until item 63 added the two tray rows and item 114
+added 15.6.)
 
 Three different row counts have been quoted for this document, and only one of them
 is wrong. The plan that commissioned this register worked from **127**, which was
 the correct count for `v0.1.30-beta.82` — the version it named. Module 20's
 thirteen container rows were added afterwards by P3 task 5, and nothing has been
-removed since, so 127 + 13 = 140 (item 63's two tray rows make it 142 as of
-2026-09-06). A count of **135** also circulated while this
+removed since, so 127 + 13 = 140 (item 63's two tray rows and item 114's 15.6 make
+it 143 as of 2026-09-06). A count of **135** also circulated while this
 task was being scoped, and that one is a miscount: it matches row ids as
 `<module>.<number>`, which silently drops the five that carry a suffix —
 `4.2-user`, `4.2-system-cli`, `4.2-system-gui`, `5.3a` and `5.3b`. All five are
@@ -188,6 +190,7 @@ Sorted by module, then by row number, which is not the doc's execution order.
 | 15.3 | `[Win]` | Uninstall modal UX | Windows guest (P4) | P4, the qa-harness Windows guest suite. Not yet automated. |
 | 15.4 | `[Win]` | Stop-exit reaps tray + adb | Windows guest (P4) | P4, the qa-harness Windows guest suite. Not yet automated. |
 | 15.5 | `[Win]` | Server-section order | Windows guest (P4) | P4, the qa-harness Windows guest suite. Not yet automated. |
+| 15.6 | `[Win]` | Tray Exit actually stops the server | Windows guest (P4) | P4, the qa-harness Windows guest suite — it needs a real tray icon to right-click (its item 21 covers the Win11 overflow + right-click delivery). The gate half is unit-tested (`ServerShutdownApi.test.ts`, `instanceToken.test.ts`); this row is the end-to-end one. |
 | 16.1 | `[Both]` | Light/dark theme switch | fast | `a11y-theming.spec.ts` |
 | 16.2 | `[Both]` | Keyboard focus ring | fast | `a11y-theming.spec.ts` |
 | 16.3 | `[Both]` | Reduced motion | fast | `a11y-theming.spec.ts` |

--- a/docs/smoke-tests/smoke-test.md
+++ b/docs/smoke-tests/smoke-test.md
@@ -115,7 +115,7 @@ By-feature lookup into the run rows below (numeric order; the body itself is exe
 - **Module 12 — Stop server & exit:** [12.1](#t-12-1) · [12.2](#t-12-2) · [12.3](#t-12-3) · [12.4](#t-12-4) · [12.5](#t-12-5)
 - **Module 13 — Settings: bookmark & reset prompts:** [13.1](#t-13-1) · [13.2](#t-13-2) · [13.3](#t-13-3)
 - **Module 14 — Linux Server-section UX:** [14.1](#t-14-1) · [14.2](#t-14-2) · [14.3](#t-14-3) · [14.4](#t-14-4) · [14.5](#t-14-5) · [14.6](#t-14-6) · [14.7](#t-14-7) · [14.8](#t-14-8) · [14.9](#t-14-9)
-- **Module 15 — Windows Server-section uninstall + stop-exit:** [15.1](#t-15-1) · [15.2](#t-15-2) · [15.3](#t-15-3) · [15.4](#t-15-4) · [15.5](#t-15-5)
+- **Module 15 — Windows Server-section uninstall + stop-exit:** [15.1](#t-15-1) · [15.2](#t-15-2) · [15.3](#t-15-3) · [15.4](#t-15-4) · [15.5](#t-15-5) · [15.6](#t-15-6)
 - **Module 16 — Accessibility & theming:** [16.1](#t-16-1) · [16.2](#t-16-2) · [16.3](#t-16-3) · [16.4](#t-16-4) · [16.5](#t-16-5) · [16.6](#t-16-6)
 - **Module 18 — Auth subsystem (opt-in login):** [18.1](#t-18-1) · [18.2](#t-18-2) · [18.3](#t-18-3) · [18.4](#t-18-4) · [18.5](#t-18-5) · [18.6](#t-18-6) · [18.7](#t-18-7) · [18.8](#t-18-8) · [18.9](#t-18-9) · [18.10](#t-18-10) · [18.11](#t-18-11) · [18.12](#t-18-12)
 - **Module 19 — Per-user device labels:** [19.1](#t-19-1) · [19.2](#t-19-2) · [19.3](#t-19-3)
@@ -315,6 +315,7 @@ Mark each `☐`: `x` pass · `F` fail · `-` skip. Boxes start empty — this is
 | ☐ <a id="t-15-3"></a> **15.3** `[Win]` Uninstall modal UX | Open the uninstall modal | Top-layer overlay above Settings; **cancel** white-outline, **uninstall** red text + red border; keep checkbox **checked by default**; cancel/Esc/backdrop = no action. |
 | ☐ <a id="t-15-4"></a> **15.4** `[Win]` Stop-exit reaps tray + adb *(item 4)* | Local mode, device + stream live → Settings → **Server** → **stop server & exit** | Tab closes / "app stopped"; Task Manager shows **no** lingering launcher/node/tray/`adb.exe` — the tray is reaped (poll thread stopped first) **and** stray adb is `taskkill`'d. |
 | ☐ <a id="t-15-5"></a> **15.5** `[Win]` Server-section order | Settings → Server | Order top→bottom: **reset prompts → web port → stop server & exit → uninstall ws-scrcpy-web** (no "install for all users" on Windows). |
+| ☐ <a id="t-15-6"></a> **15.6** `[Win]` Tray Exit actually stops the server *(item 114)* | Right-click the tray icon → **Exit** → **Yes**, in local mode and again with the service installed | tray → Exit → Yes stops the server: `ws-scrcpy-web.log` shows `shutdown requested via /api/server/shutdown` then the adb teardown, the process exits 0, the tray icon does not come back, and the app is gone from the port. |
 
 ### #18 — Auth subsystem (opt-in login) 🔐 *(new in beta.67 — run top-to-bottom; finish with 18.11)*
 

--- a/src/server/__tests__/ServerShutdownApi.test.ts
+++ b/src/server/__tests__/ServerShutdownApi.test.ts
@@ -4,8 +4,10 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ServerShutdownApi } from '../api/ServerShutdownApi';
+import { setAuthEnabled } from '../auth/authState';
 import { Config } from '../Config';
 import { EnvName } from '../EnvName';
+import { getInstanceToken } from '../security/instanceToken';
 
 const tmpDirs: string[] = [];
 const saved = { CONFIG: process.env[EnvName.CONFIG_PATH], DEPS: process.env['DEPS_PATH'] };
@@ -32,8 +34,8 @@ afterEach(() => {
  * Every request here therefore carries a socket, and the default is loopback —
  * the tray's own case.
  */
-function makeReqRes(url: string, method = 'GET', remoteAddress = '127.0.0.1') {
-    const req = { url, method, socket: { remoteAddress } } as unknown as IncomingMessage;
+function makeReqRes(url: string, method = 'GET', remoteAddress = '127.0.0.1', headers: Record<string, string> = {}) {
+    const req = { url, method, socket: { remoteAddress }, headers } as unknown as IncomingMessage;
     let statusCode = 0;
     const chunks: string[] = [];
     const res = {
@@ -79,7 +81,7 @@ describe('ServerShutdownApi', () => {
     // never appeared — the tray's Exit had been a no-op since the token landed.
     // The gate exemption lives in security/instanceToken.ts; loopback is what
     // replaces it here.
-    it('refuses a caller that is not on this machine, without saying whether auth is on', async () => {
+    it('refuses a cookieless caller that is not on this machine', async () => {
         const schedule = vi.fn();
         const exit = vi.fn();
         const api = new ServerShutdownApi({ schedule, exit });
@@ -93,10 +95,80 @@ describe('ServerShutdownApi', () => {
         expect(exit).not.toHaveBeenCalled();
     });
 
-    it('refuses a request whose peer address is unknown (fail closed)', async () => {
+    it('refuses a cookieless request whose peer address is unknown (fail closed)', async () => {
         const schedule = vi.fn();
         const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
         const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '');
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(403);
+        expect(schedule).not.toHaveBeenCalled();
+    });
+
+    // The regression CI caught on the first cut of this fix: requiring loopback
+    // outright killed the Settings "stop server & exit" button inside a
+    // container, where the browser arrives through the Docker gateway and is
+    // never on loopback (row 20.6). A caller holding the instance token is a
+    // browser that loaded the page and is authorized regardless of where it sits.
+    it('allows an off-box caller that carries the instance token (the container / LAN browser)', async () => {
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '172.17.0.1', {
+            cookie: `ws_scrcpy_token=${getInstanceToken()}`,
+        });
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(200);
+        expect(schedule).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses an off-box caller whose token is wrong', async () => {
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '172.17.0.1', {
+            cookie: `ws_scrcpy_token=${'a'.repeat(64)}`,
+        });
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(403);
+        expect(schedule).not.toHaveBeenCalled();
+    });
+
+    it('refuses an off-box token-holder that is not signed in when auth is on', async () => {
+        setAuthEnabled(Config.getInstance().db, true);
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '192.168.1.20', {
+            cookie: `ws_scrcpy_token=${getInstanceToken()}`,
+        });
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(401);
+        expect(schedule).not.toHaveBeenCalled();
+    });
+
+    // The user's decision, 2026-09-06: on the machine itself, stopping the app
+    // is the operator's call — so the tray's cookieless, session-less POST works
+    // in locked mode too, which is where its Exit is the only stop affordance.
+    it('allows the tray on loopback even when auth is on (no cookie, no session)', async () => {
+        setAuthEnabled(Config.getInstance().db, true);
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST');
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(200);
+        expect(schedule).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses a signed-in non-admin, even on loopback', async () => {
+        const db = Config.getInstance().db;
+        setAuthEnabled(db, true);
+        const viewer = db.users.create({ username: 'viewer', role: 'user', passwordHash: null });
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST');
+        (req as IncomingMessage & { user?: unknown }).user = viewer;
 
         expect(await api.handle(req, res)).toBe(true);
         expect((res as any).getStatus()).toBe(403);

--- a/src/server/__tests__/ServerShutdownApi.test.ts
+++ b/src/server/__tests__/ServerShutdownApi.test.ts
@@ -26,8 +26,14 @@ afterEach(() => {
     while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
 });
 
-function makeReqRes(url: string, method = 'GET') {
-    const req = { url, method } as IncomingMessage;
+/**
+ * `remoteAddress` matters since item 114: the handler is loopback-only, because
+ * it is exempt from the per-instance token (the tray helper has no cookie).
+ * Every request here therefore carries a socket, and the default is loopback —
+ * the tray's own case.
+ */
+function makeReqRes(url: string, method = 'GET', remoteAddress = '127.0.0.1') {
+    const req = { url, method, socket: { remoteAddress } } as unknown as IncomingMessage;
     let statusCode = 0;
     const chunks: string[] = [];
     const res = {
@@ -64,6 +70,47 @@ describe('ServerShutdownApi', () => {
         const api = new ServerShutdownApi();
         const { req, res } = makeReqRes('/api/server/shutdown', 'PUT');
         expect(await api.handle(req, res)).toBe(false);
+    });
+
+    // Item 114. The tray helper POSTs this path with no cookie and no Origin
+    // (tray/src/main.rs: ureq .post(url).send_string("")). Measured on
+    // 2026-09-06 against a real server: the per-instance token gate answered
+    // 403 {"reason":"missing or invalid token"} and the handler's own log line
+    // never appeared — the tray's Exit had been a no-op since the token landed.
+    // The gate exemption lives in security/instanceToken.ts; loopback is what
+    // replaces it here.
+    it('refuses a caller that is not on this machine, without saying whether auth is on', async () => {
+        const schedule = vi.fn();
+        const exit = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '192.168.1.20');
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(403);
+        expect(JSON.parse((res as any).getBody())).toEqual({ error: 'this endpoint answers this machine only' });
+        // Nothing was scheduled and nothing exited.
+        expect(schedule).not.toHaveBeenCalled();
+        expect(exit).not.toHaveBeenCalled();
+    });
+
+    it('refuses a request whose peer address is unknown (fail closed)', async () => {
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '');
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(403);
+        expect(schedule).not.toHaveBeenCalled();
+    });
+
+    it('accepts the IPv4-mapped loopback a dual-stack listener reports', async () => {
+        const schedule = vi.fn();
+        const api = new ServerShutdownApi({ schedule, exit: vi.fn() });
+        const { req, res } = makeReqRes('/api/server/shutdown', 'POST', '::ffff:127.0.0.1');
+
+        expect(await api.handle(req, res)).toBe(true);
+        expect((res as any).getStatus()).toBe(200);
+        expect(schedule).toHaveBeenCalledTimes(1);
     });
 
     it('POST /api/server/shutdown writes 200 with { ok: true } envelope', async () => {

--- a/src/server/api/ServerShutdownApi.ts
+++ b/src/server/api/ServerShutdownApi.ts
@@ -1,7 +1,15 @@
 import type { IncomingMessage, ServerResponse } from 'http';
+import { isAuthEnabled } from '../auth/authState';
 import { requireAdmin } from '../auth/requireAdmin';
+import { Config } from '../Config';
 import { Logger } from '../Logger';
+import { isValidToken, parseTokenFromCookie } from '../security/instanceToken';
 import { isLoopback } from '../security/loopback';
+
+/** Whether AuthGate attached a validated session user to this request. */
+function hasAuthenticatedUser(req: IncomingMessage): boolean {
+    return (req as IncomingMessage & { user?: unknown }).user !== undefined;
+}
 
 const log = Logger.for('ServerShutdownApi');
 
@@ -30,25 +38,27 @@ const log = Logger.for('ServerShutdownApi');
  *
  * Who may call it (item 114, 2026-09-06 — this used to read "No auth:
  * localhost-only intent", which stopped being true the moment the per-instance
- * token shipped):
+ * token shipped and quietly killed the tray's Exit):
  *
- *   - **Loopback only.** Anything else gets 403 and nothing runs. `listen()`
- *     binds every interface and `isHostAllowed` accepts any IP literal, so the
- *     remote address is what keeps this off the LAN — the same reasoning as
- *     `WhoamiApi` and the embed-consent endpoints.
- *   - **Token-exempt** (security/instanceToken.ts), because the tray helper is
- *     a process and has no cookie. It POSTed here cookielessly since v0.1.8 and
- *     the token gate answered 403 from the day it landed, so the tray's Exit —
- *     the ONLY stop affordance in service mode — silently did nothing.
- *   - **Still behind AuthGate.** In locked mode an unauthenticated caller is
- *     401'd before reaching this handler, so the tray's Exit does not work
- *     there. Exempting it would mean `requireAdmin` falling back to the
- *     implicit admin for a cookieless caller, which is exactly what
- *     `AuthGate`'s fail-closed comment forbids; whether a loopback process may
- *     stop a locked-mode server is a policy question for the operator, not a
- *     bug fix. See todo item 114.
- *   - **`requireAdmin` still runs**, so a signed-in non-admin browser cannot
- *     stop the server.
+ * The endpoint is exempt from BOTH gates — the per-instance token
+ * (security/instanceToken.ts) and AuthGate (auth/authState.ts) — because the
+ * tray helper is a process, not a browser: it has no cookie and no session, and
+ * in service mode its Exit is the only stop affordance the product has. This
+ * handler therefore does the authorizing itself:
+ *
+ *   - **On loopback: allowed.** Stopping the app from the machine it runs on is
+ *     the operator's call (user decision, 2026-09-06). The trade is explicit:
+ *     any local process can stop the server, including a system-scope service a
+ *     non-admin user could not otherwise stop. Loopback is the same trust
+ *     boundary `WhoamiApi` and the embed-consent endpoints already draw.
+ *   - **Off-box: unchanged from before the exemptions.** The caller must
+ *     present the instance token (403 without it — a LAN client that never
+ *     loaded the page has none), and in locked mode must be signed in (401).
+ *     Note this is NOT "loopback only": a browser reaching a containerised
+ *     server comes through the Docker gateway, and row 20.6 exists to catch
+ *     exactly that regression.
+ *   - **`requireAdmin` runs last**, so a signed-in non-admin cannot stop the
+ *     server from anywhere.
  */
 const SHUTDOWN_DELAY_MS = 100;
 
@@ -86,16 +96,36 @@ export class ServerShutdownApi {
 
         res.setHeader('Content-Type', 'application/json');
 
-        // Loopback is the authorization for the cookieless caller this endpoint
-        // exists for (the tray helper). Checked BEFORE requireAdmin so an
-        // off-box caller learns nothing about whether auth is on.
+        // Loopback is what authorizes the COOKIELESS caller this endpoint's
+        // exemptions exist for (the tray helper). An off-box caller gets the
+        // treatment it had before those exemptions: it must present the
+        // instance token it was handed with the page, and in locked mode it
+        // must be signed in.
+        //
+        // This is not "loopback only". Requiring loopback outright broke the
+        // Settings button inside a container, where the browser reaches the
+        // server through the Docker gateway and so is never on loopback —
+        // caught by row 20.6 in CI, which is exactly what that row is for.
         if (!isLoopback(req.socket?.remoteAddress ?? '')) {
-            log.warn(`refusing shutdown from non-loopback ${req.socket?.remoteAddress ?? '<unknown>'}`);
-            res.writeHead(403);
-            res.end(JSON.stringify({ error: 'this endpoint answers this machine only' }));
-            return true;
+            if (!isValidToken(parseTokenFromCookie(req.headers.cookie))) {
+                log.warn(`refusing shutdown from ${req.socket?.remoteAddress ?? '<unknown>'}: no instance token`);
+                res.writeHead(403);
+                res.end(JSON.stringify({ error: 'this endpoint answers this machine only' }));
+                return true;
+            }
+            if (isAuthEnabled(Config.getInstance().db) && !hasAuthenticatedUser(req)) {
+                // AuthGate lets this path through unauthenticated so the tray
+                // can reach it; off-box, that exemption is re-imposed here.
+                log.warn(`refusing shutdown from ${req.socket?.remoteAddress ?? '<unknown>'}: not signed in`);
+                res.writeHead(401);
+                res.end(JSON.stringify({ error: 'unauthorized' }));
+                return true;
+            }
         }
 
+        // A signed-in non-admin cannot stop the server, from anywhere. In open
+        // mode, and for the cookieless local caller in locked mode, this
+        // resolves to the implicit admin and passes — deliberate, see above.
         if (!requireAdmin(req, res)) return true;
 
         log.info('shutdown requested via /api/server/shutdown');

--- a/src/server/api/ServerShutdownApi.ts
+++ b/src/server/api/ServerShutdownApi.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { requireAdmin } from '../auth/requireAdmin';
 import { Logger } from '../Logger';
+import { isLoopback } from '../security/loopback';
 
 const log = Logger.for('ServerShutdownApi');
 
@@ -26,7 +27,28 @@ const log = Logger.for('ServerShutdownApi');
  *     daemon. process.exit(0) is a clean exit; the launcher's supervisor sees
  *     `decide_restart(0, false) == None` and does NOT restart (exit 75 is the
  *     restart sentinel — deliberately NOT used here).
- *   - No auth: localhost-only intent. Future hardening if exposed remotely.
+ *
+ * Who may call it (item 114, 2026-09-06 — this used to read "No auth:
+ * localhost-only intent", which stopped being true the moment the per-instance
+ * token shipped):
+ *
+ *   - **Loopback only.** Anything else gets 403 and nothing runs. `listen()`
+ *     binds every interface and `isHostAllowed` accepts any IP literal, so the
+ *     remote address is what keeps this off the LAN — the same reasoning as
+ *     `WhoamiApi` and the embed-consent endpoints.
+ *   - **Token-exempt** (security/instanceToken.ts), because the tray helper is
+ *     a process and has no cookie. It POSTed here cookielessly since v0.1.8 and
+ *     the token gate answered 403 from the day it landed, so the tray's Exit —
+ *     the ONLY stop affordance in service mode — silently did nothing.
+ *   - **Still behind AuthGate.** In locked mode an unauthenticated caller is
+ *     401'd before reaching this handler, so the tray's Exit does not work
+ *     there. Exempting it would mean `requireAdmin` falling back to the
+ *     implicit admin for a cookieless caller, which is exactly what
+ *     `AuthGate`'s fail-closed comment forbids; whether a loopback process may
+ *     stop a locked-mode server is a policy question for the operator, not a
+ *     bug fix. See todo item 114.
+ *   - **`requireAdmin` still runs**, so a signed-in non-admin browser cannot
+ *     stop the server.
  */
 const SHUTDOWN_DELAY_MS = 100;
 
@@ -62,10 +84,21 @@ export class ServerShutdownApi {
     public async handle(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
         if (req.url !== '/api/server/shutdown' || req.method !== 'POST') return false;
 
+        res.setHeader('Content-Type', 'application/json');
+
+        // Loopback is the authorization for the cookieless caller this endpoint
+        // exists for (the tray helper). Checked BEFORE requireAdmin so an
+        // off-box caller learns nothing about whether auth is on.
+        if (!isLoopback(req.socket?.remoteAddress ?? '')) {
+            log.warn(`refusing shutdown from non-loopback ${req.socket?.remoteAddress ?? '<unknown>'}`);
+            res.writeHead(403);
+            res.end(JSON.stringify({ error: 'this endpoint answers this machine only' }));
+            return true;
+        }
+
         if (!requireAdmin(req, res)) return true;
 
         log.info('shutdown requested via /api/server/shutdown');
-        res.setHeader('Content-Type', 'application/json');
         res.writeHead(200);
         res.end(JSON.stringify({ ok: true }));
 

--- a/src/server/auth/authState.ts
+++ b/src/server/auth/authState.ts
@@ -15,7 +15,21 @@ export const SESSION_COOKIE = 'wsscrcpy_sid';
 // records that another local app would like to be allowed to frame us, and a human still has to
 // approve that in the (gated) UI. Without the exemption, locked mode answers it with 200 + the
 // login HTML, which a JSON client reads as a malformed success rather than "you must sign in".
-const ALLOWLIST_EXACT = new Set(['/api/auth/login', '/api/auth/me', '/api/whoami', '/embed-request']);
+// `/api/server/shutdown` is the tray helper's quit (item 114, user decision
+// 2026-09-06). The tray is a process: no cookie, no session, and in service
+// mode its Exit is the only stop affordance the product has, so a locked-mode
+// 401 left it dead. `ServerShutdownApi` does the authorizing instead — a
+// loopback caller may stop the app (the operator's own machine), while an
+// off-box caller still needs the instance token AND, in locked mode, a signed-in
+// admin, which is what this allowlist entry would otherwise have given away.
+// The trade is deliberate and recorded: any local process can stop the server.
+const ALLOWLIST_EXACT = new Set([
+    '/api/auth/login',
+    '/api/auth/me',
+    '/api/whoami',
+    '/api/server/shutdown',
+    '/embed-request',
+]);
 // '/login-assets/' used to sit here too. Nothing ever served that prefix and
 // there is no /login route at all — the login page is served inline — so it was
 // an unauthenticated hole reserved for a directory that did not exist, waiting

--- a/src/server/security/instanceToken.test.ts
+++ b/src/server/security/instanceToken.test.ts
@@ -72,7 +72,7 @@ describe('instanceToken', () => {
             expect(requiresToken('POST', '/api/service/install')).toBe(true);
             expect(requiresToken('GET', '/api/devices')).toBe(true);
             expect(requiresToken('PATCH', '/api/config')).toBe(true);
-            expect(requiresToken('POST', '/api/server/shutdown')).toBe(true);
+            expect(requiresToken('POST', '/api/settings')).toBe(true);
         });
 
         it('exempts the launcher GET /api/config upgrade probe', () => {
@@ -87,6 +87,20 @@ describe('instanceToken', () => {
             expect(requiresToken('POST', '/api/whoami')).toBe(true);
             expect(requiresToken('GET', '/api/whoami/')).toBe(true);
             expect(requiresToken('GET', '/api/whoamix')).toBe(true);
+        });
+
+        // Item 114. This line used to read `expect(requiresToken('POST',
+        // '/api/server/shutdown')).toBe(true)` in the test above — the tray's
+        // breakage asserted as correct, written when the token landed by
+        // someone who did not know the tray posts exactly that. Measured
+        // 2026-09-06 against a real server: 403 {"reason":"missing or invalid
+        // token"}, the handler's log line absent, the server still up. The
+        // handler is loopback-only, so the exemption reaches nothing off-box.
+        it('exempts the tray helper POST /api/server/shutdown, that method and path only', () => {
+            expect(requiresToken('POST', '/api/server/shutdown')).toBe(false);
+            expect(requiresToken('GET', '/api/server/shutdown')).toBe(true);
+            expect(requiresToken('POST', '/api/server/shutdown/')).toBe(true);
+            expect(requiresToken('POST', '/api/server/restart')).toBe(true);
         });
 
         it('does not require a token for static (non-API) requests', () => {

--- a/src/server/security/instanceToken.ts
+++ b/src/server/security/instanceToken.ts
@@ -11,11 +11,18 @@ import { randomBytes, timingSafeEqual } from 'node:crypto';
  * surface and on every WebSocket handshake. A non-browser caller that never
  * loaded the page has no cookie and is rejected.
  *
- * Two probes are deliberately exempt, both sent by a process rather than a
+ * Three requests are deliberately exempt, all sent by a process rather than a
  * browser and so cookieless: the launcher's `GET /api/config` upgrade probe,
- * which only reads non-sensitive config to detect the live server, and the
- * sibling guard's `GET /api/whoami` identity probe (siblingInstance.ts), whose
- * handler is loopback-only so the exemption reaches nothing off-box.
+ * which only reads non-sensitive config to detect the live server; the sibling
+ * guard's `GET /api/whoami` identity probe (siblingInstance.ts); and the tray
+ * helper's `POST /api/server/shutdown` quit (tray/src/main.rs). Each of those
+ * handlers is loopback-only, so no exemption reaches anything off-box.
+ *
+ * The shutdown exemption is a fix, not a widening (item 114, 2026-09-06): the
+ * tray has POSTed that path cookieless since v0.1.8, and once this token landed
+ * the gate answered it 403 — measured, with the handler's own log line absent —
+ * so the tray's Exit silently stopped working. It is the ONLY stop affordance
+ * in service mode, where Settings' "stop server & exit" is disabled by design.
  */
 
 const COOKIE_NAME = 'ws_scrcpy_token';
@@ -87,6 +94,12 @@ export function requiresToken(method: string | undefined, pathname: string): boo
         return false;
     }
     if (m === 'GET' && pathname === '/api/whoami') {
+        return false;
+    }
+    // The tray helper's quit. Cookieless by nature (a process, not a browser);
+    // `ServerShutdownApi` refuses any caller that is not on loopback, and the
+    // Origin check above still rejects a cross-origin browser POST.
+    if (m === 'POST' && pathname === '/api/server/shutdown') {
         return false;
     }
     return true;


### PR DESCRIPTION
## The bug, measured

The tray helper POSTs `/api/server/shutdown` cookielessly — it is a process, not a browser (`tray/src/main.rs`: `ureq .post(url).send_string("")`) — and since the per-instance token shipped, `requestGate` has answered that 403. Clicking **Exit → Yes** killed only the tray icon; the launcher's supervisor put it back within ten seconds, and the server never stopped. In **service mode that is the only stop affordance**: Settings' "stop server & exit" is disabled there by design (smoke row 12.2).

Verified against a real server on an isolated data root, before the fix:

```
POST /api/server/shutdown        (no cookie, no Origin — the tray's exact request)
HTTP/1.1 403 Forbidden
{"error":"forbidden","reason":"missing or invalid token"}

GET /  -> 200                    (server still up)
grep "shutdown requested via /api/server/shutdown" ws-scrcpy-web.log  -> 0 matches
```

The same request **with** a token cookie returned 200, ran the adb teardown and exited 0 — the cookie was the only difference.

## The fix

- **`security/instanceToken.ts`** — exempt `POST /api/server/shutdown`, that method and path only, alongside the launcher's `GET /api/config` and the sibling `GET /api/whoami`. Every exempt handler is loopback-only.
- **`api/ServerShutdownApi.ts`** — refuse a non-loopback caller *before* `requireAdmin` (so an off-box caller learns nothing about whether auth is on), mirroring `WhoamiApi`. `requireAdmin` still runs, so a signed-in non-admin browser cannot stop the server. The docstring still claimed *"No auth: localhost-only intent"*, which stopped being true the moment the token landed; it now says who may call it and why.
- **`instanceToken.test.ts`** — the old `expect(requiresToken('POST', '/api/server/shutdown')).toBe(true)` **was the bug, asserted as correct**, written when the token landed by someone who did not know the tray posts exactly that. Replaced by the exemption and its negatives.
- **`ServerShutdownApi.test.ts`** — every request now carries a socket; new cases for a LAN caller, an unknown peer (fail closed) and `::ffff:127.0.0.1`.

After the fix, same script:

```
POST (no cookie)                  -> 200 {"ok":true}, handler ran, server exited 0
POST from 192.168.87.3            -> 403 {"error":"this endpoint answers this machine only"}
                                     server alive, handler never ran,
                                     log: WARN refusing shutdown from non-loopback ::ffff:192.168.87.3
```

## The regression CI caught, and the rule that replaced it

The first cut required loopback **outright**, and `build-and-test` failed on **row 20.6**: inside a container the browser reaches the server through the Docker gateway, so it is never on loopback, and the Settings "stop server & exit" button got a 403 where the row expects 200. That row exists for exactly this.

The rule is now: **loopback authorizes the *cookieless* caller** (the tray). A caller holding the instance token is a browser that loaded the page and is authorized wherever it sits — unchanged from before any of this. Off-box and cookieless is the only thing loopback shuts out.

## The locked-mode decision (user, 2026-09-06)

**A loopback process may stop the server, locked mode included**, so the path is exempt from AuthGate too and the tray's Exit works everywhere. The trade is explicit: any local process can stop the server, including a system-scope service a non-admin user could not otherwise stop. Off-box callers are untouched by that exemption — token required (403), and in locked mode a signed-in session as well (401) — so it gives nothing to the LAN. `requireAdmin` still runs last.

Measured, all five paths, against a real server:

| mode | caller | result |
|---|---|---|
| open | loopback, no cookie (the tray) | 200, stopped |
| open | LAN, no cookie | 403, alive |
| open | LAN, valid token cookie (container / LAN browser) | 200, stopped |
| locked | loopback, no cookie, no session (the tray) | 200, stopped |
| locked | LAN, token, not signed in | 401 (unit-tested) |

Locked mode was proven locked in the same run: `GET /api/settings` with a token but no session answered 401 before the shutdown POST went out.

## Smoke row

New **15.6** `[Win]`, wording acknowledged by the user: *tray → Exit → Yes stops the server: `ws-scrcpy-web.log` shows `shutdown requested via /api/server/shutdown` then the adb teardown, the process exits 0, the tray icon does not come back, and the app is gone from the port.* Register denominator 142 → 143, Windows-guest bucket 25 → 26.

## Verified

`npx vitest run src/server` — 116 files, 1,092 passed / 5 skipped. `npm run lint`, `npx tsc --noEmit`, `npm run build` clean. Fast-tier e2e green. Plus the two measured runs above (`item114-verify.sh`, `item114-loopback.sh`).
