### PR TITLE
docs: the embed-request store is under src/server/security/, not src/server/

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -2094,7 +2094,7 @@ By default only `localhost` + IP literals pass layer 1, so terminating TLS at a 
 | `src/server/security/originGuard.ts` | Host allowlist (`isHostAllowed`, `setAllowedHosts`) + Origin match (`isRequestAllowed`) |
 | `src/server/security/requestGate.ts` | Composes the Host/Origin/token layers for HTTP (`evaluateHttpRequest`) and WS (`evaluateWsConnection`) |
 | `src/server/security/frameGuard.ts` | `securityHeaders()` + the CSP `frame-ancestors` list (`setFrameAncestors`) — layer 4 |
-| `src/server/embedRequests.ts` | Pending embed-consent request store (one at a time, five-minute expiry) |
+| `src/server/security/embedRequests.ts` | Pending embed-consent request store (one at a time, five-minute expiry) |
 | `src/server/api/EmbedRequestApi.ts` | `/embed-request` ask + `/api/embed-request/decision` grant; both loopback-gated |
 | `src/server/auth/authState.ts` | `authEnabled` — the actual authentication boundary — plus the gate's allow-list |
 | `src/server/security/instanceToken.ts` | Per-launch token mint, cookie build, constant-time validation; the two probe exemptions (`requiresToken`) |


### PR DESCRIPTION
## What

One wrong path in the technical guide. §24.2's Key Files table pointed at `src/server/embedRequests.ts`; the pending embed-consent store has always lived at `src/server/security/embedRequests.ts`, next to the four other security modules the same table lists correctly.

## How it surfaced

The wrap-up doc sweep runs two passes. The forward pass derives identifiers from the release diff and greps the docs for them — it found nothing stale, because this path was never touched by the diff. The second pass goes the other way: it collects every source path any doc names and checks each one against disk.

| | |
|---|---|
| Paths checked | 213 |
| Flagged | 2 |
| Real | 1 (this one) |

The other flag is a false positive worth naming, since the same sweep will raise it again. `automation-coverage.md` row 8.11 cites `docs/adr/2026-09-01-browser-codec-matrix.md`, and the prose says plainly that the file is **in qa-harness**. It is: that ADR exists in the harness repo, as does the second cross-repo ADR cited from the SP4 design doc. The check resolves paths against this tree only, so a correctly-labelled cross-repo reference reads as missing.

The asymmetry between the two passes is the point of running both. A path can be wrong from the day it was written and stay invisible to any sweep that only looks at what recently changed.

## Scope

Docs only, one line. No release.
