### PR TITLE
fix(settings): follow the service when the install shifts its port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installing the service on a shifted port stranded the browser on the dying local instance.** MEASURED
+  2026-09-07 (qa-harness Arc 1b row 4.3): the service could not bind 8000 because the exiting local
+  instance still held it, so it took 8001. The install poll in `SettingsModal` is **same-origin** — it
+  keeps asking the port the browser is already on — and its success gate required `servedByService`, which
+  is `process.env['WS_SCRCPY_SERVICE'] === '1'` and therefore only ever true *inside the service process*.
+  When the service moves to a different port the browser never talks to it, so the signal that would say
+  "follow me" can never arrive: the `navigate` branch, written precisely for "a different bound port", was
+  unreachable in exactly the case it exists for. The poll ran to its cap and timed out, leaving the user on
+  an instance that then exited, showing a Service section that still read "not installed — install?" beside
+  a card saying the app is running as a service.
+
+  The exiting local instance can answer both halves of the question, so it is now asked: `readDiskConfig`
+  reports `diskWebPort` from config.json, and `status` comes from an `sc.exe`/`systemctl` query about the
+  **service**, not about the answering process. `classifyInstallPoll` now navigates when a port shift is
+  known and the service has been seen running, whoever is answering — and still navigates once the origin
+  dies, because the last-known disk port is remembered across ticks (the tick after the local instance
+  exits carries no body). Guards kept: no navigation before the service has ever been seen running, and
+  none when the disk port equals the port the browser is already on.
+
+  Worth recording why this survived its own tests: the existing unit test asserted `servedByService: true`
+  together with a *different* `diskWebPort` — a state the system cannot produce, since a service answering
+  the browser means the browser is already on the service's port. The test encoded an impossible world, so
+  it passed while the real path never ran.
+
 ## [0.1.30-beta.113] - 2026-09-08
 
 ### Fixed

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -60,9 +60,31 @@ export function classifyInstallPoll(args: {
     configMtime: number | null;
     baselineMtime: number;
     diskWebPort: number | null;
+    /** The port the browser is actually on, so a shift can be detected. */
+    currentPort: number | null;
+    /** Sticky: any answering instance has reported the SERVICE as running. */
+    serviceSeenRunning: boolean;
     iterations: number;
     maxIterations: number;
 }): PollOutcome {
+    // A PORT SHIFT is its own positive signal, and it is the one case
+    // servedByService can never deliver. MEASURED 2026-09-07 (qa-harness Arc 1b row
+    // 4.3): the service could not bind 8000 because the exiting local instance still
+    // held it, so it took 8001. This poll is SAME-ORIGIN, so it kept asking 8000 —
+    // where servedByService is false by construction, since that flag is only ever
+    // true inside the service process. The branch below written for "a different
+    // bound port" was therefore unreachable in exactly the situation it exists for,
+    // and the user sat on a dying instance until the timeout.
+    //
+    // The exiting local instance can answer both halves of the question: its
+    // readDiskConfig reports diskWebPort from config.json, and its `status` comes
+    // from an sc.exe/systemctl query about the SERVICE, not about itself. So once
+    // the service is known to be running and the disk port differs from ours, we
+    // know where to go — whoever is answering.
+    const portMoved = args.diskWebPort != null && args.currentPort != null && args.diskWebPort !== args.currentPort;
+    if (portMoved && (args.servedByService || args.serviceSeenRunning)) {
+        return { kind: 'navigate', port: args.diskWebPort as number };
+    }
     // Success requires a POSITIVE signal: the instance answering /api/service/status
     // is the service itself (WS_SCRCPY_SERVICE on its unit), not the exiting local
     // instance and not a transient dead port.
@@ -1893,6 +1915,11 @@ export class SettingsModal extends Modal {
             if (isSystemScope) {
                 btn.textContent = 'switching to the system service…';
             }
+            // Sticky across ticks: the origin dies mid-hand-off, so what we learned
+            // while the local instance was still answering has to outlive it.
+            let sawServiceRunning = false;
+            let lastDiskWebPort: number | null = null;
+            const browserPort = Number(window.location.port) || null;
             const poll = setInterval(async () => {
                 iterations++;
                 // A thrown/aborted fetch means whoever was answering has dropped —
@@ -1910,10 +1937,20 @@ export class SettingsModal extends Modal {
                             configMtime?: number;
                             diskWebPort?: number;
                             servedByService?: boolean;
+                            status?: string;
                         };
                         configMtime = statusData.configMtime ?? null;
                         diskWebPort = statusData.diskWebPort ?? null;
                         servedByService = statusData.servedByService === true;
+                        // `status` is the SERVICE's state (sc.exe / systemctl), not the
+                        // answering process's, so the local instance can tell us the
+                        // service came up even though it is not the service.
+                        if (statusData.status === 'running') {
+                            sawServiceRunning = true;
+                        }
+                        if (diskWebPort != null) {
+                            lastDiskWebPort = diskWebPort;
+                        }
                     }
                 } catch {
                     reachable = false;
@@ -1923,7 +1960,12 @@ export class SettingsModal extends Modal {
                     servedByService,
                     configMtime,
                     baselineMtime,
-                    diskWebPort,
+                    // The last port we saw on disk, not just this tick's: an
+                    // unreachable tick carries no body, and that is precisely the
+                    // tick after the local instance exits.
+                    diskWebPort: diskWebPort ?? lastDiskWebPort,
+                    currentPort: browserPort,
+                    serviceSeenRunning: sawServiceRunning,
                     iterations,
                     maxIterations,
                 });

--- a/src/app/client/__tests__/SettingsModal.test.ts
+++ b/src/app/client/__tests__/SettingsModal.test.ts
@@ -60,6 +60,8 @@ describe('classifyInstallPoll', () => {
         configMtime: 100,
         baselineMtime: 100,
         diskWebPort: 8000,
+        currentPort: 8000,
+        serviceSeenRunning: true,
         iterations: 1,
         maxIterations: 30,
     };
@@ -68,6 +70,76 @@ describe('classifyInstallPoll', () => {
             kind: 'navigate',
             port: 8002,
         });
+    });
+
+    // ---------------------------------------------------------------------------
+    // The port-shift hand-off. MEASURED 2026-09-07 (qa-harness Arc 1b row 4.3):
+    // the service could not bind 8000 because the local instance still held it, so
+    // it took 8001. The browser stayed on 8000, the poll is SAME-ORIGIN, and
+    // servedByService is only ever true inside the service process -- so the very
+    // branch written for "a different bound port" was unreachable in exactly the
+    // case it exists for. The user was left on a dying instance until the timeout.
+    //
+    // Note what the pre-existing test above actually encodes: servedByService=true
+    // WITH a different diskWebPort. That state cannot occur -- if the service is
+    // answering the browser, the browser is already on the service's port. The bug
+    // survived because its test asserted an impossible world.
+    // ---------------------------------------------------------------------------
+    it('navigates when the LOCAL instance reports the service running on another port', () => {
+        // The exiting local instance still answers on 8000 (servedByService=false),
+        // and readDiskConfig lets it report where the service actually went.
+        expect(
+            classifyInstallPoll({
+                ...served,
+                servedByService: false,
+                diskWebPort: 8001,
+                currentPort: 8000,
+                serviceSeenRunning: true,
+            }),
+        ).toEqual({ kind: 'navigate', port: 8001 });
+    });
+
+    it('navigates after the origin dies, once the service was seen running elsewhere', () => {
+        // The local instance exits ~15s after the service comes up, killing the
+        // origin. Timing out here strands the user on a dead port when we already
+        // know where the service is.
+        expect(
+            classifyInstallPoll({
+                ...served,
+                reachable: false,
+                servedByService: false,
+                diskWebPort: 8001,
+                currentPort: 8000,
+                serviceSeenRunning: true,
+            }),
+        ).toEqual({ kind: 'navigate', port: 8001 });
+    });
+
+    it('does NOT navigate on a dead origin before the service was ever seen running', () => {
+        // Guard: the hand-off dead window must still be waited out, not guessed at.
+        expect(
+            classifyInstallPoll({
+                ...served,
+                reachable: false,
+                servedByService: false,
+                diskWebPort: 8001,
+                currentPort: 8000,
+                serviceSeenRunning: false,
+                iterations: 2,
+            }),
+        ).toEqual({ kind: 'keep-polling' });
+    });
+
+    it('does NOT navigate when the disk port equals the port the browser is already on', () => {
+        expect(
+            classifyInstallPoll({
+                ...served,
+                servedByService: false,
+                diskWebPort: 8000,
+                currentPort: 8000,
+                serviceSeenRunning: true,
+            }),
+        ).toEqual({ kind: 'keep-polling' });
     });
     it('reconnects when the service answers on the SAME port, no mtime change (the race fix)', () => {
         expect(classifyInstallPoll(served)).toEqual({ kind: 'reconnect' });


### PR DESCRIPTION
> **Draft on purpose — merge after #642.** Two `release:beta` PRs open at once means a CHANGELOG rebase on whichever lands second, so these are sequenced rather than raced. This needs a rebase once #642 bumps the version.

Installing the service when it lands on a **different port** left the browser stranded on the local instance that was about to exit — showing "not installed — install?" next to a card saying the app is running as a service.

## What's wrong

The install poll is **same-origin**: it keeps asking the port the browser is already on. Its success gate required `servedByService`, which is `process.env['WS_SCRCPY_SERVICE'] === '1'` — true only *inside the service process*.

So when the service binds a different port, the browser never talks to it, and the signal that would say "follow me" can never arrive. The `navigate` branch — written for exactly "a different bound port" — is unreachable in exactly the case it exists for. The poll runs to its cap and times out.

Measured 2026-09-07 on a Windows guest (qa-harness Arc 1b row 4.3):

```
23:33:25  runElevated(install-service) launching
23:35:03  [Server] webPort 8000 busy; auto-shifted to 8001   <- the service
23:35:13  [ServiceApi] install-flow: local instance exiting (service is running)
```

The captured page's own bookmark link read `http://172.24.0.2:8000` — it never left the local instance. The Service section is rendered once per Settings open with no re-poll, so it kept whatever it read during the install window, and the origin then died underneath it.

## The fix

Ask the instance that *is* still answering. The exiting local instance can supply both halves: `readDiskConfig` reports `diskWebPort` from config.json, and `status` comes from an `sc.exe` / `systemctl` query about the **service**, not about itself.

`classifyInstallPoll` now navigates when a port shift is known and the service has been seen running — whoever answered — and still navigates once the origin dies, since the last-known disk port is remembered across ticks (the tick after the local instance exits carries no body).

Guards kept, both with tests: no navigation before the service has ever been seen running (the hand-off dead window is still waited out), and none when the disk port equals the port the browser is already on.

## Why this survived its own test suite

The existing unit test asserted `servedByService: true` together with a **different** `diskWebPort`. That state cannot occur — if the service is answering the browser, the browser is already on the service's port. The test encoded an impossible world, so it passed while the real path never ran. It's kept (still valid as a same-origin case) alongside four new tests covering the real one.

## Testing

- `npx vitest run` — 1923 passed, 5 skipped, 215 files
- `npx tsc --noEmit` — clean
- `npm run lint` — clean

Not guest-verified: that needs a beta build carrying this change. The qa-harness side of the same row was fixed separately and verified there.
