### PR TITLE
fix(service): bound the UAC wait; drop the unreachable handoff-timeout reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An unanswered UAC prompt hung the service install forever.** #646, measured on a Windows guest three
+  separate ways (150 s, 342 s and 600 s windows). `runElevated` awaited the `--request-uac` helper with no
+  timeout, and that helper blocks until the consent dialog is answered — so when it never was, the await
+  never returned. `ELEVATION_TIMEOUT_MS` bounded only `pollForResultFile`, which is reached *after* that
+  await, so the 300 s deadline never started and the function had no upper bound at all. The user was left
+  at `installMode: 'system-service'` with no service until the app restarted, and two `--request-uac`
+  processes still alive fifteen minutes later. **The prompt does not need to be dismissed for this**:
+  Windows auto-dismisses it after about two minutes and the await still never returned, so any user who
+  ignores the prompt long enough gets there. The wait is now bounded by the same 300 s, and the two phases
+  share one deadline rather than one each. Expiry reports the "did not complete within 300s" message that
+  was already written for this case and could not previously be reached — not "you declined", which the
+  user did not do — and reverts `installMode` the way a decline already did. Declines are unchanged: they
+  exit 1223, which is not a timeout. 4 tests.
+
+### Changed
+
+- **Removed `handoff-timeout` from `ServiceFailureReason`.** #647, reported by a QA suite that wrote a test
+  row from the type's doc comment and found the row could never pass. The variant was emitted by the
+  LocalSystem uninstall path from `1507c36` (2026-04-30), which relayed the uninstall to a user-session
+  launcher and answered 503 when it could not reach one. Phase 4 (#108, 2026-05-25) replaced that relay with
+  the `uninstall-pending` marker + operation-server sequence, which needs no user session and cannot time out
+  waiting for one — so the producer was removed with it, while the variant, its doc and its `SettingsModal`
+  message stayed behind, promising an error the server had no way to send. **The doc was stale, not the
+  code**, and the git history says so rather than us inferring it. Removed rather than marked reserved:
+  there is no handoff left to time out. `handoff-no-target` is untouched — its doc already says it is
+  reserved, which is accurate. The stale paragraph in `isLikelyLocalSystem`, which still described the
+  removed WTS handoff and its fall-through, is corrected too; it was part of what made the variant look live.
+
 ## [0.1.30-beta.115] - 2026-09-09
 
 ### Fixed

--- a/src/app/client/SettingsModal.ts
+++ b/src/app/client/SettingsModal.ts
@@ -2136,8 +2136,6 @@ export class SettingsModal extends Modal {
                 return 'Service mode is not supported on this platform.';
             case 'uac-declined':
                 return 'Administrative privileges were declined. Try again and approve the prompt.';
-            case 'handoff-timeout':
-                return "Couldn't reach the user session. Make sure ws-scrcpy-web is running for your user, then try again.";
             case 'handoff-no-target':
                 return "Couldn't identify a user session to relay the action to.";
             case 'invalid-token':

--- a/src/common/ServiceEvents.ts
+++ b/src/common/ServiceEvents.ts
@@ -111,10 +111,15 @@ export interface ServiceActionSuccess {
  * - `unsupported`: service mode not supported on this platform.
  * - `uac-declined`: user clicked No on the Windows UAC prompt
  *   (PowerShell Start-Process -Verb RunAs exited with ERROR_CANCELLED 1223).
- * - `handoff-timeout`: the service-context handoff couldn't reach a
- *   user-session launcher within the discover() timeout, OR (post-v0.1.25)
- *   the LocalSystem direct-uninstall path was deliberately not attempted
- *   because UAC can't fire from session 0.
+ * - (removed) `handoff-timeout`: emitted by the LocalSystem uninstall path
+ *   between 1507c36 (2026-04-30) and Phase 4 (#108, 2026-05-25), when that
+ *   path relayed the uninstall to a user-session launcher and could fail to
+ *   reach one. Phase 4 replaced the relay with the uninstall-pending marker +
+ *   operation-server sequence, which needs no user session and cannot time out
+ *   waiting for one, so the producer went with it — but the variant, its doc
+ *   and its `SettingsModal` message stayed, promising an error the server had
+ *   no way to send (#647). Removed rather than reserved: there is no handoff
+ *   left to time out. Do not re-add it from a pre-Phase-4 spec.
  * - `handoff-no-target`: active session resolution failed AND no fallback
  *   path is available. Reserved; not currently emitted but type-stable for
  *   future granularity.
@@ -130,7 +135,6 @@ export interface ServiceActionSuccess {
 export type ServiceFailureReason =
     | 'unsupported'
     | 'uac-declined'
-    | 'handoff-timeout'
     | 'handoff-no-target'
     | 'invalid-token'
     | 'servy-failure'

--- a/src/server/__tests__/elevatedRunner.test.ts
+++ b/src/server/__tests__/elevatedRunner.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { parseResult, pollForResultFile, toSnakeCase } from '../service/elevatedRunner';
+import { isElevationTimeout, parseResult, pollForResultFile, toSnakeCase } from '../service/elevatedRunner';
 
 describe('toSnakeCase', () => {
     it('converts camelCase keys to snake_case at the top level', () => {
@@ -88,6 +88,39 @@ describe('parseResult', () => {
 // via the existing service install/uninstall flows; pure-unit coverage
 // would require mocking the launcher subprocess, which would test the mock
 // rather than the integration.
+
+// #646. `--request-uac` blocks until the consent dialog is answered, and the
+// await had no timeout — so an unanswered prompt (including Windows' own ~2
+// minute auto-dismiss) never returned, leaving installMode at 'system-service'
+// with no service until the app restarted. The wait is now bounded; these
+// tests pin the part that decides what the user is told when it expires,
+// because the wrong answer here is "you declined", which they did not.
+describe('isElevationTimeout', () => {
+    it('treats a child killed by our own timeout as a timeout', () => {
+        // The shape Node rejects with when the `timeout` option fires.
+        const err = Object.assign(new Error('Command failed: ...'), { killed: true, signal: 'SIGTERM' });
+        expect(isElevationTimeout(err)).toBe(true);
+    });
+
+    it('does NOT treat a UAC decline as a timeout', () => {
+        // ERROR_CANCELLED — the user clicked No. The helper exited on its own,
+        // so `killed` is false and they get the decline message, not this one.
+        const err = Object.assign(new Error('Command failed: ...'), { killed: false, code: 1223 });
+        expect(isElevationTimeout(err)).toBe(false);
+    });
+
+    it('does NOT treat an unexpected non-zero exit as a timeout', () => {
+        const err = Object.assign(new Error('Command failed: ...'), { code: 1 });
+        expect(isElevationTimeout(err)).toBe(false);
+    });
+
+    it('is safe on a thrown value that carries nothing', () => {
+        expect(isElevationTimeout(new Error('boom'))).toBe(false);
+        expect(isElevationTimeout(undefined)).toBe(false);
+        expect(isElevationTimeout(null)).toBe(false);
+        expect(isElevationTimeout('a string')).toBe(false);
+    });
+});
 
 describe('pollForResultFile', () => {
     let tmpDir: string;

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -1298,10 +1298,15 @@ export class ServiceApi {
      *
      * Not bulletproof — a user could theoretically be logged in as
      * `SYSTEM` (extremely unusual), and `os.userInfo()` can fail in
-     * some edge cases. The downside of a false positive is we attempt
-     * the WTS handoff and it fails, then we fall through to direct
-     * uninstall. The downside of a false negative is the user's tab
-     * disconnects on uninstall (the v0.1.7 behavior). Acceptable.
+     * some edge cases. The downside of a false positive is we take the
+     * uninstall-pending marker + operation-server path when a plain
+     * `client.uninstall()` would have done. The downside of a false
+     * negative is the user's tab disconnects on uninstall (the v0.1.7
+     * behavior). Acceptable.
+     *
+     * (This paragraph described a WTS handoff and a fall-through to direct
+     * uninstall until #647. Phase 4 removed both in 2026-05; the stale text
+     * is part of what made `handoff-timeout` look like a live variant.)
      */
     private isLikelyLocalSystem(): boolean {
         try {

--- a/src/server/service/elevatedRunner.ts
+++ b/src/server/service/elevatedRunner.ts
@@ -183,6 +183,8 @@ export async function runElevated(
     // children.
     log.info(`runElevated(${command}) launching ${launcherPath} (direct=${useDirect}, file-poll)`);
 
+    const startedAt = Date.now();
+
     if (useDirect) {
         // Direct spawn — caller is already privileged (Local
         // System service-instance invoking spawn-user-launcher).
@@ -220,18 +222,38 @@ export async function runElevated(
         //   1223 = UAC declined by the user (Windows ERROR_CANCELLED).
         //   other = unexpected ShellExecuteExW failure.
         let uacFailed = false;
+        let uacTimedOut = false;
         let uacErrorMessage = '';
         try {
             await execFileAsync(launcherPath, ['--request-uac', command, argsPath, resultPath], {
                 windowsHide: true,
                 maxBuffer: 1024 * 1024,
+                // `--request-uac` blocks until the consent dialog is answered,
+                // so without this the wait is unbounded when it never is — and
+                // "never" includes Windows auto-dismissing the prompt after
+                // ~2 minutes, which leaves this await pending forever and the
+                // caller stuck in a half-installed state (#646). The bound is
+                // the same 300s the result-file poll uses; expiry kills the
+                // helper, which also stops the process leaking.
+                //
+                // Residual, accepted: killing `--request-uac` does not retract
+                // a consent dialog Windows has already shown, so a user who
+                // answers Yes after the 5 minutes are up can still complete an
+                // install we have already reported as failed and reverted. The
+                // window is bounded and self-correcting on the next status
+                // read; an unbounded hang was not.
+                timeout: ELEVATION_TIMEOUT_MS,
             });
         } catch (err) {
+            uacTimedOut = isElevationTimeout(err);
             uacFailed = true;
             uacErrorMessage = (err as Error).message ?? '(no message)';
-            log.warn(`runElevated request-uac failed: ${uacErrorMessage}`);
+            log.warn(`runElevated request-uac ${uacTimedOut ? 'timed out' : 'failed'}: ${uacErrorMessage}`);
         }
 
+        if (uacTimedOut) {
+            return elevationTimedOut(uacErrorMessage);
+        }
         if (uacFailed) {
             return {
                 ok: false,
@@ -245,17 +267,13 @@ export async function runElevated(
         }
     }
 
-    const result = await pollForResultFile(resultPath, ELEVATION_TIMEOUT_MS, undefined, undefined, nonce);
+    // One deadline across both phases, not one each: the consent wait and the
+    // helper's own work share the 300s this function advertises, so the caller
+    // cannot be held for twice that.
+    const remainingMs = Math.max(0, ELEVATION_TIMEOUT_MS - (Date.now() - startedAt));
+    const result = await pollForResultFile(resultPath, remainingMs, undefined, undefined, nonce);
     if (result === null) {
-        return {
-            ok: false,
-            exitCode: -1,
-            stdout: '',
-            stderr: '',
-            errorMessage:
-                `elevated helper did not complete within ${ELEVATION_TIMEOUT_MS / 1000}s. ` +
-                'The UAC prompt may have been dismissed without action, or the helper may have crashed.',
-        };
+        return elevationTimedOut('');
     }
     // `using td = tempDir(...)` above disposes the temp dir on scope exit
     // (return or throw) — replaces the prior try/finally + fs.rmSync pair.
@@ -264,6 +282,41 @@ export async function runElevated(
 
 /** 5 minutes — UAC dialog can legitimately stay up this long. */
 const ELEVATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Did our own timeout end the `--request-uac` child, rather than the helper
+ * exiting on its own?
+ *
+ * This is the distinction #646 turned on. A user clicking **No** makes the
+ * helper exit 1223, and that is the user's decision — "you declined" is the
+ * right thing to tell them. Nobody answering at all is not a decision, and
+ * telling them they declined would be wrong; it is also the case that used to
+ * hang forever, because there was no timeout to end the child and so no error
+ * of any kind. Node sets `killed` only when it was the `timeout` option that
+ * terminated the child, so it is the marker that separates the two.
+ */
+export function isElevationTimeout(err: unknown): boolean {
+    return (err as { killed?: boolean } | null | undefined)?.killed === true;
+}
+
+/**
+ * The one "we gave up waiting" result, shared by the two ways it can happen:
+ * the consent dialog was never answered, or the elevated helper never wrote a
+ * result file. The message was written for both from the start; until #646 the
+ * first path could not reach it, because the wait it needed to bound had no
+ * timeout and so never returned to produce a result at all.
+ */
+function elevationTimedOut(stderr: string): ElevatedResult {
+    return {
+        ok: false,
+        exitCode: -1,
+        stdout: '',
+        stderr,
+        errorMessage:
+            `elevated helper did not complete within ${ELEVATION_TIMEOUT_MS / 1000}s. ` +
+            'The UAC prompt may have been dismissed without action, or the helper may have crashed.',
+    };
+}
 /** Polling cadence for the result file. 200ms is fast enough that the
  *  user-perceived latency between the elevated helper finishing and our
  *  resolve is < 200ms, while not hammering the filesystem. */


### PR DESCRIPTION
Fixes #646. Answers and closes #647.

Two service-mode issues, both filed from qa-harness measurements. They land together because they are both about what the server tells you when an elevated operation doesn't work out.

## #646 — the UAC wait had no upper bound

`runElevated` awaited the `--request-uac` helper with no timeout, and that helper blocks until the consent dialog is answered. When it never was, the await never returned. `ELEVATION_TIMEOUT_MS` bounds `pollForResultFile`, which is reached *after* that await — so the 300 s deadline never started and the function had no upper bound at all. The user was left at `installMode: 'system-service'` with no service until the app restarted, and two `--request-uac` processes still alive fifteen minutes later.

The part worth keeping in mind: **the prompt does not have to be dismissed for this.** Windows auto-dismisses it after about two minutes, and the await still never returned. Any user who ignores the prompt long enough gets there — it was measured three separate ways, over 150 s, 342 s and 600 s windows.

- The `execFileAsync` call takes `timeout: ELEVATION_TIMEOUT_MS`, and the two phases now share **one** deadline rather than one each, so the caller can't be held for 600 s.
- Expiry returns the "did not complete within 300s. The UAC prompt may have been dismissed without action…" message. That message was written for exactly this case and simply could not be reached before.
- It must not say "you declined", because they didn't. `isElevationTimeout()` splits the two on the `killed` flag Node sets only when its own timeout ended the child; a decline exits 1223 with `killed` false and is unchanged.
- `!ok` still throws `ServiceInstallError` through `ServyClient`, so the timeout gets the same `installMode` revert a decline already did — which `ServiceApi.test.ts:926` requires.

**Residual, stated rather than hidden:** killing `--request-uac` does not retract a dialog Windows has already put on screen, so a user who answers Yes after the five minutes are up can still complete an install we have already reported as failed and reverted. The window is bounded and self-corrects on the next status read. An unbounded hang did not.

## #647 — `handoff-timeout` was documented and surfaced, but dead

You asked which was true rather than encoding a guess, which was the right call — and the history answers it outright. **Your reading is correct: the doc is stale.**

| | commit | date |
|---|---|---|
| producer added | `1507c36` "don't fall through to direct uninstall after LocalSystem handoff failure" | 2026-04-30 |
| producer removed | `a93721e` / `bcf5747` — Phase 4 (#108) | 2026-05-25 |

`1507c36` added `reason: 'handoff-timeout'` on the LocalSystem uninstall path, which relayed the uninstall to a user-session launcher and answered 503 when it couldn't reach one. Phase 4 replaced that relay with the `uninstall-pending` marker + operation-server sequence — which needs no user session and so cannot time out waiting for one. The producer went with the relay; the variant, its doc and its `SettingsModal` message stayed behind. Not a regression, and not a missing producer: `git log -S "reason: 'handoff-timeout'"` shows it added and deliberately removed, nothing in between.

So: the variant, its doc bullet and its `SettingsModal` case are removed. **Removed rather than marked reserved** — there is no handoff left to time out, and a reserved slot for a mechanism that no longer exists is how this happened the first time. The doc comment now records why it went, so nobody re-adds it from a pre-Phase-4 spec.

`handoff-no-target` is untouched. Its doc already says it is reserved and not emitted, which is accurate, so it isn't making the same false promise.

Also fixed: the `isLikelyLocalSystem` doc paragraph still described "we attempt the WTS handoff and it fails, then we fall through to direct uninstall" — behaviour Phase 4 removed. That stale text is part of what made the variant look live.

**For your QA suite:** the row asserting "uninstall with no reachable user session leaves the service installed and surfaces *Couldn't reach the user session*" is asserting a contract that was intentionally replaced. The Phase 4 sequence in your issue — revert `installMode`, write `uninstall-pending`, spawn the operation-server, `200 {ok: true, status: 'shutting-down'}` — is the intended contract, and is what to write the row against.

## Verification

- `npm test` — 216 files, 1937 passed / 5 skipped. 4 new tests on the timeout-vs-decline split.
- `npx tsc --noEmit` clean; `biome check` clean.
- **The `timeout` option itself is not unit-tested.** Doing so means mocking the launcher subprocess, which this test file explicitly declines to do ("would test the mock rather than the integration"). The evidence for the behaviour is the guest measurement in #646; the reachable part — what the user is told when it expires — is what the new tests pin. Worth re-running the harness's install rows against a beta carrying this.
