### PR TITLE
fix(tray): re-add the Windows icon after an explorer restart, and log the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - One `build_tray_nid` builder now feeds both the initial add and the re-add, so the icon that comes
     back is the icon that went away — same uID and callback message, or the shell routes clicks nowhere
     and the recovered icon is inert. 2 tests.
+  - **`TaskbarCreated` alone is not enough, and the sibling `minimize-to-tray` project already knew it.**
+    Two more mechanisms ported from there rather than rediscovered:
+    - **The broadcast never arrives at an elevated process.** UIPI drops messages sent from a lower
+      integrity level to a higher one, and explorer runs at medium IL — so in an elevated tray the
+      handler above is dead code. `minimize-to-tray` names this "the prime suspect" for an icon that
+      vanishes on a rebuild and never returns. `ChangeWindowMessageFilterEx(…, MSGFLT_ALLOW)` now lets
+      that one message through, unconditionally (it is harmless unelevated, and gating it on an
+      integrity check we would have to keep correct is the worse trade).
+    - **Several events drop the icon without broadcasting anything at all** — a display or resolution
+      change, a session lock/unlock, an RDP reconnect, a resume from sleep. The window now takes
+      `WM_DISPLAYCHANGE`, `WM_POWERBROADCAST` and `WM_WTSSESSION_CHANGE` (via
+      `WTSRegisterSessionNotification`), plus a 30-second `WM_TIMER` heartbeat as the backstop for
+      whatever those miss. Every one is **probe-gated**: `Shell_NotifyIconW(NIM_MODIFY)` with
+      `uFlags = 0` is a read-only "is this icon registered?" question, so a healthy icon costs one API
+      call and never flickers. Only an absent icon is re-added, and the log line names the trigger that
+      caught it. These messages reach us only because the window became top-level — a message-only
+      window receives none of them, for the same reason it never received `TaskbarCreated`.
 - **An unanswered UAC prompt hung the service install forever.** #646, measured on a Windows guest three
   separate ways (150 s, 342 s and 600 s windows). `runElevated` awaited the `--request-uac` helper with no
   timeout, and that helper blocks until the consent dialog is answered — so when it never was, the await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Windows tray icon never came back after explorer restarted, and nothing said so.** Two findings
+  from the qa-harness row-3.4 investigation (items 117 and 118), fixed together because the second is why
+  the first took a day to find.
+  - Win32 requires every tray app to register `TaskbarCreated` and re-issue `NIM_ADD` when the shell
+    recreates `Shell_TrayWnd` — which it does on any explorer restart, from a crash, an update, or a user
+    restarting it deliberately. `grep -rn "TaskbarCreated" --include=*.rs .` returned nothing across the
+    whole tree. The icon was added once and never again, so an explorer restart left a perfectly alive,
+    still-polling tray process with **no icon, permanently**, and the launcher could not rescue it either:
+    `tray_present_in` checks that the tray PROCESS exists, which it does. In service mode the tray is the
+    only stop affordance the product has, so this is not a cosmetic loss.
+  - **The window had to change first.** The host window was created with `HWND_MESSAGE` as parent, and
+    message-only windows are excluded from `HWND_BROADCAST` delivery — which is how the shell sends
+    `TaskbarCreated`. A handler alone would never have fired. It is now a hidden top-level window
+    (`WS_EX_TOOLWINDOW`, never shown, so still invisible and still absent from the taskbar and Alt-Tab).
+  - **The whole Windows tray path logged nothing** — every `log::` call in `tray.rs` sat inside
+    `#[cfg(target_os = "linux")]`. An `NIM_ADD` failure was therefore invisible: `tray.log` showed
+    `tray: starting`, then nothing, whatever happened next, so "icon added", "add failed",
+    "added-then-lost" and "added under a different name" produced byte-identical logs and the real cause
+    was only found by enumerating the shell from outside. The Windows path now logs the `NIM_ADD` result
+    with `GetLastError()` on failure, the re-add after a restart, and **the resolved tooltip** — the
+    highest-value line, since the tooltip is the icon's shell-visible identity and changes with the
+    install mode, which is exactly what the row-3.4 mismatch turned on. (`is_service_mode_at_start` was
+    already logged by the tray binary.)
+  - One `build_tray_nid` builder now feeds both the initial add and the re-add, so the icon that comes
+    back is the icon that went away — same uID and callback message, or the shell routes clicks nowhere
+    and the recovered icon is inert. 2 tests.
+
 ## [0.1.30-beta.115] - 2026-09-09
 
 ### Fixed

--- a/common/src/tray.rs
+++ b/common/src/tray.rs
@@ -20,16 +20,25 @@
 //!    handles both encodings natively, so we don't need an in-tree PNG
 //!    decoder.
 //! 2. Register a window class with a custom `WindowProc`.
-//! 3. Create a hidden message-only window (`HWND_MESSAGE` parent), the
-//!    canonical Win32 host for tray-icon callbacks.
+//! 3. Register the shell's `TaskbarCreated` broadcast, then create a hidden
+//!    TOP-LEVEL window (`WS_EX_TOOLWINDOW`, never shown). Not a message-only
+//!    window: `HWND_MESSAGE` children are excluded from `HWND_BROADCAST`, and
+//!    that is how the shell announces it has recreated the tray — so a
+//!    message-only window can never learn its icon was dropped (see step 6b).
 //! 4. `SetWindowLongPtrW(hWnd, GWLP_USERDATA, ptr)` to give the WndProc
 //!    access to a `Box<TrayState>` containing the confirm-dialog wide
-//!    strings and the "user confirmed exit" flag.
+//!    strings, the icon + tooltip needed to re-add, and the "user confirmed
+//!    exit" flag.
 //! 5. `Shell_NotifyIconW(NIM_ADD, &nid)` registers the tray icon with
 //!    `uCallbackMessage = WM_USER + 1`.
 //! 6. Pump messages with `GetMessageW` until `WM_QUIT` (posted by the
 //!    WndProc when the user clicks Yes on the dialog).
-//! 7. Cleanup runs via a `Drop` guard so it survives panics: removes the
+//! 7. On `TaskbarCreated` — explorer restarting, from a crash, an update or
+//!    a user restarting it — re-issue `NIM_ADD`. Win32 requires every tray
+//!    app to do this; without it the shell's recreation of `Shell_TrayWnd`
+//!    leaves this process alive and iconless for good, which in service mode
+//!    removes the only way the user has to stop the server.
+//! 8. Cleanup runs via a `Drop` guard so it survives panics: removes the
 //!    tray icon, destroys the window, destroys the HICON.
 //!
 //! No async runtime, no third-party tray crate, no GTK/glib transitive
@@ -66,11 +75,13 @@ pub enum TrayAction {
 use anyhow::{anyhow, Context, Result};
 #[cfg(windows)]
 use std::cell::Cell;
+#[cfg(windows)]
+use std::sync::atomic::{AtomicU32, Ordering};
 
 #[cfg(windows)]
 use windows::core::PCWSTR;
 #[cfg(windows)]
-use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::Foundation::{GetLastError, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
 #[cfg(windows)]
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 #[cfg(windows)]
@@ -82,11 +93,11 @@ use windows::Win32::UI::Shell::{
 use windows::Win32::UI::WindowsAndMessaging::{
     AppendMenuW, CreateIconFromResourceEx, CreatePopupMenu, CreateWindowExW, DefWindowProcW,
     DestroyIcon, DestroyMenu, DestroyWindow, DispatchMessageW, GetCursorPos, GetMessageW,
-    GetWindowLongPtrW, MessageBoxW, PostQuitMessage, RegisterClassW, SetForegroundWindow,
-    SetWindowLongPtrW, TrackPopupMenu, TranslateMessage, UnregisterClassW, GWLP_USERDATA, HICON,
-    HMENU, HWND_MESSAGE, IDYES, LR_DEFAULTCOLOR, MB_ICONQUESTION, MB_YESNO, MF_SEPARATOR, MF_STRING,
-    MSG, TPM_LEFTALIGN, TPM_RIGHTBUTTON, WINDOW_EX_STYLE, WINDOW_STYLE, WM_COMMAND, WM_LBUTTONUP,
-    WM_QUIT, WM_RBUTTONUP, WM_USER, WNDCLASSW,
+    GetWindowLongPtrW, MessageBoxW, PostQuitMessage, RegisterClassW, RegisterWindowMessageW,
+    SetForegroundWindow, SetWindowLongPtrW, TrackPopupMenu, TranslateMessage, UnregisterClassW,
+    GWLP_USERDATA, HICON, HMENU, IDYES, LR_DEFAULTCOLOR, MB_ICONQUESTION, MB_YESNO, MF_SEPARATOR,
+    MF_STRING, MSG, TPM_LEFTALIGN, TPM_RIGHTBUTTON, WINDOW_STYLE, WM_COMMAND, WM_LBUTTONUP,
+    WM_QUIT, WM_RBUTTONUP, WM_USER, WNDCLASSW, WS_EX_TOOLWINDOW,
 };
 #[cfg(windows)]
 use windows::Win32::UI::Shell::ShellExecuteW;
@@ -115,6 +126,25 @@ const MENU_ID_OPEN: u32 = 100;
 #[cfg(windows)]
 const MENU_ID_EXIT: u32 = 101;
 
+/// The `TaskbarCreated` message id, resolved once at startup by
+/// `RegisterWindowMessageW` and read by the WndProc.
+///
+/// The shell broadcasts this to every top-level window when it recreates
+/// `Shell_TrayWnd` — which it does whenever explorer restarts, after a crash,
+/// an update, or a user restarting it deliberately. Every icon in the tray is
+/// dropped at that moment, and an app that does not re-add its own never gets
+/// it back: the process stays perfectly alive, still polling, with no icon and
+/// no way for the user to reach it. In service mode the tray is the only stop
+/// affordance the product has, so that is not a cosmetic loss.
+///
+/// The id is allocated at runtime (it is not a constant), and the WndProc is a
+/// plain `extern "system"` fn with nowhere to hang state, so it goes in a
+/// static. Zero means "not registered yet"; the WndProc compares against it
+/// only when non-zero, since message 0 is `WM_NULL` and would otherwise match
+/// every time.
+#[cfg(windows)]
+static TASKBAR_CREATED_MSG: AtomicU32 = AtomicU32::new(0);
+
 /// Per-tray runtime state, stashed in the window's `GWLP_USERDATA` slot.
 ///
 /// Lifetime: allocated as a `Box`, leaked into `GWLP_USERDATA` on
@@ -139,6 +169,34 @@ struct TrayState {
     menu_label_open_w: Vec<u16>,
     /// "Exit" wide label for the popup menu.
     menu_label_exit_w: Vec<u16>,
+    /// The icon handle and tooltip, kept so the WndProc can rebuild the
+    /// `NOTIFYICONDATAW` and re-issue `NIM_ADD` when the shell broadcasts
+    /// `TaskbarCreated`. Owned by `TrayCleanup`, which outlives every message.
+    hicon: HICON,
+    tooltip_w: Vec<u16>,
+}
+
+/// Build the `NOTIFYICONDATAW` that registers our icon.
+///
+/// Shared by the initial `NIM_ADD` and the re-add after an explorer restart,
+/// so the icon that comes back is the icon that went away — identical uID,
+/// callback message, icon and tooltip. Two hand-rolled copies would drift.
+#[cfg(windows)]
+fn build_tray_nid(hwnd: HWND, hicon: HICON, tooltip_w: &[u16]) -> NOTIFYICONDATAW {
+    // SAFETY: NOTIFYICONDATAW is a plain C struct; zeroing is the documented
+    // way to initialize it before setting the fields uFlags names.
+    let mut nid: NOTIFYICONDATAW = unsafe { std::mem::zeroed() };
+    nid.cbSize = std::mem::size_of::<NOTIFYICONDATAW>() as u32;
+    nid.hWnd = hwnd;
+    nid.uID = TRAY_ICON_UID;
+    nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+    nid.uCallbackMessage = WM_TRAY_CALLBACK;
+    nid.hIcon = hicon;
+    // szTip: [u16; 128]; copy up to 127 chars. Already zeroed, so the copy
+    // leaves it NUL-terminated.
+    let copy_len = tooltip_w.len().min(nid.szTip.len() - 1);
+    nid.szTip[..copy_len].copy_from_slice(&tooltip_w[..copy_len]);
+    nid
 }
 
 /// Run a tray icon event loop. BLOCKS the calling thread until the user
@@ -219,18 +277,45 @@ pub fn run(
         open_url_provider,
         menu_label_open_w: to_wide("Open ws-scrcpy-web"),
         menu_label_exit_w: to_wide("Exit"),
+        hicon,
+        tooltip_w: to_wide(tooltip),
     });
     let state_ptr: *mut TrayState = Box::into_raw(state);
 
-    // 4. Create the hidden message-only window. Parent = HWND_MESSAGE means
-    //    the window is invisible and only receives messages.
+    // 3b. Resolve the shell's icon-recreation broadcast before the window
+    //     exists, so no restart can slip between creation and registration.
+    //     SAFETY: RegisterWindowMessageW takes a NUL-terminated wide string;
+    //     to_wide supplies one. It returns 0 only on failure, which we log
+    //     and carry on from — the tray still works, it just cannot recover
+    //     its icon from an explorer restart.
+    let taskbar_created_w = to_wide("TaskbarCreated");
+    let taskbar_created = unsafe { RegisterWindowMessageW(PCWSTR(taskbar_created_w.as_ptr())) };
+    if taskbar_created == 0 {
+        crate::log::error(&format!(
+            "tray: RegisterWindowMessageW(TaskbarCreated) failed (GetLastError={}); \
+             the icon will NOT come back if explorer restarts",
+            unsafe { GetLastError().0 }
+        ));
+    }
+    TASKBAR_CREATED_MSG.store(taskbar_created, Ordering::SeqCst);
+
+    // 4. Create the hidden window.
+    //
+    //    NOT a message-only window, deliberately. `HWND_MESSAGE` as parent is
+    //    the obvious choice for something that only wants messages, and it is
+    //    what this used to be — but message-only windows are excluded from
+    //    `HWND_BROADCAST` delivery, and `HWND_BROADCAST` is exactly how the
+    //    shell sends `TaskbarCreated`. A message-only window can therefore
+    //    never learn that its icon was dropped, which made the re-add above
+    //    unreachable. So: a real top-level window that is simply never shown.
+    //    `WS_EX_TOOLWINDOW` keeps it out of the taskbar and Alt-Tab, and with
+    //    no `ShowWindow` call it is never painted.
     let window_name_w = to_wide("");
     // SAFETY: All pointers derived from owned `Vec<u16>` buffers that
-    // outlive this call. HWND_MESSAGE is the documented sentinel for a
-    // message-only window. hInstance is valid from GetModuleHandleW above.
+    // outlive this call. hInstance is valid from GetModuleHandleW above.
     let hwnd: HWND = unsafe {
         CreateWindowExW(
-            WINDOW_EX_STYLE(0),
+            WS_EX_TOOLWINDOW,
             PCWSTR(class_name_w.as_ptr()),
             PCWSTR(window_name_w.as_ptr()),
             WINDOW_STYLE(0),
@@ -238,7 +323,7 @@ pub fn run(
             0,
             0,
             0,
-            HWND_MESSAGE,
+            HWND::default(),
             HMENU::default(),
             hinstance,
             None,
@@ -271,25 +356,33 @@ pub fn run(
     };
 
     // 7. Populate NOTIFYICONDATAW and add the tray icon.
-    let mut nid: NOTIFYICONDATAW = unsafe { std::mem::zeroed() };
-    nid.cbSize = std::mem::size_of::<NOTIFYICONDATAW>() as u32;
-    nid.hWnd = hwnd;
-    nid.uID = TRAY_ICON_UID;
-    nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
-    nid.uCallbackMessage = WM_TRAY_CALLBACK;
-    nid.hIcon = hicon;
-    // szTip: [u16; 128]; copy up to 127 chars + NUL.
-    let tooltip_w = to_wide(tooltip);
-    let copy_len = tooltip_w.len().min(nid.szTip.len() - 1);
-    nid.szTip[..copy_len].copy_from_slice(&tooltip_w[..copy_len]);
-    // (Already zero-initialized, so szTip is NUL-terminated.)
+    let nid = build_tray_nid(hwnd, hicon, &to_wide(tooltip));
+
+    // The tooltip is the icon's shell-visible identity and it changes with the
+    // install mode, so it is the single most useful line here: knowing which
+    // string we registered is what tells a later reader whether the icon they
+    // are looking for is the icon we added. Before this the whole Windows
+    // path logged nothing at all, and an NIM_ADD failure was indistinguishable
+    // from a success followed by a loss (#118).
+    crate::log::info(&format!(
+        "tray: registering icon (tooltip {tooltip:?}, uID {TRAY_ICON_UID}, TaskbarCreated msg {taskbar_created})"
+    ));
 
     // SAFETY: nid is fully initialized; Shell_NotifyIconW reads cbSize bytes.
     let added = unsafe { Shell_NotifyIconW(NIM_ADD, &nid) };
     if !added.as_bool() {
-        return Err(anyhow!("Shell_NotifyIconW(NIM_ADD) returned FALSE"));
+        // SAFETY: GetLastError reads this thread's last-error slot, set by the
+        // failing call above. Read it BEFORE anything else can overwrite it.
+        let err = unsafe { GetLastError().0 };
+        crate::log::error(&format!(
+            "tray: Shell_NotifyIconW(NIM_ADD) returned FALSE (GetLastError={err})"
+        ));
+        return Err(anyhow!(
+            "Shell_NotifyIconW(NIM_ADD) returned FALSE (GetLastError={err})"
+        ));
     }
     _guard.nid_added.set(true);
+    crate::log::info("tray: icon added");
 
     // 7b. Optional startup balloon notification. Uses NIM_MODIFY with the
     // NIF_INFO flag on the same icon — the balloon hangs off the existing
@@ -413,6 +506,34 @@ unsafe extern "system" fn tray_wnd_proc(
     // is sound; null check guards the (unreachable in practice) racey case.
     let state_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut TrayState;
     let state = if state_ptr.is_null() { None } else { Some(&*state_ptr) };
+
+    // Explorer restarted and recreated Shell_TrayWnd, dropping every tray
+    // icon including ours. Re-add it, or the process stays alive with no icon
+    // for the rest of its life. Guarded on non-zero because an unregistered
+    // (0) id would otherwise match WM_NULL and re-add on every stray message.
+    let taskbar_created = TASKBAR_CREATED_MSG.load(Ordering::SeqCst);
+    if taskbar_created != 0 && msg == taskbar_created {
+        if let Some(s) = state {
+            let nid = build_tray_nid(hwnd, s.hicon, &s.tooltip_w);
+            // SAFETY: nid is fully initialized by build_tray_nid.
+            let re_added = Shell_NotifyIconW(NIM_ADD, &nid);
+            if re_added.as_bool() {
+                crate::log::info("tray: explorer restarted (TaskbarCreated); icon re-added");
+            } else {
+                // SAFETY: reads this thread's last-error slot, set by the call above.
+                crate::log::error(&format!(
+                    "tray: explorer restarted (TaskbarCreated) but Shell_NotifyIconW(NIM_ADD) \
+                     returned FALSE (GetLastError={}); the icon is gone until restart",
+                    GetLastError().0
+                ));
+            }
+        } else {
+            crate::log::error(
+                "tray: TaskbarCreated arrived with no window state; icon NOT re-added",
+            );
+        }
+        return LRESULT(0);
+    }
 
     if msg == WM_TRAY_CALLBACK {
         // lParam low-word holds the mouse event. Per Win32 docs, high-word
@@ -651,6 +772,36 @@ mod tests {
     fn to_wide_handles_empty_string() {
         let v = to_wide("");
         assert_eq!(v, vec![0]);
+    }
+
+    // The icon that comes back after an explorer restart has to be the icon
+    // that went away — same uID and callback message, or the shell routes
+    // clicks nowhere and the "recovered" icon is inert. One builder is what
+    // guarantees that, so pin what it builds.
+    #[test]
+    fn build_tray_nid_sets_the_fields_uflags_promises() {
+        let nid = build_tray_nid(HWND::default(), HICON::default(), &to_wide("ws-scrcpy-web"));
+
+        assert_eq!(nid.cbSize, std::mem::size_of::<NOTIFYICONDATAW>() as u32);
+        assert_eq!(nid.uID, TRAY_ICON_UID);
+        assert_eq!(nid.uFlags, NIF_ICON | NIF_MESSAGE | NIF_TIP);
+        assert_eq!(nid.uCallbackMessage, WM_TRAY_CALLBACK);
+
+        let tip: String = char::decode_utf16(nid.szTip.iter().copied().take_while(|c| *c != 0))
+            .map(|c| c.unwrap_or('?'))
+            .collect();
+        assert_eq!(tip, "ws-scrcpy-web");
+    }
+
+    #[test]
+    fn build_tray_nid_truncates_an_over_long_tooltip_and_keeps_it_nul_terminated() {
+        // szTip is [u16; 128], so 127 chars plus the terminator is the ceiling.
+        let long = "x".repeat(400);
+        let nid = build_tray_nid(HWND::default(), HICON::default(), &to_wide(&long));
+
+        let len = nid.szTip.iter().take_while(|c| **c != 0).count();
+        assert_eq!(len, 127);
+        assert_eq!(nid.szTip[127], 0, "must stay NUL-terminated");
     }
 
     #[test]

--- a/common/src/tray.rs
+++ b/common/src/tray.rs
@@ -38,6 +38,16 @@
 //!    app to do this; without it the shell's recreation of `Shell_TrayWnd`
 //!    leaves this process alive and iconless for good, which in service mode
 //!    removes the only way the user has to stop the server.
+//!    Two things make that handler actually fire, both learned by the sibling
+//!    `minimize-to-tray` project rather than rediscovered here:
+//!      - `ChangeWindowMessageFilterEx(MSGFLT_ALLOW)`, because UIPI drops a
+//!        medium-IL explorer's broadcast to an elevated process, which would
+//!        make the handler dead code exactly when it is needed.
+//!      - A probe-and-recover path for the events that drop the icon and
+//!        announce NOTHING: display change, session lock/unlock, RDP
+//!        reconnect, resume, plus a 30s heartbeat behind them. The probe is
+//!        `NIM_MODIFY` with `uFlags = 0`, a read-only "still registered?"
+//!        question, so a healthy icon never flickers.
 //! 8. Cleanup runs via a `Drop` guard so it survives panics: removes the
 //!    tray icon, destroys the window, destroys the HICON.
 //!
@@ -93,11 +103,17 @@ use windows::Win32::UI::Shell::{
 use windows::Win32::UI::WindowsAndMessaging::{
     AppendMenuW, CreateIconFromResourceEx, CreatePopupMenu, CreateWindowExW, DefWindowProcW,
     DestroyIcon, DestroyMenu, DestroyWindow, DispatchMessageW, GetCursorPos, GetMessageW,
-    GetWindowLongPtrW, MessageBoxW, PostQuitMessage, RegisterClassW, RegisterWindowMessageW,
-    SetForegroundWindow, SetWindowLongPtrW, TrackPopupMenu, TranslateMessage, UnregisterClassW,
-    GWLP_USERDATA, HICON, HMENU, IDYES, LR_DEFAULTCOLOR, MB_ICONQUESTION, MB_YESNO, MF_SEPARATOR,
-    MF_STRING, MSG, TPM_LEFTALIGN, TPM_RIGHTBUTTON, WINDOW_STYLE, WM_COMMAND, WM_LBUTTONUP,
-    WM_QUIT, WM_RBUTTONUP, WM_USER, WNDCLASSW, WS_EX_TOOLWINDOW,
+    ChangeWindowMessageFilterEx, GetWindowLongPtrW, KillTimer, MessageBoxW, PostQuitMessage,
+    RegisterClassW, RegisterWindowMessageW, SetForegroundWindow, SetTimer, SetWindowLongPtrW,
+    TrackPopupMenu, TranslateMessage, UnregisterClassW, GWLP_USERDATA, HICON, HMENU, IDYES,
+    LR_DEFAULTCOLOR, MB_ICONQUESTION, MB_YESNO, MF_SEPARATOR, MF_STRING, MSGFLT_ALLOW, MSG,
+    TPM_LEFTALIGN, TPM_RIGHTBUTTON, WINDOW_STYLE, WM_COMMAND, WM_DISPLAYCHANGE, WM_LBUTTONUP,
+    WM_POWERBROADCAST, WM_QUIT, WM_RBUTTONUP, WM_TIMER, WM_USER, WM_WTSSESSION_CHANGE, WNDCLASSW,
+    WS_EX_TOOLWINDOW,
+};
+#[cfg(windows)]
+use windows::Win32::System::RemoteDesktop::{
+    WTSRegisterSessionNotification, WTSUnRegisterSessionNotification, NOTIFY_FOR_THIS_SESSION,
 };
 #[cfg(windows)]
 use windows::Win32::UI::Shell::ShellExecuteW;
@@ -174,6 +190,58 @@ struct TrayState {
     /// `TaskbarCreated`. Owned by `TrayCleanup`, which outlives every message.
     hicon: HICON,
     tooltip_w: Vec<u16>,
+}
+
+/// Timer id for the icon-presence heartbeat. Arbitrary but stable per window.
+#[cfg(windows)]
+const TRAY_HEARTBEAT_TIMER: usize = 1;
+
+/// How often to check that our icon is still registered.
+///
+/// The shell drops tray icons on events that raise NO `TaskbarCreated` at all —
+/// a display/resolution change, a session unlock, an RDP reconnect, a resume
+/// from sleep. `minimize-to-tray` found this the hard way and settled on a 30s
+/// heartbeat plus event-driven probes; this is the same number for the same
+/// reason. The probe is read-only, so a healthy icon costs one API call.
+#[cfg(windows)]
+const TRAY_HEARTBEAT_MS: u32 = 30_000;
+
+/// Is our icon currently registered with the shell?
+///
+/// `NIM_MODIFY` with `uFlags = 0` is a read-only existence probe: it returns
+/// non-zero iff that `(hWnd, uID)` pair is registered, and changes nothing
+/// visible. That is what makes the heartbeat safe to run unconditionally —
+/// re-adding blind would flicker the icon every 30 seconds.
+#[cfg(windows)]
+fn tray_icon_present(hwnd: HWND) -> bool {
+    let mut nid: NOTIFYICONDATAW = unsafe { std::mem::zeroed() };
+    nid.cbSize = std::mem::size_of::<NOTIFYICONDATAW>() as u32;
+    nid.hWnd = hwnd;
+    nid.uID = TRAY_ICON_UID;
+    // uFlags deliberately left 0: nothing is modified, we only want the verdict.
+    // SAFETY: nid is fully initialized; Shell_NotifyIconW reads cbSize bytes.
+    unsafe { Shell_NotifyIconW(NIM_MODIFY, &nid).as_bool() }
+}
+
+/// Re-add the icon if, and only if, it has gone missing. `reason` names the
+/// event that prompted the check so `tray.log` says which trigger recovered it.
+#[cfg(windows)]
+fn recover_icon_if_absent(hwnd: HWND, state: &TrayState, reason: &str) {
+    if tray_icon_present(hwnd) {
+        return; // healthy — no work, and no flicker
+    }
+    let nid = build_tray_nid(hwnd, state.hicon, &state.tooltip_w);
+    // SAFETY: nid is fully initialized by build_tray_nid.
+    let re_added = unsafe { Shell_NotifyIconW(NIM_ADD, &nid) };
+    if re_added.as_bool() {
+        crate::log::info(&format!("tray: icon was absent ({reason}); re-added"));
+    } else {
+        // SAFETY: reads this thread's last-error slot, set by the call above.
+        crate::log::error(&format!(
+            "tray: icon absent ({reason}) and NIM_ADD failed (GetLastError={})",
+            unsafe { GetLastError().0 }
+        ));
+    }
 }
 
 /// Build the `NOTIFYICONDATAW` that registers our icon.
@@ -338,6 +406,42 @@ pub fn run(
         anyhow!("CreateWindowExW: {e}")
     })?;
 
+    // 4b. Let `TaskbarCreated` through the UIPI message filter.
+    //
+    //     User Interface Privilege Isolation drops messages sent from a LOWER
+    //     integrity level to a higher one. Explorer runs at medium IL; if this
+    //     tray is running elevated — an admin-launched app, or any future
+    //     elevated host — the shell's broadcast is discarded by the OS before
+    //     our WndProc is ever called, and the handler below becomes dead code.
+    //     `minimize-to-tray` identified exactly this as the prime suspect for
+    //     "the icon vanished on a notification-area rebuild and never came
+    //     back", so we do not repeat the diagnosis here.
+    //
+    //     Harmless when not elevated (the filter is already permissive), so it
+    //     is unconditional rather than gated on an IL check we would then have
+    //     to keep correct.
+    if taskbar_created != 0 {
+        // SAFETY: hwnd is valid, and MSGFLT_ALLOW with a null change-info
+        // pointer is the documented single-message allow form.
+        let allowed = unsafe {
+            ChangeWindowMessageFilterEx(hwnd, taskbar_created, MSGFLT_ALLOW, None).is_ok()
+        };
+        crate::log::info(&format!(
+            "tray: TaskbarCreated UIPI filter allow={allowed}"
+        ));
+    }
+
+    // 4c. Ask for session-change notifications (lock/unlock, RDP connect and
+    //     disconnect). These rebuild the notification area WITHOUT broadcasting
+    //     TaskbarCreated, so they are invisible to the handler above.
+    //     Best-effort: without it the 30s heartbeat still recovers the icon,
+    //     just later.
+    // SAFETY: hwnd is valid; NOTIFY_FOR_THIS_SESSION is the documented flag.
+    let session_notify = unsafe { WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION) }.is_ok();
+    if !session_notify {
+        crate::log::info("tray: WTSRegisterSessionNotification failed; heartbeat still covers it");
+    }
+
     // 5. Stash the state pointer in GWLP_USERDATA so the WndProc can find it.
     // SAFETY: hwnd is valid (just created); GWLP_USERDATA is a documented
     // per-window pointer-sized slot. We are the sole writer.
@@ -383,6 +487,19 @@ pub fn run(
     }
     _guard.nid_added.set(true);
     crate::log::info("tray: icon added");
+
+    // 7c. Start the presence heartbeat. TaskbarCreated covers explorer
+    //     restarting; this covers everything that drops the icon WITHOUT
+    //     announcing it. Probe-gated, so a healthy icon costs one call per tick
+    //     and never flickers.
+    // SAFETY: hwnd is valid; a null TIMERPROC routes WM_TIMER to the WndProc.
+    if unsafe { SetTimer(hwnd, TRAY_HEARTBEAT_TIMER, TRAY_HEARTBEAT_MS, None) } == 0 {
+        crate::log::error(&format!(
+            "tray: SetTimer failed (GetLastError={}); the icon will only recover \
+             from TaskbarCreated, not from a display or session change",
+            unsafe { GetLastError().0 }
+        ));
+    }
 
     // 7b. Optional startup balloon notification. Uses NIM_MODIFY with the
     // NIF_INFO flag on the same icon — the balloon hangs off the existing
@@ -446,6 +563,14 @@ impl Drop for TrayCleanup {
         // Order: remove tray icon → destroy window → free state → destroy
         // icon → unregister class. The class can survive across runs (it's
         // process-scoped); unregistering is best-effort cleanup.
+        // Stop the heartbeat and the session feed before the window goes, so
+        // neither can fire against a destroyed HWND.
+        // SAFETY: both take the hwnd we created; each is a no-op if it was
+        // never successfully registered, and failures here are not actionable.
+        unsafe {
+            let _ = KillTimer(self.hwnd, TRAY_HEARTBEAT_TIMER);
+            let _ = WTSUnRegisterSessionNotification(self.hwnd);
+        }
         if self.nid_added.get() {
             let mut nid: NOTIFYICONDATAW = unsafe { std::mem::zeroed() };
             nid.cbSize = std::mem::size_of::<NOTIFYICONDATAW>() as u32;
@@ -533,6 +658,33 @@ unsafe extern "system" fn tray_wnd_proc(
             );
         }
         return LRESULT(0);
+    }
+
+    // Events that rebuild or disturb the notification area WITHOUT broadcasting
+    // TaskbarCreated. Each one is probe-gated inside recover_icon_if_absent, so
+    // the common case (icon is fine) does nothing at all.
+    //
+    // WM_TIMER is the backstop that catches whatever these miss; the specific
+    // events exist so recovery is immediate rather than up to 30 seconds later.
+    // Both only reach us because the window is now top-level — a message-only
+    // window receives none of them, which is the same reason TaskbarCreated
+    // could not arrive before.
+    if msg == WM_TIMER || msg == WM_DISPLAYCHANGE || msg == WM_POWERBROADCAST || msg == WM_WTSSESSION_CHANGE {
+        if let Some(s) = state {
+            let reason = match msg {
+                WM_TIMER => "heartbeat",
+                WM_DISPLAYCHANGE => "display change",
+                WM_POWERBROADCAST => "power/resume",
+                _ => "session change",
+            };
+            recover_icon_if_absent(hwnd, s, reason);
+        }
+        // WM_POWERBROADCAST wants TRUE to grant the request; the rest want 0.
+        // Fall through to DefWindowProcW for the power case rather than
+        // guessing, and answer the others ourselves.
+        if msg != WM_POWERBROADCAST {
+            return LRESULT(0);
+        }
     }
 
     if msg == WM_TRAY_CALLBACK {


### PR DESCRIPTION
Closes todo items 117 and 118, both found by the qa-harness row-3.4 investigation. They ship together because the second is the reason the first cost a day to find.

## 117 — the icon never came back

Win32 requires every tray app to `RegisterWindowMessageW("TaskbarCreated")` and re-issue `NIM_ADD` when the shell recreates `Shell_TrayWnd`. It does that on any explorer restart — a crash, an update, or a user restarting it deliberately — and drops every icon in the tray at that moment.

`grep -rn "TaskbarCreated" --include=*.rs .` returned nothing across the whole tree. The icon was added once at startup and never again, so an explorer restart left a perfectly alive, still-polling tray process with **no icon, permanently**. The launcher doesn't rescue it either: `tray_present_in` checks that the tray *process* exists, and it does — nothing anywhere notices a missing *icon*. In service mode the tray is the only stop affordance the product has, so this isn't cosmetic.

**The window had to change before the handler could work.** The host window was created with `HWND_MESSAGE` as parent, and message-only windows are excluded from `HWND_BROADCAST` delivery — which is exactly how the shell sends `TaskbarCreated`. Adding the handler alone would have been dead code. It's now a hidden **top-level** window: `WS_EX_TOOLWINDOW`, never `ShowWindow`n, so still invisible and still absent from the taskbar and Alt-Tab.

The message id is allocated at runtime and the WndProc is a bare `extern "system"` fn with nowhere to hang state, so it lives in an `AtomicU32`. It's compared only when non-zero — id 0 would otherwise match `WM_NULL` and re-add on every stray message.

## 118 — the path was silent, which is why this was expensive

Every `log::` call in `tray.rs` sat inside `#[cfg(target_os = "linux")]`. The entire Windows implementation — icon creation, class registration, the `NIM_ADD`, the message pump — logged nothing and never called `GetLastError`. So an icon-add failure was 100% invisible: `tray.log` showed `tray: starting`, then nothing, whatever happened next. "Icon added", "add failed", "added then lost" and "added under a different name" all produced byte-identical logs, and the real cause was only found by enumerating the shell from outside.

Now logged: the `NIM_ADD` result with `GetLastError()` on failure, the re-add after a restart (success and failure), and **the resolved tooltip** — the highest-value line, because the tooltip is the icon's shell-visible identity, it changes with the install mode, and it is precisely what the row-3.4 mismatch turned on. `is_service_mode_at_start` was already logged by the tray binary (`tray/src/main.rs:161`), so that ask was already met.

## Shared builder

`build_tray_nid` now feeds both the initial add and the re-add. The icon that comes back has to be the icon that went away — same `uID` and `uCallbackMessage`, or the shell routes clicks nowhere and the "recovered" icon is inert. Two hand-rolled copies would drift; the two new tests pin the fields `uFlags` promises and the 127-char tooltip truncation.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean (that's the gate CI runs).
- `cargo test -p ws-scrcpy-web-common` — 64 passed, including the 2 new.
- **Not verified against a real explorer restart.** That needs a Windows desktop with a live tray, which is the harness's territory (their item 21 / row 3.4), not something a unit test reaches. The new logging is what makes it checkable when it is: a restart should now produce `tray: explorer restarted (TaskbarCreated); icon re-added` in `tray.log`.
- Item 119 (tray spawns into the first active session only) is untouched — it's a feature request, not this defect.
