### PR TITLE
fix(deps): resolve openBrowser's URL openers by absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`openBrowser.ts` names every binary by absolute path** (todo item 115). All three platform branches
+  spawned a bare name — `cmd.exe`, `xdg-open`, `open` — so each resolved off the process `PATH`, which
+  Local-Dependencies-Only forbids. This was the last URL-opener in the repo doing so: the Rust half of the
+  same application had already decided the other way and says why in its own comments
+  (`common/src/tray.rs` opens through `/usr/bin/xdg-open`, "absolute path on purpose"), so the two halves
+  disagreed about the same binary. Windows now uses the literal `C:\Windows\System32\cmd.exe` — the string
+  `launcher/src/elevated_runner.rs` already uses, and deliberately not `%SystemRoot%`, since an env var is
+  a forbidden resolution path under the same rule. Linux and macOS go through `resolveSystemTool`, the
+  TypeScript twin of the launcher's `linux_service::tool_dir`: probe `/usr/bin`, then `/bin`, fall back to
+  `/usr/bin` — so a missing tool fails with ENOENT on a known path instead of quietly finding something
+  else on `PATH`. The resolved path is now logged rather than a generic "via xdg-open". 4 tests.
+
 ## [0.1.30-beta.115] - 2026-09-09
 
 ### Fixed

--- a/src/server/__tests__/openBrowser.test.ts
+++ b/src/server/__tests__/openBrowser.test.ts
@@ -2,7 +2,35 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { consumeSuppressBrowserMarker, shouldAutoOpenBrowser } from '../openBrowser';
+import { consumeSuppressBrowserMarker, resolveSystemTool, shouldAutoOpenBrowser } from '../openBrowser';
+
+// Item 115. openBrowser was the last place in the repo that resolved a URL
+// opener off PATH, while the Rust half of the same application already used
+// absolute paths on purpose and said so in its comments. This is the
+// TypeScript twin of `linux_service::tool_dir`, so it owes the same
+// guarantees: absolute always, /usr/bin preferred, /bin honoured, and never a
+// bare name whatever the filesystem looks like.
+describe('resolveSystemTool', () => {
+    it('prefers /usr/bin when the tool is there', () => {
+        expect(resolveSystemTool('xdg-open', (p) => p === '/usr/bin/xdg-open')).toBe('/usr/bin/xdg-open');
+    });
+
+    it('falls back to /bin when /usr/bin does not have it', () => {
+        expect(resolveSystemTool('xdg-open', (p) => p === '/bin/xdg-open')).toBe('/bin/xdg-open');
+    });
+
+    it('prefers /usr/bin when BOTH exist, matching the launcher probe order', () => {
+        expect(resolveSystemTool('xdg-open', () => true)).toBe('/usr/bin/xdg-open');
+    });
+
+    it('still returns an absolute path when the tool is nowhere — never a bare name', () => {
+        // The point of the fallback: spawn must fail with ENOENT on a known
+        // path rather than silently succeed against something on PATH.
+        const resolved = resolveSystemTool('xdg-open', () => false);
+        expect(resolved).toBe('/usr/bin/xdg-open');
+        expect(resolved.startsWith('/')).toBe(true);
+    });
+});
 
 /**
  * D1: a cold start PAST first-run must still open a browser tab. The native

--- a/src/server/openBrowser.ts
+++ b/src/server/openBrowser.ts
@@ -1,8 +1,36 @@
 import { spawn } from 'child_process';
-import { rmSync, statSync } from 'fs';
+import { existsSync, rmSync, statSync } from 'fs';
 import { Logger } from './Logger';
 
 const log = Logger.for('OpenBrowser');
+
+/**
+ * `cmd.exe` by absolute path. Local-Dependencies-Only: nothing here is
+ * resolved from `PATH`, and an env var (`%SystemRoot%`) is a forbidden
+ * resolution path under the same rule. This exact string is already the
+ * repo's precedent at `launcher/src/elevated_runner.rs`, whose comment calls
+ * it OS-stable and never moving.
+ */
+const WINDOWS_CMD = 'C:\\Windows\\System32\\cmd.exe';
+
+/**
+ * Absolute path of an OS-provided tool on Linux/macOS, probing `/usr/bin` then
+ * `/bin` and falling back to `/usr/bin`.
+ *
+ * The TypeScript twin of `linux_service::tool_dir` in the launcher, which
+ * carries the same comment for the same reason: never invoke a tool by bare
+ * name. `exists` is injected so the probe is testable without touching the
+ * filesystem of whatever machine the suite runs on.
+ */
+export function resolveSystemTool(tool: string, exists: (p: string) => boolean = existsSync): string {
+    for (const dir of ['/usr/bin', '/bin']) {
+        const candidate = `${dir}/${tool}`;
+        if (exists(candidate)) {
+            return candidate;
+        }
+    }
+    return `/usr/bin/${tool}`;
+}
 
 /**
  * Best-effort cross-platform "open this URL in the user's default browser."
@@ -16,41 +44,48 @@ const log = Logger.for('OpenBrowser');
  * browser process. Any failure is logged at info level — opening a
  * browser is a UX nicety, not a hard requirement.
  *
- * Implementation per-platform:
- *   - Windows: `start "" "<url>"` via cmd.exe /c. The empty quoted
- *     title is required because cmd's `start` interprets the first
- *     quoted token as a window title; without it, the URL would be
+ * Implementation per-platform. Every binary is named by ABSOLUTE PATH
+ * (Local-Dependencies-Only) — see `WINDOWS_CMD` and `resolveSystemTool`.
+ * These three spawns were the last URL-openers in the repo taking whatever
+ * `PATH` offered, while the Rust half of the same application had already
+ * decided the other way and says so in its own comments:
+ *   - Windows: `start "" "<url>"` via `C:\Windows\System32\cmd.exe /c`. The
+ *     empty quoted title is required because cmd's `start` interprets the
+ *     first quoted token as a window title; without it, the URL would be
  *     misparsed.
- *   - Linux:   `xdg-open <url>`. Standard freedesktop.org launcher.
- *   - macOS:   `open <url>`. (Reserved; we don't ship macOS today.)
+ *   - Linux:   `xdg-open <url>`, probed to `/usr/bin` then `/bin`. Standard
+ *     freedesktop.org launcher.
+ *   - macOS:   `/usr/bin/open <url>`. (Reserved; we don't ship macOS today.)
  */
 export function openBrowser(url: string): void {
     try {
         if (process.platform === 'win32') {
             // We pass arguments via array form (no shell interpolation),
             // so a malicious URL can't inject extra cmd.exe commands.
-            const child = spawn('cmd.exe', ['/c', 'start', '""', url], {
+            const child = spawn(WINDOWS_CMD, ['/c', 'start', '""', url], {
                 detached: true,
                 stdio: 'ignore',
                 windowsHide: true,
             });
             child.unref();
-            log.info(`opened ${url} via cmd start`);
+            log.info(`opened ${url} via ${WINDOWS_CMD} start`);
             return;
         }
         if (process.platform === 'linux') {
-            const child = spawn('xdg-open', [url], {
+            const xdgOpen = resolveSystemTool('xdg-open');
+            const child = spawn(xdgOpen, [url], {
                 detached: true,
                 stdio: 'ignore',
             });
             child.unref();
-            log.info(`opened ${url} via xdg-open`);
+            log.info(`opened ${url} via ${xdgOpen}`);
             return;
         }
         if (process.platform === 'darwin') {
-            const child = spawn('open', [url], { detached: true, stdio: 'ignore' });
+            const macOpen = resolveSystemTool('open');
+            const child = spawn(macOpen, [url], { detached: true, stdio: 'ignore' });
             child.unref();
-            log.info(`opened ${url} via open`);
+            log.info(`opened ${url} via ${macOpen}`);
             return;
         }
         log.info(`no browser-open handler for platform=${process.platform}; skipping`);


### PR DESCRIPTION
Todo item 115. Local-Dependencies-Only violation, surfaced during item 63 and lost when that item was archived — the flag lived inside the item-63 block, which moved to the shipped archive, and nothing in the active list carried it forward.

All three platform branches of `src/server/openBrowser.ts` spawned a bare binary name, so each resolved off the process `PATH`:

| line | was | now |
|---|---|---|
| 32 | `spawn('cmd.exe', …)` | `C:\Windows\System32\cmd.exe` |
| 42 | `spawn('xdg-open', …)` | `resolveSystemTool('xdg-open')` |
| 51 | `spawn('open', …)` | `resolveSystemTool('open')` |

**Why it mattered here specifically:** this was the last URL-opener in the repo taking whatever `PATH` offered, and the Rust half of the same application had already decided the other way — `common/src/tray.rs` opens through `/usr/bin/xdg-open` with a comment that states the reason outright (*"Absolute path on purpose (Local-Dependencies-Only): the Linux launcher never resolves a tool from PATH"*), and `launcher/src/main.rs` resolves through `linux_service::tool_dir`. Two halves of one app disagreeing about the same binary.

**Windows** uses the literal `C:\Windows\System32\cmd.exe` — the exact string `launcher/src/elevated_runner.rs` already uses, whose comment calls it OS-stable and never moving. Deliberately **not** `%SystemRoot%`: an env var is a forbidden resolution path under the same rule.

**Linux and macOS** go through `resolveSystemTool`, the TypeScript twin of the launcher's `tool_dir` — probe `/usr/bin`, then `/bin`, fall back to `/usr/bin`. The fallback is the point: a missing tool now fails with ENOENT on a known path rather than quietly finding something else on `PATH`. The existence check is injected so the four tests pin the probe order without touching the host filesystem.

The log line now names the resolved path instead of a generic "via xdg-open", which is what makes it checkable in the field.

## Not included, deliberately

The repo still states **two** absolute-path conventions for the same binary: `tray.rs` hardcodes `/usr/bin/xdg-open` while `main.rs` probes via `tool_dir`. Neither is a violation — both are absolute — but one should move so there is a single rule. Unifying them means editing `common/src/tray.rs`, which #652 is currently rewriting, so it stays a follow-up rather than a conflict.

## Verification

- `npm test` — 218 files, 1937 passed / 5 skipped (4 new).
- `npx tsc --noEmit` clean; `biome check` clean.
- `release:none` — no user-visible behaviour change, so no beta of its own.
- Not exercised at runtime: the first-run browser open is a best-effort UX path that already swallows its own failures. The absolute paths are the same ones the Rust side has been using in production.