### PR TITLE
ci: drop the Google Chrome apt source before installing Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,23 @@ jobs:
       # rendering differences, so a second browser would buy coverage the specs
       # do not actually exercise.
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        # `--with-deps` runs `apt-get update`, which refreshes EVERY apt source
+        # configured on the runner — including the Google Chrome repo the
+        # GitHub image ships preinstalled. We never want anything from that
+        # repo: the browser under test is Playwright's own bundled Chromium,
+        # and the deps this installs come from Ubuntu's archives. So when
+        # Google's index is unhealthy, `apt-get update` fails the whole job
+        # over a repo this project does not use. That happened on 2026-09-09:
+        # `E: Failed to fetch .../chrome-stable/.../Packages.gz Hash Sum
+        # mismatch` blocked four unrelated PRs for the better part of an hour,
+        # and re-running hit it again because it was not a flake.
+        #
+        # Dropping the source list first takes that third party off the
+        # critical path for good. The runner is ephemeral, so this affects
+        # nothing beyond this job.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          npx playwright install --with-deps chromium
       - name: E2E typecheck
         # tests/ sits outside the root tsconfig's rootDir, so `npx tsc --noEmit`
         # above does not see it. Without this the e2e sources are never typechecked.


### PR DESCRIPTION
Unblocks #650, #651, #652 and #653, all of which are currently red on the same failure.

`npx playwright install --with-deps chromium` runs `apt-get update`, and that refreshes **every** apt source configured on the runner — including the Google Chrome repo the GitHub image ships preinstalled. Nothing in this job wants anything from that repo: the browser under test is Playwright's own bundled Chromium, and the system libraries `--with-deps` installs come from Ubuntu's own archives. So an unhealthy Google index fails the entire job over a repository this project does not use.

Today it did:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download.
Failed to install browsers
Error: Installation process exited with code: 100
```

Four unrelated PRs went red for the better part of an hour, and re-running the failed jobs reproduced it — so it was an outage on Google's side, not a flake worth retrying through.

Removing the source list before the install takes that third party off our critical path permanently. The runner is ephemeral, so this affects nothing beyond the job. It is also the right shape independent of today's outage: a repo we never read should not be able to fail our build.

## Verification

The honest check is this PR's own `build-and-test`. Every other PR on the repo is currently failing at that step, so if this one gets past "Install Playwright browser" the change did its job — and if Google's index has quietly recovered in the meantime, that will show as the other PRs going green too, which I will say plainly rather than claim the credit.