### PR TITLE
ci(release): drop the Google Chrome apt source before installing musl-tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,21 @@ jobs:
         with:
           targets: x86_64-unknown-linux-musl
       - name: Install musl-tools (linker for musl target)
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        # The `rm` is the same guard ci.yml carries, and it matters MORE here.
+        # `apt-get update` refreshes every apt source on the runner, including
+        # the Google Chrome repo the GitHub image ships preinstalled — a repo
+        # nothing in this job wants. On 2026-09-09 Google's index served a
+        # `Packages.gz` that did not match the SHA256 in its own `Release`
+        # file, apt aborted on the mismatch, and four unrelated PRs went red
+        # for the better part of an hour. Re-running reproduced it, so it was
+        # an outage rather than a flake.
+        #
+        # In CI that costs a re-run. Here it would fail a RELEASE: this job
+        # publishes the MSI, AppImage and portable ZIP, so a third party's bad
+        # index would block shipping over a package we never install.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update && sudo apt-get install -y musl-tools
       # vpk 1.2.0 (stable) has --msi / --instLocation and produces
       # true Windows Installer MSIs. Match the npm `velopack` package
       # version to keep client/server serialization in sync.


### PR DESCRIPTION
Closes the gap #654 left. That PR guarded `ci.yml`; this is the same one-line guard in `release.yml`, where the consequence is worse.

`apt-get update` refreshes **every** apt source on the runner, including the Google Chrome repo the GitHub image ships preinstalled — a repo nothing in this job wants. On 2026-09-09 Google's index served a `Packages.gz` that did not match the SHA256 in its own `Release` file:

```
E: Failed to fetch .../chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
```

apt aborts on that, four unrelated PRs went red for most of an hour, and re-running the failed jobs reproduced it — an outage, not a flake.

**Why this file matters more than CI.** In `ci.yml` the cost is a re-run. This job publishes the MSI, AppImage and portable ZIP, so the same third-party index could block a **release** over a package we never install. The failure would also arrive at the worst moment: after the tag is pushed, mid-publish.

After this, every `apt-get update` in the repo is guarded — verified by grep, there are exactly two and both now drop the source list first.

## Verification

- `release.yml` does not run on a PR, so CI cannot exercise this path here. The change is textually identical to the one already proven green in `ci.yml` (#654), which was the only PR to pass during the outage.
- The runner is ephemeral, so removing the source list affects nothing beyond the job.
- The real proof is the next release cutting cleanly; if beta.116 publishes, this path ran.