### PR TITLE
feat(tray): put a tray in every active session, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A service install put a tray in the first logged-on user's session only** (todo item 119). The
+  supervisor resolved one session via `active_interactive_session()` and spawned there, which the module's
+  own header recorded as an accepted trade-off — *"SINGLE active session only … multi-session support can
+  be added later if needed."* Under Fast User Switching or RDP, Windows can have several sessions `Active`
+  with a user in each, so the second and third users got **no tray at all**. That is not cosmetic in
+  service mode: since beta.112 the tray's Exit is the only stop affordance the product has there
+  (Settings' "stop server & exit" is disabled by design), so those users had no way to stop the server
+  from the UI whatsoever.
+  - `common::session` gains `active_interactive_sessions()` — the plural of the existing resolver, same
+    filter (`WTSActive` **and** a non-empty username), same `WTSGetActiveConsoleSessionId` fallback when
+    the enumeration finds nothing. `active_interactive_session()` is now defined as its first element, so
+    the two cannot drift and a single-user box behaves exactly as before.
+  - `spawn_in_session(session_id, args)` splits the session choice out of `spawn_in_active_user_session`,
+    which keeps its name and its callers (the uninstall handoff and the local-takeover relaunch each
+    target the one user driving the operation). Everything else — the privilege enable,
+    `WTSQueryUserToken`, the environment block, `CreateProcessAsUserW` — is unchanged and shared.
+  - The supervisor now walks every active session. **Only the enumeration needed widening:** the tray's
+    per-session single-instance mutex already made a duplicate spawn a no-op, and `tray_present_in` was
+    already session-scoped, so a tray in session 1 never satisfied session 2.
+  - A success anywhere beats a failure anywhere: one user's session failing to spawn (locked mid-attempt,
+    a token that could not be queried) must not be reported as "no tray" when another user's tray did
+    appear. 5 tests on that rule; the enumeration and the cross-session spawn need a second logged-on
+    user and are not unit-testable.
+  - **Local mode is untouched** — the launcher is already inside the user's session there, and each user
+    running the app has their own launcher and their own tray. This was only ever a service-mode gap.
+
 ## [0.1.30-beta.116] - 2026-09-09
 
 ### Fixed

--- a/common/src/session.rs
+++ b/common/src/session.rs
@@ -33,6 +33,28 @@
 /// On non-Windows: always returns `None`.
 #[cfg(windows)]
 pub fn active_interactive_session() -> Option<u32> {
+    // Identical behaviour to before: the first session the enumeration finds,
+    // or the console fallback when it finds none. The plural resolver below is
+    // where both of those now live, so the two cannot drift.
+    active_interactive_sessions().into_iter().next()
+}
+
+/// Every active interactive user session, in enumeration order.
+///
+/// The plural of [`active_interactive_session`], and the same filter:
+/// `WTSActive` state AND a non-empty username. Fast User Switching and RDP
+/// can both put more than one user in that state at once, and the tray
+/// supervisor needs all of them — a service install serves every logged-on
+/// user, but spawned a tray into only the first, leaving the others with no
+/// icon and, in service mode, no way to stop the server at all (item 119).
+///
+/// Falls back to `WTSGetActiveConsoleSessionId` only when the enumeration
+/// finds nothing, exactly as the single-session resolver always did, so a
+/// bare-metal single-user box behaves as it did before.
+///
+/// Returns an empty vec on non-Windows and when both strategies fail.
+#[cfg(windows)]
+pub fn active_interactive_sessions() -> Vec<u32> {
     use windows::Win32::Foundation::HANDLE;
     use windows::Win32::System::RemoteDesktop::{
         WTSActive, WTSEnumerateSessionsW, WTSFreeMemory, WTSGetActiveConsoleSessionId,
@@ -57,7 +79,7 @@ pub fn active_interactive_session() -> Option<u32> {
         )
         .is_ok();
 
-        let mut found: Option<u32> = None;
+        let mut found: Vec<u32> = Vec::new();
         if enum_ok && !sessions_ptr.is_null() {
             let sessions = std::slice::from_raw_parts(sessions_ptr, count as usize);
             for s in sessions {
@@ -84,16 +106,16 @@ pub fn active_interactive_session() -> Option<u32> {
                 // char count.
                 let username_len = (bytes as usize / 2).saturating_sub(1);
                 if username_len > 0 {
-                    found = Some(s.SessionId);
-                    WTSFreeMemory(buf_ptr.as_ptr() as *mut _);
-                    break;
+                    // Collect rather than break: Fast User Switching and RDP
+                    // can leave several sessions Active with a user in each.
+                    found.push(s.SessionId);
                 }
                 WTSFreeMemory(buf_ptr.as_ptr() as *mut _);
             }
             WTSFreeMemory(sessions_ptr as *mut _);
         }
 
-        if found.is_some() {
+        if !found.is_empty() {
             return found;
         }
 
@@ -104,11 +126,16 @@ pub fn active_interactive_session() -> Option<u32> {
         // diverges from the actual user session.
         let console = WTSGetActiveConsoleSessionId();
         if console == 0xFFFF_FFFF {
-            None
+            Vec::new()
         } else {
-            Some(console)
+            vec![console]
         }
     }
+}
+
+#[cfg(not(windows))]
+pub fn active_interactive_sessions() -> Vec<u32> {
+    Vec::new()
 }
 
 #[cfg(not(windows))]

--- a/launcher/src/tray_supervisor.rs
+++ b/launcher/src/tray_supervisor.rs
@@ -16,10 +16,14 @@
 // silently before showing the balloon).
 //
 // Trade-offs accepted in this iteration:
-//   - SINGLE active session only. WTSEnumerateSessionsW could return multiple
-//     active sessions in RDP / fast-user-switching scenarios; we currently
-//     only spawn into the FIRST active interactive session. Multi-session
-//     support can be added later if needed.
+//   - (RESOLVED, item 119) Multi-session. This used to spawn into the FIRST
+//     active interactive session only, so under RDP or fast user switching
+//     the second and third logged-on users got no tray at all — and in
+//     service mode the tray is the only stop affordance the product has, so
+//     they had no way to stop the server either. It now spawns one tray per
+//     active interactive session. Only the enumeration needed widening: the
+//     per-session single-instance mutex already made a duplicate spawn a
+//     no-op, and `tray_present_in` was already session-scoped.
 //   - HKLM\Run removed at install time + cleanup on (re)install. Existing
 //     beta.9-era installs still have the Run entry; the launcher's startup
 //     spawn covers the post-upgrade case for them too, and the Run entry
@@ -45,7 +49,7 @@ use std::thread;
 use std::time::Duration;
 
 use crate::log;
-use crate::user_session_spawn::{spawn_in_active_user_session, SpawnUserLauncherArgs};
+use crate::user_session_spawn::{spawn_in_session, SpawnUserLauncherArgs};
 
 const TRAY_POLL_INTERVAL_SECS: u64 = 10;
 pub(crate) const TRAY_PROCESS_NAME: &str = "ws-scrcpy-web-tray.exe";
@@ -95,7 +99,9 @@ pub(crate) fn reap_tray_on_terminal_exit(data_root: &Path) {
 /// Mode-aware spawn:
 ///   - **Service mode** (`is_service_mode=true`): launcher is running as
 ///     LocalSystem in session 0. Cross-session WTS spawn into the active
-///     interactive user session via `spawn_in_active_user_session`. Requires
+///     interactive user sessions via `spawn_in_session`, one per session
+///     (item 119: Fast User Switching and RDP can have several at once).
+///     Requires
 ///     SeTcbPrivilege + SeAssignPrimaryTokenPrivilege + SeIncreaseQuotaPrivilege
 ///     which LocalSystem has by default.
 ///   - **Local mode** (`is_service_mode=false`): launcher is already in
@@ -259,14 +265,17 @@ fn ensure_tray_in_active_session(tray_exe: &Path) -> EnsureOutcome {
     // is gone now — see todo §33 Bug B for why consolidation matters
     // (Node-side and tray-side must use the SAME resolver for the
     // uninstall handoff marker session-ID check to align).
-    let session_id = match common::session::active_interactive_session() {
-        Some(id) => id,
-        None => return EnsureOutcome::NoActiveSession,
-    };
-
-    // Check if tray is already running in that session.
-    if is_tray_running_in_session(session_id) {
-        return EnsureOutcome::AlreadyRunning;
+    // EVERY active interactive session, not just the first (item 119). A
+    // service install serves every logged-on user, but this used to spawn a
+    // tray into one of them — so under Fast User Switching or RDP the second
+    // and third users got no icon, and in service mode the tray is the only
+    // stop affordance the product has, leaving them no way to stop the server
+    // at all. The per-session single-instance mutex already makes a duplicate
+    // spawn a no-op, and `tray_present_in` was already session-scoped, so only
+    // the enumeration needed widening.
+    let sessions = common::session::active_interactive_sessions();
+    if sessions.is_empty() {
+        return EnsureOutcome::NoActiveSession;
     }
 
     let tray_path_str = match tray_exe.to_str() {
@@ -274,21 +283,74 @@ fn ensure_tray_in_active_session(tray_exe: &Path) -> EnsureOutcome {
         None => return EnsureOutcome::SpawnFailed("tray path not valid UTF-8".to_string()),
     };
 
-    // Spawn with --launcher-spawn arg so the tray knows to show the
-    // explanatory balloon. The arg is consumed by tray/src/main.rs at
-    // startup.
-    let result = spawn_in_active_user_session(&SpawnUserLauncherArgs {
-        launcher_path: tray_path_str,
-        launcher_args: vec!["--launcher-spawn".to_string()],
-    });
+    // Report the FIRST spawn we perform, so a single-session box logs exactly
+    // what it always did. A failure is only reported when nothing spawned
+    // anywhere: one user's session failing (locking mid-spawn, say) must not
+    // mask a tray that did appear for another.
+    let mut spawned: Option<EnsureOutcome> = None;
+    let mut last_error: Option<String> = None;
+    let mut already = 0usize;
 
-    if result.ok {
-        EnsureOutcome::Spawned {
-            pid: result.pid,
-            session: result.session_id,
+    for session_id in sessions {
+        // Session-scoped, so a tray in session 1 does not satisfy session 2.
+        if is_tray_running_in_session(session_id) {
+            already += 1;
+            continue;
         }
-    } else {
-        EnsureOutcome::SpawnFailed(result.error_message.unwrap_or_default())
+
+        // Spawn with --launcher-spawn arg so the tray knows to show the
+        // explanatory balloon. The arg is consumed by tray/src/main.rs at
+        // startup.
+        let result = spawn_in_session(
+            session_id,
+            &SpawnUserLauncherArgs {
+                launcher_path: tray_path_str.clone(),
+                launcher_args: vec!["--launcher-spawn".to_string()],
+            },
+        );
+
+        if result.ok {
+            log::info(&format!(
+                "tray-supervisor: spawned tray pid {} in session {}",
+                result.pid, result.session_id
+            ));
+            if spawned.is_none() {
+                spawned = Some(EnsureOutcome::Spawned {
+                    pid: result.pid,
+                    session: result.session_id,
+                });
+            }
+        } else {
+            let msg = result.error_message.unwrap_or_default();
+            log::error(&format!(
+                "tray-supervisor: tray spawn failed for session {session_id}: {msg}"
+            ));
+            last_error = Some(msg);
+        }
+    }
+
+    combine_session_outcomes(spawned, last_error, already)
+}
+
+/// Reduce per-session results to the one outcome the supervisor reports.
+///
+/// Pure, so the rule that matters can be tested without a second logged-on
+/// user: **a success anywhere wins over a failure anywhere.** With more than
+/// one session in play, one user's session failing (locked mid-spawn, a token
+/// that could not be queried) must not be reported as "no tray", when another
+/// user's tray did appear — the supervisor would log an error for a state that
+/// is partly fine, and the next poll would try again anyway.
+fn combine_session_outcomes(
+    spawned: Option<EnsureOutcome>,
+    last_error: Option<String>,
+    already: usize,
+) -> EnsureOutcome {
+    match (spawned, last_error) {
+        (Some(outcome), _) => outcome,
+        (None, Some(err)) => EnsureOutcome::SpawnFailed(err),
+        // Nothing spawned and nothing failed: every session already had one.
+        (None, None) if already > 0 => EnsureOutcome::AlreadyRunning,
+        (None, None) => EnsureOutcome::NoActiveSession,
     }
 }
 
@@ -502,5 +564,60 @@ mod tests {
         // the service ran. An empty list must still read as absent here -- the
         // bug was never in this rule, it was in what the enumerator handed it.
         assert!(!tray_present_in(&[], 1));
+    }
+
+    // Item 119. The supervisor now visits EVERY active interactive session, so
+    // it can succeed in one and fail in another within a single pass. What it
+    // reports for that pass is the part worth pinning; the enumeration and the
+    // spawn themselves need a second logged-on user and cannot be unit-tested.
+    mod combine_session_outcomes {
+        use super::super::{combine_session_outcomes, EnsureOutcome};
+
+        #[test]
+        fn a_success_anywhere_beats_a_failure_anywhere() {
+            // Two users logged on, one tray spawned, the other session failed.
+            // Reporting SpawnFailed here would call a partly-working state
+            // broken, and the next poll retries the failed session regardless.
+            let out = combine_session_outcomes(
+                Some(EnsureOutcome::Spawned { pid: 42, session: 1 }),
+                Some("WTSQueryUserToken failed (session 2)".to_string()),
+                0,
+            );
+            assert!(matches!(out, EnsureOutcome::Spawned { pid: 42, session: 1 }));
+        }
+
+        #[test]
+        fn a_failure_with_no_success_is_reported() {
+            let out = combine_session_outcomes(None, Some("boom".to_string()), 0);
+            assert!(matches!(out, EnsureOutcome::SpawnFailed(ref m) if m == "boom"));
+        }
+
+        #[test]
+        fn every_session_already_had_one() {
+            let out = combine_session_outcomes(None, None, 2);
+            assert!(matches!(out, EnsureOutcome::AlreadyRunning));
+        }
+
+        #[test]
+        fn nothing_spawned_nothing_failed_nothing_present_means_no_session() {
+            // The enumerator handed us sessions but none were usable.
+            let out = combine_session_outcomes(None, None, 0);
+            assert!(matches!(out, EnsureOutcome::NoActiveSession));
+        }
+
+        #[test]
+        fn a_single_session_box_reports_exactly_what_it_always_did() {
+            // The common case must be unchanged by the multi-session widening.
+            let spawned = combine_session_outcomes(
+                Some(EnsureOutcome::Spawned { pid: 7, session: 1 }),
+                None,
+                0,
+            );
+            assert!(matches!(spawned, EnsureOutcome::Spawned { pid: 7, session: 1 }));
+            assert!(matches!(
+                combine_session_outcomes(None, None, 1),
+                EnsureOutcome::AlreadyRunning
+            ));
+        }
     }
 }

--- a/launcher/src/user_session_spawn.rs
+++ b/launcher/src/user_session_spawn.rs
@@ -172,7 +172,41 @@ fn enable_cross_session_spawn_privileges() {
     }
 }
 
+/// Spawn into whichever session the resolver calls "the" active one.
+///
+/// Thin wrapper over [`spawn_in_session`], kept because most callers genuinely
+/// want one session: the uninstall handoff and the local-takeover relaunch each
+/// target the user who is driving the operation. The tray supervisor is the
+/// exception and calls `spawn_in_session` per session (item 119).
 pub fn spawn_in_active_user_session(args: &SpawnUserLauncherArgs) -> SpawnResult {
+    let session_id = match common::session::active_interactive_session() {
+        Some(id) => id,
+        None => {
+            return SpawnResult {
+                ok: false,
+                pid: 0,
+                session_id: 0,
+                error_message: Some(
+                    "no active interactive user session found (WTSEnumerateSessions returned no Active session with a logged-on user, and WTSGetActiveConsoleSessionId fallback also failed)"
+                        .to_string(),
+                ),
+            };
+        }
+    };
+    log::info(&format!(
+        "spawn-user-launcher: resolved active interactive session id={session_id}"
+    ));
+    spawn_in_session(session_id, args)
+}
+
+/// Spawn `args.launcher_path` in a NAMED session, as that session's user.
+///
+/// Split out from `spawn_in_active_user_session` for item 119: the tray
+/// supervisor needs to place one tray in each active session, and the caller
+/// therefore has to choose the session rather than have it chosen here.
+/// Everything else — the privilege enable, `WTSQueryUserToken`, the
+/// environment block, `CreateProcessAsUserW` — is unchanged and shared.
+pub fn spawn_in_session(session_id: u32, args: &SpawnUserLauncherArgs) -> SpawnResult {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use windows::Win32::Foundation::{CloseHandle, HANDLE};
@@ -209,23 +243,7 @@ pub fn spawn_in_active_user_session(args: &SpawnUserLauncherArgs) -> SpawnResult
     // remaining two privileges were the cause. See module-level docs.
     enable_cross_session_spawn_privileges();
 
-    let session_id = match common::session::active_interactive_session() {
-        Some(id) => id,
-        None => {
-            return SpawnResult {
-                ok: false,
-                pid: 0,
-                session_id: 0,
-                error_message: Some(
-                    "no active interactive user session found (WTSEnumerateSessions returned no Active session with a logged-on user, and WTSGetActiveConsoleSessionId fallback also failed)"
-                        .to_string(),
-                ),
-            };
-        }
-    };
-    log::info(&format!(
-        "spawn-user-launcher: resolved active interactive session id={session_id}"
-    ));
+    log::info(&format!("spawn-user-launcher: targeting session id={session_id}"));
 
     unsafe {
         let mut user_token: HANDLE = HANDLE::default();


### PR DESCRIPTION
Todo item 119. The last open piece of the tray work; #652 (beta.116) fixed the icon *coming back*, this fixes it *appearing at all* for the second user on a machine.

## What was wrong

`ensure_tray_in_active_session` resolved ONE session and spawned there. The module header recorded it as a deliberate deferral:

> SINGLE active session only. WTSEnumerateSessionsW could return multiple active sessions in RDP / fast-user-switching scenarios; we currently only spawn into the FIRST active interactive session. Multi-session support can be added later if needed.

Under Fast User Switching or RDP, Windows holds several sessions `Active` with a user in each, so the second and third logged-on users got **no tray**.

**That is not cosmetic in service mode.** Since beta.112 the tray's Exit is the only stop affordance the product has there — Settings' "stop server & exit" is disabled by design in service mode — so those users had no way to stop the server from the UI at all.

## What changed

| File | Change |
|---|---|
| `common/src/session.rs` | `active_interactive_sessions()` — the plural resolver |
| `launcher/src/user_session_spawn.rs` | `spawn_in_session(session_id, args)` — session choice moved to the caller |
| `launcher/src/tray_supervisor.rs` | walk every session; `combine_session_outcomes` reduces the results |

The plural resolver uses the **same** filter as the singular (`WTSActive` **and** a non-empty username) and the same `WTSGetActiveConsoleSessionId` fallback when enumeration finds nothing. `active_interactive_session()` is now literally its first element, so the two cannot drift and a single-user box behaves exactly as it did.

`spawn_in_active_user_session` keeps its name and both its callers — the uninstall handoff and the local-takeover relaunch each target the one user driving the operation, so "the" active session is right for them. Only the tray supervisor wants all of them.

**Only the enumeration needed widening.** The tray's per-session single-instance mutex already made a duplicate spawn a no-op, and `tray_present_in` was already session-scoped (rewritten 2026-09-07 for the session-blind respawn bug), so a tray in session 1 never satisfied session 2. Both halves of the dedup were already done.

**A success anywhere beats a failure anywhere.** With several sessions in play a single pass can succeed in one and fail in another; reporting `SpawnFailed` then would call a partly-working state broken, and the next poll retries the failed session regardless.

## Scope note

**Local mode is untouched.** The launcher is already inside the user's session there, and each user running the app has their own launcher and their own tray. This was only ever a service-mode gap — worth stating because "the second user gets no tray" sounds broader than it is.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` — 234 passed, 5 new.
- The new tests cover `combine_session_outcomes`: success-beats-failure, failure-with-no-success, all-already-present, nothing-usable, and that a single-session box reports exactly what it always did.
- **Not verifiable here.** The enumeration and the cross-session spawn need a second logged-on user on a real Windows box. What can be checked once shipped: log in as a second user with the service installed, and `launcher.log` should show `tray-supervisor: spawned tray pid N in session M` for each session.
