### PR TITLE
test(e2e): stop row 10.3's inner wait from eating its own test budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Smoke row 10.3 could only ever fail uninformatively.** `test.setTimeout(180_000)` and the
+  `waitForDependencies` default were both `180_000`, so the inner wait was allowed to consume the whole
+  outer budget: Playwright killed the test first and reported a bare `Test timeout of 180000ms exceeded`,
+  while the helper's own message — the one that names which dependency stalled (`node=…, adb=…`) — was
+  unreachable by construction. A slow-but-successful first-run install and a genuine hang produced
+  identical output. It went red twice on `main` on 2026-09-09; the same commit passed as a PR run, and
+  another run of the same code passed in 1m48s in a window that overlapped one of the failures, so it was
+  runner speed rather than anything in the app. The test budget is now 360 s, the call passes an explicit
+  240 s, and the helper's default drops to 120 s with the invariant written down where the next caller
+  will read it. The download itself stays: `seedPrivateDataRoot` wipes ProgramData and seeds config only,
+  on purpose, because 10.3 is asserting on a representative first run.
+
 ## [0.1.30-beta.117] - 2026-09-09
 
 ### Fixed

--- a/tests/e2e/server-surface.spec.ts
+++ b/tests/e2e/server-surface.spec.ts
@@ -84,7 +84,19 @@ test.describe('server surface (smoke §10)', () => {
     });
 
     test('10.3 the log is clean: the teardown lines are present on stop and no error line appears that is not on the allow-list', async () => {
-        test.setTimeout(180_000);
+        // MUST stay comfortably larger than the `waitForDependencies` budget
+        // below. Both were 180_000 until 2026-09-09, so the inner wait could
+        // consume the entire outer budget: Playwright killed the test first and
+        // reported a bare "Test timeout of 180000ms exceeded", while the
+        // helper's own message — which names the dependency that stalled — was
+        // unreachable by construction. A slow-but-successful install and a real
+        // hang were indistinguishable. Measured twice on main that day, both
+        // times a timeout with no diagnostic; the same commit passed as a PR
+        // run, and another run of the same code passed in 1m48s during a window
+        // that overlapped one of the failures — it is runner speed, and this
+        // test downloads Node + ADB for a genuine first run (seedPrivateDataRoot
+        // wipes ProgramData and seeds config only, deliberately).
+        test.setTimeout(360_000);
         // Made falsifiable: (a) the teardown line must be present after a stop;
         // (b) zero lines matching the error pattern, except an allow-list where
         // every entry justifies itself in a comment. An allow-list that grows
@@ -106,7 +118,13 @@ test.describe('server surface (smoke §10)', () => {
             await waitForServer(handle, paths.baseURL);
             // Let the first-run install finish: stopping mid-download would put
             // that abort in the log and blame it on the stop.
-            await waitForDependencies(paths.baseURL);
+            // Explicit, and deliberately well inside test.setTimeout above: the
+            // budget relationship is the whole bug this call had, so it is
+            // stated here rather than inherited from a default that happened to
+            // equal the test's own. On expiry the helper throws with the
+            // per-dependency state (`node=..., adb=...`), which is the line that
+            // actually tells you what stalled.
+            await waitForDependencies(paths.baseURL, 240_000);
             // A representative run: a document, the token, a few API reads, and
             // the store — enough for the server to have said something.
             const ctx = await request.newContext({ baseURL: paths.baseURL });

--- a/tests/e2e/support/privateServer.ts
+++ b/tests/e2e/support/privateServer.ts
@@ -165,7 +165,21 @@ export async function waitForServer(handle: ServerHandle, baseURL: string, timeo
  * that stops the server mid-download would find that abort in the log and
  * blame it on the stop. Rows that read the log wait for this first.
  */
-export async function waitForDependencies(baseURL: string, timeoutMs = 180_000): Promise<void> {
+/**
+ * Wait until every dependency reports an installed version.
+ *
+ * **Budget it against the caller's `test.setTimeout`, not against nothing.**
+ * This waits on a real first-run download (Node + ADB), so on a slow runner it
+ * can legitimately take minutes. If the caller's test budget is not comfortably
+ * larger than `timeoutMs`, Playwright kills the test before this function can
+ * throw, and the failure reads `Test timeout of Nms exceeded` with no clue which
+ * dependency stalled — the message below never prints. That is exactly what
+ * happened on 2026-09-09, when this default and row 10.3's `test.setTimeout`
+ * were both 180_000.
+ *
+ * The default is deliberately lower than any current caller's test budget.
+ */
+export async function waitForDependencies(baseURL: string, timeoutMs = 120_000): Promise<void> {
     const ctx = await request.newContext({ baseURL });
     try {
         expect((await ctx.get('/')).status(), 'document GET (mints the token)').toBe(200);


### PR DESCRIPTION
Fixes the two red `build-and-test` runs on `main` from 2026-09-09. Test-only — no product code, so `release:none` and no beta.

## The bug is in the test, and it made the test unable to report anything useful

`server-surface.spec.ts` row 10.3 set `test.setTimeout(180_000)`. It then called `waitForDependencies(...)`, whose own default was **also** `180_000`.

The inner wait was therefore allowed to consume the entire outer budget. When the first-run download ran slow, Playwright killed the test before the helper could throw, and the failure read:

```
Test timeout of 180000ms exceeded.
```

The helper's actual diagnostic — `dependencies not installed within Nms: node=…, adb=…`, the line that says *which* dependency stalled — was **unreachable by construction**. A slow-but-successful install and a genuine hang produced byte-identical output.

## It was runner speed, not the app

Worth stating plainly, because two red runs on `main` after a batch of merges looks like a regression:

| Run | Window | Result |
|---|---|---|
| `main` (#650 merge) | 20:19:39 → 20:25:15 | timeout |
| `main` (beta.116 bump) | 20:27:22 → **20:35:06** | timeout |
| PR #658 (`bf2c20d`) | **20:30:04 → 20:31:52** | **passed, 1m48s** |

That last run **overlaps** the second failure's window and contains all of `main`'s code plus item 119. SHA `2070245` — #650's exact merged content — also passed as a PR run. Same code, one runner slow, another fine. In the failing runs the rest of the suite ran at its normal ~1m50s; the extra ~6 minutes is exactly two 180 s timeouts (initial + retry).

## What changed

| | before | after |
|---|---|---|
| `test.setTimeout` (row 10.3) | 180 s | **360 s** |
| `waitForDependencies` at the call site | *(default)* | **explicit 240 s** |
| `waitForDependencies` default | 180 s | **120 s** |

The call site now passes its budget explicitly rather than inheriting a default that happened to equal the test's own — the relationship between the two was the entire bug, so it is stated where it can be seen. The helper's doc comment carries the invariant for the next caller: budget it against the caller's `test.setTimeout`, not against nothing.

`waitForDependencies` has exactly one caller, so this is the only site affected. I checked the rest of the suite for the same shape: `lifecycle.spec.ts` runs a 90 s `waitForServer` inside a 180 s test, a safe 2× margin.

## What deliberately did not change

**The download stays.** `seedPrivateDataRoot` wipes ProgramData and seeds config plus one control marker — not dependencies — on purpose, because 10.3 asserts on a *representative first run*. Pre-seeding would remove the network wait and the flake with it, and hollow out what the row covers. The fix is to budget the wait honestly, not to delete it.

## Verification

- Row 10.3 passes locally in **13.8 s** with the change.
- `npm run test:e2e:types` clean; `biome check` clean (the 11 warnings are pre-existing CSS `noDescendingSpecificity`, unrelated).
- The real proof is CI staying green across future merge bursts. If it ever does time out again, it will now say which dependency stalled instead of nothing — which is the more important half of this change.
