### PR TITLE
chore: take both sides on CHANGELOG merges instead of conflicting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,32 @@
 
 * text=auto eol=lf
 
+# Append-only file: take BOTH sides on merge instead of conflicting.
+#
+# Every PR adds its entry under `## [Unreleased]`, at the same anchor, so two
+# PRs open at once conflict by construction — on text neither of them disagrees
+# about, where the answer is always "keep both". On 2026-09-09 six PRs were open
+# together and this cost four hand-resolutions, each followed by a full CI
+# re-run, none of them a real disagreement.
+#
+# `union` is a git built-in, not a custom driver: no config, works on a fresh
+# clone. Verified against the exact shape before adopting — two branches each
+# inserting under `## [Unreleased]` merge to both bullets under one heading,
+# with no markers.
+#
+# Two limits, both accepted:
+#   - Different sub-headings (### Fixed vs ### Changed) merge correctly but can
+#     drop the blank line before the second. Cosmetic; it still renders as a
+#     heading, and biome's `includes` covers src/webpack/tests only, so
+#     CHANGELOG.md is never linted.
+#   - GitHub's server-side detection may still flag the PR. Union governs the
+#     LOCAL merge, which is where the cost was: `git merge origin/main` now
+#     resolves with no manual edit, so the fix is merge-and-push.
+#
+# Scoped to CHANGELOG.md deliberately — union is wrong for any file where
+# "keep both" can be wrong.
+CHANGELOG.md merge=union
+
 # Windows-specific text files keep CRLF
 *.bat   text eol=crlf
 *.cmd   text eol=crlf


### PR DESCRIPTION
One line in `.gitattributes`. It removes a conflict class that cost four hand-resolutions in a single session.

## The problem

Every PR adds its entry under `## [Unreleased]`, at the same anchor. Two PRs open at once therefore conflict **by construction** — on text neither of them disagrees about, where the answer is always "keep both entries under one heading".

On 2026-09-09 six PRs were open together. Four of them conflicted on `CHANGELOG.md` and nothing else. Each one cost a manual resolution *and* a full CI re-run, because resolving produces a new SHA. Not one was a real disagreement.

## The fix, verified before adopting

`union` is a git **built-in**, not a custom merge driver, so it needs no `.git/config` entry and works on a fresh clone.

Reproduced against the exact shape in a scratch repo:

```
base:     ## [Unreleased]
branchA:  ## [Unreleased] + ### Fixed + "- **A: the embed cookie fix**"
branchB:  ## [Unreleased] + ### Fixed + "- **B: the tray fix**"

merge A -> clean
merge B -> clean   (today: CONFLICT)

result:
  ## [Unreleased]
  ### Fixed
  - **A: the embed cookie fix**
  - **B: the tray fix**
```

Both bullets, one heading, no markers — exactly the output produced by hand four times that day.

## Both limits, tested and accepted

- **Different sub-headings** (`### Fixed` on one branch, `### Changed` on the other) merge **correctly** — both sections, both entries, right sections — but can drop the blank line before the second heading. Cosmetic: it still renders as a heading in CommonMark, and **`CHANGELOG.md` is never linted here** — biome's `includes` is `src/**`, `webpack/**`, `tests/**` plus two config files.
- **GitHub's server-side conflict detection may still flag the PR.** Union governs the *local* merge, which is where the cost actually was: `git merge origin/main` now resolves with **zero manual editing**, so the fix becomes merge-and-push.

Both are written into `.gitattributes` itself, not just here, so the next person to hit the GitHub-still-flags case knows it is expected rather than a broken setting.

## Scope

Deliberately `CHANGELOG.md` only. Union is wrong for any file where "keep both" can be silently wrong — it takes both sides without understanding them, which is right for an append-only log and wrong for code.

`release:none`: no product code changes.
