### PR TITLE
fix(deps): one resolveSystemTool, and stop reading %SystemRoot%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **One `resolveSystemTool`, and it no longer reads `%SystemRoot%`** (todo item 123). #653 added a second
+  exported `resolveSystemTool` to `src/server/openBrowser.ts` while `src/server/service/systemTools.ts`
+  already exported one for exactly that purpose — its own doc comment says it exists because it is
+  *"required by the Local-Dependencies-Only rule"*, the very rule #653 was fixing. Nothing caught the
+  duplicate: it compiles, TypeScript is happy because they are different modules, and no test noticed. The
+  twin is deleted and `openBrowser` imports the shared resolver.
+  - **The shared resolver is also the better behaviour here.** It probes `/usr/bin`, `/bin`, `/usr/sbin`
+    and `/sbin`, then falls back to the bare name — which is what still finds `xdg-open` on a **non-FHS
+    distribution** (NixOS, Guix), where none of those directories hold it and the tools live under
+    `/run/current-system/sw/bin`. The deleted copy returned `/usr/bin/<tool>` unconditionally and would
+    simply have failed there.
+  - **`%SystemRoot%` is gone**, replaced by the literal `C:\Windows`. An env var is a forbidden resolution
+    path under the same Local-Dependencies-Only rule, being caller-controlled in the way `$PATH` is, and
+    the repo already pins the literal elsewhere for that reason (`launcher/src/elevated_runner.rs`, and
+    `openBrowser.ts` since #653). A new test hijacks `SystemRoot` and `windir` and asserts neither is
+    consulted.
+  - **The bare-name fallback stays, and its comment is corrected.** It claimed to surface "a clear ENOENT
+    rather than a silent miss", which is false — a bare name resolves through `PATH` and may well succeed.
+    The real justification is the non-FHS case above, which is now what the comment says. Removing the
+    fallback would settle a hardening argument by breaking those distributions outright, so it was not
+    removed.
+
+
+
 ### Fixed
 
 - **Smoke row 10.3 could only ever fail uninformatively.** `test.setTimeout(180_000)` and the

--- a/src/server/__tests__/openBrowser.test.ts
+++ b/src/server/__tests__/openBrowser.test.ts
@@ -2,35 +2,13 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { consumeSuppressBrowserMarker, resolveSystemTool, shouldAutoOpenBrowser } from '../openBrowser';
+import { consumeSuppressBrowserMarker, shouldAutoOpenBrowser } from '../openBrowser';
 
-// Item 115. openBrowser was the last place in the repo that resolved a URL
-// opener off PATH, while the Rust half of the same application already used
-// absolute paths on purpose and said so in its comments. This is the
-// TypeScript twin of `linux_service::tool_dir`, so it owes the same
-// guarantees: absolute always, /usr/bin preferred, /bin honoured, and never a
-// bare name whatever the filesystem looks like.
-describe('resolveSystemTool', () => {
-    it('prefers /usr/bin when the tool is there', () => {
-        expect(resolveSystemTool('xdg-open', (p) => p === '/usr/bin/xdg-open')).toBe('/usr/bin/xdg-open');
-    });
-
-    it('falls back to /bin when /usr/bin does not have it', () => {
-        expect(resolveSystemTool('xdg-open', (p) => p === '/bin/xdg-open')).toBe('/bin/xdg-open');
-    });
-
-    it('prefers /usr/bin when BOTH exist, matching the launcher probe order', () => {
-        expect(resolveSystemTool('xdg-open', () => true)).toBe('/usr/bin/xdg-open');
-    });
-
-    it('still returns an absolute path when the tool is nowhere — never a bare name', () => {
-        // The point of the fallback: spawn must fail with ENOENT on a known
-        // path rather than silently succeed against something on PATH.
-        const resolved = resolveSystemTool('xdg-open', () => false);
-        expect(resolved).toBe('/usr/bin/xdg-open');
-        expect(resolved.startsWith('/')).toBe(true);
-    });
-});
+// Item 123. This file used to test a LOCAL `resolveSystemTool` that #653 added
+// here while `service/systemTools.ts` already exported one for exactly this
+// purpose. The twin is gone and openBrowser imports the shared resolver, so the
+// resolution behaviour is covered once, in `service/systemTools.test.ts`, rather
+// than asserted twice against two implementations that could drift apart.
 
 /**
  * D1: a cold start PAST first-run must still open a browser tab. The native

--- a/src/server/openBrowser.ts
+++ b/src/server/openBrowser.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
-import { existsSync, rmSync, statSync } from 'fs';
+import { rmSync, statSync } from 'fs';
 import { Logger } from './Logger';
+import { resolveSystemTool } from './service/systemTools';
 
 const log = Logger.for('OpenBrowser');
 
@@ -13,24 +14,18 @@ const log = Logger.for('OpenBrowser');
  */
 const WINDOWS_CMD = 'C:\\Windows\\System32\\cmd.exe';
 
-/**
- * Absolute path of an OS-provided tool on Linux/macOS, probing `/usr/bin` then
- * `/bin` and falling back to `/usr/bin`.
- *
- * The TypeScript twin of `linux_service::tool_dir` in the launcher, which
- * carries the same comment for the same reason: never invoke a tool by bare
- * name. `exists` is injected so the probe is testable without touching the
- * filesystem of whatever machine the suite runs on.
- */
-export function resolveSystemTool(tool: string, exists: (p: string) => boolean = existsSync): string {
-    for (const dir of ['/usr/bin', '/bin']) {
-        const candidate = `${dir}/${tool}`;
-        if (exists(candidate)) {
-            return candidate;
-        }
-    }
-    return `/usr/bin/${tool}`;
-}
+// The URL opener is resolved by the repo's ONE system-tool resolver
+// (`service/systemTools`), not by a local copy. #653 added a second
+// `resolveSystemTool` here while that one already existed for exactly this
+// purpose — its own doc comment says it is "required by the
+// Local-Dependencies-Only rule" — so the two halves of the codebase disagreed
+// about the same problem. Consolidated 2026-09-09 (item 123).
+//
+// The shared resolver is also the better behaviour here: it probes /usr/bin,
+// /bin, /usr/sbin and /sbin, and only then falls back to the bare name, which
+// is what still finds xdg-open on a non-FHS distribution (NixOS, Guix) where
+// none of those directories hold it. The local copy returned /usr/bin/<tool>
+// unconditionally and would simply have failed there.
 
 /**
  * Best-effort cross-platform "open this URL in the user's default browser."

--- a/src/server/service/systemTools.test.ts
+++ b/src/server/service/systemTools.test.ts
@@ -47,6 +47,35 @@ describe('resolveSystemTool — Windows', () => {
     it('falls back to the bare tool name when absent', () => {
         expect(resolveSystemTool('arp', () => false, 'win32')).toBe('arp');
     });
+
+    // Item 123. This used to read `%SystemRoot%` / `%windir%`, which is a
+    // forbidden resolution path under the very Local-Dependencies-Only rule the
+    // function exists to serve — an env var is caller-controlled in the same way
+    // $PATH is. The repo pins the literal elsewhere for the same reason
+    // (elevated_runner.rs, and openBrowser.ts since #653).
+    it('probes the literal C:\\Windows, never an environment variable', () => {
+        const saved = { SystemRoot: process.env['SystemRoot'], windir: process.env['windir'] };
+        try {
+            process.env['SystemRoot'] = 'D:\\Hijacked';
+            process.env['windir'] = 'D:\\AlsoHijacked';
+            const seen: string[] = [];
+            resolveSystemTool(
+                'taskkill',
+                (p) => {
+                    seen.push(p);
+                    return false;
+                },
+                'win32',
+            );
+            expect(seen.every((p) => !p.includes('Hijacked'))).toBe(true);
+            expect(seen.some((p) => p.startsWith('C:\\Windows\\System32\\'))).toBe(true);
+        } finally {
+            for (const [k, v] of Object.entries(saved)) {
+                if (v === undefined) delete process.env[k];
+                else process.env[k] = v;
+            }
+        }
+    });
 });
 
 describe('buildDetachedSpawn', () => {

--- a/src/server/service/systemTools.ts
+++ b/src/server/service/systemTools.ts
@@ -4,19 +4,44 @@
  * %SystemRoot%\System32). Closes the PATH-hijack surface flagged by review #20
  * and required by the Local-Dependencies-Only rule: OS tools
  * (systemctl/pkexec/taskkill/icacls/ip/arp/route/…) are never invoked by bare
- * name, which would resolve via $PATH / %PATH%. Falls back to the bare name only
- * when no absolute candidate exists, so the failure surfaces as a clear ENOENT
- * rather than a silent miss.
+ * name, which would resolve via $PATH / %PATH%.
+ *
+ * The last-resort fallback IS the bare name, and that is deliberate — but not
+ * for the reason this comment used to give. It claimed the bare name "surfaces
+ * a clear ENOENT rather than a silent miss", which is simply false: a bare name
+ * is resolved through PATH and may well succeed. The real reason is
+ * NON-FHS DISTRIBUTIONS. On NixOS and Guix the system tools are not in
+ * /usr/bin, /bin, /usr/sbin or /sbin at all — they live under
+ * /run/current-system/sw/bin — so after the four absolute probes miss, PATH is
+ * the only thing that can still find them. Removing the fallback would resolve
+ * a hardening argument by breaking those systems outright.
+ *
+ * That is materially different from calling `spawn('systemctl')` directly: PATH
+ * is reached only after four absolute candidates have been checked and missed,
+ * so the hijack surface is the narrow tail rather than the default. Corrected
+ * 2026-09-09 (item 123).
  */
 import * as fs from 'node:fs';
 
 /** POSIX search order: user bins first (/usr/bin, /bin), then admin bins (/usr/sbin, /sbin). */
 const POSIX_SEARCH_DIRS = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'] as const;
 
-/** Windows OS tools (taskkill, icacls, arp, route, …) live under %SystemRoot%\System32. */
+/**
+ * Windows OS tools (taskkill, icacls, arp, route, …) live under System32.
+ *
+ * The path is a LITERAL, not `%SystemRoot%`. Reading the env var was the older
+ * shape here, and it is a forbidden resolution path under the same
+ * Local-Dependencies-Only rule this function exists to serve: an env var is
+ * attacker- and caller-controlled in exactly the way `$PATH` is. The repo
+ * already standardises on the literal elsewhere for the same reason —
+ * `launcher/src/elevated_runner.rs` pins `C:\Windows\System32\cmd.exe` with the
+ * comment "OS-stable, never moves", and `openBrowser.ts` did the same in #653.
+ * Fixed 2026-09-09 (item 123), which found the two halves disagreeing.
+ */
+const WINDOWS_ROOT = 'C:\\Windows';
+
 function windowsSystemDirs(): string[] {
-    const root = process.env['SystemRoot'] || process.env['windir'] || 'C:\\Windows';
-    return [`${root}\\System32`, root];
+    return [`${WINDOWS_ROOT}\\System32`, WINDOWS_ROOT];
 }
 
 export function resolveSystemTool(


### PR DESCRIPTION
Closes todo item 123. Found by a wrap-up documentation sweep and by nothing else — it compiles, TypeScript is happy because they are different modules, and no test noticed.

## What was wrong

#653 added a second exported `resolveSystemTool` to `src/server/openBrowser.ts`, while `src/server/service/systemTools.ts` already exported one for exactly that purpose — with a doc comment saying it exists because it is *"required by the Local-Dependencies-Only rule."* The very rule #653 was fixing. Two halves of the codebase, two answers to the same question.

## What changed

**The twin is deleted; `openBrowser` imports the shared resolver.** It was used only by its own file and its own test — `index.ts` imports the module's other three exports — so no caller changed.

**The shared resolver is also the better behaviour here.** It probes `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, then falls back to the bare name — which is what still finds `xdg-open` on a **non-FHS distribution** (NixOS, Guix), where none of those directories hold it and system tools live under `/run/current-system/sw/bin`. The deleted copy returned `/usr/bin/<tool>` unconditionally and would simply have failed there.

**`%SystemRoot%` is gone**, replaced by the literal `C:\Windows`. An env var is a forbidden resolution path under the same Local-Dependencies-Only rule — caller-controlled in the way `$PATH` is — and the repo already pins the literal elsewhere for that reason (`launcher/src/elevated_runner.rs`, "OS-stable, never moves"; and `openBrowser.ts` since #653). A new test sets `SystemRoot=D:\Hijacked` and `windir=D:\AlsoHijacked` and asserts neither reaches the probe.

## What deliberately did NOT change, and why

**The bare-name fallback stays.** The item as filed called it a defect that "re-opens the PATH hole". On inspection that was wrong, and the correction matters more than the code change:

- The comment claimed the fallback "surfaces a clear ENOENT rather than a silent miss". That is **false** — a bare name resolves through `PATH` and may well succeed.
- But the *behaviour* is load-bearing: it is the only thing that finds system tools on non-FHS distributions.
- And it is materially different from `spawn('systemctl')`: `PATH` is reached only after four absolute candidates have missed, so the hijack surface is the narrow tail rather than the default.

Removing it would have settled a hardening argument by breaking NixOS and Guix outright, and could not be tested here. So it stays, with the comment now stating the real reason. **That is a decision recorded in the code, not a deferral** — there is no follow-up item behind it.

## Verification

- `npm test` — 218 files, **1960 passed** / 5 skipped. The count moves by −4 +1: the twin's four tests are gone (resolution is now covered once, in `systemTools.test.ts`, rather than asserted twice against implementations that could drift) and the env-hijack test is new.
- `npx tsc --noEmit` clean; `biome check` clean (the 11 warnings are the pre-existing CSS ones tracked as item 122).
- No caller changed; no behaviour change on Linux or macOS. On Windows the probe root becomes a literal, which the rule already decided and #653 already shipped.

`release:beta` so this ships rather than sitting in `[Unreleased]`.
