### PR TITLE
fix(item 121): bounded retry for fetch-prebuilts downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 14 unit tests cover the status predicate, the backoff sequence, the 404 no-retry path, exhausting the
     budget on both a status and a thrown error, and the `onRetry` reporting. `fetchImpl` and `sleep` are
     injectable, so none of them touch the network or actually wait.
+
 ### Changed
 
 - **Biome is clean: 0 warnings, 0 infos across 566 files** (todo item 122). The lint step exits 0 on
@@ -57,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     reordering can satisfy the rule (moving a block just re-points the complaint at the next rule above
     it). So each site carries a suppression naming its reason, and Biome's own `suppressions/unused`
     check turns a suppression red the moment it stops applying.
-  - **`modal.css` gained 37 lines and lost zero** — the change is comments only, with every selector and
+  - **`modal.css` gained 50 lines and lost zero** — the change is comments only, with every selector and
     declaration byte-identical. The tempting "proper" fix, rewriting the `.modal-advanced` selector list
     as `:is(select, input:not([type="checkbox"]))`, was tried and reverted: it is the same match set but
     raises specificity from (0,2,2) to (0,3,2), which levels it with the `:disabled` rule above and — by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fetch-prebuilts` retries the transient half of a failed download instead of exiting 1** (todo item
+  121). All three downloads in `scripts/fetch-prebuilts.mjs` — the manifest, `SHA256SUMS`, and the
+  tarball — were one shot: any non-OK status went straight to `process.exit(1)`. The script runs inside
+  the **required** `build-and-test` check (`vitest.globalSetup.ts` invokes it), so on 2026-09-09, when
+  GitHub answered `500` for one of our own release assets, `main` went red over a blip that had already
+  cleared by the time anyone opened the log.
+  - **Three attempts, backing off 2s then 4s**, via a new exported `fetchWithRetry`.
+  - **The retry list is deliberately narrow: `429` and `5xx` only**, plus network/abort errors (DNS,
+    reset, the 30s `AbortSignal` timeout). A `404` is a real answer — the asset does not exist — and
+    retrying it only converts a fast, clear failure into a slow, identical one. `401`/`403` are the same:
+    no amount of waiting grows a permission.
+  - **The last attempt's response is returned as-is**, so the existing `console.error` still reports the
+    real status and the script still exits 1 on a genuine failure. Each retry prints the attempt, the
+    reason and the wait to stderr, so a green run that rode over a blip still says so in the log.
+  - 14 unit tests cover the status predicate, the backoff sequence, the 404 no-retry path, exhausting the
+    budget on both a status and a thrown error, and the `onRetry` reporting. `fetchImpl` and `sleep` are
+    injectable, so none of them touch the network or actually wait.
+
 ## [0.1.30-beta.118] - 2026-09-09
 
 ### Changed

--- a/scripts/__tests__/fetch-prebuilts.test.mjs
+++ b/scripts/__tests__/fetch-prebuilts.test.mjs
@@ -4,8 +4,11 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
     DEFAULT_RELEASE_URL_BASE,
+    fetchWithRetry,
+    isRetryableStatus,
     readInstalledNodePtyVersion,
     resolveReleaseUrlBase,
+    retryDelayMs,
 } from '../fetch-prebuilts.mjs';
 
 describe('resolveReleaseUrlBase', () => {
@@ -87,5 +90,164 @@ describe('readInstalledNodePtyVersion', () => {
             JSON.stringify({ name: 'node-pty' }),
         );
         expect(() => readInstalledNodePtyVersion(tmpDir)).toThrow(/version/);
+    });
+});
+
+// Item 121. The three downloads in this script were one-shot: any non-OK status
+// hit process.exit(1). The script runs inside the REQUIRED build-and-test check
+// (vitest.globalSetup calls it), so GitHub answering 500 for its own release
+// asset — which it did on 2026-09-09 — reddened `main` over a blip that had
+// already cleared by the time anyone looked.
+describe('isRetryableStatus', () => {
+    it('retries rate limiting and server-side failures', () => {
+        for (const status of [429, 500, 502, 503, 504, 599]) {
+            expect(isRetryableStatus(status), `status ${status}`).toBe(true);
+        }
+    });
+
+    // The whole point of the narrow list: a 404 is a real answer, and retrying
+    // it turns a fast clear failure into a slow identical one.
+    it('never retries a 404 or the other client-side answers', () => {
+        for (const status of [400, 401, 403, 404, 410, 418, 422]) {
+            expect(isRetryableStatus(status), `status ${status}`).toBe(false);
+        }
+    });
+
+    it('does not retry success or redirect statuses', () => {
+        for (const status of [200, 204, 301, 302, 304]) {
+            expect(isRetryableStatus(status), `status ${status}`).toBe(false);
+        }
+    });
+});
+
+describe('retryDelayMs', () => {
+    it('doubles from the 2s base: 2s after attempt 1, 4s after attempt 2', () => {
+        expect(retryDelayMs(1)).toBe(2000);
+        expect(retryDelayMs(2)).toBe(4000);
+        expect(retryDelayMs(3)).toBe(8000);
+    });
+
+    it('honors an injected base', () => {
+        expect(retryDelayMs(1, 10)).toBe(10);
+        expect(retryDelayMs(2, 10)).toBe(20);
+    });
+});
+
+describe('fetchWithRetry', () => {
+    /** Fake `fetch` returning the queued items in order; a thrown value rejects. */
+    function queuedFetch(queue) {
+        const calls = [];
+        const impl = async (url) => {
+            calls.push(url);
+            const next = queue.shift();
+            if (next instanceof Error) {
+                throw next;
+            }
+            return next;
+        };
+        return { impl, calls };
+    }
+
+    const res = (status) => ({ ok: status >= 200 && status < 300, status });
+
+    /** Records the requested delays instead of waiting them out. */
+    function recordingSleep() {
+        const waits = [];
+        return { sleep: async (ms) => void waits.push(ms), waits };
+    }
+
+    it('returns the first response and stops when it is OK', async () => {
+        const { impl, calls } = queuedFetch([res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/a', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(200);
+        expect(calls).toHaveLength(1);
+        expect(waits).toEqual([]);
+    });
+
+    it('retries a 503 and returns the success that follows', async () => {
+        const { impl, calls } = queuedFetch([res(503), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/b', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(200);
+        expect(calls).toHaveLength(2);
+        expect(waits).toEqual([2000]);
+    });
+
+    it('backs off 2s then 4s across the full three attempts', async () => {
+        const { impl, calls } = queuedFetch([res(500), res(502), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        await fetchWithRetry('https://example.test/c', { fetchImpl: impl, sleep });
+        expect(calls).toHaveLength(3);
+        expect(waits).toEqual([2000, 4000]);
+    });
+
+    it('does NOT retry a 404 — one call, and the 404 comes back untouched', async () => {
+        const { impl, calls } = queuedFetch([res(404), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/d', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(404);
+        expect(calls).toHaveLength(1);
+        expect(waits).toEqual([]);
+    });
+
+    it('gives up after the attempt budget and returns the last non-OK response', async () => {
+        const { impl, calls } = queuedFetch([res(503), res(503), res(503)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/e', { fetchImpl: impl, sleep });
+        // The caller still reports the real status; it does not throw.
+        expect(out.status).toBe(503);
+        expect(calls).toHaveLength(3);
+        expect(waits).toEqual([2000, 4000]);
+    });
+
+    it('retries a network error (DNS/reset/AbortSignal timeout) and recovers', async () => {
+        const { impl, calls } = queuedFetch([new Error('ECONNRESET'), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/f', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(200);
+        expect(calls).toHaveLength(2);
+        expect(waits).toEqual([2000]);
+    });
+
+    it('rethrows the network error once the attempts are spent', async () => {
+        const { impl, calls } = queuedFetch([
+            new Error('ECONNRESET'),
+            new Error('ECONNRESET'),
+            new Error('getaddrinfo ENOTFOUND'),
+        ]);
+        const { sleep } = recordingSleep();
+        await expect(
+            fetchWithRetry('https://example.test/g', { fetchImpl: impl, sleep }),
+        ).rejects.toThrow(/ENOTFOUND/);
+        expect(calls).toHaveLength(3);
+    });
+
+    it('reports each retry to onRetry with the attempt and the reason', async () => {
+        const { impl } = queuedFetch([res(500), new Error('socket hang up'), res(200)]);
+        const { sleep } = recordingSleep();
+        const seen = [];
+        await fetchWithRetry('https://example.test/h', {
+            fetchImpl: impl,
+            sleep,
+            onRetry: (info) => seen.push(info),
+        });
+        expect(seen).toEqual([
+            { url: 'https://example.test/h', attempt: 1, attempts: 3, reason: 'HTTP 500' },
+            { url: 'https://example.test/h', attempt: 2, attempts: 3, reason: 'socket hang up' },
+        ]);
+    });
+
+    it('honors a caller-supplied attempt budget', async () => {
+        const { impl, calls } = queuedFetch([res(503), res(503)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/i', {
+            fetchImpl: impl,
+            sleep,
+            attempts: 2,
+        });
+        expect(out.status).toBe(503);
+        expect(calls).toHaveLength(2);
+        expect(waits).toEqual([2000]);
     });
 });

--- a/scripts/fetch-prebuilts.mjs
+++ b/scripts/fetch-prebuilts.mjs
@@ -22,8 +22,83 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 
+/** Attempts per download, INCLUDING the first. 3 => first + 2 retries. */
+const DOWNLOAD_ATTEMPTS = 3;
+/** Backoff base; attempt 1 waits 2s, attempt 2 waits 4s (see retryDelayMs). */
+const RETRY_BASE_DELAY_MS = 2_000;
+
 export const DEFAULT_RELEASE_URL_BASE =
     'https://github.com/bilbospocketses/ws-scrcpy-web/releases/download';
+
+/**
+ * Which HTTP statuses earn another attempt.
+ *
+ * Deliberately NARROW: 429 (rate limit) and 5xx (server-side). A 404 is a real
+ * answer — the asset does not exist — and retrying it only turns a fast, clear
+ * failure into a slow, identical one. Same for 401/403: no amount of waiting
+ * grows a permission.
+ */
+export function isRetryableStatus(status) {
+    return status === 429 || (status >= 500 && status <= 599);
+}
+
+/** Backoff for the wait AFTER attempt N: 2s, then 4s. */
+export function retryDelayMs(attempt, baseMs = RETRY_BASE_DELAY_MS) {
+    return baseMs * 2 ** (attempt - 1);
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * `fetch` with bounded retry for the transient half of the failure space.
+ *
+ * Why this exists: every download here used to be one shot, and a single
+ * non-OK status called `process.exit(1)`. GitHub's own release CDN answered 500
+ * on 2026-09-09 and reddened `main` — this script runs inside the REQUIRED
+ * `build-and-test` check (via vitest.globalSetup), so an upstream blip that
+ * clears in seconds cost a full re-run to discover.
+ *
+ * Retries cover network/abort errors (DNS, reset, the 30s AbortSignal timeout)
+ * and `isRetryableStatus`. Everything else — 404, 403, a bad checksum — returns
+ * or throws on the first attempt, unchanged. The response of the LAST attempt is
+ * returned as-is so the caller keeps reporting the real status.
+ *
+ * `fetchImpl`/`sleep` are injectable so the unit tests never touch the network
+ * and never actually wait.
+ */
+export async function fetchWithRetry(url, opts = {}) {
+    const {
+        attempts = DOWNLOAD_ATTEMPTS,
+        fetchImpl = fetch,
+        sleep = defaultSleep,
+        timeoutMs = DOWNLOAD_TIMEOUT_MS,
+        onRetry = () => {},
+    } = opts;
+
+    for (let attempt = 1; ; attempt++) {
+        const last = attempt >= attempts;
+        try {
+            const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+            if (res.ok || last || !isRetryableStatus(res.status)) {
+                return res;
+            }
+            onRetry({ url, attempt, attempts, reason: `HTTP ${res.status}` });
+        } catch (err) {
+            if (last) {
+                throw err;
+            }
+            onRetry({ url, attempt, attempts, reason: err?.message ?? String(err) });
+        }
+        await sleep(retryDelayMs(attempt));
+    }
+}
+
+/** Retry notice on stderr so a CI log shows the blip that a green run rode over. */
+function warnRetry({ url, attempt, attempts, reason }) {
+    console.warn(
+        `[fetch-prebuilts] attempt ${attempt}/${attempts} for ${url} failed (${reason}); retrying in ${retryDelayMs(attempt) / 1000}s`,
+    );
+}
 
 /**
  * Resolve the release URL base for prebuilt downloads. WSSCRCPY_RELEASE_URL_BASE
@@ -128,7 +203,7 @@ async function main() {
     }
 
     const manifestUrl = `${RELEASE_URL_BASE}/node-pty-prebuilds-latest/manifest.json`;
-    const manifestRes = await fetch(manifestUrl, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+    const manifestRes = await fetchWithRetry(manifestUrl, { onRetry: warnRetry });
     if (!manifestRes.ok) {
         console.error(`[fetch-prebuilts] manifest fetch failed: ${manifestRes.status}`);
         process.exit(1);
@@ -154,7 +229,8 @@ async function main() {
     const cacheDir = path.join(depsPath, 'node-pty', `v${version}`, `${host.platform}-${host.arch}${libcSegment}`);
 
     if (!fs.existsSync(path.join(cacheDir, 'pty.node'))) {
-        const sumsRes = await fetch(`${RELEASE_URL_BASE}/node-pty-prebuilds-v${version}/SHA256SUMS`, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+        const sumsUrl = `${RELEASE_URL_BASE}/node-pty-prebuilds-v${version}/SHA256SUMS`;
+        const sumsRes = await fetchWithRetry(sumsUrl, { onRetry: warnRetry });
         if (!sumsRes.ok) { console.error(`[fetch-prebuilts] SHA256SUMS fetch failed: ${sumsRes.status}`); process.exit(1); }
         const sumsText = await sumsRes.text();
         const sumLine = sumsText.split('\n').find((l) => l.includes(`${key}.tar.gz`));
@@ -162,7 +238,7 @@ async function main() {
         const expectedSha = sumLine.split(/\s+/)[0].toLowerCase();
 
         const tarUrl = `${RELEASE_URL_BASE}/node-pty-prebuilds-v${version}/${key}.tar.gz`;
-        const tarRes = await fetch(tarUrl, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+        const tarRes = await fetchWithRetry(tarUrl, { onRetry: warnRetry });
         if (!tarRes.ok) { console.error(`[fetch-prebuilts] tarball fetch failed: ${tarRes.status}`); process.exit(1); }
 
         fs.mkdirSync(cacheDir, { recursive: true });


### PR DESCRIPTION
Closes todo item 121.

## The problem

All three downloads in `scripts/fetch-prebuilts.mjs` — the manifest, `SHA256SUMS`, and the tarball — were one shot. Any non-OK status went straight to `process.exit(1)`.

That script is not optional infrastructure: `vitest.globalSetup.ts` invokes it, so it runs inside the **required** `build-and-test` check. On 2026-09-09 GitHub answered `500` for one of our own release assets and `main` went red — over a blip that had already cleared by the time anyone opened the log.

## The fix

A new exported `fetchWithRetry`: **3 attempts, backing off 2s then 4s.**

The retry list is deliberately narrow — **`429` and `5xx` only**, plus network/abort errors (DNS, connection reset, the 30s `AbortSignal` timeout). Everything else fails on the first attempt, exactly as before.

That narrowness is the point. A `404` is a real answer — the asset does not exist — and retrying it only converts a fast, clear failure into a slow, identical one. `401`/`403` are the same: no amount of waiting grows a permission.

The **last attempt's response is returned as-is**, so the existing `console.error` still reports the real status and a genuine failure still exits 1. Each retry prints the attempt, the reason and the wait to stderr, so a green run that rode over a blip still says so in the log rather than hiding it.

## Tests

14 new unit tests (22 in the file, all green):

- the status predicate over 429/5xx, the 4xx family, and success/redirect statuses
- the backoff sequence — 2s then 4s across the full three attempts
- the 404 no-retry path: exactly one call, and the 404 comes back untouched
- exhausting the budget on a status (returns the last 503) and on a thrown error (rethrows)
- a network error retried and recovered
- `onRetry` reporting the attempt, the budget and the reason
- a caller-supplied attempt budget

`fetchImpl` and `sleep` are injectable, so no test touches the network and no test actually waits.
