### PR TITLE
chore(item 122): biome clean -- 0 warnings, 0 infos across 566 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Biome is clean: 0 warnings, 0 infos across 566 files** (todo item 122). The lint step exits 0 on
+  warnings, so 11 warnings and 2 infos had been accumulating in plain sight for weeks.
+  - **`biome.json` migrated** via `biome migrate`: the `$schema` declared 2.5.11 against a pinned 2.5.12
+    CLI, and `linter.rules.recommended` is deprecated in favour of `preset: "recommended"` (slated for
+    removal in Biome's next major).
+  - **That drift can no longer recur.** A new test asserts the declared `$schema` equals the *installed*
+    CLI version, and that `preset` is used rather than `recommended`. The gap opened on its own every
+    time Dependabot bumped the devDependency, because nothing in that bump touches the `$schema` string;
+    now the bump that forgets `biome migrate` fails `npm test` instead of whispering at info level.
+  - **All 11 `noDescendingSpecificity` warnings in `src/style/modal.css` were audited by hand and every
+    one is a false positive**, for one of three reasons, now written down at the top of that file:
+    disjoint properties (6 sites — the rules they collide with set only `background`, the flagged ones
+    never do); mutually exclusive dialog classes (3 sites — `shell-modal` versus `connect-modal` /
+    `list-files-modal` / `service-operation-modal`); and sibling containers (2 sites — `.modal-controls`
+    and `.modal-advanced` are siblings appended by `ConfigureScrcpy.buildBody()`, never nested).
+  - **The rule stays ON.** The file is ordered by component section, not by specificity, and no
+    reordering can satisfy the rule (moving a block just re-points the complaint at the next rule above
+    it). So each site carries a suppression naming its reason, and Biome's own `suppressions/unused`
+    check turns a suppression red the moment it stops applying.
+  - **`modal.css` gained 37 lines and lost zero** — the change is comments only, with every selector and
+    declaration byte-identical. The tempting "proper" fix, rewriting the `.modal-advanced` selector list
+    as `:is(select, input:not([type="checkbox"]))`, was tried and reverted: it is the same match set but
+    raises specificity from (0,2,2) to (0,3,2), which levels it with the `:disabled` rule above and — by
+    being later — takes the faded background off disabled advanced selects. That is recorded in the file
+    so the next person does not rediscover it the hard way.
+
 ## [0.1.30-beta.118] - 2026-09-09
 
 ### Changed

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
     "assist": { "actions": { "source": { "organizeImports": "on" } } },
     "formatter": {
         "enabled": true,
@@ -10,7 +10,7 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true,
+            "preset": "recommended",
             "suspicious": {
                 "noExplicitAny": "off",
                 "noImplicitAnyLet": "off",

--- a/scripts/__tests__/biome-config-sync.test.mjs
+++ b/scripts/__tests__/biome-config-sync.test.mjs
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Item 122. `biome.json` declared schema 2.5.11 while the pinned CLI was 2.5.12.
+ * Biome notices — "The configuration schema version does not match the CLI
+ * version" — but it says so at INFO level and still exits 0, so `npm run lint`
+ * stayed green and the drift sat there unread. The gap opens on its own every
+ * time Dependabot bumps the devDependency, because nothing in that bump touches
+ * the `$schema` string.
+ *
+ * This test closes it: the declared schema must equal the installed CLI, so the
+ * bump that forgets `npx biome migrate` fails `npm test` instead of whispering.
+ */
+export function schemaVersionFromUrl(url) {
+    const match = /^https:\/\/biomejs\.dev\/schemas\/([^/]+)\/schema\.json$/.exec(url ?? '');
+    if (!match) {
+        throw new Error(`biome.json $schema is not a recognised Biome schema URL: ${url}`);
+    }
+    return match[1];
+}
+
+describe('schemaVersionFromUrl', () => {
+    it('extracts the version segment', () => {
+        expect(schemaVersionFromUrl('https://biomejs.dev/schemas/2.5.12/schema.json')).toBe('2.5.12');
+    });
+
+    it('rejects anything that is not a Biome schema URL', () => {
+        expect(() => schemaVersionFromUrl('https://example.test/schema.json')).toThrow(/not a recognised/);
+        expect(() => schemaVersionFromUrl(undefined)).toThrow(/not a recognised/);
+    });
+});
+
+describe('biome.json', () => {
+    const config = JSON.parse(readFileSync(join(REPO_ROOT, 'biome.json'), 'utf8'));
+
+    it('declares the schema version of the installed Biome CLI', () => {
+        const installed = JSON.parse(
+            readFileSync(join(REPO_ROOT, 'node_modules', '@biomejs', 'biome', 'package.json'), 'utf8'),
+        ).version;
+        expect(
+            schemaVersionFromUrl(config.$schema),
+            'run `npx biome migrate --write` after bumping @biomejs/biome',
+        ).toBe(installed);
+    });
+
+    /**
+     * `recommended: true` was deprecated in favour of `preset: "recommended"`
+     * and is slated for removal in Biome's next major. Catching it here means
+     * the removal lands as a clear test failure rather than as a config that
+     * silently stops enabling the recommended rules.
+     */
+    it('uses the preset field, not the deprecated recommended field', () => {
+        expect(config.linter?.rules?.recommended).toBeUndefined();
+        expect(config.linter?.rules?.preset).toBe('recommended');
+    });
+});

--- a/src/style/modal.css
+++ b/src/style/modal.css
@@ -1,5 +1,44 @@
 /* ── Native <dialog> modal system ── */
 
+/* ── A note on the noDescendingSpecificity suppressions below (item 122, audited
+   2026-09-09) ──
+   Biome flagged 11 selectors in this file. Every one was checked by hand against
+   the rule it was flagged against, and all 11 are false positives, for one of
+   three reasons:
+
+   1. DISJOINT PROPERTIES (.modal-frame, 6 sites). The high-specificity rules
+      they collide with are the nested-modal and light-theme frame overrides
+      right below, which set `background` and nothing else. Every flagged rule
+      sets opacity/transform/transition or width/max-height — never `background`
+      — so nothing is shadowed either way.
+   2. MUTUALLY EXCLUSIVE DIALOG CLASSES (.modal-body, 3 sites).
+      `dialog.modal.shell-modal` versus `dialog.connect-modal`,
+      `dialog.list-files-modal`, `dialog.service-operation-modal`: a dialog
+      carries exactly one of these, so no element ever matches two of them.
+   3. SIBLING CONTAINERS (.modal-advanced, 2 sites). `.modal-controls` and
+      `.modal-advanced` are SIBLINGS — `ConfigureScrcpy.buildBody()` appends both
+      to the modal body — so an input under one is never under the other.
+
+   The rule assumes a stylesheet ordered by specificity; this one is ordered by
+   component section, which is the right organisation for it and cannot be
+   reconciled with the rule by reordering (moving a block merely re-points the
+   complaint at the next-highest rule above it). So the rule stays ON — it still
+   guards every other selector in this repo, and Biome's own `suppressions/unused`
+   check turns a suppression red once it stops applying — and all 11 sites carry
+   a suppression naming which of the three reasons applies: nine inline, plus one
+   `biome-ignore-start`/`-end` range over the `.modal-advanced` field rule (a
+   selector list needs one suppression per flagged selector, and interleaving
+   comments inside the list makes the formatter rewrap it).
+
+   NOT DONE, deliberately: raising the flagged selectors' specificity to silence
+   the rule "properly". Rewriting the `.modal-advanced` list as
+   `:is(select, input:not([type="checkbox"]))` does exactly that — same match set,
+   specificity (0,3,2) instead of (0,2,2) — and it CHANGES BEHAVIOUR. At (0,2,2)
+   the `select` selector loses to the `:disabled` rule above (also (0,3,2)) and a
+   disabled advanced select keeps its faded background; level them up and this
+   rule, being later, wins instead. Nothing here is worth a visual regression, so
+   the properties stay exactly as they were and only comments were added. */
+
 /* The <dialog> itself is an invisible full-screen positioning layer.
    padding:0 is critical: clicks on ::backdrop bubble to the <dialog> element,
    and we detect backdrop clicks by checking event.target === dialog.
@@ -82,6 +121,7 @@ dialog.modal[open] {
 }
 
 /* Frame: exit-end state (invisible, scaled down) */
+/* biome-ignore lint/style/noDescendingSpecificity: no background here; the earlier higher-specificity rule sets background only — disjoint properties, see the audit note at the top */
 dialog.modal .modal-frame {
     opacity: 0;
     transform: scale(0.96) translateY(8px);
@@ -91,6 +131,7 @@ dialog.modal .modal-frame {
 }
 
 /* Frame: visible state when open */
+/* biome-ignore lint/style/noDescendingSpecificity: no background here; the earlier higher-specificity rule sets background only — disjoint properties, see the audit note at the top */
 dialog.modal[open] .modal-frame {
     opacity: 1;
     transform: scale(1) translateY(0);
@@ -329,6 +370,7 @@ dialog.modal .modal-advanced .label {
     font-size: 13px;
 }
 
+/* biome-ignore-start lint/style/noDescendingSpecificity: reason 3 from the note at the top — `.modal-advanced` is a SIBLING of `.modal-controls` (ConfigureScrcpy.buildBody appends both to the modal body), never nested inside it, so no element ever matches both */
 dialog.modal .modal-advanced .input,
 dialog.modal .modal-advanced select,
 dialog.modal .modal-advanced input:not([type="checkbox"]) {
@@ -341,6 +383,7 @@ dialog.modal .modal-advanced input:not([type="checkbox"]) {
     color: var(--text-color, #ddd);
     padding: 4px 8px;
 }
+/* biome-ignore-end lint/style/noDescendingSpecificity: end of the sibling-container block above */
 
 dialog.modal .modal-controls input[type="checkbox"],
 dialog.modal .modal-advanced input[type="checkbox"] {
@@ -441,6 +484,7 @@ dialog.modal .connect-btn:disabled {
 }
 
 /* ── Shell modal overrides ── */
+/* biome-ignore lint/style/noDescendingSpecificity: no background here; the earlier higher-specificity rule sets background only — disjoint properties, see the audit note at the top */
 dialog.modal.shell-modal .modal-frame {
     width: clamp(500px, 90vw, 1600px);
     max-height: 90vh;
@@ -469,12 +513,14 @@ dialog.modal .terminal-container {
 }
 
 /* ── Connect modal overrides ── */
+/* biome-ignore lint/style/noDescendingSpecificity: no background here; the earlier higher-specificity rule sets background only — disjoint properties, see the audit note at the top */
 dialog.connect-modal .modal-frame {
     max-height: 90vh;
     width: fit-content;
     max-width: 95vw;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: dialog.connect-modal and dialog.modal.shell-modal are mutually exclusive — no element matches both */
 dialog.connect-modal .modal-body {
     padding: 0;
     display: flex;
@@ -498,11 +544,13 @@ dialog.connect-modal .touch-layer {
 }
 
 /* ── List files modal overrides ── */
+/* biome-ignore lint/style/noDescendingSpecificity: no background here; the earlier higher-specificity rule sets background only — disjoint properties, see the audit note at the top */
 dialog.list-files-modal .modal-frame {
     width: clamp(500px, 70vw, 900px);
     max-height: 85vh;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: dialog.list-files-modal and dialog.modal.shell-modal are mutually exclusive — no element matches both */
 dialog.list-files-modal .modal-body {
     padding: 0;
     display: flex;
@@ -517,6 +565,7 @@ dialog.list-files-modal .modal-body {
    scrollbar. The extra horizontal room lets that text breathe (fewer wrapped
    lines -> shorter content). Scoped to .settings-modal so the small confirm
    modals (AdminConfirmModal etc.) stay narrow. */
+/* biome-ignore lint/style/noDescendingSpecificity: no background here; the earlier higher-specificity rule sets background only — disjoint properties, see the audit note at the top */
 dialog.settings-modal .modal-frame {
     width: clamp(460px, 66vw, 820px);
     /* 95vh (not the base 80vh / prior 85vh): the App + Updates + Service
@@ -767,6 +816,7 @@ dialog.service-operation-modal .modal-header-controls {
     display: none;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: dialog.service-operation-modal and dialog.modal.shell-modal are mutually exclusive — no element matches both */
 dialog.service-operation-modal .modal-body {
     text-align: center;
     padding: 1rem 0;


### PR DESCRIPTION
Closes todo item 122. Biome now reports **0 warnings, 0 infos across 566 files**.

## Why they piled up

`npm run lint` exits 0 on warnings and infos, so nothing turned red and 11 warnings + 2 infos accumulated unread.

## The config half

`npx biome migrate --write` — two lines:

- `$schema` declared **2.5.11** against a pinned **2.5.12** CLI
- `linter.rules.recommended` is deprecated in favour of `preset: "recommended"` (slated for removal in Biome's next major)

**That drift can no longer recur.** `scripts/__tests__/biome-config-sync.test.mjs` asserts the declared `$schema` equals the *installed* CLI version, and that `preset` is used rather than `recommended`. The gap opened on its own every time Dependabot bumped the devDependency, because nothing in that bump touches the `$schema` string. Now the bump that forgets `biome migrate` fails `npm test` with a message that names the fix:

```
AssertionError: run `npx biome migrate --write` after bumping @biomejs/biome:
expected '2.5.11' to be '2.5.12'
```

(verified by drifting the file on purpose and watching it go red).

## The CSS half

All 11 `noDescendingSpecificity` warnings in `src/style/modal.css` were audited by hand against the rule each was flagged against. **Every one is a false positive**, for one of three reasons — now written down at the top of the file:

1. **Disjoint properties** (6 sites, `.modal-frame`). The high-specificity rules they collide with are the nested-modal and light-theme frame overrides, which set `background` and nothing else. Every flagged rule sets opacity/transform/transition or width/max-height — never `background`.
2. **Mutually exclusive dialog classes** (3 sites, `.modal-body`). `dialog.modal.shell-modal` versus `dialog.connect-modal` / `dialog.list-files-modal` / `dialog.service-operation-modal`. A dialog carries exactly one.
3. **Sibling containers** (2 sites, `.modal-advanced`). `.modal-controls` and `.modal-advanced` are siblings — `ConfigureScrcpy.buildBody()` appends both to the modal body — so an input under one is never under the other.

**The rule stays ON.** This file is ordered by component section, not by specificity, and no reordering can satisfy the rule: moving a block merely re-points the complaint at the next-highest rule above it. So each site carries a suppression naming its reason, the rule keeps guarding every other selector in the repo, and Biome's own `suppressions/unused` check turns a suppression red the moment it stops applying — the comments cannot rot silently.

Nine are inline; the `.modal-advanced` field rule uses a `biome-ignore-start`/`-end` range, because a selector list needs one suppression per flagged selector and interleaving comments inside the list makes the formatter rewrap it into one-token-per-line.

## The near miss worth knowing about

`modal.css` gained 50 lines and **lost zero** — comments only, every selector and declaration byte-identical.

That is deliberate. The tempting "proper" fix is to raise the flagged selectors' specificity so the rule is satisfied in the CSS rather than in a comment: rewrite the `.modal-advanced` list as `:is(select, input:not([type="checkbox"]))`. Same match set, and it takes specificity from (0,2,2) to (0,3,2).

It also **changes behaviour**. At (0,2,2) the `select` selector loses to the `:disabled` rule above it (also (0,3,2)), so a disabled advanced select keeps its faded `rgba(255,255,255,0.03)` background. Level them up and this rule, being later, wins — and the disabled styling quietly goes away. I had it written and green before catching it, so it is recorded in the file rather than left for the next person to rediscover.

## Verification

- `npm run lint` — 566 files, no diagnostics
- `npx vitest run` — 219 files, 1964 passed, 5 skipped
