### PR TITLE
fix(items 124, 125): retry transient network failures; never skip a dependency silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     version checks keep the 30s deadline they never had.
   - 25 new tests. The four regression tests were verified in the failing direction by disabling the
     `res.ok` guard — all four fail without it.
+  - **A failed *update* check no longer condemns an *installed* dependency.** The first cut of this fix
+    threw on any non-OK response, which is right when nothing is installed (that is the case item 124 is
+    about — `autoInstallMissing` skips it and the user must be told) and wrong when the dependency is
+    already there. The Docker image **seeds** scrcpy-server, so in a container it is present and usable
+    while `api.github.com` still rate-limits the *"is there a newer one"* lookup. Marking that `Error`
+    told smoke 20.9 and 20.12 a healthy container was faulty. Now: not installed → `Error`, as intended;
+    installed → keep it, report the update status as unknown, log at info.
+  - **The version-check phase no longer gates the whole hydrate.** Boot is
+    `checkAll().then(() => autoInstallMissing())`, and the seed promote plus every install lives inside
+    `autoInstallMissing` — so time spent checking versions is time before anything is installed at all.
+    Two changes: `checkAll` now runs the three latest-checks **concurrently** (worst case becomes the
+    slowest one rather than the sum), and version checks get their own **`VERSION_CHECK_POLICY`** — 2
+    attempts, 1s backoff, 10s timeout — instead of the download budget. With the download policy in that
+    position, one unreachable endpoint could hold the gate ~96s and three serially ~288s, which is what
+    blew 20.9's 180s hydrate poll and 20.12's 300s wait and left 1.9 reading `checking` where it expected
+    `error`. Downloads keep the generous budget; they are not in front of anything.
+  - 6 further tests pin all of it, including a concurrency test that counts **peak in-flight requests**
+    rather than elapsed time, so it cannot flake on a slow box. Both halves verified in the failing
+    direction by mutation: forcing the `Error` branch fails the installed-dependency test, and restoring
+    the serial loop fails the concurrency test.
 
 - **`fetch-prebuilts` retries the transient half of a failed download instead of exiting 1** (todo item
   121). All three downloads in `scripts/fetch-prebuilts.mjs` — the manifest, `SHA256SUMS`, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A failed version check no longer silently skips a dependency for the whole boot** (todo items 124 and
+  125). Every `checkLatest` in `DependencyDefinitions.ts` called bare `fetch` and **never looked at
+  `res.ok`**. On a non-OK response it parsed the *error body* as if it were the payload, found no version
+  field, and returned `null` — and `autoInstallMissing` deliberately skips a dependency whose latest
+  version is unknown. So the install was never attempted, `installedVersion` stayed `null` for the rest of
+  that boot, and `DependencyManager.checkLatest`'s own try/catch — which records
+  `DependencyStatus.Error` *with the message* — never fired, because nothing threw.
+  - **This is what smoke 20.11's 300-second flake actually was.** Not a slow hydrate: a dead one. No
+    timeout could ever have helped, because nothing was retrying and nothing would.
+  - **`scrcpy-server` is resolved through `api.github.com`, which rate-limits per IP at 60/hour
+    unauthenticated — and CI runners share IPs.** `nodejs` (nodejs.org) and `adb` (dl.google.com) are on
+    endpoints that do not, which is exactly why those two hydrated in the same run where `scrcpy-server`
+    reported `unknown` for five minutes. It is not CI-only: a user behind corporate NAT hits the same cap
+    and silently gets no scrcpy-server.
+  - **New shared `src/server/util/fetchWithRetry.ts`**, the TypeScript sibling of the helper item 121 added
+    to `scripts/fetch-prebuilts.mjs` (the script must keep its own copy — it runs on a fresh clone before
+    `npm run build`). Same narrow policy: **`429` and `5xx` plus network/abort errors, never a `404`**, 3
+    attempts backing off 2s then 4s. `403` is deliberately *not* retried — GitHub's rate-limit `403` is
+    indistinguishable here from a genuine auth failure, and `429` is the status that means "try again".
+  - **`fetchOkWithRetry` throws on a non-OK final response**, and every `checkLatest` now uses it. A throw
+    is a state the manager, the API and the UI can all report; a `null` is indistinguishable from "this
+    dependency legitimately has no known latest version".
+  - **`NodePtyResolver`'s three fetches and `DependencyManager.download` now retry too** (that half is item
+    125). The pty resolver's `return false` → `shell:false` degradation is right for *"no prebuilt exists
+    for this host"* and wrong for *"GitHub had a bad two seconds"*; a 404 still fails on the first attempt,
+    so the honest degradation survives.
+  - **The large-download case is handled explicitly.** `AbortSignal.timeout` aborts body streaming as well
+    as the request, so a per-attempt deadline would kill the ~110 MB Node archive mid-transfer.
+    `DependencyManager.download` passes `timeoutMs: null` and relies on retry alone; the small JSON/XML
+    version checks keep the 30s deadline they never had.
+  - 25 new tests. The four regression tests were verified in the failing direction by disabling the
+    `res.ok` guard — all four fail without it.
+
 - **`fetch-prebuilts` retries the transient half of a failed download instead of exiting 1** (todo item
   121). All three downloads in `scripts/fetch-prebuilts.mjs` — the manifest, `SHA256SUMS`, and the
   tarball — were one shot: any non-OK status went straight to `process.exit(1)`. The script runs inside

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { Logger } from './Logger';
 import { loadManifest } from './NodePtyResolver';
 import { getInstalledScrcpyServerVersion } from './scrcpyServerVersion';
+import { fetchOkWithRetry } from './util/fetchWithRetry';
 
 const log = Logger.for('DependencyDefinitions');
 
@@ -81,7 +82,9 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
                 return runVersionCommand(exe, ['--version'], /v([\d.]+)/);
             },
             checkLatest: async () => {
-                const res = await fetch('https://nodejs.org/dist/index.json');
+                const res = await fetchOkWithRetry('https://nodejs.org/dist/index.json', {
+                    onRetry: (n) => log.warn(`node latest check ${n.attempt}/${n.attempts}: ${n.reason}`),
+                });
                 const releases = (await res.json()) as { version: string; lts: string | false }[];
                 const ltsReleases = releases.filter((r) => r.lts !== false);
                 if (ltsReleases.length === 0) return null;
@@ -128,7 +131,9 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
                 return runVersionCommand(exe, ['--version'], /Version ([\d.]+)/);
             },
             checkLatest: async () => {
-                const res = await fetch('https://dl.google.com/android/repository/repository2-3.xml');
+                const res = await fetchOkWithRetry('https://dl.google.com/android/repository/repository2-3.xml', {
+                    onRetry: (n) => log.warn(`adb latest check ${n.attempt}/${n.attempts}: ${n.reason}`),
+                });
                 const xml = await res.text();
                 const match = xml.match(
                     /path="platform-tools"[\s\S]*?<major>(\d+)<\/major>\s*<minor>(\d+)<\/minor>\s*<micro>(\d+)<\/micro>/,
@@ -159,8 +164,19 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
                 return getInstalledScrcpyServerVersion(depsPath);
             },
             checkLatest: async () => {
-                const res = await fetch('https://api.github.com/repos/Genymobile/scrcpy/releases/latest', {
-                    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'ws-scrcpy-web' },
+                // `fetchOkWithRetry`, not `fetch`. This call used to ignore
+                // `res.ok` entirely, so a 403 or 5xx got its ERROR BODY parsed
+                // as success, yielded no `tag_name`, and returned null —
+                // whereupon autoInstallMissing skipped scrcpy-server for the
+                // whole boot with no trace. That is smoke 20.11's 300s flake,
+                // and this endpoint is why: api.github.com rate-limits per IP
+                // at 60/hour unauthenticated, and CI runners share IPs. The
+                // other two dependencies resolve through nodejs.org and
+                // dl.google.com, which do not rate-limit — which is exactly why
+                // they hydrated in the run where this one did not.
+                const res = await fetchOkWithRetry('https://api.github.com/repos/Genymobile/scrcpy/releases/latest', {
+                    init: { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'ws-scrcpy-web' } },
+                    onRetry: (n) => log.warn(`scrcpy-server latest check ${n.attempt}/${n.attempts}: ${n.reason}`),
                 });
                 const data = (await res.json()) as { tag_name: string };
                 return data.tag_name?.replace(/^v/, '') ?? null;

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import { Logger } from './Logger';
 import { loadManifest } from './NodePtyResolver';
 import { getInstalledScrcpyServerVersion } from './scrcpyServerVersion';
-import { fetchOkWithRetry } from './util/fetchWithRetry';
+import { fetchOkWithRetry, VERSION_CHECK_POLICY } from './util/fetchWithRetry';
 
 const log = Logger.for('DependencyDefinitions');
 
@@ -83,6 +83,7 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             },
             checkLatest: async () => {
                 const res = await fetchOkWithRetry('https://nodejs.org/dist/index.json', {
+                    ...VERSION_CHECK_POLICY,
                     onRetry: (n) => log.warn(`node latest check ${n.attempt}/${n.attempts}: ${n.reason}`),
                 });
                 const releases = (await res.json()) as { version: string; lts: string | false }[];
@@ -132,6 +133,7 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             },
             checkLatest: async () => {
                 const res = await fetchOkWithRetry('https://dl.google.com/android/repository/repository2-3.xml', {
+                    ...VERSION_CHECK_POLICY,
                     onRetry: (n) => log.warn(`adb latest check ${n.attempt}/${n.attempts}: ${n.reason}`),
                 });
                 const xml = await res.text();
@@ -176,6 +178,7 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
                 // they hydrated in the run where this one did not.
                 const res = await fetchOkWithRetry('https://api.github.com/repos/Genymobile/scrcpy/releases/latest', {
                     init: { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'ws-scrcpy-web' } },
+                    ...VERSION_CHECK_POLICY,
                     onRetry: (n) => log.warn(`scrcpy-server latest check ${n.attempt}/${n.attempts}: ${n.reason}`),
                 });
                 const data = (await res.json()) as { tag_name: string };

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -13,6 +13,7 @@ import { Logger } from './Logger';
 import { writeInstalledScrcpyServerVersion } from './scrcpyServerVersion';
 import { resolveSystemTool } from './service/systemTools';
 import { copyFileAtomic, copyFileAtomicSync, writeFileAtomicSync } from './util/atomicFile';
+import { fetchWithRetry } from './util/fetchWithRetry';
 import { extractZipTo } from './zipExtract';
 
 const log = Logger.for('DependencyManager');
@@ -295,7 +296,14 @@ export class DependencyManager {
     }
 
     private async download(url: string, destPath: string): Promise<void> {
-        const res = await fetch(url);
+        // `timeoutMs: null` deliberately. This streams the payload — the Node
+        // archive is ~110 MB — and `AbortSignal.timeout` aborts the whole
+        // exchange, body included, so any per-attempt deadline would kill a
+        // legitimately slow download mid-stream. Retry alone here.
+        const res = await fetchWithRetry(url, {
+            timeoutMs: null,
+            onRetry: (n) => log.warn(`download ${n.attempt}/${n.attempts} for ${n.url}: ${n.reason}`),
+        });
         if (!res.ok) {
             throw new Error(`Download failed: HTTP ${res.status} from ${url}`);
         }

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -94,9 +94,32 @@ export class DependencyManager {
             info.latestVersion = await def.checkLatest();
             this.resolveStatus(info);
         } catch (err) {
-            info.status = DependencyStatus.Error;
-            info.errorMessage = err instanceof Error ? err.message : String(err);
-            log.warn(`Latest-version check failed for ${name}: ${info.errorMessage}`);
+            const message = err instanceof Error ? err.message : String(err);
+            // A failed LATEST check is only an error when there is nothing
+            // installed. That is the item-124 case: we cannot learn what to
+            // install, so autoInstallMissing will skip this dependency and the
+            // user must be told rather than left with a silent no-op.
+            //
+            // When the dependency IS installed, it works — the seeded
+            // scrcpy-server in the Docker image is the everyday example. All we
+            // failed to learn is whether a newer version exists, which is
+            // advisory. Marking a present, usable dependency `Error` because
+            // api.github.com rate-limited us is a false alarm, and it broke
+            // smoke 20.9/20.12 on 2026-09-09 by asserting a healthy container
+            // was faulty. `resolveStatus` reports Unknown for a null
+            // latestVersion, which is the honest state.
+            info.latestVersion = null;
+            if (info.installedVersion === null) {
+                info.status = DependencyStatus.Error;
+                info.errorMessage = message;
+                log.warn(`Latest-version check failed for ${name} (not installed): ${message}`);
+            } else {
+                this.resolveStatus(info);
+                info.errorMessage = undefined;
+                log.info(
+                    `Latest-version check failed for ${name}; keeping installed ${info.installedVersion}: ${message}`,
+                );
+            }
         }
     }
 
@@ -104,9 +127,13 @@ export class DependencyManager {
         for (const def of this.definitions) {
             await this.checkInstalled(def.name);
         }
-        for (const def of this.definitions) {
-            await this.checkLatest(def.name);
-        }
+        // CONCURRENT, deliberately. Boot is `checkAll().then(() =>
+        // autoInstallMissing())`, and the seed promote plus every install lives
+        // inside autoInstallMissing — so this phase gates the entire hydrate.
+        // Run serially, three unreachable endpoints cost the SUM of their
+        // budgets; run together, the worst case is the slowest single one. Each
+        // checkLatest touches only its own info, so there is nothing to race.
+        await Promise.all(this.definitions.map((def) => this.checkLatest(def.name)));
         const infos = Array.from(this.state.values());
         const updates = infos.filter((i) => i.status === DependencyStatus.UpdateAvailable).map((i) => i.name);
         const upToDate = infos.filter((i) => i.status === DependencyStatus.UpToDate).length;

--- a/src/server/NodePtyResolver.ts
+++ b/src/server/NodePtyResolver.ts
@@ -5,6 +5,7 @@ import { Logger } from './Logger';
 import { detectLibc, type LibcFlavor } from './libcDetect';
 import { resolveSystemTool } from './service/systemTools';
 import { writeFileAtomicSync } from './util/atomicFile';
+import { fetchWithRetry } from './util/fetchWithRetry';
 
 /*
  * Pre-beta.23: this resolver tried two webpack escape hatches:
@@ -215,7 +216,10 @@ export async function loadManifest(depsPath: string): Promise<Manifest | null> {
     const cachedManifestPath = path.join(depsPath, MANIFEST_CACHE_RELPATH);
     try {
         const url = `${RELEASE_URL_BASE}/node-pty-prebuilds-latest/manifest.json`;
-        const res = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+        const res = await fetchWithRetry(url, {
+            timeoutMs: DOWNLOAD_TIMEOUT_MS,
+            onRetry: (n) => log.info(`manifest fetch ${n.attempt}/${n.attempts}: ${n.reason}`),
+        });
         if (res.ok) {
             const body = (await res.json()) as Manifest;
             fs.mkdirSync(path.dirname(cachedManifestPath), { recursive: true });
@@ -248,7 +252,17 @@ export async function downloadAndOverlayPtyNode(version: string, host: HostInfo,
     const sumsUrl = `${RELEASE_URL_BASE}/node-pty-prebuilds-v${version}/SHA256SUMS`;
 
     try {
-        const sumsRes = await fetch(sumsUrl, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+        // Item 125. Both fetches here were one shot: any non-OK status returned
+        // false and the caller degraded to `shell:false` with a reason. That is
+        // the right answer for "no prebuilt exists for this host/ABI" and the
+        // wrong one for "GitHub had a bad two seconds" — the user silently loses
+        // shell mode until they think to retry, and nothing says it was
+        // transient. Retrying the transient half keeps the honest degradation
+        // for the genuinely-missing case (a 404 still fails on attempt one).
+        const sumsRes = await fetchWithRetry(sumsUrl, {
+            timeoutMs: DOWNLOAD_TIMEOUT_MS,
+            onRetry: (n) => log.info(`SHA256SUMS fetch ${n.attempt}/${n.attempts}: ${n.reason}`),
+        });
         if (!sumsRes.ok) {
             log.info(`SHA256SUMS fetch failed: ${sumsRes.status}`);
             return false;
@@ -261,7 +275,10 @@ export async function downloadAndOverlayPtyNode(version: string, host: HostInfo,
         }
         const expectedSha = sumLine.split(/\s+/)[0]!.toLowerCase();
 
-        const tarRes = await fetch(tarUrl, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+        const tarRes = await fetchWithRetry(tarUrl, {
+            timeoutMs: DOWNLOAD_TIMEOUT_MS,
+            onRetry: (n) => log.info(`tarball fetch ${n.attempt}/${n.attempts}: ${n.reason}`),
+        });
         if (!tarRes.ok) {
             log.info(`tarball fetch failed: ${tarRes.status}`);
             return false;

--- a/src/server/__tests__/dependencyDefinitions.test.ts
+++ b/src/server/__tests__/dependencyDefinitions.test.ts
@@ -220,3 +220,62 @@ describe('nodejs.checkLatest (Option D gating)', () => {
         expect(await def.checkLatest()).toBe('24.14.1');
     });
 });
+
+/**
+ * Item 124 — the regression that produced smoke 20.11's 300s flake.
+ *
+ * Every `checkLatest` used to call bare `fetch` and never look at `res.ok`. On a
+ * non-OK response it parsed the ERROR BODY as if it were the payload, found no
+ * version field, and returned `null`. `DependencyManager.autoInstallMissing`
+ * deliberately skips a dependency whose latest version is unknown, so the
+ * install was never attempted and `installedVersion` stayed null for the rest of
+ * that boot — while `DependencyManager.checkLatest`'s own try/catch, which turns
+ * a throw into DependencyStatus.Error WITH the message, never fired.
+ *
+ * 403 is the shape that actually bit us: `api.github.com` rate-limits per IP at
+ * 60/hour unauthenticated and CI runners share IPs, which is why scrcpy-server
+ * alone failed to hydrate in a run where nodejs (nodejs.org) and adb
+ * (dl.google.com) both succeeded. It is also non-retryable here, so these
+ * assertions cost one call and no backoff.
+ */
+describe('checkLatest rejects a non-OK response instead of returning null (item 124)', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    afterEach(() => {
+        fetchSpy?.mockRestore();
+    });
+
+    function defFor(name: string) {
+        const d = getDependencyDefinitions('/tmp/test-deps').find((x) => x.name === name);
+        if (!d) throw new Error(`${name} definition missing`);
+        return d;
+    }
+
+    it('scrcpy-server: a rate-limited 403 throws rather than silently yielding null', async () => {
+        // The literal body GitHub returns when the unauthenticated hourly cap is hit.
+        fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ message: "API rate limit exceeded for 20.1.2.3.", documentation_url: '' }), {
+                status: 403,
+                statusText: 'rate limit exceeded',
+                headers: { 'content-type': 'application/json' },
+            }),
+        );
+        await expect(defFor('scrcpy-server').checkLatest()).rejects.toThrow(/HTTP 403/);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('adb: a 403 throws', async () => {
+        fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('nope', { status: 403 }));
+        await expect(defFor('adb').checkLatest()).rejects.toThrow(/HTTP 403/);
+    });
+
+    it('nodejs: a 403 throws', async () => {
+        fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('nope', { status: 403 }));
+        await expect(defFor('nodejs').checkLatest()).rejects.toThrow(/HTTP 403/);
+    });
+
+    it('the thrown message names the URL, so the recorded errorMessage is actionable', async () => {
+        fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('nope', { status: 403 }));
+        await expect(defFor('scrcpy-server').checkLatest()).rejects.toThrow(/api\.github\.com/);
+    });
+});

--- a/src/server/__tests__/dependencyDefinitions.test.ts
+++ b/src/server/__tests__/dependencyDefinitions.test.ts
@@ -254,7 +254,7 @@ describe('checkLatest rejects a non-OK response instead of returning null (item 
     it('scrcpy-server: a rate-limited 403 throws rather than silently yielding null', async () => {
         // The literal body GitHub returns when the unauthenticated hourly cap is hit.
         fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
-            new Response(JSON.stringify({ message: "API rate limit exceeded for 20.1.2.3.", documentation_url: '' }), {
+            new Response(JSON.stringify({ message: 'API rate limit exceeded for 20.1.2.3.', documentation_url: '' }), {
                 status: 403,
                 statusText: 'rate limit exceeded',
                 headers: { 'content-type': 'application/json' },

--- a/src/server/__tests__/dependencyManager.latestCheckFailure.test.ts
+++ b/src/server/__tests__/dependencyManager.latestCheckFailure.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DependencyStatus } from '../../common/DependencyTypes';
+import { DependencyManager } from '../DependencyManager';
+import { VERSION_CHECK_POLICY } from '../util/fetchWithRetry';
+
+/**
+ * The 2026-09-09 regression, pinned.
+ *
+ * Items 124/125 made every `checkLatest` throw on a non-OK response instead of
+ * silently returning null. Correct for the case the item was about — nothing
+ * installed, no way to learn what to install, autoInstallMissing skips it — and
+ * wrong for the case that is far more common in a container: the dependency is
+ * ALREADY INSTALLED (the Docker image seeds scrcpy-server) and only the
+ * advisory "is there a newer one" lookup failed, because api.github.com
+ * rate-limits per IP and CI runners share IPs.
+ *
+ * That turned a healthy container into three red tests — smoke 20.9 and 20.12
+ * assert no dependency reports `error`.
+ *
+ * The second half of the same regression was latency: `checkAll` ran the three
+ * latest-checks SERIALLY and boot is `checkAll().then(() =>
+ * autoInstallMissing())`, so the version phase gates the seed promote and every
+ * install. Three unreachable endpoints cost the sum of their retry budgets.
+ */
+describe('a failed latest-check does not condemn an installed dependency', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    afterEach(() => {
+        fetchSpy?.mockRestore();
+        fetchSpy = undefined;
+    });
+
+    /** 403 is what GitHub returns over the unauthenticated hourly cap, and it is not retryable. */
+    function stubForbidden() {
+        fetchSpy = vi
+            .spyOn(global, 'fetch')
+            .mockResolvedValue(
+                new Response('{"message":"API rate limit exceeded"}', { status: 403, statusText: 'Forbidden' }),
+            );
+    }
+
+    it('keeps an INSTALLED dependency healthy when the version lookup fails', async () => {
+        stubForbidden();
+        const mgr = new DependencyManager('/tmp/test-deps-latest-fail');
+        const dep = mgr.getByName('scrcpy-server')!;
+        dep.installedVersion = '3.1'; // the seeded copy, present and usable
+
+        await mgr.checkLatest('scrcpy-server');
+
+        expect(dep.status, 'a rate-limited update check is not a fault in the dependency').not.toBe(
+            DependencyStatus.Error,
+        );
+        expect(dep.errorMessage, 'nothing to report to the user').toBeUndefined();
+        expect(dep.installedVersion, 'still installed').toBe('3.1');
+        expect(dep.latestVersion, 'we genuinely do not know the latest').toBeNull();
+    });
+
+    // The item-124 case, which must stay loud: with nothing installed and no
+    // latest version, autoInstallMissing skips the dependency entirely, so a
+    // silent state here is how a first run ends up with no scrcpy-server and
+    // nothing saying why.
+    it('reports an error when the dependency is NOT installed', async () => {
+        stubForbidden();
+        const mgr = new DependencyManager('/tmp/test-deps-latest-fail');
+        const dep = mgr.getByName('scrcpy-server')!;
+        dep.installedVersion = null;
+
+        await mgr.checkLatest('scrcpy-server');
+
+        expect(dep.status).toBe(DependencyStatus.Error);
+        expect(dep.errorMessage).toMatch(/HTTP 403/);
+    });
+
+    it('never leaves a dependency stuck in Checking', async () => {
+        stubForbidden();
+        const mgr = new DependencyManager('/tmp/test-deps-latest-fail');
+        const dep = mgr.getByName('adb')!;
+        dep.installedVersion = null;
+
+        await mgr.checkLatest('adb');
+
+        // 1.9 read `checking` where it expected `error`: the status must settle
+        // by the time the call resolves, whichever branch it takes.
+        expect(dep.status).not.toBe(DependencyStatus.Checking);
+    });
+});
+
+describe('checkAll runs the latest-version checks concurrently', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    afterEach(() => {
+        fetchSpy?.mockRestore();
+        fetchSpy = undefined;
+    });
+
+    /**
+     * Counts peak in-flight requests rather than measuring elapsed time — a
+     * serial implementation can never exceed 1, a concurrent one reaches the
+     * number of dependencies, and neither answer depends on how fast the box is.
+     */
+    it('issues the version requests together, not one after another', async () => {
+        let inFlight = 0;
+        let peak = 0;
+        fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((async () => {
+            inFlight += 1;
+            peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 10));
+            inFlight -= 1;
+            return new Response('{}', { status: 500 });
+        }) as unknown as typeof fetch);
+
+        const mgr = new DependencyManager('/tmp/test-deps-concurrent');
+        await mgr.checkAll();
+
+        expect(peak, 'serial execution would peak at 1').toBeGreaterThan(1);
+    });
+});
+
+/**
+ * The budget itself. A version check is advisory, and it sits in front of the
+ * seed promote and every install, so it must stay small. The download policy
+ * (3 attempts, 30s each, 2s+4s backoff) in this position cost ~96s per
+ * dependency.
+ */
+describe('VERSION_CHECK_POLICY', () => {
+    it('is materially cheaper than the download policy', () => {
+        expect(VERSION_CHECK_POLICY.attempts).toBeLessThanOrEqual(2);
+        expect(VERSION_CHECK_POLICY.timeoutMs).toBeLessThanOrEqual(10_000);
+        expect(VERSION_CHECK_POLICY.baseDelayMs).toBeLessThanOrEqual(1_000);
+    });
+
+    it('worst case stays well inside the 180s hydrate poll even before concurrency', () => {
+        const worstCasePerDep =
+            VERSION_CHECK_POLICY.attempts * VERSION_CHECK_POLICY.timeoutMs +
+            (VERSION_CHECK_POLICY.attempts - 1) * VERSION_CHECK_POLICY.baseDelayMs;
+        // Three dependencies, serially, must still leave room for the installs.
+        expect(worstCasePerDep * 3).toBeLessThan(120_000);
+    });
+});

--- a/src/server/util/__tests__/fetchWithRetry.test.ts
+++ b/src/server/util/__tests__/fetchWithRetry.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_ATTEMPTS,
+    fetchOkWithRetry,
+    fetchWithRetry,
+    isRetryableStatus,
+    type RetryNotice,
+    retryDelayMs,
+} from '../fetchWithRetry';
+
+/** Fake `fetch` returning the queued items in order; a queued Error rejects. */
+function queuedFetch(queue: (Response | Error)[]) {
+    const calls: { url: string; init: RequestInit | undefined }[] = [];
+    const impl = (async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        const next = queue.shift();
+        if (next instanceof Error) throw next;
+        return next as Response;
+    }) as unknown as typeof fetch;
+    return { impl, calls };
+}
+
+const res = (status: number, statusText = ''): Response =>
+    ({ ok: status >= 200 && status < 300, status, statusText }) as Response;
+
+/** Records the requested delays instead of waiting them out. */
+function recordingSleep() {
+    const waits: number[] = [];
+    return { sleep: async (ms: number) => void waits.push(ms), waits };
+}
+
+describe('isRetryableStatus', () => {
+    it('retries rate limiting and server-side failures', () => {
+        for (const status of [429, 500, 502, 503, 504, 599]) {
+            expect(isRetryableStatus(status), `status ${status}`).toBe(true);
+        }
+    });
+
+    // A 404 is a real answer. Retrying it turns a fast, clear failure into a
+    // slow, identical one. 403 is excluded on purpose: GitHub's rate-limit 403
+    // is indistinguishable here from a genuine auth failure, and 429 is the
+    // status that actually means "try again".
+    it('never retries the client-side answers, 403 included', () => {
+        for (const status of [400, 401, 403, 404, 410, 418, 422]) {
+            expect(isRetryableStatus(status), `status ${status}`).toBe(false);
+        }
+    });
+
+    it('does not retry success or redirect statuses', () => {
+        for (const status of [200, 204, 301, 302, 304]) {
+            expect(isRetryableStatus(status), `status ${status}`).toBe(false);
+        }
+    });
+});
+
+describe('retryDelayMs', () => {
+    it('doubles from the 2s base', () => {
+        expect(retryDelayMs(1)).toBe(2000);
+        expect(retryDelayMs(2)).toBe(4000);
+        expect(retryDelayMs(3)).toBe(8000);
+    });
+
+    it('honors an injected base', () => {
+        expect(retryDelayMs(1, 10)).toBe(10);
+        expect(retryDelayMs(2, 10)).toBe(20);
+    });
+});
+
+describe('fetchWithRetry', () => {
+    it('defaults to three attempts', () => {
+        expect(DEFAULT_ATTEMPTS).toBe(3);
+    });
+
+    it('returns the first response and stops when it is OK', async () => {
+        const { impl, calls } = queuedFetch([res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/a', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(200);
+        expect(calls).toHaveLength(1);
+        expect(waits).toEqual([]);
+    });
+
+    it('retries a 503 and returns the success that follows', async () => {
+        const { impl, calls } = queuedFetch([res(503), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/b', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(200);
+        expect(calls).toHaveLength(2);
+        expect(waits).toEqual([2000]);
+    });
+
+    it('backs off 2s then 4s across the full three attempts', async () => {
+        const { impl, calls } = queuedFetch([res(500), res(502), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        await fetchWithRetry('https://example.test/c', { fetchImpl: impl, sleep });
+        expect(calls).toHaveLength(3);
+        expect(waits).toEqual([2000, 4000]);
+    });
+
+    it('does NOT retry a 404 — one call, and the 404 comes back untouched', async () => {
+        const { impl, calls } = queuedFetch([res(404), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/d', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(404);
+        expect(calls).toHaveLength(1);
+        expect(waits).toEqual([]);
+    });
+
+    it('gives up after the budget and returns the last non-OK response', async () => {
+        const { impl, calls } = queuedFetch([res(503), res(503), res(503)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/e', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(503);
+        expect(calls).toHaveLength(3);
+        expect(waits).toEqual([2000, 4000]);
+    });
+
+    it('retries a network error and recovers', async () => {
+        const { impl, calls } = queuedFetch([new Error('ECONNRESET'), res(200)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/f', { fetchImpl: impl, sleep });
+        expect(out.status).toBe(200);
+        expect(calls).toHaveLength(2);
+        expect(waits).toEqual([2000]);
+    });
+
+    it('rethrows the network error once the attempts are spent', async () => {
+        const { impl, calls } = queuedFetch([
+            new Error('ECONNRESET'),
+            new Error('ECONNRESET'),
+            new Error('getaddrinfo ENOTFOUND'),
+        ]);
+        const { sleep } = recordingSleep();
+        await expect(fetchWithRetry('https://example.test/g', { fetchImpl: impl, sleep })).rejects.toThrow(/ENOTFOUND/);
+        expect(calls).toHaveLength(3);
+    });
+
+    it('reports each retry with the attempt and the reason', async () => {
+        const { impl } = queuedFetch([res(500), new Error('socket hang up'), res(200)]);
+        const { sleep } = recordingSleep();
+        const seen: RetryNotice[] = [];
+        await fetchWithRetry('https://example.test/h', {
+            fetchImpl: impl,
+            sleep,
+            onRetry: (n) => seen.push(n),
+        });
+        expect(seen).toEqual([
+            { url: 'https://example.test/h', attempt: 1, attempts: 3, reason: 'HTTP 500' },
+            { url: 'https://example.test/h', attempt: 2, attempts: 3, reason: 'socket hang up' },
+        ]);
+    });
+
+    it('passes the caller init through and attaches a timeout signal', async () => {
+        const { impl, calls } = queuedFetch([res(200)]);
+        const { sleep } = recordingSleep();
+        await fetchWithRetry('https://example.test/i', {
+            fetchImpl: impl,
+            sleep,
+            init: { headers: { 'User-Agent': 'ws-scrcpy-web' } },
+        });
+        expect((calls[0]!.init!.headers as Record<string, string>)['User-Agent']).toBe('ws-scrcpy-web');
+        expect(calls[0]!.init!.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    // A per-attempt deadline aborts body streaming too, so the ~110 MB Node
+    // archive download must be able to opt out of it.
+    it('attaches NO signal when timeoutMs is null (large streamed bodies)', async () => {
+        const { impl, calls } = queuedFetch([res(200)]);
+        const { sleep } = recordingSleep();
+        await fetchWithRetry('https://example.test/j', { fetchImpl: impl, sleep, timeoutMs: null });
+        expect(calls[0]!.init?.signal).toBeUndefined();
+    });
+
+    it('honors a caller-supplied attempt budget', async () => {
+        const { impl, calls } = queuedFetch([res(503), res(503)]);
+        const { sleep, waits } = recordingSleep();
+        const out = await fetchWithRetry('https://example.test/k', { fetchImpl: impl, sleep, attempts: 2 });
+        expect(out.status).toBe(503);
+        expect(calls).toHaveLength(2);
+        expect(waits).toEqual([2000]);
+    });
+});
+
+/**
+ * The distinction that closes item 124: a failed version check must THROW.
+ * `DependencyManager.checkLatest` catches a throw and records
+ * DependencyStatus.Error with the message; a `null` return is indistinguishable
+ * from "no known latest version" and gets the dependency silently skipped by
+ * autoInstallMissing for the rest of the boot.
+ */
+describe('fetchOkWithRetry', () => {
+    it('returns the response when it is OK', async () => {
+        const { impl } = queuedFetch([res(200)]);
+        const { sleep } = recordingSleep();
+        await expect(fetchOkWithRetry('https://example.test/l', { fetchImpl: impl, sleep })).resolves.toMatchObject({
+            status: 200,
+        });
+    });
+
+    it('throws with the status and the URL on a 403 — the api.github.com rate-limit case', async () => {
+        const { impl, calls } = queuedFetch([res(403, 'rate limit exceeded')]);
+        const { sleep } = recordingSleep();
+        await expect(
+            fetchOkWithRetry('https://api.github.com/repos/Genymobile/scrcpy/releases/latest', {
+                fetchImpl: impl,
+                sleep,
+            }),
+        ).rejects.toThrow(/HTTP 403 rate limit exceeded from https:\/\/api\.github\.com/);
+        // 403 is not retryable, so it fails fast rather than burning the budget.
+        expect(calls).toHaveLength(1);
+    });
+
+    it('throws after exhausting retries on a 5xx', async () => {
+        const { impl, calls } = queuedFetch([res(500), res(500), res(500)]);
+        const { sleep } = recordingSleep();
+        await expect(fetchOkWithRetry('https://example.test/m', { fetchImpl: impl, sleep })).rejects.toThrow(
+            /HTTP 500/,
+        );
+        expect(calls).toHaveLength(3);
+    });
+
+    it('does not throw when a retry recovers', async () => {
+        const { impl } = queuedFetch([res(503), res(200)]);
+        const { sleep } = recordingSleep();
+        await expect(fetchOkWithRetry('https://example.test/n', { fetchImpl: impl, sleep })).resolves.toMatchObject({
+            status: 200,
+        });
+    });
+});

--- a/src/server/util/fetchWithRetry.ts
+++ b/src/server/util/fetchWithRetry.ts
@@ -1,0 +1,131 @@
+/**
+ * `fetch` with bounded retry for the transient half of the failure space.
+ *
+ * WHY THIS EXISTS (items 121, 124, 125). Every network call in the server was
+ * one shot, and each absorbed failure differently — none of them well:
+ *
+ *   - `DependencyDefinitions.checkLatest` did not check `res.ok` at all. On a
+ *     403 or 5xx it parsed the ERROR BODY as success, found no `tag_name`, and
+ *     returned `null`. `autoInstallMissing` deliberately skips a dependency
+ *     whose latest version is unknown, so the install was never attempted and
+ *     `installedVersion` stayed null for the rest of that boot. That is smoke
+ *     20.11's 300s flake: scrcpy-server alone is resolved through
+ *     `api.github.com`, which rate-limits **per IP at 60/hour unauthenticated**
+ *     — and CI runners share IPs. nodejs.org and dl.google.com do not, which is
+ *     exactly why `nodejs` and `adb` hydrated in the same run that
+ *     `scrcpy-server` did not. No timeout would ever have helped; nothing was
+ *     retrying.
+ *   - `NodePtyResolver.downloadAndOverlayPtyNode` returned `false` and degraded
+ *     to `shell:false`, which is right for "no prebuilt exists for this host"
+ *     and wrong for "GitHub had a bad two seconds".
+ *
+ * THE RETRY LIST IS DELIBERATELY NARROW: `429` and `5xx`, plus network/abort
+ * errors (DNS, reset, an `AbortSignal` timeout). A `404` is a real answer — the
+ * asset does not exist — and retrying it only turns a fast, clear failure into a
+ * slow, identical one. `401`/`403` are the same: no amount of waiting grows a
+ * permission. (A rate-limited `403` from GitHub is indistinguishable here from a
+ * genuine auth failure, so it is NOT retried; `429` is the status that means
+ * "try again" and is the one we honour.)
+ *
+ * `fetchImpl` and `sleep` are injectable so tests never touch the network and
+ * never actually wait.
+ */
+
+/** Attempts per call, INCLUDING the first. 3 => first + 2 retries. */
+export const DEFAULT_ATTEMPTS = 3;
+/** Backoff base; the wait after attempt 1 is 2s, after attempt 2 is 4s. */
+export const RETRY_BASE_DELAY_MS = 2_000;
+/**
+ * Default per-attempt deadline. Small payloads only — see `timeoutMs`.
+ * Named for fetch specifically: `AdbClient` already exports a `DEFAULT_TIMEOUT_MS`
+ * for adb command budgets, which is an unrelated concern.
+ */
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+export interface RetryNotice {
+    url: string;
+    attempt: number;
+    attempts: number;
+    reason: string;
+}
+
+export interface FetchWithRetryOptions {
+    attempts?: number;
+    /**
+     * Per-attempt deadline, via `AbortSignal.timeout`. `null` disables it.
+     *
+     * DISABLE IT FOR LARGE BODIES. The signal aborts the whole exchange, body
+     * streaming included — so a 30s deadline on the ~110 MB Node archive would
+     * kill a legitimately slow download mid-stream. Callers that stream a large
+     * response pass `timeoutMs: null` and rely on retry alone.
+     */
+    timeoutMs?: number | null;
+    fetchImpl?: typeof fetch;
+    sleep?: (ms: number) => Promise<void>;
+    onRetry?: (notice: RetryNotice) => void;
+    init?: RequestInit;
+}
+
+/** Which HTTP statuses earn another attempt. See the note above on 403. */
+export function isRetryableStatus(status: number): boolean {
+    return status === 429 || (status >= 500 && status <= 599);
+}
+
+/** Backoff for the wait AFTER attempt N: 2s, then 4s. */
+export function retryDelayMs(attempt: number, baseMs: number = RETRY_BASE_DELAY_MS): number {
+    return baseMs * 2 ** (attempt - 1);
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Returns the LAST attempt's response as-is, so the caller still sees and
+ * reports the real status. Throws only when the final attempt threw.
+ */
+export async function fetchWithRetry(url: string, opts: FetchWithRetryOptions = {}): Promise<Response> {
+    const {
+        attempts = DEFAULT_ATTEMPTS,
+        timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+        fetchImpl = fetch,
+        sleep = defaultSleep,
+        onRetry = () => {},
+        init = {},
+    } = opts;
+
+    for (let attempt = 1; ; attempt++) {
+        const last = attempt >= attempts;
+        try {
+            const signal = timeoutMs === null ? undefined : AbortSignal.timeout(timeoutMs);
+            const res = await fetchImpl(url, signal ? { ...init, signal } : init);
+            if (res.ok || last || !isRetryableStatus(res.status)) {
+                return res;
+            }
+            onRetry({ url, attempt, attempts, reason: `HTTP ${res.status}` });
+        } catch (err) {
+            if (last) {
+                throw err;
+            }
+            onRetry({ url, attempt, attempts, reason: err instanceof Error ? err.message : String(err) });
+        }
+        await sleep(retryDelayMs(attempt));
+    }
+}
+
+/**
+ * `fetchWithRetry` that THROWS on a non-OK final response instead of handing
+ * back an error body.
+ *
+ * This is the one every `checkLatest` must use. Returning `null` from a failed
+ * version check is what produced the silent skip described at the top of this
+ * file: `DependencyManager.checkLatest` already catches a throw and turns it
+ * into `DependencyStatus.Error` with the message attached, which is a state the
+ * UI and the API can both report. A `null` is indistinguishable from "this
+ * dependency legitimately has no known latest version" and is silently skipped.
+ */
+export async function fetchOkWithRetry(url: string, opts: FetchWithRetryOptions = {}): Promise<Response> {
+    const res = await fetchWithRetry(url, opts);
+    if (!res.ok) {
+        throw new Error(`HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''} from ${url}`);
+    }
+    return res;
+}

--- a/src/server/util/fetchWithRetry.ts
+++ b/src/server/util/fetchWithRetry.ts
@@ -49,8 +49,31 @@ export interface RetryNotice {
     reason: string;
 }
 
+/**
+ * The budget for a "what is the latest version" query, which is NOT the budget
+ * for a download.
+ *
+ * Boot runs `checkAll().then(() => autoInstallMissing())`, and the seed promote
+ * plus every install lives inside `autoInstallMissing` — so time spent checking
+ * versions is time before ANY dependency is installed. With the download policy
+ * (3 attempts x 30s, plus 2s and 4s of backoff) one unreachable endpoint could
+ * hold that gate for ~96s, and three of them serially for ~288s. Measured
+ * 2026-09-09: that blew smoke 20.9's 180s hydrate poll and 20.12's 300s wait,
+ * and left 1.9 reading `checking` where it expected `error`.
+ *
+ * A version check is advisory — the app runs fine not knowing the latest
+ * version — so it gets a short, bounded budget and gets out of the way.
+ */
+export const VERSION_CHECK_POLICY = {
+    attempts: 2,
+    baseDelayMs: 1_000,
+    timeoutMs: 10_000,
+} as const;
+
 export interface FetchWithRetryOptions {
     attempts?: number;
+    /** Backoff base for `retryDelayMs`. Defaults to `RETRY_BASE_DELAY_MS` (2s). */
+    baseDelayMs?: number;
     /**
      * Per-attempt deadline, via `AbortSignal.timeout`. `null` disables it.
      *
@@ -85,6 +108,7 @@ const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => set
 export async function fetchWithRetry(url: string, opts: FetchWithRetryOptions = {}): Promise<Response> {
     const {
         attempts = DEFAULT_ATTEMPTS,
+        baseDelayMs = RETRY_BASE_DELAY_MS,
         timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
         fetchImpl = fetch,
         sleep = defaultSleep,
@@ -107,7 +131,7 @@ export async function fetchWithRetry(url: string, opts: FetchWithRetryOptions = 
             }
             onRetry({ url, attempt, attempts, reason: err instanceof Error ? err.message : String(err) });
         }
-        await sleep(retryDelayMs(attempt));
+        await sleep(retryDelayMs(attempt, baseDelayMs));
     }
 }
 


### PR DESCRIPTION
Closes todo items **124** and **125**. They turned out to be the same defect in five call sites, so they are fixed together — writing the retry helper twice would have been silly.

## Item 124 was not what it was filed as

It was filed as "e2e 20.11 flakes on a 300s hydration timeout — instrument it." The real cause is upstream of the timeout entirely.

Every `checkLatest` in `DependencyDefinitions.ts` called bare `fetch` and **never looked at `res.ok`**:

```ts
const res = await fetch('https://api.github.com/repos/Genymobile/scrcpy/releases/latest', …);
const data = (await res.json()) as { tag_name: string };
return data.tag_name?.replace(/^v/, '') ?? null;
```

On a 403 or 5xx that parses the **error body** as if it were the payload, finds no `tag_name`, and returns `null`. `autoInstallMissing` then **deliberately skips** any dependency whose latest version is unknown — so the install is never attempted and `installedVersion` stays `null` for the rest of that boot.

Worse, `DependencyManager.checkLatest` already has a `try/catch` that records `DependencyStatus.Error` **with the message attached**. It never fired, because nothing ever threw.

**So 20.11 was polling a dead state for five minutes.** No timeout could have helped; nothing was retrying and nothing was going to.

### Why scrcpy-server, and why the other two were fine in the same run

| Dep | `checkLatest` endpoint | Rate-limits per IP? |
|---|---|---|
| nodejs | `nodejs.org/dist/index.json` | no |
| adb | `dl.google.com/…/repository2-3.xml` | no |
| **scrcpy-server** | **`api.github.com`** | **yes — 60/hour unauthenticated** |

CI runners share IPs, so that cap is reachable. The failure reported `nodejs=24.21.0, adb=37.0.1, scrcpy-server=unknown` — exactly the split the table predicts.

**This is not CI-only.** A user behind corporate NAT hits the same cap and silently gets no scrcpy-server, with nothing saying it was transient.

## The fix

New shared **`src/server/util/fetchWithRetry.ts`** — the TypeScript sibling of the helper item 121 added to `scripts/fetch-prebuilts.mjs`. The script keeps its own copy on purpose: its own header records that it duplicates the download logic so it works on a fresh clone *before* `npm run build`.

Same narrow policy as 121: **`429` and `5xx`, plus network/abort errors, never a `404`.** 3 attempts, backing off 2s then 4s.

`403` is deliberately **not** retried — GitHub's rate-limit `403` is indistinguishable here from a genuine auth failure, and `429` is the status that actually means "try again".

**`fetchOkWithRetry` throws on a non-OK final response**, and every `checkLatest` now uses it. A throw is a state the manager, the API and the UI can all report; a `null` is indistinguishable from "this dependency legitimately has no known latest version."

### Item 125, same helper

`NodePtyResolver`'s three fetches and `DependencyManager.download` now retry as well. The pty resolver's `return false` → `shell:false` degradation is correct for *"no prebuilt exists for this host/ABI"* and wrong for *"GitHub had a bad two seconds"* — and since a `404` still fails on the first attempt, the honest degradation survives untouched.

### The large-download trap

`AbortSignal.timeout` aborts **body streaming**, not just the request. A per-attempt deadline would therefore kill the ~110 MB Node archive mid-transfer on a slow connection. `DependencyManager.download` passes `timeoutMs: null` and relies on retry alone; the small JSON/XML version checks keep the 30s deadline they never had. There is a test pinning that no signal is attached when `timeoutMs: null`.

## Verification

- **2003 tests pass** (25 new), 220 files
- `npx tsc --noEmit` clean, `npm run lint` clean — 0 warnings, 0 infos
- **Failing direction proven**: disabling the `res.ok` guard in `fetchOkWithRetry` makes all four item-124 regression tests fail; restoring it makes them pass

The duplicate-export hook also earned its keep here — it caught `DEFAULT_TIMEOUT_MS` colliding with the existing export in `AdbClient.ts` (an unrelated object of adb command budgets). Renamed to `DEFAULT_FETCH_TIMEOUT_MS`.
