### PR TITLE
chore: bump to v0.1.30-beta.119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30-beta.119] - 2026-09-09
+
 ### Fixed
 
 - **A failed version check no longer silently skips a dependency for the whole boot** (todo items 124 and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws-scrcpy-web-common"
-version = "0.1.30-beta.118"
+version = "0.1.30-beta.119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-launcher"
-version = "0.1.30-beta.118"
+version = "0.1.30-beta.119"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "ws-scrcpy-web-tray"
-version = "0.1.30-beta.118"
+version = "0.1.30-beta.119"
 dependencies = [
  "anyhow",
  "ureq 2.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["common", "launcher", "tray"]
 
 [workspace.package]
-version = "0.1.30-beta.118"
+version = "0.1.30-beta.119"
 edition = "2021"
 authors = ["ws-scrcpy-web contributors"]
 license = "GPL-3.0-or-later"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.118",
+  "version": "0.1.30-beta.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ws-scrcpy-web",
-      "version": "0.1.30-beta.118",
+      "version": "0.1.30-beta.119",
       "license": "GPL-3.0-only",
       "dependencies": {
         "velopack": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-scrcpy-web",
-  "version": "0.1.30-beta.118",
+  "version": "0.1.30-beta.119",
   "description": "Browser-based Android screen mirroring and control, powered by scrcpy",
   "license": "GPL-3.0-only",
   "author": "bilbospocketses",


### PR DESCRIPTION
release v0.1.30-beta.119

Carries items 121, 122, 124 and 125 — the first beta since .118.

- **121** — bounded retry for the three `fetch-prebuilts` downloads. `429`/`5xx`/network only, never a `404`.
- **122** — biome clean: **0 warnings, 0 infos across 566 files**, with a test pinning `biome.json`'s `$schema` to the *installed* CLI so the drift cannot come back on the next Dependabot bump.
- **124 + 125** — a failed version check no longer skips a dependency silently, no longer condemns an *installed* one, and no longer gates the hydrate.

The 124/125 story is worth reading in the CHANGELOG: the first cut of that fix went red on three container tests, and the root cause was a single design mistake plus its latency cost. `checkAll()` gates `autoInstallMissing()`, which owns the seed promote and every install — so putting the download retry budget in front of it cost ~96s per dependency, serially. Version checks now have their own short budget and run concurrently, and a rate-limited update check no longer marks a present, working dependency as `Error`.
