### PR TITLE
fix(deps): fall back to SERVER_VERSION when the version lookup is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A first-run install is no longer hostage to a version lookup.** `autoInstallMissing` installs only
+  where `latestVersion !== null`; scrcpy-server's `latestVersion` comes from `api.github.com`, which
+  rate-limits **per IP at 60/hour unauthenticated**. On a rate-limited host that loop installed nothing
+  and said nothing. CI does not run `stage-seed` before the fast tier either, so there was no seed to
+  promote: the network download was the only path, and a refused API call closed it. Smoke 9.4's 120s
+  poll went red on it 2026-09-09.
+  - **`DependencyDefinition` gains an optional `fallbackVersion`**, set to `SERVER_VERSION` for
+    scrcpy-server — the version this build ships in `assets/scrcpy-server`, with a pinned hash in
+    `common/Constants.ts`. Installing the version we already vouch for beats installing none. The release
+    **asset** download is not the API and is not rate-limited the same way, so it genuinely works while
+    the lookup is refused.
+  - **Gated on REFUSED, not merely absent.** A new `HttpStatusError` separates *the server answered and
+    said no* from *there was no answer*. Only a refused lookup earns a fallback: offline, the download
+    would fail too, and attempting it would only hold the status at `Updating` — which is precisely what
+    smoke 1.9 asserts is `error`. The gate is load-bearing, and removing it fails five tests.
+  - **The fallback is a download target, not a claim.** `latestVersion` stays `null`, because we still do
+    not know what the newest release is; writing `SERVER_VERSION` there would render a false *"up to
+    date"* in the panel.
+  - Only scrcpy-server carries one. Node and adb have no shipped version to fall back to.
+
 ## [0.1.30-beta.119] - 2026-09-09
 
 ### Fixed

--- a/src/server/DependencyDefinitions.ts
+++ b/src/server/DependencyDefinitions.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
+import { SERVER_VERSION } from '../common/Constants';
 import { Logger } from './Logger';
 import { loadManifest } from './NodePtyResolver';
 import { getInstalledScrcpyServerVersion } from './scrcpyServerVersion';
@@ -50,6 +51,21 @@ export interface DependencyDefinition {
     checkInstalled: (depsPath: string) => Promise<string | null>;
     checkLatest: () => Promise<string | null>;
     getDownloadUrl: (version: string) => string;
+    /**
+     * A version this build already knows how to install, used when
+     * `checkLatest` cannot answer.
+     *
+     * Without it, a first-run install is hostage to a version LOOKUP: nothing
+     * installs unless `latestVersion` is known, and scrcpy-server's lookup goes
+     * through `api.github.com`, which rate-limits per IP at 60/hour
+     * unauthenticated. A rate-limited runner therefore installed nothing and
+     * said nothing — smoke 9.4's 120s poll on 2026-09-09.
+     *
+     * Only meaningful where the repo ships a known-good version. The ASSET
+     * download is not the API and is not rate-limited the same way, so falling
+     * back genuinely works while the lookup is refused.
+     */
+    fallbackVersion?: string;
 }
 
 async function runVersionCommand(exe: string, args: string[], pattern: RegExp): Promise<string | null> {
@@ -154,6 +170,11 @@ export function getDependencyDefinitions(depsPath: string): DependencyDefinition
             displayName: 'scrcpy-server',
             description: 'Runs on Android device to capture screen, audio, and accept input',
             requiresRestart: false,
+            // The version this build ships in `assets/scrcpy-server`, with a
+            // pinned hash in common/Constants.ts. If api.github.com will not say
+            // what the newest release is, installing the one we already vouch
+            // for beats installing nothing.
+            fallbackVersion: SERVER_VERSION,
             checkInstalled: async (depsPath) => {
                 // The JAR file presence gates "installed at all"; the actual version
                 // comes from the .version marker (or SERVER_VERSION as fallback for

--- a/src/server/DependencyManager.ts
+++ b/src/server/DependencyManager.ts
@@ -13,7 +13,7 @@ import { Logger } from './Logger';
 import { writeInstalledScrcpyServerVersion } from './scrcpyServerVersion';
 import { resolveSystemTool } from './service/systemTools';
 import { copyFileAtomic, copyFileAtomicSync, writeFileAtomicSync } from './util/atomicFile';
-import { fetchWithRetry } from './util/fetchWithRetry';
+import { fetchWithRetry, HttpStatusError } from './util/fetchWithRetry';
 import { extractZipTo } from './zipExtract';
 
 const log = Logger.for('DependencyManager');
@@ -23,6 +23,14 @@ export class DependencyManager {
     private readonly definitions: DependencyDefinition[];
     private readonly state: Map<string, DependencyInfo>;
     private readonly restartMarkerPath: string;
+    /**
+     * Names whose last `checkLatest` was REFUSED by the server (an HTTP status)
+     * rather than failing to reach it. Only these may fall back to a bundled
+     * version — see the note in `autoInstallMissing`. Deliberately not part of
+     * `DependencyInfo`: it is an internal diagnosis, not something the wire
+     * format or the UI has any use for.
+     */
+    private readonly lookupRefused = new Set<string>();
 
     constructor(
         private readonly depsPath: string,
@@ -92,9 +100,17 @@ export class DependencyManager {
         info.status = DependencyStatus.Checking;
         try {
             info.latestVersion = await def.checkLatest();
+            this.lookupRefused.delete(name);
             this.resolveStatus(info);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
+            // Refused (the server answered with a status) vs unreachable (no
+            // answer). Only the former earns a fallback install.
+            if (err instanceof HttpStatusError) {
+                this.lookupRefused.add(name);
+            } else {
+                this.lookupRefused.delete(name);
+            }
             // A failed LATEST check is only an error when there is nothing
             // installed. That is the item-124 case: we cannot learn what to
             // install, so autoInstallMissing will skip this dependency and the
@@ -176,17 +192,35 @@ export class DependencyManager {
         };
 
         try {
-            // Ensure latest version is known
+            // Ensure latest version is known. `checkLatest` THROWS on a non-OK
+            // response (items 124/125), so the catch is what lets a definition
+            // with a fallbackVersion still install while the lookup is refused —
+            // without it, a rate-limited api.github.com turns a perfectly
+            // installable scrcpy-server into an update failure.
             if (!info.latestVersion) {
-                info.latestVersion = await def.checkLatest();
+                try {
+                    info.latestVersion = await def.checkLatest();
+                } catch (err) {
+                    // Same rule as autoInstallMissing: a refused lookup may fall
+                    // back, an unreachable one may not.
+                    if (!def.fallbackVersion || !(err instanceof HttpStatusError)) {
+                        throw err;
+                    }
+                    const why = err instanceof Error ? err.message : String(err);
+                    log.warn(`Latest-version lookup failed for ${name} (${why}); using bundled ${def.fallbackVersion}`);
+                }
             }
-            if (!info.latestVersion) {
+
+            // The fallback is used for the DOWNLOAD but deliberately not written
+            // to info.latestVersion: we still do not know what the latest is, and
+            // claiming otherwise would show a false "up to date" in the panel.
+            const version = info.latestVersion ?? def.fallbackVersion;
+            if (!version) {
                 throw new Error('Could not determine latest version');
             }
 
-            log.info(`Updating ${name}: ${fromVersion} → ${info.latestVersion}`);
+            log.info(`Updating ${name}: ${fromVersion} → ${version}`);
 
-            const version = info.latestVersion;
             const url = def.getDownloadUrl(version);
 
             // Create temp directory
@@ -240,7 +274,23 @@ export class DependencyManager {
         }
 
         for (const info of this.state.values()) {
-            if (info.installedVersion === null && info.latestVersion !== null) {
+            // A first-run install must not be hostage to a version LOOKUP.
+            // scrcpy-server's goes through api.github.com, which rate-limits per
+            // IP at 60/hour unauthenticated — and on a rate-limited runner this
+            // loop installed nothing and said nothing, which is smoke 9.4's 120s
+            // poll on 2026-09-09. Installing the version this build already ships
+            // beats installing none.
+            //
+            // Gated on the lookup having been REFUSED rather than merely absent.
+            // A refused lookup says nothing about whether release assets are
+            // reachable, so the download is worth trying. On a genuinely offline
+            // host the download would fail too, and attempting it only burns the
+            // retry budget while the status reads `Updating` — which is what
+            // smoke 1.9 asserts is `error`.
+            const def = this.definitions.find((d) => d.name === info.name);
+            const mayFallBack = def?.fallbackVersion !== undefined && this.lookupRefused.has(info.name);
+            const target = info.latestVersion ?? (mayFallBack ? def!.fallbackVersion! : null);
+            if (info.installedVersion === null && target != null) {
                 // Nothing is skipped here any more. Node and adb used to be, on
                 // every platform, whenever the packaged launcher was absent —
                 // which is every source checkout. On Windows that was invisible

--- a/src/server/__tests__/dependencyManager.latestCheckFailure.test.ts
+++ b/src/server/__tests__/dependencyManager.latestCheckFailure.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SERVER_VERSION } from '../../common/Constants';
 import { DependencyStatus } from '../../common/DependencyTypes';
 import { DependencyManager } from '../DependencyManager';
-import { VERSION_CHECK_POLICY } from '../util/fetchWithRetry';
+import { HttpStatusError, VERSION_CHECK_POLICY } from '../util/fetchWithRetry';
 
 /**
  * The 2026-09-09 regression, pinned.
@@ -113,6 +114,100 @@ describe('checkAll runs the latest-version checks concurrently', () => {
         await mgr.checkAll();
 
         expect(peak, 'serial execution would peak at 1').toBeGreaterThan(1);
+    });
+});
+
+/**
+ * The SERVER_VERSION fallback (2026-09-09, smoke 9.4).
+ *
+ * A first-run install was hostage to a version LOOKUP. `autoInstallMissing`
+ * installs only where `latestVersion !== null`, scrcpy-server's latestVersion
+ * comes from `api.github.com`, and that rate-limits per IP at 60/hour
+ * unauthenticated — so a rate-limited runner installed nothing and said
+ * nothing. CI does not run `stage-seed` before the fast tier, so there is no
+ * seed to promote either: the network download was the only path, and a refused
+ * API call closed it.
+ *
+ * The fallback is gated on REFUSED (the server answered with a status), not on
+ * UNREACHABLE (no answer). A refused lookup says nothing about whether release
+ * assets are reachable, so the download is worth trying. Offline, the download
+ * would fail too, and attempting it only holds the status at `Updating` — which
+ * is exactly what smoke 1.9 asserts is `error`.
+ */
+describe('the bundled-version fallback', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    afterEach(() => {
+        fetchSpy?.mockRestore();
+        fetchSpy = undefined;
+    });
+
+    async function managerAfterLookup(failure: 'refused' | 'unreachable') {
+        fetchSpy =
+            failure === 'refused'
+                ? vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}', { status: 403 }))
+                : vi.spyOn(global, 'fetch').mockRejectedValue(new TypeError('fetch failed'));
+        const mgr = new DependencyManager('/tmp/test-deps-fallback');
+        const dep = mgr.getByName('scrcpy-server')!;
+        dep.installedVersion = null;
+        await mgr.checkLatest('scrcpy-server');
+        return mgr;
+    }
+
+    it('installs the bundled version when the lookup was REFUSED', async () => {
+        const mgr = await managerAfterLookup('refused');
+        const updateSpy = vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: true,
+            newVersion: SERVER_VERSION,
+            requiresRestart: false,
+        });
+
+        await mgr.autoInstallMissing();
+
+        expect(updateSpy).toHaveBeenCalledWith('scrcpy-server');
+    });
+
+    it('does NOT attempt an install when the network was UNREACHABLE', async () => {
+        const mgr = await managerAfterLookup('unreachable');
+        const updateSpy = vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: true,
+            newVersion: SERVER_VERSION,
+            requiresRestart: false,
+        });
+
+        await mgr.autoInstallMissing();
+
+        expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves latestVersion null — the fallback is a download target, not a claim', async () => {
+        const mgr = await managerAfterLookup('refused');
+        // Reporting SERVER_VERSION as "latest" would render a false "up to date"
+        // in the panel; we genuinely do not know what the newest release is.
+        expect(mgr.getByName('scrcpy-server')!.latestVersion).toBeNull();
+    });
+
+    it('only scrcpy-server carries a fallback — node and adb have no shipped version to fall back to', async () => {
+        const mgr = await managerAfterLookup('refused');
+        const updateSpy = vi.spyOn(mgr, 'update').mockResolvedValue({
+            success: true,
+            newVersion: 'x',
+            requiresRestart: false,
+        });
+
+        await mgr.autoInstallMissing();
+
+        expect(updateSpy).not.toHaveBeenCalledWith('nodejs');
+        expect(updateSpy).not.toHaveBeenCalledWith('adb');
+    });
+});
+
+describe('HttpStatusError', () => {
+    it('carries the status so callers can tell refused from unreachable', () => {
+        const err = new HttpStatusError(403, 'Forbidden', 'https://api.github.com/x');
+        expect(err.status).toBe(403);
+        expect(err.message).toMatch(/HTTP 403 Forbidden from https:\/\/api\.github\.com\/x/);
+        expect(err).toBeInstanceOf(Error);
     });
 });
 

--- a/src/server/util/fetchWithRetry.ts
+++ b/src/server/util/fetchWithRetry.ts
@@ -146,10 +146,30 @@ export async function fetchWithRetry(url: string, opts: FetchWithRetryOptions = 
  * UI and the API can both report. A `null` is indistinguishable from "this
  * dependency legitimately has no known latest version" and is silently skipped.
  */
+/**
+ * The server ANSWERED and refused. Distinct from a network failure, where there
+ * was no answer at all.
+ *
+ * The distinction is load-bearing for the dependency fallback: a refused lookup
+ * (`403` from a rate-limited api.github.com) says nothing about whether release
+ * ASSETS are reachable, so falling back to a bundled version and downloading it
+ * is worth trying. An unreachable network says the download will fail too, so
+ * attempting it only burns the retry budget while the status sits at `Updating`.
+ */
+export class HttpStatusError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, statusText: string, url: string) {
+        super(`HTTP ${status}${statusText ? ` ${statusText}` : ''} from ${url}`);
+        this.name = 'HttpStatusError';
+        this.status = status;
+    }
+}
+
 export async function fetchOkWithRetry(url: string, opts: FetchWithRetryOptions = {}): Promise<Response> {
     const res = await fetchWithRetry(url, opts);
     if (!res.ok) {
-        throw new Error(`HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''} from ${url}`);
+        throw new HttpStatusError(res.status, res.statusText, url);
     }
     return res;
 }


### PR DESCRIPTION
## The single point of failure

A first-run install was hostage to a version **lookup**:

1. `autoInstallMissing` installs only where `latestVersion !== null`
2. scrcpy-server's `latestVersion` comes from `api.github.com`
3. which rate-limits **per IP at 60/hour unauthenticated** — and CI runners share IPs

On a rate-limited host that loop installed nothing and said nothing. CI does not run `stage-seed` before the fast tier either, so there is no seed to promote there: the network download was the only path, and a refused API call closed it. Smoke 9.4's 120s poll went red on it on 2026-09-09.

## The fix

`DependencyDefinition` gains an optional **`fallbackVersion`**, set to `SERVER_VERSION` for scrcpy-server — the version this build ships in `assets/scrcpy-server`, with a pinned hash in `common/Constants.ts`. Installing the version we already vouch for beats installing none.

This works because the release **asset** download is not the API and is not rate-limited the same way. The lookup being refused says nothing about whether assets are reachable.

### Gated on REFUSED, not merely absent

A new `HttpStatusError` separates *the server answered and said no* from *there was no answer*.

| | lookup outcome | fallback? | why |
|---|---|---|---|
| `403` from a rate-limited API | refused | **yes** | assets are probably still reachable |
| DNS/connection failure | unreachable | **no** | the download would fail too |

That second row matters more than it looks. Offline, attempting the download would only hold the dependency at `Updating` while the retry budget burns — and `Updating` is exactly what smoke **1.9** asserts is `error`. Without the gate this PR would have traded one flake for another.

**The gate is load-bearing and proven so:** removing it fails five tests — the offline case here plus the four pre-existing `autoInstallMissing` cases.

### The fallback is a download target, not a claim

`latestVersion` stays `null`. We still do not know what the newest release is, and writing `SERVER_VERSION` there would render a false *"up to date"* in the panel.

Only scrcpy-server carries a fallback. Node and adb have no shipped version to fall back to.

## Honest scope

**The `main` CI run that prompted this passed on re-run.** So 9.4 was transient, and I could not prove the rate limit caused that specific failure — the server log is not in the uploaded Playwright report, and a slow ~110 MB Node download inside 120s looks identical from outside.

This is therefore **hardening, not a fix for a reproducible break**. The single point of failure it removes is real either way, and it is the same root cause item 124 identified — I fixed the reporting of it then and stopped short of the install gate.

## Verification

- `tsc` 0, `lint` 0, `vitest` 0 — **2014 passing across 221 files**
- 5 new tests: refused installs, unreachable does not, `latestVersion` stays null, node/adb unaffected, `HttpStatusError` carries the status
- Gate verified in the failing direction by mutation
