### PR TITLE
docs: correct the elevation-delegation claim and document the Windows app uninstall (19.2b)

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -1721,6 +1721,38 @@ The uninstall flow avoids UAC by deferring privileged work to a `post-stop.bat` 
 7. The fresh launcher writes its `webPort` to `config.json` and drops a stop marker. The operation-server detects the stop marker (or the fresh Node's readiness via `/api/discover`) and winds down.
 8. The browser's `ServiceOperationModal` detects the `config.json` mtime change, reads the new `webPort`, and navigates to the local-mode URL.
 
+### 19.2b Windows App Uninstall (whole-app removal) — distinct from 19.2
+
+**Do not confuse this with 19.2.** That section removes the *service* and deliberately avoids UAC by
+deferring privileged work to Servy's `post-stop.bat`. This one removes *the whole application*, and it
+**does** raise a UAC prompt.
+
+Entry point is `POST /api/service/uninstall-app` (Settings → Server → Uninstall…), which spawns the Rust
+helper with `--windows-app-uninstall` and sacrifices the local instance so the helper can remove the
+running install from outside it.
+
+1. **Phase 1** stages a copy of the launcher in temp (`ws-scrcpy-web-uninstall-<pid>.exe`) so the
+   original's image lock can release, then spawns that copy and exits.
+2. **Phase 2** (the copy) waits for phase 1 to exit, removes the app, then deletes the data-root targets
+   with a bounded retry. `keep` preserves `config.json` + `logs/`; `--wipe` takes the whole root.
+
+**Removal is `msiexec /x <ProductCode>`, not Update.exe.** Every real Windows install of this app is the
+MSI, and Velopack refuses to uninstall one (#120). The ProductCode is discovered from the ARP
+`UninstallString`, never hardcoded and never read from the key leaf — this app's key is literally
+`MSI:WsScrcpyWeb`. `Update.exe --uninstall` remains the path when no MSI ARP entry exists.
+
+**Phase 1 elevates the cleaner** with `ShellExecuteExW(verb="runas")` — the same hand-off §30 uses for
+`--request-uac`. Removing a per-machine MSI needs an elevated token, and without one `msiexec` answers
+`Error 1730` and the uninstall silently does nothing (item 128, measured on beta.119). The prompt fires
+in phase 1, while the app the user clicked is still alive, rather than later from a detached temp
+binary. Elevation is requested **only** when it is needed — an MSI install *and* a non-elevated process —
+so a per-user Velopack install and an already-elevated process spawn exactly as before.
+
+**A declined prompt deletes nothing** and returns `1223` (`ERROR_CANCELLED`), never 0. More generally,
+**a failed uninstall deletes nothing** (#655): the data root is only touched after removal is confirmed,
+and the log says the app is still installed and can be removed from Add/Remove Programs. Before #655 a
+refused uninstall gutted the install and reported success.
+
 ### 19.3 API Endpoints
 
 | Method | Path | Purpose |
@@ -1729,7 +1761,7 @@ The uninstall flow avoids UAC by deferring privileged work to a `post-stop.bat` 
 | POST | `/api/service/install` | Install the service. Triggers UAC. Returns 501 if not a Velopack install. |
 | POST | `/api/service/uninstall` | Uninstall the service via the operation-server pattern (no UAC). |
 | POST | `/api/service/install-system-wide` | (Linux) Relocate a local install to a machine-wide `/opt` install under one `pkexec` prompt; re-execs from `/opt`. |
-| POST | `/api/service/uninstall-app` `{keep}` | (Linux) Complete app uninstall — cascades through any service + `/opt` in one pass; `keep` preserves `config.json` + logs. |
+| POST | `/api/service/uninstall-app` `{keep}` | **(Linux + Windows)** Complete app uninstall — see 19.2b. On Linux it cascades through any service + `/opt` in one pass. `keep` preserves `config.json` + logs. |
 
 ### 19.4 Config.json Port Discovery
 

--- a/src/server/__tests__/ServiceApi.test.ts
+++ b/src/server/__tests__/ServiceApi.test.ts
@@ -2001,10 +2001,16 @@ describe('ServiceApi', () => {
 
         // ── win32 branch (mirrors the linux structure: spawn the detached Rust
         //    helper, 200 uninstalling, scheduleExit). The staged launcher carries
-        //    raw `--windows-app-uninstall` argv; elevation is delegated to
-        //    Update.exe (PerMachine UAC manifest) at runtime, the same
-        //    "elevation lives in the launcher" model as the §30 --request-uac
-        //    path and the linux helper's pkexec self-elevation.
+        //    raw `--windows-app-uninstall` argv and THIS spawn stays unelevated;
+        //    the helper elevates itself via ShellExecuteExW(verb="runas") before
+        //    running msiexec — the same "elevation lives in the launcher" model
+        //    as the §30 --request-uac path and the linux helper's pkexec
+        //    self-elevation.
+        //
+        //    This used to say elevation was delegated to Update.exe's PerMachine
+        //    UAC manifest. It was not: #120 put msiexec first on every MSI
+        //    install, so Update.exe never ran, nothing requested a token, and
+        //    `msiexec /x` failed with Error 1730 (item 128).
 
         it('POST /uninstall-app {keep:false} on win32 → 200 uninstalling, spawns the staged launcher with --windows-app-uninstall --wipe + Update.exe', async () => {
             const client = fakeClient();

--- a/src/server/api/ServiceApi.ts
+++ b/src/server/api/ServiceApi.ts
@@ -1138,14 +1138,26 @@ export class ServiceApi {
      * helper self-elevates (root → direct; non-root → pkexec; declined →
      * relaunch local), so this spawn stays unelevated.
      *
-     * win32 (`--windows-app-uninstall`): the helper runs
-     * `<installRoot>\Update.exe --uninstall` (fires Velopack's --veloapp-uninstall
-     * hook → service/tray teardown + ARP cleanup) then removes the dataRoot
-     * targets. Elevation is delegated to Update.exe (a PerMachine install's
-     * Update.exe self-elevates via UAC) — the same "elevation lives in the
-     * launcher binary" model as the §30 --request-uac path; this spawn itself
-     * stays unelevated. Both branches mirror the detached teardown handoff in
-     * handleUninstall.
+     * win32 (`--windows-app-uninstall`): the helper stages a copy of itself in
+     * temp and that copy does the work — on an MSI install (which is every real
+     * Windows install of this app) `msiexec /x <ProductCode>`, falling back to
+     * `<installRoot>\Update.exe --uninstall` only when no MSI ARP entry exists.
+     *
+     * **The cleaner elevates itself** via `ShellExecuteExW(verb="runas")`, the
+     * same mechanism as the §30 --request-uac path. This spawn stays unelevated;
+     * the UAC prompt is raised by the helper in its first phase, while this app
+     * is still alive.
+     *
+     * This paragraph used to say elevation was "delegated to Update.exe, which
+     * self-elevates via UAC". That was never true on an MSI install — #120 made
+     * `perform_uninstall` reach for msiexec FIRST, so Update.exe was not on the
+     * path at all — and nothing else asked for a token either, so `msiexec /x`
+     * died on `Error 1730` and the in-app uninstall silently did nothing on
+     * every Windows install (item 128). The comment asserting elevation was
+     * handled is a large part of why that went unnoticed; it is corrected here
+     * rather than deleted, so the next reader knows the claim was checked.
+     *
+     * Both branches mirror the detached teardown handoff in handleUninstall.
      *
      * `keep` (request body) preserves config.json + logs/ (`--keep`) vs. wiping
      * all state (`--wipe`). On keep we ALSO reset installMode to null up front so


### PR DESCRIPTION
Comments and documentation only — no behaviour change. Found by the wrap-up's diff-driven doc sweep for item 128 (#672).

## The one that matters

`ServiceApi.handleAppUninstall`'s doc comment said:

> Elevation is delegated to Update.exe (a PerMachine install's Update.exe self-elevates via UAC) — … this spawn itself stays unelevated.

**That was never true on an MSI install.** #120 made `perform_uninstall` reach for `msiexec` *first*, so `Update.exe` was not on the path at all — and nothing else requested a token. So a comment asserting elevation was handled sat directly above code where it was not, which is a plausible part of why item 128's `Error 1730` survived review for as long as it did.

Corrected in place rather than deleted, so the next reader can see the claim was checked rather than wonder whether anyone looked. The mirroring comment in `ServiceApi.test.ts` gets the same correction.

## Two smaller ones

**`POST /api/service/uninstall-app` was labelled `(Linux)`** in TECHNICAL_GUIDE §19.3. The handler has served **Linux and win32** since it shipped — its own doc comment says so.

**The Windows whole-app uninstall had no documentation at all.** That is how it came to sit beside §19.2 — the *service* uninstall, which deliberately avoids UAC via Servy's `post-stop.bat` — with nothing distinguishing the two. Anyone reading §19.2 and reasoning about "the Windows uninstall" would conclude no prompt is involved, which is now exactly wrong for the app uninstall.

New **§19.2b** covers:

- the two-phase staged-cleaner handoff and why phase 1 stages a copy at all (image lock)
- removal via `msiexec /x <ProductCode>` rather than `Update.exe`, with the ProductCode discovered from the ARP `UninstallString` (this app's key leaf is literally `MSI:WsScrcpyWeb`, so reading the leaf would be wrong)
- the `ShellExecuteExW(verb="runas")` elevation, and the two guards that keep it from firing when it is not needed
- the "a failed uninstall deletes nothing" guarantee (#655), and that a declined prompt returns `1223` rather than `0`

## Verification

`ServiceApi.test.ts` 75 passed, `npm run lint` exit 0. Nothing executable changed — the diff is comments, one table cell, and a new doc section.

Labelled `release:none`: no CHANGELOG entry, so it cannot conflict with an in-flight bump PR.
