### PR TITLE
ci(docker): scope packages:write to the publishing job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,14 +13,23 @@ on:
   push:
     tags: ['v*']
 
+# Workflow-level default is read-only. `packages: write` is granted on the job
+# that actually pushes, NOT here -- a top-level write grant would extend to every
+# job added to this file later, including ones with no reason to touch packages.
+# Scorecard's Token-Permissions rule scores a top-level write as 0 for exactly
+# that reason (alert #39, introduced by PR #675 and fixed here).
 permissions:
   contents: read
-  # GHCR pushes authenticate with GITHUB_TOKEN; without this the push 403s.
-  packages: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # A job-level block REPLACES the workflow default rather than merging with
+    # it, so `contents: read` has to be restated here for actions/checkout.
+    permissions:
+      contents: read
+      # GHCR pushes authenticate with GITHUB_TOKEN; without this the push 403s.
+      packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Fixes Scorecard code-scanning alert **#39** (Token-Permissions, high), which PR #675 introduced.

```
score is 0: topLevel 'packages' permission set to 'write'
.github/workflows/docker-publish.yml:19
```

## The fix

The grant was right in substance and wrong in placement. A workflow-level `permissions:` write extends to **every** job in the file — including jobs added later with no reason to touch packages, and this file already runs a Docker Scout gate step that pushes nothing. Moving `packages: write` onto the publishing job is what the rule asks for, and it's genuine least privilege rather than a score-chasing edit.

One gotcha is recorded inline because it's how this breaks if copied carelessly: **a job-level `permissions` block replaces the workflow default rather than merging with it**, so `contents: read` has to be restated on the job or `actions/checkout` loses its read grant.

## Correcting the record on how this was found

The failing `Scorecard` check was dismissed earlier tonight — by me, and independently by another session — as *"too fast at 4 seconds to be real analysis, almost certainly a config or token fault."*

That was wrong, and it's the more useful half of this PR. The four seconds is GitHub Advanced Security **comparing** pre-computed Scorecard results against the base branch, not running an analysis. The check was reporting an accurate finding the entire time:

> **New alerts in code changed by this pull request** — Security Alerts: **1 high**

It was also correctly excluded from the required checks, so it never blocked anything — which is precisely why a wrong dismissal could sit unchallenged. Judging a security check by its runtime isn't a heuristic; it's a way to talk yourself out of reading the output.

## What is deliberately not fixed

Alerts **#37** and **#38** stay open, untouched:

| Alert | File | Why it stays |
|---|---|---|
| #38 | `release.yml:265` | job-level `contents: write` — the release job genuinely writes |
| #37 | `dependabot-auto-merge.yml:20` | job-level `contents: write` — the job genuinely merges |

Both are already in the recommended shape (job-scoped, not workflow-scoped). Scorecard is scoring the *permission* rather than the *placement*, and there's no way to satisfy it without breaking the jobs. Changing working code to move a score is the wrong trade.

## Verification

`docker-publish.yml` parses; top-level permissions are now `{contents: read}` and the job carries `{contents: read, packages: write}`. Single job in the file.

**Not proven until the next release:** that the GHCR push still authenticates with the job-scoped grant. The semantics are documented and unambiguous, but the only real proof is a publish. beta.122 proved the top-level form works; the next beta proves this one. If it ever 403s on the ghcr refs after the Hub refs are up, repair with `docker buildx imagetools create` to copy the manifest across — **never a rebuild**, which produces a different digest and breaks the identical-digest-everywhere property smoke row 20.8 asserts.

Labelled `release:none` deliberately: this is a CI-only change with no user-facing effect, and cutting a beta to carry a permissions edit would burn a version number. Say the word if you'd rather prove it immediately instead.
