### PR TITLE
docs(changelog): record the packages:write scoping under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`packages: write` is granted on the publishing job rather than on the whole container-publish workflow.** A workflow-level write extends to every job in the file — including the Docker Scout gate step, which pushes nothing — and Scorecard's Token-Permissions rule scores a top-level write as 0. The grant was correct in substance and wrong in placement. One gotcha is recorded inline because it is how the change breaks if copied: a job-level `permissions` block *replaces* the workflow default rather than merging with it, so `contents: read` has to be restated on the job or `actions/checkout` loses its read grant.
+
 ## [0.1.30-beta.122] - 2026-09-11
 
 ### Changed


### PR DESCRIPTION
Records PR #677 under `[Unreleased]`.

#677 moved the GHCR write grant from the workflow level to the publishing job. That's a change to how releases authenticate, and this changelog has precedent for logging workflow behaviour — the Scout gate and the publish-trigger fix are both recorded — so it earns a bullet rather than being treated as invisible plumbing.

The entry carries the gotcha as well as the change, because the gotcha is what makes the edit dangerous to copy: **a job-level `permissions` block replaces the workflow default rather than merging with it**, so `contents: read` has to be restated or `actions/checkout` loses its read grant.

## Deliberately not recorded

The smoke-row namespace edits in #678. Those are test documentation owned by qa-harness, not a product change, and this changelog describes the product.

## Wrap-up context

Surfaced by the T2 doc sweep. For the record, that sweep found nothing stale: 9 session identifiers grepped across README / docs / CLAUDE.md returned 0 stale hits, and a reverse pass checked 146 distinct path tokens named across 4 docs, flagging 5 — all classified as known false-positive classes (a URL, a runtime control path, a `src/server/`-relative path that does exist, and the two correctly-labelled qa-harness cross-repo references the protocol says this repo carries).
